### PR TITLE
Add Claude Code memory rules for project context

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -1,0 +1,90 @@
+# JoustMania Architecture
+
+## Service Overview
+
+| Service | Port | Role |
+|---------|------|------|
+| Settings | 50051 | Configuration management, persists to `joustsettings.yaml` |
+| Controller Manager | 50052 | PS Move hardware, button events, motion streaming |
+| Game Coordinator | 50053 | Game lifecycle, death detection, scoring |
+| Menu | 50054 | Lobby, game selection, ready state, admin mode |
+| Audio | 50056 | Sound effects, music, voice announcements |
+
+## Data Flow
+
+### Game Start Sequence
+
+```
+Menu (lobby)
+  │ monitors button events via StreamButtonEvents
+  │
+  ├─ Controllers connect → dim LED (game color)
+  ├─ Trigger pressed → READY state, bright LED
+  │
+  ▼ All ready (≥2 players)
+Menu → GameCoordinator.StreamGameEvents(start_config)
+  │
+  ▼
+GameCoordinator
+  ├─ Creates game instance
+  ├─ Subscribes to StreamGameplayData (motion)
+  ├─ Emits "game_started" event
+  │
+  ▼
+Menu receives confirmation
+  ├─ Clears ready state
+  ├─ Stops button monitor
+  │
+  ▼
+Game runs (60Hz motion processing)
+  ├─ Detects deaths (movement threshold)
+  ├─ Sends LED effects (warning, death, winner)
+  ├─ Plays sounds via Audio service
+  │
+  ▼
+Game ends → "game_ended" event → Menu restarts lobby
+```
+
+### Streaming Patterns
+
+**Bidirectional streams** (primary communication):
+- `StreamButtonEvents`: Button events ↔ LED commands
+- `StreamGameplayData`: Motion data ↔ Game effects
+
+**Server streams**:
+- `StreamGameEvents`: Game lifecycle events
+- `StreamMenuEvents`: Menu state changes
+- `SubscribeToChanges`: Settings change notifications
+
+## Key Concepts
+
+### Controller States (Menu)
+
+```
+DISCONNECTED → CONNECTED (dim LED) → READY (bright LED)
+                    ↓                      ↓
+               ADMIN MODE (white LED, 60s timeout)
+```
+
+### Game States
+
+```
+IDLE → STARTING → RUNNING → ENDING → ENDED
+```
+
+### Motion Processing
+
+- Hardware polls at 1000Hz
+- Streams to game at 60Hz (active) or 10Hz (idle)
+- Game uses EMA filter for smoothing
+- Death threshold varies by sensitivity setting (0-4)
+
+## Service Dependencies
+
+```
+Settings ← foundational (no deps)
+Audio ← foundational (no deps)
+Controller Manager ← Settings
+Game Coordinator ← Settings, Controller Manager, Audio
+Menu ← Settings, Controller Manager, Game Coordinator, Audio
+```

