### PR TITLE
fix: Reduce verbose controller discovery logs

### DIFF
--- a/services/controller_manager/bluetooth_backend.py
+++ b/services/controller_manager/bluetooth_backend.py
@@ -462,10 +462,12 @@ class BluetoothBackend(ControllerBackend):
             # Rescan if count changed OR force_rescan requested (Phase 79)
             # Force rescan is used by periodic discovery to catch externally paired controllers
             if count != self._last_controller_count or force_rescan:
-                logger.info(
-                    f"Controller count changed: {self._last_controller_count} -> {count}, "
-                    f"tracked: {len(self.controllers)}"
-                )
+                # Only log count change when count actually changed (not on force_rescan with same count)
+                if count != self._last_controller_count:
+                    logger.info(
+                        f"Controller count changed: {self._last_controller_count} -> {count}, "
+                        f"tracked: {len(self.controllers)}"
+                    )
                 self._last_controller_count = count
 
                 # Scan for new controllers - enumerate all and check which are new
@@ -535,7 +537,7 @@ class BluetoothBackend(ControllerBackend):
                     self._last_led_update.pop(stale_serial, None)
                     self._effect_active.discard(stale_serial)
 
-                logger.info(
+                logger.debug(
                     f"Scan complete: found {len(seen_serials)} serials: {seen_serials}, "
                     f"now tracking {len(self.controllers)}: {list(self.controllers.keys())}"
                 )

--- a/services/controller_manager/discovery_loop.py
+++ b/services/controller_manager/discovery_loop.py
@@ -355,7 +355,7 @@ class DiscoveryLoop:
 
             # Debug: Log tracked controller count periodically (every 5 seconds)
             if current_time - self._last_controller_count_log >= 5.0:
-                logger.info(
+                logger.debug(
                     f"Polling {len(serials_to_poll)}/{len(all_serials)} controllers "
                     f"(active={active_count}, idle={idle_count}): {serials_to_poll}"
                 )


### PR DESCRIPTION
## Summary
- Change "Polling X/Y controllers" to DEBUG level
- Only log "Controller count changed" when count actually changes
- Change "Scan complete" to DEBUG level

Fixes #231

## Before
```
INFO - Polling 8/11 controllers (active=8, idle=3): ['00:06:f5:ed:88:8c', ...]
INFO - Controller count changed: 11 -> 11, tracked: 11
INFO - Scan complete: found 11 serials: [...], now tracking 11: [...]
```
These appeared every ~5 seconds, making it hard to find important events.

## After
INFO logs only show meaningful state changes:
- New controller connected
- Controller disconnected  
- Actual count changes (e.g., 10 -> 11)

Periodic polling status is available at DEBUG level when needed for troubleshooting.

## Test plan
- [ ] Run with LOG_LEVEL=INFO, verify no verbose polling logs
- [ ] Run with LOG_LEVEL=DEBUG, verify polling logs appear
- [ ] Connect/disconnect controller, verify INFO logs for actual changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)