### PR TITLE
fix(game): Remove 300-second safety timeout from games

### DIFF
--- a/services/game_coordinator/games/base.py
+++ b/services/game_coordinator/games/base.py
@@ -505,9 +505,6 @@ class BaseGameMode(ABC):
             loop_iterations = 0
             last_iteration_time = loop_start_time
 
-            # Safety timeout: maximum 5 minutes per game
-            max_game_duration = 300  # seconds
-
             # Stream gameplay data and process game logic
             logger.info("Starting gameplay data stream loop, waiting for first update...")
             async for gameplay_update in self.gameplay_stream:
@@ -525,11 +522,6 @@ class BaseGameMode(ABC):
 
                 if not self.running:
                     logger.info("Game running=False, breaking loop")
-                    break
-
-                # Safety check: timeout if game runs too long
-                if (time.time() - loop_start_time) > max_game_duration:
-                    logger.error(f"Game exceeded maximum duration of {max_game_duration}s, forcing end")
                     break
 
                 # Process each controller's gameplay data


### PR DESCRIPTION
## Summary
- Remove hardcoded 300-second (5 minute) safety timeout that was forcefully ending games

## Problem
Games were being terminated with this error:
```
Game exceeded maximum duration of 300s, forcing end
```

## Solution
Remove the safety timeout. Games should run until their natural end condition:
- FFA/Teams: Last player/team standing
- Nonstop Joust: Has its own `nonstop_time_limit` setting
- Zombie: Has its own time-based win condition
- Fight Club: Has round timers

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)