--- a/.claude/rules/debugging.md
+++ b/.claude/rules/debugging.md
@@ -1,0 +1,100 @@
+# Debugging Guide
+
+## Logs
+
+### Docker Compose Logs
+
+```bash
+docker compose logs -f <service>           # Follow specific service
+docker compose logs -f menu game-coordinator  # Multiple services
+docker compose logs --tail=100 <service>   # Last 100 lines
+```
+
+### Log Levels
+
+Set via environment variable:
+```bash
+LOG_LEVEL=DEBUG docker compose up <service>
+```
+
+## Observability Stack
+
+Access at `http://localhost:8080/`:
+- `/jaeger/` - Distributed traces
+- `/grafana/` - Dashboards and metrics
+- `/prometheus/` - Raw metrics
+
+### Useful Traces
+
+Search in Jaeger by:
+- Service: `menu`, `game-coordinator`, `controller-manager`
+- Operation: `StartGame`, `StreamGameEvents`, `process_controller_state`
+- Tags: `game.mode=JoustFFA`, `player.serial=...`
+
+### Key Dashboards
+
+- **Service Health Overview** - All services up/down status
+- **Game Quality** - Frame timing, jitter, dropped frames
+- **Player Insights** - Per-player movement, deaths
+- **Controller Overview** - Battery, connection status
+
+## Common Issues
+
+### "No module named X"
+
+```bash
+cd services/<service>
+uv sync --dev    # Reinstall dependencies
+```
+
+### gRPC Connection Refused
+
+Check service is running:
+```bash
+docker compose ps
+docker compose logs <service> | tail -20
+```
+
+### Proto Mismatch
+
+Regenerate after any `.proto` changes:
+```bash
+make protos
+```
+
+### Controller Not Detected
+
+1. Check backend: `CONTROLLER_BACKEND=mock` for testing
+2. Check Bluetooth: `bluetoothctl devices`
+3. Check permissions: user must be in `bluetooth` group
+
+## Interactive Debugging
+
+### Python REPL with Service Context
+
+```bash
+cd services/<service>
+uv run python
+>>> from proto import service_pb2
+>>> # Explore proto messages
+```
+
+### Mock Controller Testing
+
+```bash
+CONTROLLER_BACKEND=mock docker compose up controller-manager
+# Use MockControllerService on port 50062 to simulate controllers
+```
+
+## Performance Profiling
+
+Enable in docker-compose:
+```yaml
+environment:
+  - OTEL_TRACES_SAMPLER=always_on  # Sample all traces
+```
+
+Check Jaeger for slow spans, look at:
+- `game_loop` iteration times
+- `process_controller_state` latency
+- gRPC call durations

--- a/.claude/rules/game-modes.md
+++ b/.claude/rules/game-modes.md
@@ -1,0 +1,134 @@
+# Game Modes Reference
+
+All game modes in `services/game_coordinator/games/`.
+
+## Solo/FFA Modes
+
+### FFA (Free-For-All)
+**File:** `ffa.py` | **Class:** `FFAGame`
+
+Last player standing wins. All players compete individually.
+- No teams (everyone on team=0)
+- Unique colors per player
+- Death is permanent
+
+### Nonstop Joust
+**File:** `nonstop_joust.py` | **Class:** `NonstopJoustGame`
+
+Endless respawn with scoring. Compete for highest score.
+- Respawn after 3 seconds
+- 2 seconds spawn protection
+- Time-limited (configurable via `nonstop_time_limit`)
+- Tracks kills, deaths, streaks
+
+## Team Modes
+
+### Teams (Simple)
+**File:** `teams.py` | **Class:** `SimpleTeamsGame`
+
+Teams compete, last team standing wins.
+- Round-robin team assignment
+- Team colors assigned at start
+
+### Random Teams
+**File:** `random_teams.py` | **Class:** `RandomTeamsGame`
+
+Like Teams but with random assignment.
+- 5 second team formation phase
+- Colors pulsed during formation
+
+### Swapper
+**File:** `swapper.py` | **Class:** `SwapperGame`
+
+Switch teams when you die instead of elimination.
+- Always 2 teams
+- 2 second grace period after swap
+- Ends when all on same team
+- Last swapper excluded from winners
+
+## Hidden Role Modes
+
+### Werewolf
+**File:** `werewolf.py` | **Class:** `WerewolfGame`
+
+~44% are secret werewolves, revealed after 35 seconds.
+- All start yellow (human color)
+- Werewolves get rumble signal during countdown
+- Werewolves turn blue at reveal
+- Werewolves have higher death thresholds
+
+### Traitor
+**File:** `traitor.py` | **Class:** `TraitorGame`
+
+Team game with secret traitors.
+- Traitor count scales with players (1-3+)
+- Traitors appear as their team but win with enemy
+- Traitors get rumble signal
+
+### Zombie
+**File:** `zombie.py` | **Class:** `ZombieGame`
+
+Humans vs Zombies. Killed humans become zombies.
+- Starts with 2 zombies
+- Zombies respawn after 2-10 seconds
+- Zombies have higher thresholds (harder to kill)
+- Time-limited (~3-7 min based on player count)
+- Humans win if time expires
+
+## Tournament Modes
+
+### Fight Club
+**File:** `fight_club.py` | **Class:** `FightClubGame`
+
+1v1 arena with queue system.
+- 22 second rounds, 4 second invincibility
+- Defender (red) vs Challenger (green)
+- Winner stays, loser goes to back of queue
+- Min 10 rounds before game can end
+
+### Tournament
+**File:** `tournament.py` | **Class:** `TournamentGame`
+
+Single elimination bracket.
+- 22 second matches, 4 second invincibility
+- Bracket with byes for non-power-of-2
+- Red vs Blue, winner turns green
+- Single champion wins
+
+## Modifying Game Modes
+
+### Adding a New Mode
+
+1. Create `services/game_coordinator/games/my_mode.py`
+2. Extend `BaseGameMode` or `TeamsGameBase`
+3. Register in `services/game_coordinator/games/__init__.py`
+4. Add to menu in `services/menu/handlers/admin.py`
+
+### Key Methods to Override
+
+```python
+class MyGame(BaseGameMode):
+    def get_game_name(self) -> str:
+        return "MyMode"
+
+    async def _kill_player_impl(self, serial, accel_mag):
+        # Custom death handling
+
+    def _check_win_condition(self) -> bool:
+        # Custom win logic
+
+    def _get_death_thresholds(self):
+        # Custom sensitivity thresholds
+```
+
+### Threshold Tuning
+
+Thresholds in `base.py` (index 0-4 = ULTRA_SLOW to ULTRA_FAST):
+```python
+SLOW_WARNING = [1.2, 1.3, 1.6, 2.0, 2.5]  # Music slow
+SLOW_MAX = [1.3, 1.5, 1.8, 2.5, 3.2]      # Death threshold
+FAST_WARNING = [1.4, 1.5, 2.0, 2.8, 3.2]  # Music fast
+FAST_MAX = [1.6, 1.8, 2.8, 3.2, 3.5]      # Death threshold
+```
+
+Zombie/Werewolf override in their files with higher thresholds.

