### PR TITLE
fix(controller-manager): Don't clear base_colors when ButtonEventStream connects

### DIFF
--- a/services/controller_manager/servicer.py
+++ b/services/controller_manager/servicer.py
@@ -181,10 +181,9 @@ class ControllerManagerServicer(controller_manager_pb2_grpc.ControllerManagerSer
         # Update stream metrics (Phase 38)
         metrics.active_streams.inc()
 
-        # Clear stale base_colors from previous session (e.g., game that just ended)
-        # This ensures fresh color state when menu reconnects after a game
-        self.feedback_manager.base_colors.clear()
-        logger.debug(f"[{subscriber_id}] Cleared stale base_colors for fresh session")
+        # Note: Don't clear base_colors here - effects may still be running and need
+        # to restore to current base color. Menu will overwrite colors when it sends
+        # new base_color commands for each controller.
 
         # Send initial connection events for all currently tracked controllers
         # This allows new subscribers to immediately know about existing controllers


### PR DESCRIPTION
## Summary

Fix race condition where winner's LED stays on the last rainbow color instead of restoring to menu's lobby color after game ends.

## Root Cause

When the menu's `ButtonEventStream` connects after a game ends, `base_colors.clear()` was called immediately. This created a race condition:

1. Game ends → `WINNER_RAINBOW` effect starts (3 sec duration)
2. `GameplayStream` closes
3. Menu's `ButtonEventStream` connects → **`base_colors.clear()` wipes all colors**
4. Rainbow effect finishes, checks `base_colors[serial]` → **returns `None`**
5. No color is restored → LED stays on last rainbow frame

## Fix

Remove `base_colors.clear()`. The menu will overwrite colors when it sends new `base_color` commands for each controller anyway. Effects that finish will now find the correct base_color that the menu set.

## Test plan

- [x] Identify root cause via code analysis
- [ ] Play a game and verify winner's LED transitions back to lobby color after rainbow effect

🤖 Generated with [Claude Code](https://claude.com/claude-code)