### PR TITLE
fix(pairing-daemon): Use lowercase MAC addresses

### DIFF
--- a/scripts/pairing-daemon/psmove_pairing/bluetooth_monitor.py
+++ b/scripts/pairing-daemon/psmove_pairing/bluetooth_monitor.py
@@ -64,7 +64,7 @@ class BluetoothMonitor:
         for line in output.split("\n"):
             match = mac_pattern.search(line)
             if match:
-                connections.append(match.group(0).upper())
+                connections.append(match.group(0).lower())
 
         return connections
 


### PR DESCRIPTION
## Summary
- Fix MAC address case mismatch between pairing daemon and system
- The system uses lowercase MAC addresses (e.g., `90:89:5f:dc:36:0d`)
- The pairing daemon was converting to uppercase, causing dashboard join issues

## Test plan
- [ ] Verify controller health dashboard shows matching MAC addresses
- [ ] Confirm RSSI metrics are properly associated with controllers

🤖 Generated with [Claude Code](https://claude.com/claude-code)