### PR TITLE
fix(controller): Clear stale base_colors when button stream reconnects

### DIFF
--- a/services/controller_manager/servicer.py
+++ b/services/controller_manager/servicer.py
@@ -182,6 +182,11 @@ class ControllerManagerServicer(controller_manager_pb2_grpc.ControllerManagerSer
         # Update stream metrics (Phase 38)
         metrics.active_streams.inc()
 
+        # Clear stale base_colors from previous session (e.g., game that just ended)
+        # This ensures fresh color state when menu reconnects after a game
+        self.feedback_manager.base_colors.clear()
+        logger.debug(f"[{subscriber_id}] Cleared stale base_colors for fresh session")
+
         # Send initial connection events for all currently tracked controllers
         # This allows new subscribers to immediately know about existing controllers
         for serial, info in self.tracked_controllers.items():


### PR DESCRIPTION
## Summary
Fix controller colors not resetting properly when returning to menu after a game ends.

## Problem
When a game ended and the menu restarted its button monitor, controller LED colors
would remain stuck with their game colors (e.g., winner's rainbow) instead of
transitioning to menu/lobby colors.

## Root Cause
The `feedback_manager.base_colors` dict retained colors from the game session.
When controllers stayed connected during the game-to-menu transition, these
stale colors interfered with the menu's color commands.

## Solution
Clear `base_colors` when a new button stream subscriber connects. This ensures
fresh color state when the menu reconnects after a game.

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)