### PR TITLE
feat: Add auto-update to systemd service with observability alerts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -236,6 +236,8 @@ services:
     environment:
       - OTEL_SERVICE_NAME=supervisor-service
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
+    volumes:
+      - /tmp/joustmania:/tmp/joustmania:ro  # Host startup status (read-only)
     depends_on:
       otel-collector:
         condition: service_started

--- a/scripts/setup/joustmania-start.sh
+++ b/scripts/setup/joustmania-start.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# JoustMania startup script with optional auto-update
+# Gracefully handles missing internet connection
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+JOUSTMANIA_DIR="$(dirname "$(dirname "$SCRIPT_DIR")")"
+STATUS_DIR="/tmp/joustmania"
+STATUS_FILE="$STATUS_DIR/update-status.json"
+
+cd "$JOUSTMANIA_DIR"
+
+echo "=== JoustMania Startup ==="
+echo "Working directory: $JOUSTMANIA_DIR"
+
+# Create status directory
+mkdir -p "$STATUS_DIR"
+
+# Files to track for updates
+TRACKED_FILES=(
+    "scripts/setup/joustmania.service"
+    "scripts/setup/joustmania-start.sh"
+    "scripts/setup/install_autostart.sh"
+)
+
+# Calculate checksums before git pull
+declare -A CHECKSUMS_BEFORE
+for file in "${TRACKED_FILES[@]}"; do
+    if [ -f "$file" ]; then
+        CHECKSUMS_BEFORE["$file"]=$(sha256sum "$file" 2>/dev/null | cut -d' ' -f1)
+    fi
+done
+
+# Attempt git pull (non-fatal)
+echo "Checking for code updates..."
+GIT_PULL_STATUS="success"
+if git pull --ff-only 2>&1; then
+    echo "Code updated successfully"
+else
+    echo "Could not update code (offline or conflict) - continuing with current version"
+    GIT_PULL_STATUS="failed"
+fi
+
+# Check which files changed
+CHANGED_FILES=()
+for file in "${TRACKED_FILES[@]}"; do
+    if [ -f "$file" ]; then
+        CHECKSUM_AFTER=$(sha256sum "$file" 2>/dev/null | cut -d' ' -f1)
+        if [ "${CHECKSUMS_BEFORE[$file]}" != "$CHECKSUM_AFTER" ]; then
+            CHANGED_FILES+=("$file")
+            echo "Service file changed: $file"
+        fi
+    fi
+done
+
+# Write status file for observability
+CHANGED_FILES_JSON=$(printf '%s\n' "${CHANGED_FILES[@]}" | jq -R . | jq -s .)
+cat > "$STATUS_FILE" << EOF
+{
+    "timestamp": "$(date -Iseconds)",
+    "git_pull_status": "$GIT_PULL_STATUS",
+    "service_files_changed": ${CHANGED_FILES_JSON:-[]},
+    "update_pending": $([ ${#CHANGED_FILES[@]} -gt 0 ] && echo "true" || echo "false")
+}
+EOF
+
+if [ ${#CHANGED_FILES[@]} -gt 0 ]; then
+    echo "WARNING: Service files have changed. Run 'sudo ./scripts/setup/install_autostart.sh' to apply updates."
+fi
+
+# Attempt docker compose pull (non-fatal)
+echo "Checking for image updates..."
+if docker compose pull 2>&1; then
+    echo "Images updated successfully"
+else
+    echo "Could not pull images (offline) - continuing with cached images"
+fi
+
+# Clean up any orphaned containers
+echo "Cleaning up..."
+docker compose down --remove-orphans || true
+
+# Start services (this must succeed)
+echo "Starting JoustMania..."
+exec docker compose up -d

--- a/scripts/setup/joustmania.service
+++ b/scripts/setup/joustmania.service
@@ -8,10 +8,9 @@ Wants=network-online.target
 Type=oneshot
 RemainAfterExit=yes
 WorkingDirectory=/home/pi/JoustMania
-ExecStartPre=/usr/bin/docker compose down --remove-orphans
-ExecStart=/usr/bin/docker compose up -d
+ExecStart=/home/pi/JoustMania/scripts/setup/joustmania-start.sh
 ExecStop=/usr/bin/docker compose down
-TimeoutStartSec=300
+TimeoutStartSec=600
 User=pi
 Group=pi
 

--- a/services/grafana/dashboards/system-status.json
+++ b/services/grafana/dashboards/system-status.json
@@ -1,0 +1,374 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Shows if service configuration files have been updated and need to be reinstalled.\n\nIf this shows \"Update Available\", run:\nsudo ./scripts/setup/install_autostart.sh",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "Up to Date"
+                },
+                "1": {
+                  "color": "orange",
+                  "index": 1,
+                  "text": "Update Available"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.2.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "joustmania_service_update_pending",
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "title": "Service Configuration",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Details about the last startup check for service file updates",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 18,
+        "x": 6,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": ["sum"],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "10.2.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "joustmania_service_update_info",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "title": "Update Details",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value": true,
+              "__name__": true,
+              "instance": true,
+              "job": true
+            },
+            "indexByName": {},
+            "renameByName": {
+              "changed_files": "Changed Files",
+              "git_pull_status": "Git Pull Status",
+              "timestamp": "Last Check"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Number of services currently running",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 5
+              },
+              {
+                "color": "green",
+                "value": 7
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 4
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.2.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "count(up{job=~\"controller-manager|game-coordinator|menu|settings|supervisor|webui|audio\"} == 1)",
+          "legendFormat": "Services Up",
+          "refId": "A"
+        }
+      ],
+      "title": "Services Running",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Current status of all JoustMania services",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "color-background"
+            },
+            "inspect": false
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "red",
+                  "index": 0,
+                  "text": "DOWN"
+                },
+                "1": {
+                  "color": "green",
+                  "index": 1,
+                  "text": "UP"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 18,
+        "x": 6,
+        "y": 4
+      },
+      "id": 4,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": ["sum"],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "10.2.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "up{job=~\"controller-manager|game-coordinator|menu|settings|supervisor|webui|audio\"}",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "title": "Service Status",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true
+            },
+            "indexByName": {},
+            "renameByName": {
+              "Value": "Status",
+              "instance": "Instance",
+              "job": "Service"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": ["joustmania", "system", "status"],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "JoustMania - System Status",
+  "uid": "joustmania-system-status",
+  "version": 0,
+  "weekStart": ""
+}

