### PR TITLE
docs: Refactor CLAUDE.md following progressive disclosure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,59 +1,27 @@
 # Claude Code Guidelines for JoustMania
 
-Project-specific instructions for Claude Code when working on this repository.
+Multiplayer motion-controlled party game system using PS Move controllers.
+
+## Quick Reference
+
+```bash
+make lint          # Lint code
+make test          # Run integration tests
+make protos        # Regenerate proto files after .proto changes
+```
 
 ## Git Worktree Workflow
 
-When working on a GitHub issue, use a separate git worktree to isolate changes:
+When working on a GitHub issue, use a separate git worktree:
 
 ```bash
-# Create worktree for an issue
-git worktree add ../JoustMania-issue-<NUMBER> -b issue-<NUMBER>
-
-# Work in the isolated directory
-cd ../JoustMania-issue-<NUMBER>
-
-# After PR is merged, clean up
-git worktree remove ../JoustMania-issue-<NUMBER>
+git worktree add ../JoustMania-issue-<NUMBER> -b issue-<NUMBER> origin/dev-refactor
 ```
 
-**Why:** This prevents mingling changes when multiple agents or tasks work in parallel. Each issue gets its own isolated working directory.
+This isolates changes when multiple agents work in parallel.
 
-**Directory structure:**
-```
-~/
-├── JoustMania/                    # Main worktree (dev-refactor)
-├── JoustMania-issue-28/           # Work on issue #28
-├── JoustMania-issue-29/           # Work on issue #29
-```
+## Key Documentation
 
-## Branch Naming
-
-- `issue-<NUMBER>` - Feature/fix branches tied to GitHub issues
-- `dev-refactor` - Main development branch
-- `master` - Stable branch
-
-## Testing
-
-Run tests before committing:
-```bash
-make test          # Run all integration tests
-make test-ffa      # Run FFA game test only
-make lint          # Run linting
-```
-
-## Proto Changes
-
-After modifying `.proto` files:
-```bash
-make protos        # Regenerate Python code
-```
-
-## Docker
-
-```bash
-make builders      # Build base images (once)
-make images        # Build all service images
-make up            # Start the stack
-make up-mock       # Start in mock mode (no hardware)
-```
+- [Contributing Guide](docs/CONTRIBUTING.md) - Development workflow, CI checks, code style
+- [Development Guide](docs/DEVELOPMENT.md) - Building, running, debugging services
+- [Architecture](docs/ARCHITECTURE.md) - System design and service interactions

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -44,11 +44,26 @@ The dev container includes:
 
 ## Development Workflow
 
+### Git Worktree (Recommended for Issue Work)
+
+Use git worktrees to isolate work on different issues:
+
+```bash
+# Create worktree for an issue
+git worktree add ../JoustMania-issue-<NUMBER> -b issue-<NUMBER> origin/dev-refactor
+
+# Work in the isolated directory
+cd ../JoustMania-issue-<NUMBER>
+
+# After PR is merged, clean up
+git worktree remove ../JoustMania-issue-<NUMBER>
+```
+
 ### Making Changes
 
-1. Create a feature branch:
+1. Create a branch (or use worktree above):
    ```bash
-   git checkout -b feature/my-feature
+   git checkout -b issue-<NUMBER>
    ```
 
 2. Make your changes
@@ -71,7 +86,7 @@ The dev container includes:
 
 6. Push and create pull request:
    ```bash
-   git push origin feature/my-feature
+   git push origin issue-<NUMBER>
    ```
 
 ## Continuous Integration


### PR DESCRIPTION
## Summary

Refactors CLAUDE.md to follow progressive disclosure principles - essentials first, links to details when needed.

## Changes

**CLAUDE.md: 60 → 27 lines (55% reduction)**
- Add one-sentence project description
- Keep only essential commands (`make lint`, `make test`, `make protos`)
- Keep agent-specific worktree workflow
- Link to existing docs instead of duplicating content

**docs/CONTRIBUTING.md**
- Add worktree workflow section for all contributors
- Standardize branch naming to `issue-<NUMBER>`

## Removed (was duplicating existing docs)

| Removed from CLAUDE.md | Now in |
|------------------------|--------|
| Branch naming details | CONTRIBUTING.md |
| Testing command details | CONTRIBUTING.md |
| Proto regeneration details | CONTRIBUTING.md |
| Docker commands | DEVELOPMENT.md |

🤖 Generated with [Claude Code](https://claude.com/claude-code)