### PR TITLE
chore: Add diagnostic logging for LED color issues (#223)

### DIFF
--- a/services/controller_manager/servicer.py
+++ b/services/controller_manager/servicer.py
@@ -240,6 +240,12 @@ class ControllerManagerServicer(controller_manager_pb2_grpc.ControllerManagerSer
                             # Only set LED immediately if no effect is running
                             if serial not in self.feedback_manager.active_effects:
                                 await self.feedback_manager.set_controller_color(serial, color)
+                                logger.info(f"[ButtonStream] Applied base color for {serial}: {color}")
+                            else:
+                                effect_type = self.feedback_manager.active_effect_types.get(serial, "unknown")
+                                logger.warning(
+                                    f"[ButtonStream] Base color for {serial} blocked by active effect: {effect_type}"
+                                )
 
                             logger.debug(f"[{subscriber_id}] Base color set: serial={serial}, rgb={color}")
 
@@ -428,6 +434,12 @@ class ControllerManagerServicer(controller_manager_pb2_grpc.ControllerManagerSer
                             # Only set LED immediately if no effect is running
                             if serial not in self.feedback_manager.active_effects:
                                 await self.feedback_manager.set_controller_color(serial, color)
+                                logger.info(f"[GameplayStream] Applied base color for {serial}: {color}")
+                            else:
+                                effect_type = self.feedback_manager.active_effect_types.get(serial, "unknown")
+                                logger.warning(
+                                    f"[GameplayStream] Base color for {serial} blocked by active effect: {effect_type}"
+                                )
 
                             logger.debug(f"[{subscriber_id}] Base color set: serial={serial}, rgb={color}")
 

--- a/services/menu/utils/led.py
+++ b/services/menu/utils/led.py
@@ -63,6 +63,10 @@ class LedController:
             queue: asyncio.Queue for outbound stream messages, or None to disable
             lock: Lock for thread-safe queue access (uses internal lock if not provided)
         """
+        if queue is None:
+            logger.info("LED stream disconnected")
+        else:
+            logger.info("LED stream connected")
         self._stream_queue = queue
         if lock is not None:
             self._stream_lock = lock
@@ -111,6 +115,7 @@ class LedController:
 
         async with self._stream_lock:
             if self._stream_queue is None:
+                logger.warning(f"Cannot send base color for {serial}: stream not connected")
                 return False
 
             try:
@@ -152,6 +157,7 @@ class LedController:
 
         async with self._stream_lock:
             if self._stream_queue is None:
+                logger.warning(f"Cannot send game effect for {serial}: stream not connected")
                 return False
 
             try:


### PR DESCRIPTION
## Summary
- Add logging to diagnose why LED colors aren't being applied in menu/admin mode
- Helps identify stream connection issues, active effect blocking, and timing problems

## Problem
After a game ends and menu restarts:
- Admin controller stays white with no visual feedback for settings changes
- Controllers don't show lobby colors properly
- Colors only update when game starts

## Diagnostic Logging Added

### Menu LED Controller (`services/menu/utils/led.py`)
- Log when LED stream connects/disconnects
- Warn when stream not connected for color/effect sends

### Controller Manager (`services/controller_manager/servicer.py`)
- Log when base colors are applied vs blocked by active effects
- Distinguish between ButtonStream and GameplayStream sources

## Expected Logs
```
LED stream connected
[ButtonStream] Applied base color for 00:07:04:a8:f2:2f: (76, 51, 0)
```

Or if blocked:
```
[ButtonStream] Base color for 00:07:04:a8:f2:2f blocked by active effect: GAME_EFFECT_DEATH
```

## Test plan
- [ ] Rebuild and test menu flow after game ends
- [ ] Check logs for stream connection status
- [ ] Check logs for blocked color updates

Fixes #223

🤖 Generated with [Claude Code](https://claude.com/claude-code)