### PR TITLE
fix(menu): Wait for stream connection before resetting controller colors

### DIFF
--- a/services/menu/controller_events.py
+++ b/services/menu/controller_events.py
@@ -91,13 +91,35 @@ class ControllerEventLoop:
         self._stream: grpc.aio.StreamStreamCall | None = None
         self._stream_lock = asyncio.Lock()
         self._stream_queue: asyncio.Queue | None = None
+        self._connected_event: asyncio.Event | None = None
 
     async def start(self) -> None:
         """Start the event loop."""
         if not self._running:
             self._running = True
+            self._connected_event = asyncio.Event()
             self._task = asyncio.create_task(self._run())
             logger.info("Controller event loop started")
+
+    async def wait_for_connection(self, timeout_seconds: float = 5.0) -> bool:
+        """
+        Wait for the stream connection to be established.
+
+        Args:
+            timeout_seconds: Maximum time to wait in seconds
+
+        Returns:
+            True if connected, False if timeout
+        """
+        if self._connected_event is None:
+            return False
+        try:
+            async with asyncio.timeout(timeout_seconds):
+                await self._connected_event.wait()
+            return True
+        except TimeoutError:
+            logger.warning(f"Timeout waiting for controller stream connection ({timeout_seconds}s)")
+            return False
 
     async def stop(self) -> None:
         """Stop the event loop."""
@@ -158,6 +180,10 @@ class ControllerEventLoop:
                 logger.info("Connected to Controller Manager")
                 retry_delay = 1.0
 
+                # Signal that connection is ready
+                if self._connected_event:
+                    self._connected_event.set()
+
                 # Process incoming events
                 async for event in stream:
                     if not self._running:
@@ -178,11 +204,13 @@ class ControllerEventLoop:
                 await asyncio.sleep(retry_delay)
                 retry_delay = min(retry_delay * 2, max_retry_delay)
             finally:
-                # Clear stream reference on disconnect
+                # Clear stream reference and connection state on disconnect
                 async with self._stream_lock:
                     self._stream = None
                     self._stream_queue = None
                     self._led.set_stream(None)
+                if self._connected_event:
+                    self._connected_event.clear()
 
     async def _dispatch_event(self, event) -> None:
         """

--- a/services/menu/servicer.py
+++ b/services/menu/servicer.py
@@ -429,8 +429,9 @@ class MenuServicer(menu_pb2_grpc.MenuServiceServicer):
                         logger.info(f"Game event '{event.event_type}' - restarting button monitor and lobby music")
                         self.state = menu_pb2.MenuState.RUNNING
 
-                        # Start button monitor FIRST so stream is available for color commands
+                        # Start button monitor and wait for connection before setting colors
                         await self.start_button_monitor()
+                        await self.controller_events.wait_for_connection()
 
                         # Reset lobby state - both servicer state and state_manager
                         self.ready_controllers.clear()


### PR DESCRIPTION
## Summary
- Fix controller colors not resetting properly after game ends
- Add `wait_for_connection()` method to properly wait for stream before sending colors

## Root Cause
Two issues combined:

1. `start_button_monitor()` creates a background task and returns immediately - it doesn't wait for the gRPC stream to actually connect

2. `reset()` sends color commands via the stream, but the stream wasn't ready yet

This caused all color commands to silently fail because `_stream_queue` was `None`.

## Fix
Added an `asyncio.Event` to signal when the stream is connected:

```python
# controller_events.py
async def wait_for_connection(self, timeout_seconds: float = 5.0) -> bool:
    """Wait for the stream connection to be established."""
    async with asyncio.timeout(timeout_seconds):
        await self._connected_event.wait()
    return True
```

Then wait for it in the game-end handler:

```python
# servicer.py
await self.start_button_monitor()
await self.controller_events.wait_for_connection()  # Wait for stream!
re_registered = await self.state_manager.reset()    # Now colors work
```

## Test plan
- [ ] Start a game with 2+ controllers
- [ ] Let one player die (controller goes OFF)
- [ ] Let game end naturally (winner gets rainbow)
- [ ] Verify all controllers return to dim lobby color after game ends

Fixes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)