### PR TITLE
perf(metrics): Increase acceleration metrics frequency to 10Hz

### DIFF
--- a/services/game_coordinator/runtime_config.py
+++ b/services/game_coordinator/runtime_config.py
@@ -33,7 +33,7 @@ class AnalyticsConfig:
     # > 2.0g = danger zone
 
     # Metrics emission interval (emit Prometheus gauges every N frames)
-    metrics_emit_interval_frames: int = 60  # ~1 second at 60Hz
+    metrics_emit_interval_frames: int = 6  # ~100ms at 60Hz (10Hz updates)
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- Reduce `metrics_emit_interval_frames` from 60 to 6 (1Hz → 10Hz)
- Enables near-realtime acceleration data in Grafana dashboards
- Allows visibility of peaks and rapid movement changes during gameplay

## Test plan
- [ ] Deploy and verify acceleration time series updates ~10x per second in Grafana
- [ ] Confirm Prometheus storage and query performance remains acceptable

🤖 Generated with [Claude Code](https://claude.com/claude-code)