### PR TITLE
fix(swapper): Use temporary death state to fix SimulateDeath

### DIFF
--- a/services/game_coordinator/games/swapper.py
+++ b/services/game_coordinator/games/swapper.py
@@ -134,7 +134,8 @@ class SwapperGame(TeamsGameBase):
         Handle player death by switching their team.
 
         Instead of dying, players switch to the opposing team.
-        The player is given a brief grace period on their new team.
+        The player is temporarily marked as dead (to stop base class processing),
+        then respawned on the new team after the death animation.
 
         Span handling:
         - End the player's span under the old team with "team_swap_out" event
@@ -148,6 +149,10 @@ class SwapperGame(TeamsGameBase):
         old_team = player.team
         old_team_obj = self.teams[old_team]
 
+        # Mark player as temporarily dead to stop base class from processing
+        # the held high-acceleration data from SimulateDeath
+        player.alive = False
+
         # Switch teams
         new_team = 1 - old_team  # Toggle between 0 and 1
         new_team_obj = self.teams[new_team]
@@ -157,8 +162,9 @@ class SwapperGame(TeamsGameBase):
         # Track last death for winner exclusion
         self.last_death_serial = serial
 
-        # Give grace period on new team
-        player.grace_until = time.time() + 2.0
+        # Set grace period for after respawn (2.0s total from now)
+        grace_duration = 2.0
+        player.grace_until = time.time() + grace_duration
 
         # Log the swap
         swap_count = getattr(player, "swap_count", 0) + 1
@@ -224,6 +230,11 @@ class SwapperGame(TeamsGameBase):
         # After death flash, set new team color
         await asyncio.sleep(0.5)
         await self._set_player_color(serial, player.color)
+
+        # Respawn the player on their new team
+        # This re-enables base class processing for this player
+        player.alive = True
+        logger.debug(f"Player {serial} respawned on team {new_team}")
 
         # Publish swap event
         self.event_publisher(


### PR DESCRIPTION
## Summary

- Fixes Swapper integration test timeouts caused by `SimulateDeath` not triggering team swaps
- Sets `player.alive = False` temporarily when killed to stop base class from processing held high-acceleration data
- Respawns player on new team after death animation completes

## Problem

`SimulateDeath` holds high acceleration for 2 seconds, but Swapper's `_kill_player_impl` never set `player.alive = False`. This caused:
- Base class continued processing the held acceleration data
- Filter updates never happened (base class filters by `player.alive`)
- Integration tests timed out waiting for game to end

## Solution

Use temporary death state pattern (like Zombie and NonStop modes):
1. `player.alive = False` when killed → stops base class processing
2. Team switch, death flash effect, set new color
3. `player.alive = True` after 0.5s → player respawns on new team
4. Grace period (1.5s remaining) protects from immediate re-death

## Test plan

- [ ] Run Swapper integration test: `make test TEST=test_full_game_lifecycle`
- [ ] Verify team swaps work correctly with `SimulateDeath`
- [ ] Verify grace period protects respawned player

🤖 Generated with [Claude Code](https://claude.ai/code)