### PR TITLE
fix: Address Docker and shell SonarCloud issues

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,45 +2,43 @@ FROM python:3.12-slim
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    git \
-    make \
-    curl \
     ca-certificates \
-    sudo \
+    curl \
+    gcc \
+    git \
     # Bluetooth development (for controller_manager work)
     libbluetooth-dev \
-    libusb-dev \
     libdbus-1-dev \
     libglib2.0-dev \
+    libusb-dev \
+    make \
     pkg-config \
-    gcc \
+    sudo \
     && rm -rf /var/lib/apt/lists/*
 
-# Install uv
-RUN pip install --no-cache-dir uv==0.5.11
-
-# Install development tools
+# Install uv and development tools
 RUN pip install --no-cache-dir \
+    ipdb \
+    ipython \
     ruff==0.8.4 \
     ty==0.0.11 \
-    ipython \
-    ipdb
+    uv==0.5.11
 
 # Create non-root user
 ARG USERNAME=vscode
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 
-RUN groupadd --gid $USER_GID $USERNAME \
-    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME \
-    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
-    && chmod 0440 /etc/sudoers.d/$USERNAME
+RUN groupadd --gid "$USER_GID" "$USERNAME" \
+    && useradd --uid "$USER_UID" --gid "$USER_GID" -m "$USERNAME" \
+    && echo "$USERNAME ALL=(root) NOPASSWD:ALL" > /etc/sudoers.d/"$USERNAME" \
+    && chmod 0440 /etc/sudoers.d/"$USERNAME"
 
 # Install Docker CLI (for Docker-in-Docker)
 RUN curl -fsSL https://get.docker.com -o get-docker.sh \
     && sh get-docker.sh \
     && rm get-docker.sh \
-    && usermod -aG docker $USERNAME
+    && usermod -aG docker "$USERNAME"
 
 USER $USERNAME
 

--- a/images/builder/Dockerfile
+++ b/images/builder/Dockerfile
@@ -21,13 +21,12 @@ LABEL org.opencontainers.image.description="JoustMania shared builder base image
 LABEL org.opencontainers.image.title="joustmania-builder"
 
 # Build dependencies needed by various Python packages
-# - gcc, g++: Compile C/C++ extensions (grpcio, pygame, etc.)
-# - build-essential: Common build tools
+# - build-essential: Common build tools (includes gcc, g++)
 # - python3-dev: Python headers for C extensions
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    gcc \
-    g++ \
     build-essential \
+    g++ \
+    gcc \
     python3-dev \
     && rm -rf /var/lib/apt/lists/*
 

--- a/images/psmove-builder/Dockerfile
+++ b/images/psmove-builder/Dockerfile
@@ -34,21 +34,21 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     cmake \
     git \
-    pkg-config \
-    libudev-dev \
     libbluetooth-dev \
-    libusb-dev \
-    libusb-1.0-0-dev \
     libdbus-1-dev \
-    swig \
+    libudev-dev \
+    libusb-1.0-0-dev \
+    libusb-dev \
+    pkg-config \
     python3-dev \
+    swig \
     && rm -rf /var/lib/apt/lists/*
 
 # Clone psmoveapi at specific commit
 WORKDIR /build
 RUN git clone --recursive https://github.com/thp/psmoveapi.git && \
     cd psmoveapi && \
-    git checkout ${PSMOVE_COMMIT}
+    git checkout "${PSMOVE_COMMIT}"
 
 # Build psmoveapi with Python bindings only (no tracker, no examples)
 WORKDIR /build/psmoveapi/build

--- a/scripts/hardware/update_asound.sh
+++ b/scripts/hardware/update_asound.sh
@@ -2,7 +2,7 @@
 
 # Prevent apt from prompting us about restarting services.
 export DEBIAN_FRONTEND=noninteractive
-HOMENAME=$(who | head -n1 | cut -d " " -f1)
+HOMENAME="$(who | head -n1 | cut -d " " -f1)"
 HOMEDIR="/home/$HOMENAME"
 cd "$HOMEDIR"
 

--- a/scripts/setup/build_psmoveapi.sh
+++ b/scripts/setup/build_psmoveapi.sh
@@ -6,7 +6,7 @@
 
 set -e  # Exit on error
 
-HOMENAME=$(logname)
+HOMENAME="$(logname)"
 HOMEDIR="/home/$HOMENAME"
 
 echo "=========================================="

--- a/scripts/setup/setup_host.sh
+++ b/scripts/setup/setup_host.sh
@@ -9,7 +9,7 @@ set -e  # Exit on error
 # Prevent apt from prompting about restarting services
 export DEBIAN_FRONTEND=noninteractive
 
-HOMENAME=$(logname)
+HOMENAME="$(logname)"
 HOMEDIR="/home/$HOMENAME"
 
 echo "=========================================="
@@ -50,7 +50,7 @@ if ! command -v docker &> /dev/null; then
     rm get-docker.sh
 
     # Add user to docker group
-    sudo usermod -aG docker $USER
+    sudo usermod -aG docker "$USER"
     echo "  → Docker installed. You may need to log out and back in for group changes to take effect."
 else
     echo "  → Docker already installed"

--- a/scripts/setup/setup_runtime.sh
+++ b/scripts/setup/setup_runtime.sh
@@ -30,8 +30,8 @@ GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
-HOMENAME=$(logname 2>/dev/null || echo $USER)
-HOMEDIR=/home/$HOMENAME
+HOMENAME=$(logname 2>/dev/null || echo "$USER")
+HOMEDIR="/home/$HOMENAME"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 JOUSTMANIA_DIR="$(dirname "$(dirname "$SCRIPT_DIR")")"
 
@@ -58,7 +58,7 @@ if ! command -v docker &> /dev/null; then
     rm /tmp/get-docker.sh
 
     # Add user to docker group
-    sudo usermod -aG docker $USER
+    sudo usermod -aG docker "$USER"
     echo -e "  → ${GREEN}Docker installed${NC}"
     echo -e "  → ${YELLOW}NOTE: Log out and back in for docker group to take effect${NC}"
     DOCKER_GROUP_CHANGED=true

--- a/services/audio/Dockerfile
+++ b/services/audio/Dockerfile
@@ -22,8 +22,8 @@ ARG BUILDER_IMAGE=ghcr.io/watchmejoustmyflags/joustmania/builder:latest
 FROM debian:bookworm-slim AS system-libs
 ARG TARGETARCH
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    libasound2 \
     libasound2-data \
+    libasound2 \
     && rm -rf /var/lib/apt/lists/* \
     && mkdir /extra-libs \
     && if [ "$TARGETARCH" = "arm64" ]; then \
@@ -31,7 +31,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
        else \
          LIB_DIR=/usr/lib/x86_64-linux-gnu; \
        fi \
-    && cp $LIB_DIR/libasound.so* /extra-libs/ \
+    && cp "$LIB_DIR"/libasound.so* /extra-libs/ \
     && mkdir -p /extra-etc \
     && grep -E "^(root|audio):" /etc/group > /extra-etc/group
 

--- a/services/controller_manager/Dockerfile
+++ b/services/controller_manager/Dockerfile
@@ -27,11 +27,11 @@ FROM ${BUILDER_IMAGE} AS python-builder
 
 # Install additional bluetooth build dependencies (not in common builder)
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    pkg-config \
     libbluetooth-dev \
-    libusb-dev \
     libdbus-1-dev \
     libglib2.0-dev \
+    libusb-dev \
+    pkg-config \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
@@ -58,11 +58,11 @@ FROM python:3.11-slim
 
 # Install runtime dependencies (bluetooth for PS Move controllers)
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    bluez \
     libbluetooth3 \
-    libusb-1.0-0 \
     libdbus-1-3 \
     libglib2.0-0 \
-    bluez \
+    libusb-1.0-0 \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app

--- a/setup.sh
+++ b/setup.sh
@@ -29,7 +29,7 @@ read -p "Select option [1-3]: " -n 1 -r
 echo
 echo ""
 
-case $REPLY in
+case "$REPLY" in
     1)
         echo "=========================================="
         echo "Runtime Setup"

--- a/tools/ci-proto/Dockerfile
+++ b/tools/ci-proto/Dockerfile
@@ -2,12 +2,12 @@ FROM python:3.12-slim
 
 # Install system dependencies (including build tools for packages with C extensions)
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    git \
     build-essential \
-    pkg-config \
+    git \
     libasound2-dev \
     libdbus-1-dev \
     libglib2.0-dev \
+    pkg-config \
     && rm -rf /var/lib/apt/lists/*
 
 # Install uv

--- a/tools/ci-test/Dockerfile
+++ b/tools/ci-test/Dockerfile
@@ -4,8 +4,8 @@ FROM python:3.12-slim
 
 # Install system dependencies for testcontainers and Docker SDK
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    curl \
     ca-certificates \
+    curl \
     gnupg \
     lsb-release \
     && rm -rf /var/lib/apt/lists/*

--- a/tools/lint-dockerfiles.sh
+++ b/tools/lint-dockerfiles.sh
@@ -102,4 +102,4 @@ else
     fi
 fi
 
-exit $EXIT_CODE
+exit "$EXIT_CODE"


### PR DESCRIPTION
## Summary
- Fix SonarCloud Docker issues (S6570, S7018, S7031)
- Fix SonarCloud shell script issues (unquoted variables)
- Improve code quality and consistency across Dockerfiles and shell scripts

## Changes

### Docker fixes (S6570 - quote variables)
- `services/audio/Dockerfile`: Quote `$LIB_DIR` variable
- `images/psmove-builder/Dockerfile`: Quote `${PSMOVE_COMMIT}` variable
- `.devcontainer/Dockerfile`: Quote all user-related variables (`$USER_GID`, `$USERNAME`, `$USER_UID`)

### Docker fixes (S7018 - sort package names)
Alphabetically sorted apt-get package lists in:
- `.devcontainer/Dockerfile`
- `images/builder/Dockerfile`
- `images/psmove-builder/Dockerfile`
- `services/controller_manager/Dockerfile`
- `services/audio/Dockerfile`
- `tools/ci-test/Dockerfile`
- `tools/ci-proto/Dockerfile`

### Docker fixes (S7031 - merge consecutive RUN)
- `.devcontainer/Dockerfile`: Merged two pip install commands into single RUN instruction

### Shell script fixes
- `scripts/setup/setup_runtime.sh`: Quote `$USER` and `$HOMENAME` variables
- `scripts/setup/setup_host.sh`: Quote `$(logname)` and `$USER` variables
- `scripts/setup/build_psmoveapi.sh`: Quote `$(logname)` variable
- `scripts/hardware/update_asound.sh`: Quote command substitution
- `setup.sh`: Quote `$REPLY` variable
- `tools/lint-dockerfiles.sh`: Quote `$EXIT_CODE` variable

## Test plan
- [ ] CI passes (linting, tests)
- [ ] SonarCloud analysis shows reduced issues
- [ ] Docker builds still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)