--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -1,0 +1,66 @@
+# Git Workflow
+
+## Worktrees are Mandatory
+
+Never commit directly to the main checkout. Always use git worktrees:
+
+```bash
+git worktree add ../JoustMania-issue-<NUMBER> -b fix/description origin/dev-refactor
+cd ../JoustMania-issue-<NUMBER>
+# ... make changes ...
+git push -u origin fix/description
+gh pr create --base dev-refactor
+```
+
+This keeps the main checkout clean for:
+- Multiple parallel agent work
+- Quick reference and exploration
+- Avoiding accidental commits to wrong branch
+
+## Main Branch
+
+The main development branch is **`dev-refactor`** (not `master`).
+
+All PRs target `dev-refactor`.
+
+## Branch Naming
+
+- `fix/description` - Bug fixes
+- `feat/description` - New features
+- `refactor/description` - Code improvements
+- `docs/description` - Documentation
+- `perf/description` - Performance improvements
+
+Include issue number when applicable: `fix/issue-256-clear-ready-state`
+
+## Commit Messages
+
+Follow conventional commits:
+
+```
+type: Short description
+
+Longer explanation if needed.
+
+Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
+```
+
+Types: `fix`, `feat`, `refactor`, `docs`, `perf`, `test`, `chore`
+
+## Pre-commit Checks
+
+Hooks run automatically:
+- `ruff check` - Linting
+- `ruff format` - Formatting
+
+Run manually before committing:
+```bash
+make lint
+```
+
+## Pull Requests
+
+1. Create via `gh pr create --base dev-refactor`
+2. Include issue reference: `Fixes #123`
+3. Add test plan with checkboxes
+4. Wait for CI to pass

