### PR TITLE
fix(tracing): Handle sync handlers in server interceptor

### DIFF
--- a/lib/grpc_tracing.py
+++ b/lib/grpc_tracing.py
@@ -25,6 +25,7 @@ Usage (Server):
     server = grpc.aio.server(options=options, interceptors=interceptors)
 """
 
+import inspect
 import logging
 import os
 from collections.abc import Callable
@@ -329,7 +330,11 @@ class ServerUnaryUnaryInterceptor(grpc.aio.ServerInterceptor):
                 parent_ctx = _extract_context_from_metadata(context)
                 token = otel_context.attach(parent_ctx)
                 try:
-                    return await original_handler(request, context)
+                    result = original_handler(request, context)
+                    # Handle both sync and async handlers
+                    if inspect.iscoroutine(result):
+                        return await result
+                    return result
                 finally:
                     otel_context.detach(token)
 
@@ -364,7 +369,11 @@ class ServerUnaryUnaryInterceptor(grpc.aio.ServerInterceptor):
                 parent_ctx = _extract_context_from_metadata(context)
                 token = otel_context.attach(parent_ctx)
                 try:
-                    return await original_handler(request_iterator, context)
+                    result = original_handler(request_iterator, context)
+                    # Handle both sync and async handlers
+                    if inspect.iscoroutine(result):
+                        return await result
+                    return result
                 finally:
                     otel_context.detach(token)
 


### PR DESCRIPTION
## Summary

- Fixes TypeError when gRPC server interceptor encounters sync handlers
- Uses `inspect.iscoroutine()` to check if handler result needs awaiting

## Problem

The server-side tracing interceptor always awaited handler results:
```python
return await original_handler(request, context)
```

But some handlers return response objects directly (not coroutines), causing:
```
TypeError: object StartGameResponse can't be used in 'await' expression
```

## Affected Services

Services with sync handlers that triggered this error:
- `audio/servicer.py`: PlaySound, PlayMusic, StopMusic, ChangeTempo, SetVolume
- `game_coordinator/servicer.py`: StartGame  
- `settings/servicer.py`: GetSettings, GetSetting

## Solution

Check if the result is a coroutine before awaiting:
```python
result = original_handler(request, context)
if inspect.iscoroutine(result):
    return await result
return result
```

## Test plan

- [x] Lint passes
- [ ] Start a game via menu and verify no TypeError in logs
- [ ] Audio plays correctly during game

🤖 Generated with [Claude Code](https://claude.ai/code)