### PR TITLE
fix(tracing): Close player spans before gameplay_phase ends

### DIFF
--- a/services/game_coordinator/games/base.py
+++ b/services/game_coordinator/games/base.py
@@ -896,6 +896,10 @@ class BaseGameMode(ABC):
                         with contextlib.suppress(asyncio.CancelledError):
                             await self.music_loop_task
 
+                    # Close all player spans before gameplay_phase ends
+                    # This ensures player spans are children of gameplay_phase, not teardown
+                    self._close_all_player_spans()
+
             # Phase 70: Stop game music
             await self._stop_game_music()
 
@@ -952,6 +956,32 @@ class BaseGameMode(ABC):
                 "game.mode": self.get_game_name(),
             },
         )
+
+    def _close_all_player_spans(self):
+        """
+        Close all open player lifecycle spans.
+
+        Called at the end of gameplay_phase to ensure all player spans
+        end with the gameplay phase, not during teardown.
+        Subclasses can override to add custom attributes before closing.
+        """
+        from opentelemetry.trace import Status, StatusCode
+
+        for serial, player in self.players.items():
+            if player.span:
+                # Add final event based on player state
+                if player.alive:
+                    player.span.add_event(
+                        "game_ended",
+                        attributes={
+                            "survived": True,
+                            "game_duration": time.time() - self.start_time if self.start_time else 0,
+                        },
+                    )
+                player.span.set_status(Status(StatusCode.OK))
+                player.span.end()
+                player.span = None  # Mark as closed
+                logger.debug(f"Closed lifecycle span for player {serial}")
 
     async def _play_sound(self, sound: str | Sound, priority: int = 2):
         """

--- a/services/game_coordinator/games/ffa.py
+++ b/services/game_coordinator/games/ffa.py
@@ -174,6 +174,39 @@ class FFAGame(BaseGameMode):
         """
         return [Phase(name="color_assignment", execute=self._assign_ffa_colors)]
 
+    def _close_all_player_spans(self):
+        """
+        Close all player lifecycle spans with analytics data.
+
+        Override base implementation to add victory event and analytics
+        summary to surviving players' spans.
+        """
+        # Find winner for victory event
+        alive_players = [p for p in self.players.values() if p.alive]
+        winner_serial = alive_players[0].serial if len(alive_players) == 1 else None
+
+        for serial, player in self.players.items():
+            if player.span:
+                # Build attributes including analytics summary if available
+                if player.alive:
+                    victory_attrs = {
+                        "game_duration": time.time() - self.start_time if self.start_time else 0,
+                        "winner": serial == winner_serial,
+                    }
+
+                    # Add analytics summary to span
+                    if player.analytics is not None:
+                        analytics_summary = player.analytics.get_summary()
+                        for key, value in analytics_summary.items():
+                            victory_attrs[f"analytics.{key}"] = value
+
+                    player.span.add_event("victory", attributes=victory_attrs)
+
+                player.span.set_status(Status(StatusCode.OK))
+                player.span.end()
+                player.span = None  # Mark as closed
+                logger.debug(f"Closed lifecycle span for player {serial}")
+
     async def _end_game_impl(self):
         """Handle game ending - show winner, cleanup."""
         from proto import controller_manager_pb2
@@ -218,26 +251,8 @@ class FFAGame(BaseGameMode):
                 break
             await asyncio.sleep(0.1)
 
-        # End spans for surviving players AFTER the celebration
-        # This ensures winner's span is longer than losers'
-        for serial, player in self.players.items():
-            if player.span and player.alive:
-                # Build attributes including analytics summary if available
-                victory_attrs = {
-                    "game_duration": time.time() - self.start_time if self.start_time else 0,
-                    "winner": serial == winner_serial,
-                }
-
-                # Add analytics summary to span
-                if player.analytics is not None:
-                    analytics_summary = player.analytics.get_summary()
-                    for key, value in analytics_summary.items():
-                        victory_attrs[f"analytics.{key}"] = value
-
-                player.span.add_event("victory", attributes=victory_attrs)
-                player.span.set_status(Status(StatusCode.OK))
-                player.span.end()
-                logger.debug(f"Ended lifecycle span for surviving player {serial}")
+        # Note: Player spans are already closed by _close_all_player_spans()
+        # at the end of gameplay_phase (before teardown_phase starts)
 
         # Publish analytics summaries for all players
         for serial, player in self.players.items():


### PR DESCRIPTION
## Summary
- Add `_close_all_player_spans()` method in `BaseGameMode` to close player spans at end of gameplay_phase
- Override in `FFAGame` to include victory event and analytics data before closing
- Remove duplicate span closing from `_end_game_impl()` (was happening during teardown_phase)

## Problem
When viewing traces in Jaeger, the winning player's `player_lifecycle` span extended beyond `gameplay_phase` into `teardown_phase`. This happened because spans were being closed in `_end_game_impl()` which runs during teardown.

**Before:**
```
gameplay_phase:    |-----------------|
player_lifecycle:  |------------------------|  (extends into teardown)
teardown_phase:                      |------|
```

**After:**
```
gameplay_phase:    |-----------------|
player_lifecycle:  |-----------------|  (ends with gameplay)
teardown_phase:                      |------|
```

## Test plan
- [ ] Run a FFA game and view the trace in Jaeger
- [ ] Verify winning player's span ends when `gameplay_phase` ends
- [ ] Verify losing players' spans still end when they die (during gameplay)
- [ ] Verify analytics data is still attached to the victory event

🤖 Generated with [Claude Code](https://claude.com/claude-code)