### PR TITLE
perf: Optimize Docker container startup times

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -237,6 +237,11 @@ services:
       - MOCK_MODE=${AUDIO_MOCK_MODE:-false}
       - OTEL_SERVICE_NAME=audio-service
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
+    depends_on:
+      redis:
+        condition: service_healthy
+      settings:
+        condition: service_healthy
     networks:
       - joustmania
     restart: unless-stopped
@@ -402,10 +407,10 @@ services:
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://localhost:8080/health"]
-      interval: 10s
+      interval: 5s
       timeout: 5s
-      retries: 5
-      start_period: 5s
+      retries: 3
+      start_period: 3s
 
   # Dashboard (Real-time controller visualization SPA)
   dashboard:

--- a/services/audio/server.py
+++ b/services/audio/server.py
@@ -60,8 +60,8 @@ async def serve(metrics_port=8000):
     # Set the event loop for async operations (tempo transitions)
     audio_servicer.audio_manager.set_event_loop(asyncio.get_running_loop())
 
-    # Load audio enabled setting from settings service
-    await audio_servicer._load_audio_setting()
+    # Note: Audio settings are loaded lazily on first PlaySound/PlayMusic call
+    # This avoids blocking startup waiting for settings service
 
     # Add health checking service
     health_servicer = health.aio.HealthServicer()

--- a/services/audio/servicer.py
+++ b/services/audio/servicer.py
@@ -355,8 +355,9 @@ class AudioServiceServicer(audio_pb2_grpc.AudioServiceServicer):
     def __init__(self):
         """Initialize audio servicer."""
         self.audio_manager = AudioManager()
-        self.audio_enabled = True  # Controlled by play_audio setting
+        self.audio_enabled = True  # Controlled by play_audio setting (default: enabled)
         self.menu_voice = "ivy"  # Controlled by menu_voice setting
+        self._settings_loaded = False  # Lazy load settings on first audio request
         self.sound_registry: dict[str, tuple[str, str]] = {}  # sound_name -> (type, base_dir)
         self._build_sound_registry()
         logger.info("AudioServiceServicer initialized")
@@ -449,6 +450,9 @@ class AudioServiceServicer(audio_pb2_grpc.AudioServiceServicer):
 
     async def _load_audio_setting(self):
         """Load audio settings from settings service."""
+        if self._settings_loaded:
+            return  # Already loaded
+
         try:
             from lib.grpc_utils import create_channel
             from proto import settings_pb2, settings_pb2_grpc
@@ -473,11 +477,17 @@ class AudioServiceServicer(audio_pb2_grpc.AudioServiceServicer):
                 except Exception as voice_err:
                     logger.debug(f"Could not load menu_voice setting: {voice_err}, using default: ivy")
 
+            self._settings_loaded = True
         except Exception as e:
             logger.debug(f"Could not load audio settings: {e}, using defaults")
+            # Mark as loaded even on failure to avoid repeated attempts
+            self._settings_loaded = True
 
     async def PlaySound(self, request, context):  # noqa: N802, ARG002
         """Play a sound effect."""
+        # Lazy load settings on first audio request (avoids blocking startup)
+        await self._load_audio_setting()
+
         # Resolve sound name/path to full path with voice selection
         resolved_path = self._resolve_sound_path(request.file_path)
 
@@ -500,6 +510,9 @@ class AudioServiceServicer(audio_pb2_grpc.AudioServiceServicer):
 
     async def PlayMusic(self, request, context):  # noqa: N802, ARG002
         """Play background music."""
+        # Lazy load settings on first audio request (avoids blocking startup)
+        await self._load_audio_setting()
+
         # Extract music directory for span (e.g., "Joust" from "Joust/music/*.wav")
         music_dir = request.file_pattern.split("/")[0] if "/" in request.file_pattern else "music"
 

--- a/services/dashboard/Dockerfile
+++ b/services/dashboard/Dockerfile
@@ -35,6 +35,6 @@ ENV SERVER_COMPRESSION=true
 
 EXPOSE 8080
 
-# Health check
-HEALTHCHECK --interval=10s --timeout=5s --retries=5 \
+# Health check (optimized: 5s interval, 3s start-period for faster startup)
+HEALTHCHECK --interval=5s --timeout=5s --start-period=3s --retries=3 \
     CMD wget -q -O /dev/null http://localhost:8080/ || exit 1


### PR DESCRIPTION
## Summary
- Fix Dashboard health check intervals (10s→5s) and add `start_period`
- Add Audio service dependencies on settings/redis
- Move Audio settings loading to lazy (on first PlaySound/PlayMusic)
- Optimize Connect-Proxy health check intervals

## Problem
Docker container startup takes ~60 seconds. Analysis identified:
1. **Dashboard** health check uses 10s interval (not 5s) and no `start_period`
2. **Audio** service has race condition (tries to load settings before Settings is ready)
3. **Connect-Proxy** health check has 10s intervals instead of 5s

## Changes

### Dashboard Dockerfile
```dockerfile
# Before: --interval=10s --timeout=5s --retries=5 (no start_period!)
# After:  --interval=5s --timeout=5s --start_period=3s --retries=3
```

### docker-compose.yml - Audio
```yaml
audio:
  depends_on:
    redis:
      condition: service_healthy
    settings:
      condition: service_healthy  # NEW: prevents race condition
```

### Audio servicer.py
- Load settings lazily on first `PlaySound`/`PlayMusic` call
- Skip re-loading if already loaded (`_settings_loaded` flag)
- Still defaults to audio enabled if settings unavailable

### docker-compose.yml - Connect-Proxy
```yaml
healthcheck:
  interval: 5s      # was 10s
  retries: 3        # was 5
  start_period: 3s  # was 5s
```

## Expected Improvement
| Change | Savings |
|--------|---------|
| Dashboard health check | 15-25s |
| Audio lazy loading | 3-5s |
| Connect-Proxy health check | 2-5s |
| **Total** | **20-30s** |

Target: ~60s → ~35-40s startup time

## Test plan
- [x] `make lint` passes
- [x] Audio service tests pass (21 tests)
- [ ] Integration tests pass
- [ ] Manual test: `IMAGE_TAG=dev-refactor docker compose up -d` shows faster startup

Fixes #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)