### PR TITLE
feat(menu): Add sensitivity voice announcements and use Select for game mode

### DIFF
--- a/lib/types.py
+++ b/lib/types.py
@@ -326,6 +326,14 @@ class Sound(str, Enum):
     MENU_VOX_ADDED_RANDOM = "added_random"
     MENU_VOX_REMOVED_RANDOM = "removed_random"
 
+    # Menu voice announcements - sensitivity levels (in Menu/vox/)
+    # Note: "ultra_high" means ultra-high sensitivity (slow movement allowed)
+    MENU_VOX_SENSITIVITY_ULTRA_HIGH = "ultra_high"
+    MENU_VOX_SENSITIVITY_HIGH = "high"
+    MENU_VOX_SENSITIVITY_MEDIUM = "medium"
+    MENU_VOX_SENSITIVITY_LOW = "low"
+    MENU_VOX_SENSITIVITY_ULTRA_LOW = "ultra_low"
+
 
 class GameEvent(str, Enum):
     """

--- a/services/menu/handlers/admin.py
+++ b/services/menu/handlers/admin.py
@@ -670,15 +670,16 @@ class AdminModeHandler:
                 )
                 await controller_stub.PlayControllerEffect(effect_request)
 
-                # Play sound for sensitivity level (3 sounds for 5 levels)
-                sensitivity_sounds = [
-                    Sound.MENU_SFX_SENSITIVITY_SLOW,  # ULTRA_SLOW
-                    Sound.MENU_SFX_SENSITIVITY_SLOW,  # SLOW
-                    Sound.MENU_SFX_SENSITIVITY_MID,  # MEDIUM
-                    Sound.MENU_SFX_SENSITIVITY_FAST,  # FAST
-                    Sound.MENU_SFX_SENSITIVITY_FAST,  # ULTRA_FAST
+                # Play voice for sensitivity level (matches original JoustMania)
+                # Note: "ultra_high" = ultra-high sensitivity (detects slow movement)
+                sensitivity_voices = [
+                    Sound.MENU_VOX_SENSITIVITY_ULTRA_HIGH,  # ULTRA_SLOW (0)
+                    Sound.MENU_VOX_SENSITIVITY_HIGH,  # SLOW (1)
+                    Sound.MENU_VOX_SENSITIVITY_MEDIUM,  # MEDIUM (2)
+                    Sound.MENU_VOX_SENSITIVITY_LOW,  # FAST (3)
+                    Sound.MENU_VOX_SENSITIVITY_ULTRA_LOW,  # ULTRA_FAST (4)
                 ]
-                await self._play_sound(sensitivity_sounds[int(new_value)])
+                await self._play_voice(sensitivity_voices[int(new_value)])
 
                 # Restore white after feedback
                 async def restore_white():

--- a/services/menu/handlers/connected.py
+++ b/services/menu/handlers/connected.py
@@ -23,7 +23,7 @@ class ConnectedHandler:
 
     Button mappings:
     - Trigger: Transition to ready state
-    - Move: Cycle game modes
+    - Select: Cycle game modes
     """
 
     def __init__(self):
@@ -61,10 +61,10 @@ class ConnectedHandler:
                 return
             await self._handle_trigger(serial)
 
-        elif button == "move":
-            if not self._should_process_button(serial, "move", current_time):
+        elif button == "select":
+            if not self._should_process_button(serial, "select", current_time):
                 return
-            await self._handle_move(serial)
+            await self._handle_select(serial)
 
     async def on_enter(self, serial: str) -> None:
         """
@@ -129,9 +129,9 @@ class ConnectedHandler:
         # Transition to ready state
         await self._state_manager.transition_to(serial, ControllerState.READY)
 
-    async def _handle_move(self, serial: str) -> None:
+    async def _handle_select(self, serial: str) -> None:
         """
-        Handle move press - cycle game modes.
+        Handle select button press - cycle game modes.
 
         Args:
             serial: Controller serial number
@@ -158,4 +158,4 @@ class ConnectedHandler:
         # Play voice announcement
         await self._state_manager.audio.play_game_mode_voice(next_mode)
 
-        logger.info(f"Controller {serial} cycled game mode to: {next_mode}")
+        logger.info(f"Controller {serial} select button -> game mode: {next_mode}")

--- a/services/menu/tests/test_handlers.py
+++ b/services/menu/tests/test_handlers.py
@@ -60,12 +60,12 @@ class TestConnectedHandler:
 
     @pytest.mark.asyncio
     @patch("services.menu.handlers.connected.time")
-    async def test_handle_button_move_cycles_game(self, mock_time, handler, mock_state_manager):
-        """Move press should cycle game modes."""
+    async def test_handle_button_select_cycles_game(self, mock_time, handler, mock_state_manager):
+        """Select button press should cycle game modes."""
         mock_time.time.return_value = 100.0
         handler.set_state_manager(mock_state_manager)
 
-        await handler.handle_button("serial1", "move")
+        await handler.handle_button("serial1", "select")
 
         mock_state_manager.settings.get_next_game_mode.assert_called_once()
         mock_state_manager.settings.save_current_game.assert_called_once()


### PR DESCRIPTION
## Summary
- Add sensitivity level voice announcements matching original JoustMania (ultra_high, high, medium, low, ultra_low) instead of generic SFX beeps
- Change game mode cycling from Move button to Select button (more intuitive UX)
- Update corresponding unit tests

## Test plan
- [ ] Verify sensitivity changes announce proper voice feedback when cycling through levels in admin mode
- [ ] Verify Select button cycles game modes in connected state
- [ ] Verify Move button no longer triggers game mode cycling

🤖 Generated with [Claude Code](https://claude.com/claude-code)