### PR TITLE
[Docs] Expand settings service README

### DIFF
--- a/services/settings/README.md
+++ b/services/settings/README.md
@@ -47,14 +47,84 @@ grpcurl -plaintext -d '{"keys": ["sensitivity"]}' \
   localhost:50051 joustmania.settings.SettingsService/SubscribeToChanges
 ```
 
-## Common Settings
+## Settings Schema
 
-| Key | Values | Description |
-|-----|--------|-------------|
-| `sensitivity` | `slow`, `medium`, `fast` | Motion sensitivity threshold |
-| `instructions` | `true`, `false` | Whether to show game instructions |
-| `teams` | `2`, `3`, `4` | Number of teams for team games |
-| `game_mode` | Game mode name | Currently selected game mode |
+All available settings with their types, defaults, and validation rules:
+
+### Game Settings
+
+| Key | Type | Default | Range/Values | Description |
+|-----|------|---------|--------------|-------------|
+| `sensitivity` | int | `2` | 0-4 | Movement sensitivity (0=ultra slow, 4=ultra fast) |
+| `instructions` | bool | `true` | true/false | Play voice instructions before games |
+| `num_teams` | int | `2` | 2-6 | Number of teams for team games |
+| `force_all_start` | bool | `false` | true/false | Start with all controllers (vs only ready ones) |
+| `nonstop_time_limit` | int | `0` | 0-3600 | Time limit for Nonstop Joust in seconds (0=no limit) |
+| `random_teams` | bool | `true` | true/false | Randomize team assignments (vs sequential) |
+
+### Menu Settings
+
+| Key | Type | Default | Values | Description |
+|-----|------|---------|--------|-------------|
+| `current_game` | str | `"JoustFFA"` | See game modes | Currently selected game mode |
+| `menu_voice` | str | `"ivy"` | "ivy", "aaron" | Voice pack for announcements |
+| `play_audio` | bool | `true` | true/false | Enable/disable all audio |
+| `random_modes` | list | See below | Game mode names | Modes included in random selection |
+
+### Sensitivity Levels
+
+| Value | Name | Description |
+|-------|------|-------------|
+| 0 | Ultra Slow | Most sensitive - easiest to die |
+| 1 | Slow | High sensitivity |
+| 2 | Medium | Default balanced setting |
+| 3 | Fast | Low sensitivity |
+| 4 | Ultra Fast | Least sensitive - hardest to die |
+
+### Valid Game Modes
+
+```
+JoustFFA, JoustTeams, JoustRandomTeams, Werewolf, Traitor,
+Zombies, Commander, Swapper, FightClub, Tournament, NonstopJoust, Ninja
+```
+
+### Default Random Modes
+
+```yaml
+random_modes:
+  - JoustFFA
+  - JoustRandomTeams
+  - Werewolf
+  - Nonstop
+```
+
+## Configuration File
+
+Settings are persisted in `joustsettings.yaml` at the project root.
+
+### Example Configuration
+
+```yaml
+# JoustMania Settings
+sensitivity: 2
+instructions: true
+num_teams: 2
+force_all_start: false
+nonstop_time_limit: 0
+menu_voice: ivy
+random_modes:
+  - JoustFFA
+  - JoustRandomTeams
+  - Werewolf
+  - Nonstop
+```
+
+### File Location
+
+| Environment | Path |
+|-------------|------|
+| Docker | `/app/joustsettings.yaml` (mounted volume) |
+| Local | `./joustsettings.yaml` (project root) |
 
 ## Architecture
 
@@ -66,8 +136,15 @@ grpcurl -plaintext -d '{"keys": ["sensitivity"]}' \
 └────────┬────────┘
          │
          ▼
-    Redis (persistence)
+   joustsettings.yaml
 ```
+
+### How It Works
+
+1. **Startup**: Service loads `joustsettings.yaml`, validates against schema, applies defaults
+2. **Read**: `GetSettings`/`GetSetting` return current in-memory values
+3. **Write**: `UpdateSetting` validates value, updates memory, persists to YAML
+4. **Subscribe**: `SubscribeToChanges` streams real-time change events to clients
 
 ## Development
 


### PR DESCRIPTION
## Summary
Significantly expands the settings service README with complete schema documentation.

## Changes

### Added Sections
- **Settings Schema**: Complete reference tables for all settings
- **Sensitivity Levels**: 0-4 scale explanation
- **Valid Game Modes**: Complete list
- **Configuration File**: Example YAML, file locations
- **How It Works**: Service operation explanation

### Fixed
- Architecture diagram: Changed "Redis" to "joustsettings.yaml" (was incorrect)

## Settings Documented

| Category | Settings |
|----------|----------|
| Game | sensitivity, instructions, num_teams, force_all_start, nonstop_time_limit, random_teams |
| Menu | current_game, menu_voice, play_audio, random_modes |

## Test plan
- [x] Markdown renders correctly
- [x] All settings from schema are documented
- [ ] Links work correctly

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)