### PR TITLE
fix(jaeger): Add base_path for Jaeger v2 UI routing

### DIFF
--- a/services/envoy/envoy.yaml
+++ b/services/envoy/envoy.yaml
@@ -5,7 +5,7 @@
 #   /joustmania*    -> connect-proxy:8080 (PRESERVE prefix, gRPC-Web)
 #   /grafana/*      -> grafana:3000       (PRESERVE prefix, serve_from_sub_path=true)
 #   /prometheus/*   -> prometheus:9090    (STRIP prefix, --web.route-prefix=/)
-#   /jaeger/*       -> jaeger:16686       (PRESERVE prefix, --query.base-path=/jaeger/)
+#   /jaeger/*       -> jaeger:16686       (PRESERVE prefix, base_path=/jaeger in config.yaml)
 #   /loki/*         -> loki:3100          (STRIP prefix, API expects root)
 #   /legacy/*       -> webui:80           (STRIP prefix, Flask at root)
 #   /health         -> envoy internal     (health check)

--- a/services/jaeger/config.yaml
+++ b/services/jaeger/config.yaml
@@ -17,6 +17,7 @@ extensions:
         memory:
           max_traces: 100000
   jaeger_query:
+    base_path: /jaeger
     storage:
       traces: memory
 


### PR DESCRIPTION
## Summary
- Add `base_path: /jaeger` to the `jaeger_query` extension in Jaeger v2 config
- Update Envoy config comment to reflect the new configuration method

Jaeger v2 replaced command-line flags with YAML configuration. The `/jaeger/` route wasn't working because the `base_path` setting was missing from the config file.

## Test plan
- [ ] Run `make up` and verify http://192.168.1.9/jaeger/ loads correctly
- [ ] Verify Jaeger UI assets (CSS, JS) load without 404 errors
- [ ] Check trace search functionality works

🤖 Generated with [Claude Code](https://claude.com/claude-code)