### PR TITLE
[Menu] Detect random mode for game start

### DIFF
--- a/services/menu/process.py
+++ b/services/menu/process.py
@@ -256,12 +256,18 @@ class MenuProcess(Process):
         # Stop menu
         self.menu_running = False
 
+        # Import Games enum to check for Random mode
+        from common import Games
+
+        # Detect if Random mode is selected
+        is_random_mode = self.game_mode == Games.Random if self.game_mode else False
+
         # Send game_requested event
         self.send_event(
             "game_requested",
             {
                 "game_mode": self.game_mode.name if self.game_mode else "JoustFFA",
-                "random_mode": False,  # TODO: Detect random mode
+                "random_mode": is_random_mode,
                 "force_all": False,  # TODO: Get from settings
             },
         )


### PR DESCRIPTION
## Summary
When requesting a game start, now properly detects if the selected game mode is Random and sets the `random_mode` flag accordingly.

## Changes
- `services/menu/process.py`: Check if `self.game_mode == Games.Random` and set the flag

## Context
This allows the game coordinator to handle random mode selection appropriately (e.g., picking a random game from the configured list).

## Test plan
- [ ] Linting passes
- [ ] When Random mode is selected, `random_mode: true` is included in the event
- [ ] When other modes are selected, `random_mode: false`

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)