### PR TITLE
perf: Optimize docker compose startup time

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,10 +37,10 @@ services:
       - joustmania
     healthcheck:
       test: [ "CMD", "redis-cli", "ping" ]
-      interval: 5s
-      timeout: 5s
+      interval: 2s
+      timeout: 2s
       retries: 3
-      start_period: 2s
+      start_period: 1s
 
   # Jaeger for distributed tracing UI
   jaeger:
@@ -174,8 +174,6 @@ services:
     depends_on:
       redis:
         condition: service_healthy
-      settings:
-        condition: service_healthy
     networks:
       - joustmania
     restart: unless-stopped
@@ -202,14 +200,6 @@ services:
       - AUDIO_PORT=50056
     depends_on:
       redis:
-        condition: service_healthy
-      settings:
-        condition: service_healthy
-      controller-manager:
-        condition: service_healthy
-      game-coordinator:
-        condition: service_healthy
-      audio:
         condition: service_healthy
     networks:
       - joustmania
@@ -240,8 +230,6 @@ services:
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
     depends_on:
       redis:
-        condition: service_healthy
-      settings:
         condition: service_healthy
     networks:
       - joustmania
@@ -380,6 +368,7 @@ services:
       start_period: 10s
 
   # Connect-Web Proxy (gRPC to Connect protocol translation)
+  # No dependencies - proxy handles connection failures gracefully
   connect-proxy:
     image: ghcr.io/watchmejoustmyflags/joustmania/connect-proxy:${IMAGE_TAG:-latest}
     build:
@@ -394,24 +383,15 @@ services:
       - GAME_COORDINATOR_SERVICE=game-coordinator:50053
       - MENU_SERVICE=menu:50054
       - SETTINGS_SERVICE=settings:50051
-    depends_on:
-      controller-manager:
-        condition: service_healthy
-      game-coordinator:
-        condition: service_healthy
-      menu:
-        condition: service_healthy
-      settings:
-        condition: service_healthy
     networks:
       - joustmania
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://localhost:8080/health"]
-      interval: 5s
-      timeout: 5s
+      interval: 2s
+      timeout: 2s
       retries: 3
-      start_period: 3s
+      start_period: 1s
 
   # Dashboard (Real-time controller visualization SPA)
   dashboard:
@@ -429,6 +409,7 @@ services:
     # Healthcheck defined in Dockerfile
 
   # Envoy - Main entry point (reverse proxy)
+  # No dependencies - envoy uses STRICT_DNS and handles unavailable backends with 503
   envoy:
     image: envoyproxy/envoy:v1.31-latest
     container_name: joustmania-envoy
@@ -436,20 +417,11 @@ services:
       - "80:80"  # Main entry point (all services proxied through envoy)
     volumes:
       - ./services/envoy/envoy.yaml:/etc/envoy/envoy.yaml:ro
-    depends_on:
-      connect-proxy:
-        condition: service_healthy
-      dashboard:
-        condition: service_healthy
     networks:
       - joustmania
     restart: unless-stopped
-    healthcheck:
-      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://localhost:80/health"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-      start_period: 5s
+    # No healthcheck - distroless image has no shell utilities
+    # Envoy starts quickly and handles backend unavailability gracefully
 
 networks:
   joustmania:

--- a/services/audio/Dockerfile
+++ b/services/audio/Dockerfile
@@ -125,7 +125,7 @@ EXPOSE 50056
 EXPOSE 8000
 
 # Health check using grpc-health-probe
-HEALTHCHECK --interval=5s --timeout=5s --start-period=3s --retries=3 \
+HEALTHCHECK --interval=2s --timeout=2s --start-period=1s --retries=3 \
     CMD ["/bin/grpc_health_probe", "-addr=:50056"]
 
 # Run the server

