### PR TITLE
fix(audio): Remove generator iteration that caused race condition

### DIFF
--- a/services/audio/servicer.py
+++ b/services/audio/servicer.py
@@ -78,10 +78,15 @@ class SoundChannel:
                         stream = miniaudio.stream_memory(file_data)
                         with self.device:
                             self.device.start(stream)
-                            # Wait for stream to finish
-                            for _ in stream:
-                                if not self.is_playing:
-                                    break
+                            # Wait for playback to complete (device callback consumes the stream)
+                            # Poll is_playing flag which can be set to False by stop()
+                            import time
+
+                            duration = file_info.duration
+                            elapsed = 0.0
+                            while self.is_playing and elapsed < duration + 1.0:
+                                time.sleep(0.1)
+                                elapsed += 0.1
                     except Exception as e:
                         logger.warning(f"Playback error on channel {self.channel_id}: {e}")
                     finally:


### PR DESCRIPTION
## Summary

Fixes SFX playback error:
```
generator already executing
```

The miniaudio device consumes the stream generator via internal callbacks. Manually iterating it with `for _ in stream` caused a race condition. Changed to time-based wait using file duration.

## Test plan

- [ ] Build audio service image
- [ ] Run on Raspberry Pi with `--device /dev/snd`
- [ ] Verify sound effects play without "generator already executing" error

Fixes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)