--- a/services/prometheus/alerts.yml
+++ b/services/prometheus/alerts.yml
@@ -85,3 +85,13 @@ groups:
         annotations:
           summary: "High game crash rate"
           description: "{{$value | humanizePercentage}} of games are crashing."
+
+      # Host update alerts
+      - alert: ServiceUpdatePending
+        expr: joustmania_service_update_pending == 1
+        for: 1m
+        labels:
+          severity: info
+        annotations:
+          summary: "Service files have been updated"
+          description: "Run 'sudo ./scripts/setup/install_autostart.sh' to apply the new service configuration."

--- a/services/supervisor/metrics.py
+++ b/services/supervisor/metrics.py
@@ -4,10 +4,21 @@ Prometheus metrics for Supervisor Service (Phase 38).
 Tracks system resources and gRPC request performance.
 """
 
-from prometheus_client import Counter, Gauge, Histogram
+from prometheus_client import Counter, Gauge, Histogram, Info
 
 # System metrics
 process_cpu_percent = Gauge("process_cpu_percent", "Process CPU usage percentage")
+
+# Host update status metrics
+service_update_pending = Gauge(
+    "joustmania_service_update_pending",
+    "Whether service files have changed and need reinstallation (1=pending, 0=up-to-date)",
+)
+
+service_update_info = Info(
+    "joustmania_service_update",
+    "Information about pending service updates",
+)
 
 process_memory_mb = Gauge("process_memory_mb", "Process memory usage in MB")
 

--- a/services/supervisor/server.py
+++ b/services/supervisor/server.py
@@ -11,9 +11,11 @@ See services/supervisor/servicer.py for the SupervisorOrchestrator implementatio
 """
 
 import asyncio
+import json
 import logging
 import os
 import sys
+from pathlib import Path
 
 import grpc.aio
 from grpc_health.v1 import health, health_pb2, health_pb2_grpc
