### PR TITLE
fix(audio): Convert samples to bytes for miniaudio stream_memory

### DIFF
--- a/services/audio/servicer.py
+++ b/services/audio/servicer.py
@@ -78,9 +78,9 @@ class SoundChannel:
                 def play_thread():
                     try:
                         # Use stream_memory for one-shot playback
-                        # Args: audio_data, output_format, nchannels, sample_rate
+                        # Args: audio_data (bytes), output_format, nchannels, sample_rate
                         stream = miniaudio.stream_memory(
-                            decoded.samples, decoded.sample_format, decoded.nchannels, decoded.sample_rate
+                            decoded.samples.tobytes(), decoded.sample_format, decoded.nchannels, decoded.sample_rate
                         )
                         with self.device:
                             self.device.start(stream)


### PR DESCRIPTION
## Summary

Fixes sound effect playback error:
```
initializer for ctype 'void *' must be a cdata pointer, not array.array
```

`miniaudio.decode_file()` returns samples as `array.array`, but `stream_memory()` expects bytes. Added `.tobytes()` conversion.

## Test plan

- [ ] Build audio service image
- [ ] Run on Raspberry Pi with `--device /dev/snd`
- [ ] Verify sound effects play without errors

Fixes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)