--- a/.claude/rules/observability.md
+++ b/.claude/rules/observability.md
@@ -1,0 +1,128 @@
+# Observability Guide
+
+## Dashboards
+
+Located in `services/grafana/dashboards/`:
+
+| Dashboard | Purpose |
+|-----------|---------|
+| `service-health-overview.json` | All services up/down, CPU, memory |
+| `game-quality.json` | Frame timing, jitter, dropped frames |
+| `game-analytics.json` | Game duration, deaths, win rates |
+| `player-insights.json` | Per-player movement, deaths, playstyle |
+| `controller-overview.json` | Battery levels, connection status |
+| `controller-maintenance.json` | Hardware health, signal strength |
+| `host-metrics.json` | Raspberry Pi CPU, memory, temperature |
+| `system-overview.json` | High-level system status |
+| `bluetooth-adapter.json` | Bluetooth adapter metrics |
+| `cache-performance.json` | State cache hit rates |
+
+## Adding Metrics
+
+### Define in `metrics.py`
+
+```python
+from lib.otel_metrics import Counter, Gauge, Histogram
+
+# Counter - cumulative, only increases
+my_events_total = Counter(
+    "my_events_total",
+    "Total events processed",
+    ["event_type"]  # Labels
+)
+
+# Gauge - current value, can go up/down
+my_active_connections = Gauge(
+    "my_active_connections",
+    "Currently active connections"
+)
+
+# Histogram - distribution of values
+my_latency_seconds = Histogram(
+    "my_latency_seconds",
+    "Request latency",
+    buckets=[0.01, 0.05, 0.1, 0.5, 1.0]
+)
+```
+
+### Use in Code
+
+```python
+# Counter
+metrics.my_events_total.labels(event_type="click").inc()
+
+# Gauge
+metrics.my_active_connections.set(len(connections))
+metrics.my_active_connections.inc()  # +1
+metrics.my_active_connections.dec()  # -1
+
+# Histogram
+metrics.my_latency_seconds.observe(0.042)
+with metrics.my_latency_seconds.time():
+    do_work()  # Auto-records duration
+```
+
+## Metric Naming Conventions
+
+- Prefix with service: `game_`, `controller_`, `menu_`
+- Use snake_case
+- End counters with `_total`
+- End histograms with `_seconds`, `_bytes`, etc.
+- Include units in name
+
+## Dashboard Updates
+
+After adding metrics:
+1. Metrics auto-export via OTEL (no config needed)
+2. Edit dashboard JSON or use Grafana UI
+3. Export and save to `services/grafana/dashboards/`
+
+## Tracing
+
+### Add Spans
+
+```python
+from lib.otel_tracing import tracer
+
+with tracer.start_as_current_span("my_operation") as span:
+    span.set_attribute("player.serial", serial)
+    span.set_attribute("game.mode", mode)
+    # ... do work
+```
+
+### Span Naming
+
+- Use dot notation: `game.process_death`
+- Include service context: `menu.handle_button`
+- Be specific: `controller.poll_batch` not just `poll`
+
+## Viewing Traces
+
+1. Open Jaeger: http://localhost:16686
+2. Select service from dropdown
+3. Search by:
+   - Service name
+   - Operation name
+   - Tags (e.g., `player.serial=XX:XX`)
+   - Duration (find slow operations)
+
+## Alerts
+
+Defined in `services/prometheus/alerts.yml`:
+
+```yaml
+- alert: ServiceDown
+  expr: up{job="menu"} == 0
+  for: 30s
+  labels:
+    severity: critical
+  annotations:
+    summary: "Menu service is down"
+```
+
+## Log Aggregation
+
+Logs go to Loki, viewable in Grafana:
+1. Go to Explore
+2. Select Loki datasource
+3. Query: `{service="menu"} |= "error"`

