### PR TITLE
fix(tracing): Break trace context chain between games

### DIFF
--- a/services/menu/servicer.py
+++ b/services/menu/servicer.py
@@ -6,6 +6,7 @@ import logging
 import os
 import time
 
+from opentelemetry import context as otel_context
 from opentelemetry import trace
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 
@@ -490,7 +491,11 @@ class MenuServicer(menu_pb2_grpc.MenuServiceServicer):
 
         metrics.button_presses_total.labels(button="trigger", action="press").inc()
 
-        with tracer.start_as_current_span("start_game") as span:
+        # Determine trace context for the game:
+        # - Web source: inherit current context (connects to dashboard trace)
+        # - Controller/button sources: fresh context (prevents chaining to previous game)
+        span_ctx = None if source == "web" else otel_context.Context()
+        with tracer.start_as_current_span("start_game", context=span_ctx) as span:
             span.set_attribute("controller.serial", serial)
             span.set_attribute("game.name", self.current_selection)
             span.set_attribute("game.source", source)


### PR DESCRIPTION
## Summary
- Fixes endless trace chains where multiple games appeared in a single trace
- When game ends and new game starts via controller, previous trace context was being inherited
- Now controller-initiated starts use fresh context (new trace), while web-initiated starts inherit context (connects to dashboard)

## Problem
After a game ended and the menu reset, starting a new game via controller button would create a `start_game` span as a child of the previous game's `restart_button_monitor` span. This caused:
- All games in a session to appear in one massive trace
- Traces spanning 10+ minutes with multiple game sessions
- Difficult to analyze individual game performance

## Solution
Conditionally choose trace context in `_start_game`:
- `source="web"`: Inherit current context → game trace connects to dashboard request
- `source="controller"` or `"button_input"`: Use fresh `otel_context.Context()` → new trace per game

## Test plan
- [ ] Play game 1 via controller → ends → play game 2 via controller → verify separate traces in Jaeger
- [ ] Start game from web dashboard → verify game trace is child of dashboard request trace
- [ ] Check that individual game traces have clean parent-child relationships

🤖 Generated with [Claude Code](https://claude.com/claude-code)