### PR TITLE
fix(dashboard): Fix Connect protocol content-type and Grafana embed

### DIFF
--- a/services/dashboard/src/client.ts
+++ b/services/dashboard/src/client.ts
@@ -38,7 +38,7 @@ async function unaryCall<Req, Res>(
   const response = await fetch(url, {
     method: "POST",
     headers: {
-      "Content-Type": "application/json",
+      "Content-Type": "application/connect+json",
     },
     body: JSON.stringify(request),
   });
@@ -60,7 +60,7 @@ async function* serverStream<Req, Res>(
   const response = await fetch(url, {
     method: "POST",
     headers: {
-      "Content-Type": "application/json",
+      "Content-Type": "application/connect+json",
       Accept: "application/connect+json",
     },
     body: JSON.stringify(request),

--- a/services/dashboard/src/index.html
+++ b/services/dashboard/src/index.html
@@ -69,11 +69,11 @@
           <div class="embed-container">
             <div class="embed-header">
               <h3>Controller Health</h3>
-              <a href="/grafana/d/controller-health" target="_blank" class="external-link">Open in Grafana &#8599;</a>
+              <a href="/grafana/d/joustmania-controller-health" target="_blank" class="external-link">Open in Grafana &#8599;</a>
             </div>
             <iframe
               id="grafana-embed"
-              src="/grafana/d/controller-health/controller-health?orgId=1&theme=dark&kiosk"
+              src="/grafana/d/joustmania-controller-health/controller-health?orgId=1&theme=dark&kiosk"
               class="embed-iframe"
             ></iframe>
           </div>


### PR DESCRIPTION
## Summary
- Use `application/connect+json` content-type for all RPC calls (unaryCall and serverStream)
- Fix Grafana dashboard UID reference from `controller-health` to `joustmania-controller-health`

## Problem
- All gRPC calls were failing with `415 Unsupported Media Type` because the client was sending `application/json` instead of `application/connect+json`
- Grafana dashboard iframe wasn't loading because the UID was incorrect

## Affected RPCs (all fixed)
- `forceEndGame` (unary)
- `getSettings`, `getSetting`, `updateSetting` (unary)
- `processInput` (unary)
- `streamGameplayData` (server stream)
- `streamGameEvents` (server stream)

## Test plan
- [ ] Verify controller cards appear in dashboard
- [ ] Verify Grafana dashboard loads in Metrics tab
- [ ] Verify game events stream works

🤖 Generated with [Claude Code](https://claude.com/claude-code)