--- a/.claude/rules/proto.md
+++ b/.claude/rules/proto.md
@@ -1,0 +1,97 @@
+# Protocol Buffer Development
+
+## Proto Files Location
+
+All `.proto` files are in the `proto/` directory:
+
+```
+proto/
+├── settings.proto           # Configuration service
+├── controller_manager.proto # Hardware control
+├── game_coordinator.proto   # Game lifecycle
+├── menu.proto               # Menu/lobby service
+├── audio.proto              # Audio playback
+└── controller_manager_mock.proto  # Mock controller testing
+```
+
+## Making Changes
+
+1. Edit the `.proto` file
+2. Regenerate Python bindings:
+   ```bash
+   make protos
+   ```
+3. Run integration tests:
+   ```bash
+   make test
+   ```
+
+## Common Patterns
+
+### Message Definition
+
+```protobuf
+message PlayerState {
+  string serial = 1;
+  bool alive = 2;
+  int32 score = 3;
+  optional string killer_serial = 4;  // Optional field
+}
+```
+
+### Enum Definition
+
+```protobuf
+enum GameState {
+  GAME_STATE_UNSPECIFIED = 0;
+  GAME_STATE_IDLE = 1;
+  GAME_STATE_RUNNING = 2;
+  GAME_STATE_ENDED = 3;
+}
+```
+
+### RPC Patterns
+
+```protobuf
+service MyService {
+  // Unary (request-response)
+  rpc GetState(GetStateRequest) returns (GetStateResponse);
+
+  // Server streaming
+  rpc StreamEvents(StreamRequest) returns (stream Event);
+
+  // Bidirectional streaming
+  rpc StreamData(stream DataRequest) returns (stream DataResponse);
+}
+```
+
+## Importing in Python
+
+```python
+from proto import service_pb2
+from proto import service_pb2_grpc
+
+# Create message
+msg = service_pb2.MyMessage(field="value")
+
+# Create stub
+stub = service_pb2_grpc.MyServiceStub(channel)
+```
+
+## Versioning
+
+- Use `optional` for new fields (backwards compatible)
+- Never reuse field numbers
+- Add new fields at the end
+- Deprecate rather than remove fields
+
+## Testing Proto Changes
+
+After modifying protos:
+```bash
+make protos                  # Regenerate
+make lint                    # Check syntax
+cd services/<affected>
+uv run pytest               # Unit tests
+make test                   # Full integration
+```

