### PR TITLE
fix(audio): Add asound.conf to bypass dmix and use hardware directly

### DIFF
--- a/services/audio/Dockerfile
+++ b/services/audio/Dockerfile
@@ -89,7 +89,11 @@ COPY --from=system-libs /extra-libs/ /usr/lib/
 # Copy ALSA configuration files (required for PCM device resolution)
 COPY --from=system-libs /usr/share/alsa/ /usr/share/alsa/
 
-# Copy group file with audio group (required for ALSA dmix IPC)
+# Copy simple ALSA config that uses hw:0,0 directly (bypasses dmix)
+# Can be overridden by mounting: -v /path/to/asound.conf:/etc/asound.conf:ro
+COPY services/audio/asound.conf /etc/asound.conf
+
+# Copy group file with audio group (for ALSA IPC if dmix is used via override)
 COPY --from=system-libs /extra-etc/group /etc/group
 
 # Copy installed packages from builder to distroless stdlib location

--- a/services/audio/asound.conf
+++ b/services/audio/asound.conf
@@ -1,0 +1,15 @@
+# Simple ALSA configuration for container use
+# Uses hardware device directly, bypassing dmix (which requires IPC setup)
+# 
+# Override by mounting your own: -v /path/to/asound.conf:/etc/asound.conf:ro
+
+pcm.!default {
+    type hw
+    card 0
+    device 0
+}
+
+ctl.!default {
+    type hw
+    card 0
+}


### PR DESCRIPTION
## Summary

- Adds `asound.conf` that routes audio directly to `hw:0,0`, bypassing the dmix software mixer
- The dmix plugin requires IPC setup (shared memory, audio group permissions) that's complex in containers
- Using hardware directly is simpler and avoids the "unable to open slave" errors

Users can override by mounting their own config:
```bash
-v /path/to/asound.conf:/etc/asound.conf:ro
```

## Test plan

- [ ] Build audio service image
- [ ] Run on Raspberry Pi with `--device /dev/snd`
- [ ] Verify audio playback works (test via gRPC calls)

Fixes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)