### PR TITLE
fix(audio): Add ALSA config files and fix play_music call

### DIFF
--- a/services/audio/Dockerfile
+++ b/services/audio/Dockerfile
@@ -17,12 +17,13 @@
 ARG BUILDER_IMAGE=joustmania/builder:latest
 
 # =============================================================================
-# Stage 0: Extract shared libraries for distroless
+# Stage 0: Extract shared libraries and config for distroless
 # =============================================================================
 FROM debian:bookworm-slim AS system-libs
 ARG TARGETARCH
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libasound2 \
+    libasound2-data \
     && rm -rf /var/lib/apt/lists/* \
     && mkdir /extra-libs \
     && if [ "$TARGETARCH" = "arm64" ]; then \
@@ -80,8 +81,11 @@ WORKDIR /app
 # Copy grpc-health-probe from official multi-arch image
 COPY --from=ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.38 /ko-app/grpc-health-probe /bin/grpc_health_probe
 
-# Copy system shared libraries (ALSA + glibc math/vector libs for miniaudio)
+# Copy system shared libraries (ALSA libs for miniaudio/pyalsaaudio)
 COPY --from=system-libs /extra-libs/ /usr/lib/
+
+# Copy ALSA configuration files (required for PCM device resolution)
+COPY --from=system-libs /usr/share/alsa/ /usr/share/alsa/
 
 # Copy installed packages from builder to distroless stdlib location
 COPY --from=builder /usr/local/lib/python3.11/site-packages/ /usr/lib/python3.11/

--- a/services/audio/servicer.py
+++ b/services/audio/servicer.py
@@ -544,9 +544,9 @@ class AudioServiceServicer(audio_pb2_grpc.AudioServiceServicer):
 
             track_id = self.audio_manager.play_music(
                 file_pattern=request.file_pattern,
-                loop=request.loop,
+                _loop=request.loop,
                 tempo=request.tempo or 1.0,
-                priority=request.priority,
+                _priority=request.priority,
             )
 
             if track_id:


### PR DESCRIPTION
## Summary
- Adds missing ALSA configuration files to distroless container
- Fixes `play_music()` parameter name mismatch

## Issues Fixed

### 1. Missing ALSA config (`/usr/share/alsa/alsa.conf`)
```
ALSA lib conf.c:4555:(snd_config_update_r) Cannot access file /usr/share/alsa/alsa.conf
ALSA lib pcm.c:2666:(snd_pcm_open_noupdate) Unknown PCM default
```

**Fix**: Install `libasound2-data` and copy `/usr/share/alsa/` to the distroless container.

### 2. play_music() TypeError
```
TypeError: AudioManager.play_music() got an unexpected keyword argument 'loop'
```

**Fix**: The method params use underscore prefixes (`_loop`, `_priority`) because they're intentionally unused. Updated the call site to match.

## Test plan
- [ ] Rebuild audio image
- [ ] On Pi: `docker logs joustmania-audio` shows no ALSA errors
- [ ] Audio playback works

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)