### PR TITLE
chore(docker): Remove deprecated version field from compose files

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   dev:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 # JoustMania Docker Compose Configuration
 #
 # Quick Start (pull from GHCR - no build needed):


### PR DESCRIPTION
## Summary

Remove the deprecated `version` field from docker-compose files to eliminate the warning on every compose command.

## Changes

- `docker-compose.yml`: Remove `version: '3.8'`
- `.devcontainer/docker-compose.yml`: Remove `version: '3.8'`

The version attribute is obsolete in modern Docker Compose (v2+) and is ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)