### PR TITLE
fix(menu): Re-register controllers after game ends to restore lobby colors

### DIFF
--- a/services/menu/servicer.py
+++ b/services/menu/servicer.py
@@ -435,7 +435,9 @@ class MenuServicer(menu_pb2_grpc.MenuServiceServicer):
                         self.controller_lobby_state.clear()
                         self.last_lobby_feedback_update.clear()
                         self.ready_controller_count = 0
-                        self.state_manager.reset()  # Reset state_manager too
+                        # Reset state_manager and re-register controllers (sets lobby colors)
+                        re_registered = await self.state_manager.reset()
+                        self.connected_controllers.update(re_registered)
 
                         await self.audio.start_lobby_music()
                         await self.start_button_monitor()

--- a/services/menu/state_manager.py
+++ b/services/menu/state_manager.py
@@ -249,12 +249,31 @@ class StateManager:
         """
         self.current_game_mode = game_mode
 
-    def reset(self) -> None:
-        """Reset all controller states (e.g., after game ends)."""
+    async def reset(self) -> list[str]:
+        """
+        Reset all controller states (e.g., after game ends).
+
+        Re-registers all previously connected controllers, triggering on_enter
+        handlers to set appropriate lobby colors.
+
+        Returns:
+            List of controller serials that were re-registered
+        """
+        # Remember which controllers were connected before clearing
+        serials = list(self.controller_states.keys())
+
+        # Clear all state completely
         self.controller_states.clear()
         self.connected_controllers.clear()
         self.ready_controllers.clear()
         self.button_states.clear()
+
         # Clear all player ready metrics
         metrics.player_ready._metrics.clear()
-        logger.info("StateManager reset")
+
+        # Re-register each controller as CONNECTED (triggers on_enter → sets colors)
+        for serial in serials:
+            await self.on_controller_connected(serial)
+
+        logger.info(f"StateManager reset, re-registered {len(serials)} controllers")
+        return serials

--- a/services/menu/tests/test_state_manager.py
+++ b/services/menu/tests/test_state_manager.py
@@ -166,15 +166,24 @@ class TestStateManagerHelpers:
         state_manager.set_game_mode("Werewolf")
         assert state_manager.current_game_mode == "Werewolf"
 
+    @pytest.mark.asyncio
     @patch("services.menu.state_manager.metrics")
-    def test_reset(self, mock_metrics, state_manager):
-        """reset should clear all state."""
+    async def test_reset(self, mock_metrics, state_manager):
+        """reset should clear ready state and re-register controllers."""
         state_manager.connected_controllers = {"s1", "s2"}
         state_manager.ready_controllers = {"s1"}
-        state_manager.controller_states = {"s1": ControllerState.READY}
+        state_manager.controller_states = {"s1": ControllerState.READY, "s2": ControllerState.CONNECTED}
+        state_manager.button_states = {"s1": {"trigger": True}}
 
-        state_manager.reset()
+        re_registered = await state_manager.reset()
 
-        assert state_manager.connected_controllers == set()
+        # Controllers from controller_states should be re-registered
+        assert set(re_registered) == {"s1", "s2"}
+        # Re-registered controllers should be in connected set
+        assert state_manager.connected_controllers == {"s1", "s2"}
+        # All controllers should be in CONNECTED state (not READY)
+        assert state_manager.controller_states == {"s1": ControllerState.CONNECTED, "s2": ControllerState.CONNECTED}
+        # Ready controllers should be cleared
         assert state_manager.ready_controllers == set()
-        assert state_manager.controller_states == {}
+        # Button states should be cleared
+        assert state_manager.button_states == {}


### PR DESCRIPTION
## Summary

- Makes `StateManager.reset()` async and re-registers all previously connected controllers
- Triggers `on_enter` handlers for the CONNECTED state, which sets lobby colors
- Updates servicer to await the async reset and maintain its own controller tracking

## Problem

When a game ends, `StateManager.reset()` clears all controller state but the controllers remain physically connected. Since no new `on_controller_connected()` events fire for already-connected controllers, the `on_enter` handler for the CONNECTED state is never called, leaving controllers without their lobby colors set.

## Solution

The fix remembers which controllers were connected before clearing state, then re-registers each one via `on_controller_connected()`. This triggers the `on_enter` handler which sets the appropriate lobby color based on game mode.

Fixes #137

## Test plan

- [ ] Start a game with multiple controllers
- [ ] End the game
- [ ] Verify all controllers return to lobby colors immediately (no button press required)
- [ ] Verify admin menu works correctly after game ends

🤖 Generated with [Claude Code](https://claude.com/claude-code)