### PR TITLE
perf(startup): Reduce container startup time

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -105,8 +105,6 @@ services:
     volumes:
       - ./joustsettings.yaml:/app/joustsettings.yaml
     depends_on:
-      otel-collector:
-        condition: service_started
       redis:
         condition: service_healthy
     networks:
@@ -153,8 +151,6 @@ services:
       - OTEL_SERVICE_NAME=controller-manager-service
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
     depends_on:
-      otel-collector:
-        condition: service_started
       redis:
         condition: service_healthy
     restart: unless-stopped
@@ -177,13 +173,9 @@ services:
       - OTEL_SERVICE_NAME=game-coordinator-service
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
     depends_on:
-      otel-collector:
-        condition: service_started
       redis:
         condition: service_healthy
       settings:
-        condition: service_healthy
-      controller-manager:
         condition: service_healthy
     networks:
       - joustmania
@@ -210,8 +202,6 @@ services:
       - AUDIO_HOST=audio
       - AUDIO_PORT=50056
     depends_on:
-      otel-collector:
-        condition: service_started
       redis:
         condition: service_healthy
       settings:
@@ -246,8 +236,6 @@ services:
     volumes:
       - /tmp/joustmania:/tmp/joustmania:ro  # Host startup status (read-only)
     depends_on:
-      otel-collector:
-        condition: service_started
       settings:
         condition: service_healthy
       controller-manager:
@@ -282,8 +270,6 @@ services:
       - MENU_SERVICE=menu:50054
       - SUPERVISOR_SERVICE=supervisor:50055
     depends_on:
-      otel-collector:
-        condition: service_started
       settings:
         condition: service_healthy
       controller-manager:
@@ -319,9 +305,6 @@ services:
       - MOCK_MODE=${AUDIO_MOCK_MODE:-false}
       - OTEL_SERVICE_NAME=audio-service
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
-    depends_on:
-      otel-collector:
-        condition: service_started
     networks:
       - joustmania
     restart: unless-stopped
@@ -517,12 +500,6 @@ services:
       - ./services/envoy/envoy.yaml:/etc/envoy/envoy.yaml:ro
     depends_on:
       connect-proxy:
-        condition: service_healthy
-      jaeger:
-        condition: service_healthy
-      prometheus:
-        condition: service_healthy
-      grafana:
         condition: service_healthy
       webui:
         condition: service_healthy

--- a/services/audio/Dockerfile
+++ b/services/audio/Dockerfile
@@ -125,7 +125,7 @@ EXPOSE 50056
 EXPOSE 8000
 
 # Health check using grpc-health-probe
-HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+HEALTHCHECK --interval=5s --timeout=5s --start-period=3s --retries=3 \
     CMD ["/bin/grpc_health_probe", "-addr=:50056"]
 
 # Run the server

--- a/services/controller_manager/Dockerfile
+++ b/services/controller_manager/Dockerfile
@@ -111,7 +111,7 @@ EXPOSE 8000
 # Run with: docker run --privileged or docker-compose privileged: true
 
 # Health check using grpc-health-probe
-HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+HEALTHCHECK --interval=5s --timeout=5s --start-period=3s --retries=3 \
     CMD ["/bin/grpc_health_probe", "-addr=:50052"]
 
 # Run the server

--- a/services/game_coordinator/Dockerfile
+++ b/services/game_coordinator/Dockerfile
@@ -68,7 +68,7 @@ EXPOSE 50053
 EXPOSE 8000
 
 # Health check using grpc-health-probe (proper gRPC health checking)
-HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+HEALTHCHECK --interval=5s --timeout=5s --start-period=3s --retries=3 \
     CMD ["/bin/grpc_health_probe", "-addr=:50053"]
 
 # Run the server (distroless has python as entrypoint)

--- a/services/menu/Dockerfile
+++ b/services/menu/Dockerfile
@@ -68,7 +68,7 @@ EXPOSE 50054
 EXPOSE 8000
 
 # Health check using grpc-health-probe (proper gRPC health checking)
-HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+HEALTHCHECK --interval=5s --timeout=5s --start-period=3s --retries=3 \
     CMD ["/bin/grpc_health_probe", "-addr=:50054"]
 
 # Run the server (distroless has python as entrypoint)

--- a/services/settings/Dockerfile
+++ b/services/settings/Dockerfile
@@ -67,7 +67,7 @@ EXPOSE 50051
 EXPOSE 8000
 
 # Health check using grpc-health-probe (proper gRPC health checking)
-HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+HEALTHCHECK --interval=5s --timeout=5s --start-period=3s --retries=3 \
     CMD ["/bin/grpc_health_probe", "-addr=:50051"]
 
 # Run the server (distroless has python as entrypoint)

--- a/services/supervisor/Dockerfile
+++ b/services/supervisor/Dockerfile
@@ -68,7 +68,7 @@ EXPOSE 50055
 EXPOSE 8000
 
 # Health check using grpc-health-probe (proper gRPC health checking)
-HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+HEALTHCHECK --interval=5s --timeout=5s --start-period=3s --retries=3 \
     CMD ["/bin/grpc_health_probe", "-addr=:50055"]
 
 # Run the server (distroless has python as entrypoint)


### PR DESCRIPTION
## Summary
- Reduce health check intervals from 30s to 5s in all service Dockerfiles for faster startup
- Remove otel-collector from core service dependencies (OTEL SDK uses non-blocking gRPC)
- Remove controller-manager from game-coordinator dependencies (menu handles this)
- Remove jaeger, prometheus, grafana from envoy dependencies (graceful degradation with 502)

## Test plan
- [ ] Run `docker compose up -d` - Full stack should start faster
- [ ] Check health: `docker compose ps` - Services become healthy quicker
- [ ] Access dashboard - Should work before observability is fully ready
- [ ] Start a game - Should work normally
- [ ] Check Jaeger - Traces should appear once otel-collector is healthy

Fixes #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)