### PR TITLE
perf: Remove redundant sleep in game loop to halve latency

### DIFF
--- a/services/game_coordinator/games/base.py
+++ b/services/game_coordinator/games/base.py
@@ -640,8 +640,10 @@ class BaseGameMode(ABC):
 
                 last_iteration_time = iteration_end
 
-                # Small sleep to maintain tick rate
-                await asyncio.sleep(1.0 / update_frequency_hz)
+                # Note: No sleep needed here - the stream itself is rate-limited by
+                # controller-manager at update_frequency_hz. Adding a sleep here would
+                # double the latency (stream waits 16.7ms + we wait 16.7ms more).
+                # The async for loop naturally blocks waiting for the next message.
 
         except Exception as e:
             logger.error(f"Game loop error: {e}", exc_info=True)


### PR DESCRIPTION
## Summary

- Removes redundant `asyncio.sleep(1.0 / update_frequency_hz)` from the game loop
- The controller-manager already rate-limits the data stream at 60Hz (16.7ms intervals)
- The previous sleep effectively doubled input latency from ~16ms to ~33ms
- The async for loop naturally blocks waiting for the next streaming message, so no additional sleep is needed

## Test plan

- [ ] Run integration tests with `make test`
- [ ] Verify game responsiveness feels improved during gameplay
- [ ] Monitor telemetry for any unexpected frame timing changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)