### PR TITLE
fix(audio): Add audio group for ALSA dmix IPC

### DIFF
--- a/services/audio/Dockerfile
+++ b/services/audio/Dockerfile
@@ -31,7 +31,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
        else \
          LIB_DIR=/usr/lib/x86_64-linux-gnu; \
        fi \
-    && cp $LIB_DIR/libasound.so* /extra-libs/
+    && cp $LIB_DIR/libasound.so* /extra-libs/ \
+    && mkdir -p /extra-etc \
+    && grep -E "^(root|audio):" /etc/group > /extra-etc/group
 
 # =============================================================================
 # Stage 2: Build Python dependencies
@@ -86,6 +88,9 @@ COPY --from=system-libs /extra-libs/ /usr/lib/
 
 # Copy ALSA configuration files (required for PCM device resolution)
 COPY --from=system-libs /usr/share/alsa/ /usr/share/alsa/
+
+# Copy group file with audio group (required for ALSA dmix IPC)
+COPY --from=system-libs /extra-etc/group /etc/group
 
 # Copy installed packages from builder to distroless stdlib location
 COPY --from=builder /usr/local/lib/python3.11/site-packages/ /usr/lib/python3.11/


### PR DESCRIPTION
## Summary
Adds the `audio` group to the distroless container's `/etc/group` file.

## Issue
```
ALSA lib pcm_direct.c:2049:(snd1_pcm_direct_parse_open_conf) The field ipc_gid must be a valid group (create group audio)
```

## Root Cause
ALSA's `dmix` plugin uses shared memory for mixing audio from multiple processes. It requires the `audio` group to exist for IPC permissions. The distroless container has a minimal `/etc/group` that doesn't include this group.

## Fix
Extract `root` and `audio` group entries from Debian's `/etc/group` and copy to the distroless container.

## Test plan
- [ ] Rebuild audio image
- [ ] On Pi: verify no "ipc_gid must be a valid group" errors
- [ ] Audio playback works

🤖 Generated with [Claude Code](https://claude.com/claude-code)