### PR TITLE
fix(setup): Prompt to build psmoveapi in runtime setup

### DIFF
--- a/scripts/setup/setup_runtime.sh
+++ b/scripts/setup/setup_runtime.sh
@@ -142,11 +142,32 @@ else
     echo -e "  → ${YELLOW}psmove CLI not found${NC}"
     echo ""
     echo "    The pairing daemon needs the psmove CLI to pair controllers."
-    echo "    Options:"
-    echo "      1. Build psmoveapi: ./scripts/setup/build_psmoveapi.sh"
-    echo "      2. Pair manually: Connect via USB, use bluetoothctl"
-    echo "      3. Skip pairing daemon (existing paired controllers will work)"
+    echo "    Building psmoveapi takes ~10 minutes but is required for automatic pairing."
     echo ""
+    read -p "    Build psmoveapi now? (y/n) " -n 1 -r
+    echo
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+        echo ""
+        echo "  → Building psmoveapi (this takes ~10 minutes)..."
+        BUILD_SCRIPT="$JOUSTMANIA_DIR/scripts/setup/build_psmoveapi.sh"
+        if [ -f "$BUILD_SCRIPT" ]; then
+            bash "$BUILD_SCRIPT"
+            if [ $? -eq 0 ]; then
+                echo -e "  → ${GREEN}psmoveapi built successfully${NC}"
+                export PATH="$HOMEDIR/psmoveapi/build:$PATH"
+                PSMOVE_AVAILABLE=true
+            else
+                echo -e "  → ${RED}psmoveapi build failed${NC}"
+            fi
+        else
+            echo -e "  → ${RED}Build script not found: $BUILD_SCRIPT${NC}"
+        fi
+    else
+        echo ""
+        echo "    Skipping psmoveapi build."
+        echo "    You can build it later with: ./scripts/setup/build_psmoveapi.sh"
+        echo ""
+    fi
 fi
 
 # Step 5: Install pairing daemon


### PR DESCRIPTION
## Summary
- Prompt user to build psmoveapi when it's not found during runtime setup
- Previously just printed a note that was easy to miss

## Problem
The pairing daemon requires `psmove` CLI for:
- `psmove list` - detect USB controllers
- `psmove pair` - pair controllers to host  
- `psmove calibrate` - calibrate controllers

Runtime setup would skip psmoveapi and leave users with a non-functional pairing daemon.

## Solution
When psmove CLI is not found, ask:
```
Build psmoveapi now? (y/n)
```

- If yes: runs `build_psmoveapi.sh` (~10 min)
- If no: skips with instructions to build later

## Test plan
- [ ] Run `./setup.sh`, select option 1 (Runtime Only)
- [ ] Verify prompt appears when psmove is not installed
- [ ] Verify "y" triggers the build script
- [ ] Verify "n" skips with helpful message

🤖 Generated with [Claude Code](https://claude.com/claude-code)