### PR TITLE
fix: Prevent duplicate game start attempts (#230)

### DIFF
--- a/services/menu/handlers/ready.py
+++ b/services/menu/handlers/ready.py
@@ -41,6 +41,9 @@ class ReadyHandler:
         # Debounce tracking
         self._last_button_press: dict[str, dict[str, float]] = {}
 
+        # Prevent duplicate game start attempts (Issue #230)
+        self._game_start_in_progress = False
+
     @property
     def state(self) -> ControllerState:
         """The state this handler manages."""
@@ -95,7 +98,8 @@ class ReadyHandler:
         )
 
         # Check if all ready - auto start with feedback delay
-        if self._state_manager.all_ready():
+        if self._state_manager.all_ready() and not self._game_start_in_progress:
+            self._game_start_in_progress = True
             logger.info("All controllers ready - showing feedback before game start")
             # Brief delay so last player sees their LED go bright
             await asyncio.sleep(0.3)
@@ -107,6 +111,15 @@ class ReadyHandler:
         Called when a controller exits the ready state.
         """
         logger.debug(f"Controller {serial} exiting ready state")
+
+    def reset_game_start_flag(self) -> None:
+        """
+        Reset the game start flag when returning to lobby.
+
+        Called by StateManager.reset() to allow new game starts after
+        a game ends or fails.
+        """
+        self._game_start_in_progress = False
 
     def _should_process_button(self, serial: str, button: str, current_time: float) -> bool:
         """
@@ -140,10 +153,13 @@ class ReadyHandler:
         if self._state_manager is None:
             return
 
-        # Check if all ready
-        if self._state_manager.all_ready():
+        # Check if all ready and no start already in progress
+        if self._state_manager.all_ready() and not self._game_start_in_progress:
+            self._game_start_in_progress = True
             logger.info(f"All ready, starting game via trigger from {serial}")
             await self._start_game_callback(serial)
+        elif self._game_start_in_progress:
+            logger.debug(f"Trigger press from {serial} ignored - game start already in progress")
         else:
             logger.debug(
                 f"Trigger press from {serial} but not all ready "

--- a/services/menu/state_manager.py
+++ b/services/menu/state_manager.py
@@ -271,6 +271,11 @@ class StateManager:
         # Clear all player ready metrics
         metrics.player_ready._metrics.clear()
 
+        # Reset ready handler's game start flag (Issue #230)
+        ready_handler = self._handlers.get(ControllerState.READY)
+        if ready_handler and hasattr(ready_handler, "reset_game_start_flag"):
+            ready_handler.reset_game_start_flag()
+
         # Re-register each controller as CONNECTED (triggers on_enter → sets colors)
         for serial in serials:
             await self.on_controller_connected(serial)


### PR DESCRIPTION
## Summary

- Add `_game_start_in_progress` flag to prevent race condition in ReadyHandler
- Fix issue where trigger press during 0.3s feedback delay caused duplicate game start
- Reset flag in StateManager.reset() when returning to lobby

## Problem

When all controllers become ready, two code paths could trigger game start simultaneously:
1. `on_enter` - auto-starts after 0.3s feedback delay
2. `_handle_trigger` - starts immediately if all ready

If a player pressed trigger during the 0.3s delay, both fired. The second start failed with "Game already in progress", causing the menu to incorrectly restart the lobby while the game was running. This led to controllers receiving lobby colors (76, 38, 0) instead of their assigned game colors.

## Solution

Add a simple flag that's set when game start begins and checked before starting:
- Flag set to `True` before calling `_start_game_callback`
- Flag reset in `StateManager.reset()` when returning to lobby
- Second attempt logs debug message and exits early

## Test plan

- [x] `make lint` passes
- [x] All 10 integration tests pass
- [ ] Manual test: rapidly press trigger when becoming last ready player - should only start one game

Closes #230

🤖 Generated with [Claude Code](https://claude.ai/code)