### PR TITLE
feat(game-coordinator): Add frame consistency and jitter metrics

### DIFF
--- a/services/game_coordinator/games/base.py
+++ b/services/game_coordinator/games/base.py
@@ -17,6 +17,7 @@ import contextlib
 import logging
 import math
 import random
+import statistics
 import time
 from abc import ABC, abstractmethod
 from collections.abc import Callable
@@ -520,6 +521,11 @@ class BaseGameMode(ABC):
             loop_iterations = 0
             last_iteration_time = loop_start_time
 
+            # Track frame consistency (Issue #183)
+            target_frame_time_ms = 1000.0 / update_frequency_hz
+            recent_frame_times: list[float] = []  # Store recent frame times for jitter calculation
+            frames_on_target = 0  # Frames within 50% of target time
+
             # Stream gameplay data and process game logic
             logger.info("Starting gameplay data stream loop, waiting for first update...")
             async for gameplay_update in self.gameplay_stream:
@@ -597,11 +603,33 @@ class BaseGameMode(ABC):
                 metrics.game_loop_iterations_total.labels(mode=self.get_game_name()).inc()
                 metrics.game_loop_latency_ms.labels(mode=self.get_game_name()).observe(iteration_latency_ms)
 
-                # Calculate actual Hz every 10 iterations
+                # Track frame consistency (Issue #183)
+                recent_frame_times.append(iteration_latency_ms)
+                if len(recent_frame_times) > 60:  # Keep last 60 frames (1 second at 60Hz)
+                    recent_frame_times.pop(0)
+
+                # Check if frame is within target (50% tolerance)
+                if iteration_latency_ms <= target_frame_time_ms * 1.5:
+                    frames_on_target += 1
+
+                # Check for dropped frames (>2x target time)
+                if iteration_latency_ms > target_frame_time_ms * 2:
+                    metrics.game_loop_frames_dropped_total.labels(mode=self.get_game_name()).inc()
+
+                # Calculate actual Hz and frame consistency every 10 iterations
                 if loop_iterations % 10 == 0:
                     elapsed = time.time() - loop_start_time
                     actual_hz = loop_iterations / elapsed if elapsed > 0 else 0
                     metrics.actual_update_frequency_hz.set(actual_hz)
+
+                    # Calculate frame consistency percentage
+                    consistency_percent = (frames_on_target / loop_iterations) * 100
+                    metrics.game_loop_frame_consistency_percent.set(consistency_percent)
+
+                    # Calculate jitter (standard deviation of recent frame times)
+                    if len(recent_frame_times) >= 2:
+                        jitter_ms = statistics.stdev(recent_frame_times)
+                        metrics.game_loop_jitter_ms.set(jitter_ms)
 
                 last_iteration_time = iteration_end
 

--- a/services/game_coordinator/metrics.py
+++ b/services/game_coordinator/metrics.py
@@ -135,6 +135,23 @@ game_loop_latency_ms = Histogram(
     buckets=[10, 20, 30, 40, 50, 75, 100, 150, 200, 300, 500],
 )
 
+# Frame consistency metrics (Issue #183)
+game_loop_frame_consistency_percent = Gauge(
+    "game_loop_frame_consistency_percent",
+    "Percentage of frames within target timing (within 50% of target frame time)",
+)
+
+game_loop_jitter_ms = Gauge(
+    "game_loop_jitter_ms",
+    "Standard deviation of frame times in milliseconds",
+)
+
+game_loop_frames_dropped_total = Counter(
+    "game_loop_frames_dropped_total",
+    "Total number of frames that exceeded 2x the target frame time",
+    ["mode"],
+)
+
 # Adaptive controller filtering metrics (Phase 45)
 filtered_controllers = Gauge("game_filtered_controllers", "Number of controllers currently filtered out (dead players)")
 

