### PR TITLE
fix(audio): Fix miniaudio API and use dmix for software mixing

### DIFF
--- a/services/audio/asound.conf
+++ b/services/audio/asound.conf
@@ -1,12 +1,27 @@
-# Simple ALSA configuration for container use
-# Uses hardware device directly, bypassing dmix (which requires IPC setup)
-# 
+# ALSA configuration for JoustMania container
+# Uses dmix for software mixing (allows multiple audio streams)
+#
 # Override by mounting your own: -v /path/to/asound.conf:/etc/asound.conf:ro
 
+# Define the dmix plugin for software mixing
+pcm.dmixer {
+    type dmix
+    ipc_key 1024
+    ipc_perm 0666
+    slave {
+        pcm "hw:0,0"
+        period_time 0
+        period_size 1024
+        buffer_size 4096
+        rate 44100
+        channels 2
+    }
+}
+
+# Default output goes through dmix
 pcm.!default {
-    type hw
-    card 0
-    device 0
+    type plug
+    slave.pcm "dmixer"
 }
 
 ctl.!default {

--- a/services/audio/servicer.py
+++ b/services/audio/servicer.py
@@ -78,7 +78,10 @@ class SoundChannel:
                 def play_thread():
                     try:
                         # Use stream_memory for one-shot playback
-                        stream = miniaudio.stream_memory(decoded.samples, decoded.nchannels, decoded.sample_rate)
+                        # Args: audio_data, output_format, nchannels, sample_rate
+                        stream = miniaudio.stream_memory(
+                            decoded.samples, decoded.sample_format, decoded.nchannels, decoded.sample_rate
+                        )
                         with self.device:
                             self.device.start(stream)
                             # Wait for stream to finish


### PR DESCRIPTION
## Summary

Fixes two issues that prevented audio playback on Raspberry Pi:

1. **Fixed miniaudio.stream_memory() API bug** - was missing `output_format` parameter which caused `'int' object has no attribute 'value'` errors during sound effect playback

2. **Updated asound.conf to use dmix for software mixing** - allows miniaudio (sound effects) and alsaaudio (music) to play simultaneously instead of competing for hw:0,0
   - Uses `ipc_perm 0666` to avoid group permission issues in container
   - Wraps dmix with `plug` for automatic format conversion

## Test plan

- [ ] Build audio service image
- [ ] Run on Raspberry Pi with `--device /dev/snd`
- [ ] Verify sound effects play without "'int' object has no attribute 'value'" error
- [ ] Verify music plays without "Device or resource busy" error
- [ ] Verify sound effects and music can play simultaneously

Fixes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)