--- a/.claude/rules/services.md
+++ b/.claude/rules/services.md
@@ -1,0 +1,98 @@
+# Service Development
+
+## Adding/Modifying Services
+
+### Directory Structure
+
+```
+services/<service-name>/
+├── __init__.py
+├── server.py              # Entry point, gRPC server setup
+├── servicer.py            # gRPC servicer implementation
+├── metrics.py             # OTEL metrics definitions
+├── pyproject.toml         # Dependencies (uv managed)
+├── Dockerfile
+├── README.md
+└── tests/
+```
+
+### gRPC Servicer Pattern
+
+```python
+class MyServiceServicer(my_pb2_grpc.MyServiceServicer):
+    def __init__(self, settings_client, ...):
+        self.settings = settings_client
+        # Initialize state
+
+    async def MyMethod(self, request, context):
+        # Implement RPC
+        return my_pb2.MyResponse(...)
+```
+
+### Metrics
+
+Use OTEL push metrics (not prometheus pull):
+
+```python
+from lib.otel_metrics import Counter, Gauge, Histogram
+
+requests_total = Counter("my_requests_total", "Total requests", ["method"])
+active_connections = Gauge("my_active_connections", "Active connections")
+```
+
+### Proto Definitions
+
+1. Add/modify in `proto/<service>.proto`
+2. Run `make protos` to regenerate
+3. Import from `proto import <service>_pb2, <service>_pb2_grpc`
+
+## Common Patterns
+
+### Settings Integration
+
+```python
+# Get setting
+response = await settings_stub.GetSetting(
+    settings_pb2.GetSettingRequest(key="sensitivity")
+)
+value = response.value
+
+# Subscribe to changes
+async for event in settings_stub.SubscribeToChanges(...):
+    if event.key == "sensitivity":
+        self.update_sensitivity(event.new_value)
+```
+
+### Controller Manager Integration
+
+```python
+# Button events (menu uses this)
+stream = stub.StreamButtonEvents(request_generator())
+async for event in stream:
+    if event.event_type == EVENT_CONNECT:
+        handle_connect(event.serial)
+    elif event.button == BUTTON_TRIGGER:
+        handle_trigger(event.serial, event.action)
+
+# Gameplay data (game coordinator uses this)
+stream = stub.StreamGameplayData(request_generator())
+async for update in stream:
+    for controller in update.controllers:
+        process_motion(controller.serial, controller.accel)
+```
+
+### LED Feedback
+
+Send via the stream's write channel:
+
+```python
+# Set color
+await stream.write(ButtonEventStreamControl(
+    color_config=ControllerColorConfig(serial=serial, color=RGB(r=255, g=0, b=0))
+))
+
+# Game effect
+await stream.write(GameplayStreamControl(
+    effect=GameEffectCommand(serial=serial, effect=GAME_EFFECT_PLAYER_DEATH)
+))
+```

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,0 +1,63 @@
+# Testing Guidelines
+
+## Unit Tests
+
+Run unit tests from within the service directory using `uv`:
+
+```bash
+cd services/<service-name>
+uv run pytest                      # Run all tests
+uv run pytest -v                   # Verbose output
+uv run pytest -x                   # Stop on first failure
+uv run pytest -k test_name         # Run specific test
+uv run pytest tests/test_file.py   # Run specific file
+```
+
+Each service has its own virtual environment managed by `uv`. The `pyproject.toml` in each service defines test dependencies.
+
+## Integration Tests
+
+Integration tests run with Docker Compose:
+
+```bash
+make test                    # Full test suite (starts and stops containers)
+SKIP_TEARDOWN=1 make test    # Keep containers running after tests
+```
+
+Use `SKIP_TEARDOWN=1` when:
+- Debugging test failures
+- Inspecting container logs
+- Running tests repeatedly during development
+- Checking Grafana dashboards or Jaeger traces
+
+To manually stop containers after using SKIP_TEARDOWN:
+```bash
+docker compose -f docker-compose.test.yml down
+```
+
+## Test Structure
+
+Each service follows this pattern:
+```
+services/<service>/
+├── tests/
+│   ├── __init__.py
+│   ├── conftest.py          # Pytest fixtures
+│   ├── test_servicer.py     # gRPC servicer tests
+│   └── test_<module>.py     # Unit tests per module
+└── pyproject.toml           # Test deps in [project.optional-dependencies]
+```
+
+## Proto Changes
+
+After modifying `.proto` files:
+```bash
+make protos    # Regenerate Python bindings
+make test      # Run full integration tests
+```
+
+## Mocking
+
+- Use `unittest.mock` for service dependencies
+- Controller Manager has a mock backend (`CONTROLLER_BACKEND=mock`)
+- Tests use `MockControllerManagerService`, `MockSettingsService`, etc.

--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,4 @@ get-docker.sh
 
 # Linter cache
 .ruff_cache/
+*.local.md


### PR DESCRIPTION
## Summary

Add `.claude/rules/` directory with comprehensive project documentation that auto-loads in Claude Code sessions. This provides consistent context across all sessions without repeating instructions.

## Files Added

| File | Purpose |
|------|---------|
| `testing.md` | Unit tests (uv in service dir), integration tests (SKIP_TEARDOWN) |
| `architecture.md` | Service overview, data flow diagrams, game start sequence |
| `services.md` | Service development patterns, gRPC, metrics, LED feedback |
| `debugging.md` | Logs, observability stack, common issues |
| `git-workflow.md` | Worktrees mandatory, branch naming, commits |
| `proto.md` | Protocol buffer development guide |
| `game-modes.md` | All 10 game modes with mechanics and thresholds |
| `observability.md` | Metrics, dashboards, tracing guide |

Also adds `*.local.md` to `.gitignore` for personal preferences that shouldn't be committed.

## How It Works

Claude Code automatically loads all `.md` files from `.claude/rules/` at session start. This gives Claude immediate context about:
- How to run tests
- Project architecture and data flow
- Git workflow requirements
- All game modes and their mechanics

## Test Plan

- [x] Files created and committed
- [ ] Verify `/memory` command shows loaded rules in Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)