### PR TITLE
fix(grafana): Filter disconnected controllers from battery and RSSI panels

### DIFF
--- a/services/grafana/dashboards/controller-maintenance.json
+++ b/services/grafana/dashboards/controller-maintenance.json
@@ -969,7 +969,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "controller_battery_level * on(serial) group_left(name) controller_info",
+          "expr": "(controller_battery_level and on(serial) controller_connected == 1) * on(serial) group_left(name) controller_info",
           "legendFormat": "{{name}}",
           "refId": "A"
         }
@@ -1040,7 +1040,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "bluetooth_device_rssi_dbm * on(serial) group_left(name) controller_info",
+          "expr": "(bluetooth_device_rssi_dbm and on(serial) controller_connected == 1) * on(serial) group_left(name) controller_info",
           "legendFormat": "{{name}}",
           "refId": "A"
         }

--- a/services/grafana/dashboards/controller-overview.json
+++ b/services/grafana/dashboards/controller-overview.json
@@ -1324,7 +1324,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "controller_battery_level * on(serial) group_left(name) controller_info",
+          "expr": "(controller_battery_level and on(serial) controller_connected == 1) * on(serial) group_left(name) controller_info",
           "legendFormat": "{{name}}",
           "refId": "A"
         }
@@ -1420,7 +1420,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "bluetooth_device_rssi_dbm * on(serial) group_left(name) controller_info",
+          "expr": "(bluetooth_device_rssi_dbm and on(serial) controller_connected == 1) * on(serial) group_left(name) controller_info",
           "legendFormat": "{{name}}",
           "refId": "A"
         }


### PR DESCRIPTION
## Summary

- Filter out disconnected controllers from battery and RSSI panels to reduce noise
- Affects Controller Overview and Controller Maintenance dashboards
- Uses PromQL `and on(serial) controller_connected == 1` to show only connected controllers

## Test plan

- [ ] Deploy to test environment with some connected and some disconnected controllers
- [ ] Verify Battery Levels panel only shows connected controllers
- [ ] Verify Signal Strength (RSSI) panel only shows connected controllers
- [ ] Verify other panels (stats, tables) still show all controllers as expected

Closes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)