### PR TITLE
[Config] Make audio service port configurable

### DIFF
--- a/services/audio/server.py
+++ b/services/audio/server.py
@@ -86,8 +86,8 @@ async def serve(metrics_port=8000):
     await health_servicer.set("audio.AudioService", health_pb2.HealthCheckResponse.SERVING)
     await health_servicer.set("", health_pb2.HealthCheckResponse.SERVING)  # Overall health
 
-    # Bind to port
-    port = "50056"
+    # Bind to port (configurable via AUDIO_PORT env var)
+    port = int(os.environ.get("AUDIO_PORT", "50056"))
     server.add_insecure_port(f"[::]:{port}")
 
     logger.info(f"Audio service listening on port {port}")


### PR DESCRIPTION
## Summary
- Makes the audio service gRPC port configurable via `AUDIO_PORT` environment variable
- Defaults to `50056` for backward compatibility
- Fixes the type from string to int

## Changes
- `services/audio/server.py`: Replace hardcoded `"50056"` with `int(os.environ.get("AUDIO_PORT", "50056"))`

## Test plan
- [ ] Service starts with default port when `AUDIO_PORT` is not set
- [ ] Service uses custom port when `AUDIO_PORT` is set
- [ ] Verify gRPC connections still work

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)