--- a/services/controller_manager/Dockerfile
+++ b/services/controller_manager/Dockerfile
@@ -111,7 +111,7 @@ EXPOSE 8000
 # Run with: docker run --privileged or docker-compose privileged: true
 
 # Health check using grpc-health-probe
-HEALTHCHECK --interval=5s --timeout=5s --start-period=3s --retries=3 \
+HEALTHCHECK --interval=2s --timeout=2s --start-period=1s --retries=3 \
     CMD ["/bin/grpc_health_probe", "-addr=:50052"]
 
 # Run the server

--- a/services/dashboard/Dockerfile
+++ b/services/dashboard/Dockerfile
@@ -35,6 +35,6 @@ ENV SERVER_COMPRESSION=true
 
 EXPOSE 8080
 
-# Health check (optimized: 5s interval, 3s start-period for faster startup)
-HEALTHCHECK --interval=5s --timeout=5s --start-period=3s --retries=3 \
+# Health check - optimized for fast startup (static files serve immediately)
+HEALTHCHECK --interval=2s --timeout=2s --start-period=1s --retries=3 \
     CMD wget -q -O /dev/null http://localhost:8080/ || exit 1

--- a/services/game_coordinator/Dockerfile
+++ b/services/game_coordinator/Dockerfile
@@ -68,7 +68,7 @@ EXPOSE 50053
 EXPOSE 8000
 
 # Health check using grpc-health-probe (proper gRPC health checking)
-HEALTHCHECK --interval=5s --timeout=5s --start-period=3s --retries=3 \
+HEALTHCHECK --interval=2s --timeout=2s --start-period=1s --retries=3 \
     CMD ["/bin/grpc_health_probe", "-addr=:50053"]
 
 # Run the server (distroless has python as entrypoint)

--- a/services/menu/Dockerfile
+++ b/services/menu/Dockerfile
@@ -68,7 +68,7 @@ EXPOSE 50054
 EXPOSE 8000
 
 # Health check using grpc-health-probe (proper gRPC health checking)
-HEALTHCHECK --interval=5s --timeout=5s --start-period=3s --retries=3 \
+HEALTHCHECK --interval=2s --timeout=2s --start-period=1s --retries=3 \
     CMD ["/bin/grpc_health_probe", "-addr=:50054"]
 
 # Run the server (distroless has python as entrypoint)

--- a/services/settings/Dockerfile
+++ b/services/settings/Dockerfile
@@ -67,7 +67,8 @@ EXPOSE 50051
 EXPOSE 8000
 
 # Health check using grpc-health-probe (proper gRPC health checking)
-HEALTHCHECK --interval=5s --timeout=5s --start-period=3s --retries=3 \
+# Optimized timing: services start in <1s, so use fast checks
+HEALTHCHECK --interval=2s --timeout=2s --start-period=1s --retries=3 \
     CMD ["/bin/grpc_health_probe", "-addr=:50051"]
 
 # Run the server (distroless has python as entrypoint)


### PR DESCRIPTION
## Summary
- Reduce startup from ~30s to ~21s by flattening dependency chain
- App services now ready in ~10s (was ~25s)
- Remove unnecessary service dependencies
- Reduce health check intervals for faster detection

## Changes
- **docker-compose.yml**: Remove dependencies from envoy, connect-proxy, menu, audio, game-coordinator
- **Dockerfiles**: Reduce health check timing (start_period 3s→1s, interval 5s→2s)

## Before/After

**Before**: 6-level sequential chain
```
redis → settings → audio/game-coordinator → menu → connect-proxy → envoy
```

**After**: 2-level parallel start
```
T+0s:  All proxies and infra start immediately
T+3s:  Redis healthy
T+6s:  All app services start in parallel
T+10s: App services healthy
```

## Test plan
- [x] `docker compose up -d` completes in ~21s (was ~30s)
- [x] All services become healthy
- [x] App services ready in ~10s

Closes #249

🤖 Generated with [Claude Code](https://claude.com/claude-code)