### PR TITLE
fix: Ensure winner rainbow effect plays before stream cleanup

### DIFF
--- a/services/game_coordinator/games/base.py
+++ b/services/game_coordinator/games/base.py
@@ -646,9 +646,8 @@ class BaseGameMode(ABC):
         except Exception as e:
             logger.error(f"Game loop error: {e}", exc_info=True)
             raise
-        finally:
-            # Cleanup stream reference (Phase 46)
-            self.gameplay_stream = None
+        # Note: Don't set gameplay_stream = None here - it's needed by _end_game_impl
+        # for sending winner effects. Stream cleanup happens after teardown phase.
 
     async def _process_controller_state(self, controller_state):
         """
@@ -962,6 +961,9 @@ class BaseGameMode(ABC):
             # Phase 6: Teardown
             with tracer.start_as_current_span("teardown_phase"):
                 await self._end_game_impl()
+
+                # Cleanup stream reference after winner effects are sent
+                self.gameplay_stream = None
 
                 # Clear all analytics metrics so dashboards show no data when game is over
                 metrics.clear_all_player_analytics()


### PR DESCRIPTION
## Summary
- Fix winner rainbow effect not playing because `gameplay_stream` was set to `None` before `_end_game_impl` could send it
- Move stream cleanup to after `_end_game_impl` completes in the teardown phase

## Root Cause
In `_game_loop`'s finally block, `self.gameplay_stream = None` was executed before `_end_game_impl` ran. When ffa.py tried to send the winner effect:
```python
if winner_serial and self.gameplay_stream:  # gameplay_stream was None!
```

## Test plan
- [x] `make lint` passes
- [ ] Manual test: Play FFA game, verify winner rainbow plays

🤖 Generated with [Claude Code](https://claude.com/claude-code)