### PR TITLE
feat(grafana): Show controller names in Player Insights row headers

### DIFF
--- a/services/grafana/dashboards/player-insights.json
+++ b/services/grafana/dashboards/player-insights.json
@@ -101,7 +101,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "controller_info{serial=\"$controller\"}",
+          "expr": "controller_info and on(serial) controller_info{name=\"$controller\"}",
           "format": "table",
           "instant": true,
           "legendFormat": "{{name}}",
@@ -260,7 +260,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "controller_color_hex{serial=\"$controller\"}",
+          "expr": "controller_color_hex and on(serial) controller_info{name=\"$controller\"}",
           "legendFormat": "Color",
           "refId": "A"
         }
@@ -334,7 +334,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "game_player_accel_magnitude{serial=\"$controller\"}",
+          "expr": "game_player_accel_magnitude and on(serial) controller_info{name=\"$controller\"}",
           "legendFormat": "Accel",
           "refId": "A",
           "instant": false,
@@ -519,7 +519,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "game_player_accel_magnitude{serial=\"$controller\"}",
+          "expr": "game_player_accel_magnitude and on(serial) controller_info{name=\"$controller\"}",
           "legendFormat": "Acceleration",
           "refId": "A",
           "instant": false,
@@ -610,7 +610,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "game_player_peak_accel{serial=\"$controller\"}",
+          "expr": "game_player_peak_accel and on(serial) controller_info{name=\"$controller\"}",
           "legendFormat": "Peak",
           "refId": "A"
         }
@@ -680,7 +680,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "bluetooth_device_rssi_dbm{serial=\"$controller\"}",
+          "expr": "bluetooth_device_rssi_dbm and on(serial) controller_info{name=\"$controller\"}",
           "legendFormat": "RSSI",
           "refId": "A"
         }
@@ -786,7 +786,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "controller_battery_level{serial=\"$controller\"}",
+          "expr": "controller_battery_level and on(serial) controller_info{name=\"$controller\"}",
           "legendFormat": "Battery",
           "refId": "A"
         }
@@ -882,7 +882,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "game_player_playstyle{serial=\"$controller\"}",
+          "expr": "game_player_playstyle and on(serial) controller_info{name=\"$controller\"}",
           "legendFormat": "Playstyle",
           "refId": "A"
         }
@@ -989,7 +989,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "game_player_movement_zone{serial=\"$controller\"}",
+          "expr": "game_player_movement_zone and on(serial) controller_info{name=\"$controller\"}",
           "legendFormat": "Zone",
           "refId": "A"
         }
@@ -1009,7 +1009,7 @@
           "type": "prometheus",
           "uid": "prometheus"
         },
-        "definition": "label_values({__name__=~\"game_player_alive|game_player_accel_magnitude|menu_player_ready\"}, serial)",
+        "definition": "label_values(controller_info, name)",
         "hide": 0,
         "includeAll": true,
         "label": "Controller",
@@ -1017,7 +1017,7 @@
         "name": "controller",
         "options": [],
         "query": {
-          "query": "label_values({__name__=~\"game_player_alive|game_player_accel_magnitude|menu_player_ready\"}, serial)",
+          "query": "label_values(controller_info, name)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 2,


### PR DESCRIPTION
## Summary

- Changed the `controller` variable to query names from `controller_info` metric instead of serials
- Updated all panel queries to use reverse lookups via `and on(serial) controller_info{name="$controller"}`
- Row headers now display human-readable names (e.g., `🎮 Player1`) instead of serial numbers

## Before/After

**Before:** Row headers showed `🎮 00:12:34:56:78:90`
**After:** Row headers show `🎮 Player1`

## Test plan

- [ ] Open Player Insights dashboard
- [ ] Verify controller dropdown shows names instead of serials
- [ ] Verify collapsible row headers display controller names
- [ ] Verify all panels still show correct data for each controller

🤖 Generated with [Claude Code](https://claude.com/claude-code)