--- a/services/grafana/dashboards/game-quality.json
+++ b/services/grafana/dashboards/game-quality.json
@@ -300,12 +300,16 @@
       },
       "id": 5,
       "options": {
-        "displayLabels": ["percent"],
+        "displayLabels": [
+          "percent"
+        ],
         "legend": {
           "displayMode": "table",
           "placement": "right",
           "showLegend": true,
-          "values": ["value"]
+          "values": [
+            "value"
+          ]
         },
         "pieType": "pie",
         "reduceOptions": {
@@ -404,7 +408,10 @@
       "id": 6,
       "options": {
         "legend": {
-          "calcs": ["mean", "max"],
+          "calcs": [
+            "mean",
+            "max"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -516,7 +523,10 @@
       "id": 7,
       "options": {
         "legend": {
-          "calcs": ["mean", "min"],
+          "calcs": [
+            "mean",
+            "min"
+          ],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -716,12 +726,220 @@
       ],
       "title": "Audio Playback Rate",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Percentage of frames within 50% of target timing",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 90
+              },
+              {
+                "color": "green",
+                "value": 95
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 16,
+        "y": 5
+      },
+      "id": 10,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.2.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "game_loop_frame_consistency_percent",
+          "refId": "A"
+        }
+      ],
+      "title": "Frame Consistency",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Standard deviation of frame times (lower is better)",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 5
+              },
+              {
+                "color": "red",
+                "value": 10
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 20,
+        "y": 5
+      },
+      "id": 11,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.2.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "game_loop_jitter_ms",
+          "refId": "A"
+        }
+      ],
+      "title": "Frame Jitter",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Frames that exceeded 2x target time (5min window)",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 10
+              },
+              {
+                "color": "red",
+                "value": 50
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 8,
+        "x": 16,
+        "y": 10
+      },
+      "id": 12,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.2.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(increase(game_loop_frames_dropped_total[5m]))",
+          "refId": "A"
+        }
+      ],
+      "title": "Dropped Frames (5m)",
+      "type": "stat"
     }
   ],
   "refresh": "5s",
   "schemaVersion": 38,
   "style": "dark",
-  "tags": ["joustmania", "game"],
+  "tags": [
+    "joustmania",
+    "game"
+  ],
   "templating": {
     "list": []
   },

--- a/services/prometheus/alerts.yml
+++ b/services/prometheus/alerts.yml
@@ -60,13 +60,13 @@ groups:
 
       # Game quality alerts
       - alert: PoorFrameConsistency
-        expr: game_loop_frame_consistency_percent < 90
+        expr: game_loop_frame_consistency_percent < 95
         for: 2m
         labels:
           severity: warning
         annotations:
-          summary: "Poor frame consistency in {{$labels.game_mode}}"
-          description: "Only {{$value}}% of frames within target (should be >95%)."
+          summary: "Poor frame consistency"
+          description: "Only {{$value}}% of frames within target timing (should be >95%)."
 
       - alert: HighGCPauses
         expr: histogram_quantile(0.95, rate(gc_pause_seconds_bucket[5m])) > 0.010


### PR DESCRIPTION
## Summary

Implement metrics to detect when the game loop is struggling.

## New metrics

| Metric | Description |
|--------|-------------|
| `game_loop_frame_consistency_percent` | % of frames within 50% of target timing |
| `game_loop_jitter_ms` | Standard deviation of frame times (lower is better) |
| `game_loop_frames_dropped_total` | Counter of frames exceeding 2x target time |

## Changes

- **metrics.py**: Add new Gauge and Counter definitions
- **base.py**: Instrument game loop to track frame timing statistics
- **game-quality.json**: Add panels for Frame Consistency, Frame Jitter, and Dropped Frames
- **alerts.yml**: Update PoorFrameConsistency alert threshold from 90% to 95%

## Test plan

- [ ] Start a game and verify metrics appear in Prometheus
- [ ] Verify Game Quality dashboard shows new panels
- [ ] Verify Frame Consistency stays above 95% during normal operation
- [ ] Verify Jitter stays below 5ms during normal operation

Closes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)