@@ -26,6 +28,55 @@ from services.supervisor import metrics
 from services.supervisor.servicer import SupervisorOrchestrator
 
 logger = logging.getLogger(__name__)
+
+# Path to host status file (mounted as volume)
+UPDATE_STATUS_FILE = Path("/tmp/joustmania/update-status.json")
+
+
+def _read_update_status_file() -> dict | None:
+    """Read update status file synchronously (for use with asyncio.to_thread)."""
+    if not UPDATE_STATUS_FILE.exists():
+        return None
+    with open(UPDATE_STATUS_FILE) as f:
+        return json.load(f)
+
+
+async def monitor_update_status(interval: float = 30.0):
+    """Periodically read host update status file and update metrics."""
+    while True:
+        try:
+            # Run blocking file I/O in thread pool
+            status = await asyncio.to_thread(_read_update_status_file)
+
+            if status is not None:
+                # Update pending metric (1 if updates pending, 0 otherwise)
+                update_pending = 1 if status.get("update_pending", False) else 0
+                metrics.service_update_pending.set(update_pending)
+
+                # Update info metric with details
+                changed_files = status.get("service_files_changed", [])
+                metrics.service_update_info.info(
+                    {
+                        "timestamp": status.get("timestamp", "unknown"),
+                        "git_pull_status": status.get("git_pull_status", "unknown"),
+                        "changed_files": ",".join(changed_files) if changed_files else "none",
+                    }
+                )
+
+                if update_pending:
+                    logger.warning(
+                        f"Service files have changed: {changed_files}. "
+                        "Run 'sudo ./scripts/setup/install_autostart.sh' to apply."
+                    )
+            else:
+                # No status file - set to 0 (unknown/not applicable)
+                metrics.service_update_pending.set(0)
+        except json.JSONDecodeError as e:
+            logger.error(f"Error parsing update status file: {e}")
+        except Exception as e:
+            logger.error(f"Error reading update status file: {e}")
+
+        await asyncio.sleep(interval)
 
 
 async def serve(port=50055, metrics_port=8000):
@@ -47,6 +98,10 @@ async def serve(port=50055, metrics_port=8000):
         memory_gauge=metrics.process_memory_mb,
         threads_gauge=metrics.process_threads,
     )
+
+    # Start host update status monitoring
+    asyncio.create_task(monitor_update_status())
+    logger.info("Host update status monitoring started")
 
     # Create gRPC server for health checking only
     from lib.grpc_utils import get_server_options


### PR DESCRIPTION
## Summary
- Add automatic update functionality to systemd service on boot
- Track service file changes and expose metrics for observability
- Add visual alert in Grafana when reinstallation is needed

## Changes
- **`scripts/setup/joustmania-start.sh`** (new): Startup script that attempts `git pull` and `docker compose pull` on boot, gracefully handling offline scenarios
- **`scripts/setup/joustmania.service`**: Use new startup script, increase timeout to 600s
- **`docker-compose.yml`**: Add volume mount for status file to supervisor service
- **`services/supervisor/metrics.py`**: Add `joustmania_service_update_pending` gauge and info metrics
- **`services/supervisor/server.py`**: Add async task to read status file and update metrics
- **`services/prometheus/alerts.yml`**: Add `ServiceUpdatePending` alert rule
- **`services/grafana/dashboards/system-status.json`** (new): Dashboard showing update status, service health

## How It Works
1. On boot, `joustmania-start.sh` calculates checksums of service files before/after `git pull`
2. Writes status JSON to `/tmp/joustmania/update-status.json`
3. Supervisor service reads this file every 30s and exposes Prometheus metrics
4. Grafana dashboard shows "Up to Date" (green) or "Update Available" (orange)
5. When service files change, user is prompted to run `sudo ./scripts/setup/install_autostart.sh`

## Test plan
- [ ] Verify startup script runs successfully on boot
- [ ] Verify offline behavior (should continue with cached images)
- [ ] Verify metrics are exposed at supervisor's `/metrics` endpoint
- [ ] Verify Grafana dashboard displays correctly
- [ ] Verify alert fires when service files change

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)