### PR TITLE
fix: Prevent OpenTelemetry span double-ending warnings

### DIFF
--- a/services/game_coordinator/games/ffa.py
+++ b/services/game_coordinator/games/ffa.py
@@ -138,6 +138,7 @@ class FFAGame(BaseGameMode):
             )
             player.span.set_status(Status(StatusCode.OK))
             player.span.end()
+            player.span = None  # Mark as closed to prevent double-ending
             logger.debug(f"Ended lifecycle span for player {serial}")
 
     async def _assign_ffa_colors(self):

--- a/services/game_coordinator/games/swapper.py
+++ b/services/game_coordinator/games/swapper.py
@@ -189,6 +189,7 @@ class SwapperGame(TeamsGameBase):
             )
             player.span.set_status(Status(StatusCode.OK))
             player.span.end()
+            player.span = None  # Mark as closed before creating new span
             logger.debug(f"Ended player {serial} span under team {old_team}")
 
         # Create new span under new team

--- a/services/game_coordinator/games/teams_base.py
+++ b/services/game_coordinator/games/teams_base.py
@@ -384,6 +384,7 @@ class TeamsGameBase(BaseGameMode):
             )
             player.span.set_status(Status(StatusCode.OK))
             player.span.end()
+            player.span = None  # Mark as closed to prevent double-ending
             logger.debug(f"Ended lifecycle span for player {serial}")
 
         # If team eliminated, end team span
@@ -394,6 +395,7 @@ class TeamsGameBase(BaseGameMode):
             )
             team.span.set_status(Status(StatusCode.OK))
             team.span.end()
+            team.span = None  # Mark as closed to prevent double-ending
             logger.info(f"Team {team.name} eliminated! Ended team lifecycle span")
 
     async def _end_game_impl(self):

--- a/services/game_coordinator/games/tournament.py
+++ b/services/game_coordinator/games/tournament.py
@@ -509,6 +509,7 @@ class TournamentGame(BaseGameMode):
                 )
                 loser.span.set_status(Status(StatusCode.OK))
                 loser.span.end()
+                loser.span = None  # Mark as closed to prevent double-ending
 
             self.event_publisher(
                 "match_end",

--- a/services/game_coordinator/games/traitor.py
+++ b/services/game_coordinator/games/traitor.py
@@ -348,6 +348,7 @@ class TraitorGame(TeamsGameBase):
             )
             player.span.set_status(Status(StatusCode.OK))
             player.span.end()
+            player.span = None  # Mark as closed to prevent double-ending
 
         # If secret team eliminated, end team span
         # Note: Team spans are based on visible teams, so this might not align perfectly
@@ -365,6 +366,7 @@ class TraitorGame(TeamsGameBase):
             )
             visible_team.span.set_status(Status(StatusCode.OK))
             visible_team.span.end()
+            visible_team.span = None  # Mark as closed to prevent double-ending
             logger.info(f"Visible team {visible_team.name} eliminated")
 
     async def _end_game_impl(self):

--- a/services/game_coordinator/games/werewolf.py
+++ b/services/game_coordinator/games/werewolf.py
@@ -386,6 +386,7 @@ class WerewolfGame(BaseGameMode):
             )
             player.span.set_status(Status(StatusCode.OK))
             player.span.end()
+            player.span = None  # Mark as closed to prevent double-ending
 
     async def _end_game_impl(self):
         """Handle game ending."""


### PR DESCRIPTION
## Summary
- Set `player.span = None` after calling `span.end()` to prevent double-ending
- Fixes OpenTelemetry warnings at game end for dead players

## Problem
When players died during gameplay, their lifecycle spans were ended but the reference wasn't cleared. At game end, `_close_all_player_spans()` checked `if player.span:` which was still truthy, causing it to call `set_status()` and `end()` on already-ended spans.

## Changes
Updated 6 game files to set span references to None after ending:
- `ffa.py`: `_kill_player_impl`
- `teams_base.py`: `_kill_player_impl` (player and team spans)
- `werewolf.py`: `_kill_player_impl`
- `traitor.py`: `_kill_player_impl` (player and team spans)
- `swapper.py`: team swap handler
- `tournament.py`: match end handler

## Test plan
- [ ] Play FFA game with multiple players dying
- [ ] Verify no "Calling end() on an ended span" warnings at game end
- [ ] Verify spans still appear correctly in traces

Closes #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)