### PR TITLE
fix(sonar): Fix coverage source paths for SonarCloud

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,10 @@ jobs:
             --cov=. \
             --cov-report=xml:coverage.xml \
             --cov-report=term-missing
-          # Fix paths in coverage.xml to be relative to repo root
+          # Fix paths in coverage.xml for SonarCloud:
+          # 1. Set source to "." (repo root) - SonarCloud resolves paths relative to sonar.sources
+          # 2. Prefix filenames with services/<name>/ to match repo structure
+          sed -i 's|<source>.*</source>|<source>.</source>|g' coverage.xml
           sed -i 's|filename="|filename="services/${{ matrix.service }}/|g' coverage.xml
 
       - name: Upload coverage report

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -8,8 +8,8 @@ sonar.organization=watchmejoustmyflags
 sonar.projectName=JoustMania
 sonar.projectVersion=2.0.0
 
-# Source code locations
-sonar.sources=services,lib
+# Source code locations (relative to repo root)
+sonar.sources=.
 sonar.tests=services/controller_manager/tests,services/game_coordinator/tests,services/menu/tests,services/audio/tests,services/settings/tests,tests/integration
 
 # Python configuration


### PR DESCRIPTION
## Summary
Fix coverage XML paths so SonarCloud can match coverage data to source files.

## Problem
Two issues prevented coverage from being imported:

1. **sonar.sources mismatch**: Set to `services,lib` which indexed files as `settings/__init__.py`, but coverage had `services/settings/__init__.py`

2. **Coverage XML source path**: Had absolute paths like `/runner/work/.../services/settings` that didn't resolve correctly

## Solution
- Change `sonar.sources=.` (repo root) so SonarCloud indexes with full repo-relative paths
- Simplify sed to set coverage `<source>` to `.` directly
- Keep filename prefixing with `services/<name>/`

This ensures coverage file paths (`services/settings/__init__.py`) match the indexed source paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)