### PR TITLE
dashboard: Improve Player Insights for presentations

### DIFF
--- a/services/grafana/dashboards/player-insights.json
+++ b/services/grafana/dashboards/player-insights.json
@@ -15,7 +15,7 @@
       }
     ]
   },
-  "description": "Per-player detailed view with acceleration gauge, thresholds, and real-time status",
+  "description": "Per-player detailed view with acceleration gauge, thresholds, and real-time status - optimized for presentations",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
@@ -43,6 +43,364 @@
         "w": 24,
         "x": 0,
         "y": 0
+      },
+      "id": 200,
+      "panels": [],
+      "title": "Game Status",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Players currently alive in the game",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 2
+              },
+              {
+                "color": "green",
+                "value": 3
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 6,
+        "x": 0,
+        "y": 1
+      },
+      "id": 201,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value_and_name"
+      },
+      "pluginVersion": "10.2.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "game_players_alive",
+          "legendFormat": "Alive",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "game_active_players",
+          "legendFormat": "Total",
+          "refId": "B"
+        }
+      ],
+      "title": "Players",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Current death threshold - lower = faster/harder game",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "max": 3.5,
+          "min": 1.0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1.8
+              },
+              {
+                "color": "yellow",
+                "value": 2.2
+              },
+              {
+                "color": "green",
+                "value": 2.5
+              }
+            ]
+          },
+          "unit": "g"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 6,
+        "x": 6,
+        "y": 1
+      },
+      "id": 202,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": true,
+        "showThresholdMarkers": true,
+        "sizing": "auto"
+      },
+      "pluginVersion": "10.2.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "game_effective_death_threshold",
+          "legendFormat": "Death Threshold",
+          "refId": "A"
+        }
+      ],
+      "title": "Death Threshold",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Game speed relative to base threshold (100% = normal, lower = faster)",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "max": 120,
+          "min": 40,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 60
+              },
+              {
+                "color": "yellow",
+                "value": 80
+              },
+              {
+                "color": "green",
+                "value": 95
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 6,
+        "x": 12,
+        "y": 1
+      },
+      "id": 203,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value"
+      },
+      "pluginVersion": "10.2.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "(game_effective_death_threshold / 2.5) * 100",
+          "legendFormat": "Speed",
+          "refId": "A"
+        }
+      ],
+      "title": "Game Speed",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Death threshold over time - shows game speed ramping",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "axisSoftMin": 1.0,
+            "axisSoftMax": 3.0,
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "unit": "g"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Death"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Warning"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 6,
+        "x": 18,
+        "y": 1
+      },
+      "id": 204,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.2.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "game_effective_death_threshold",
+          "legendFormat": "Death",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "game_effective_warning_threshold",
+          "legendFormat": "Warning",
+          "refId": "B"
+        }
+      ],
+      "title": "Thresholds",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 4
       },
       "id": 100,
       "panels": [],
@@ -91,10 +449,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 4,
+        "h": 6,
         "w": 4,
         "x": 0,
-        "y": 1
+        "y": 5
       },
       "id": 10,
       "options": {
@@ -274,10 +632,10 @@
         ]
       },
       "gridPos": {
-        "h": 3,
-        "w": 12,
+        "h": 5,
+        "w": 14,
         "x": 4,
-        "y": 1
+        "y": 5
       },
       "id": 1,
       "options": {
@@ -368,10 +726,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 4,
-        "w": 2,
-        "x": 16,
-        "y": 1
+        "h": 6,
+        "w": 3,
+        "x": 18,
+        "y": 5
       },
       "id": 4,
       "options": {
@@ -400,76 +758,6 @@
       ],
       "title": "Peak",
       "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "description": "Bluetooth signal strength (RSSI in dBm). Green: excellent (> -60), Yellow: good (-60 to -80), Red: weak (< -80)",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "max": -30,
-          "min": -100,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "red",
-                "value": null
-              },
-              {
-                "color": "yellow",
-                "value": -80
-              },
-              {
-                "color": "green",
-                "value": -60
-              }
-            ]
-          },
-          "unit": "dB"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 2,
-        "x": 18,
-        "y": 1
-      },
-      "id": 15,
-      "options": {
-        "minVizHeight": 50,
-        "minVizWidth": 50,
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": ["lastNotNull"],
-          "fields": "",
-          "values": false
-        },
-        "showThresholdLabels": false,
-        "showThresholdMarkers": true,
-        "sizing": "auto"
-      },
-      "pluginVersion": "10.2.3",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "expr": "bluetooth_device_rssi_dbm{serial=\"$controller\"}",
-          "legendFormat": "RSSI",
-          "refId": "A"
-        }
-      ],
-      "title": "Signal",
-      "type": "gauge"
     },
     {
       "datasource": {
@@ -534,10 +822,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 4,
-        "w": 4,
-        "x": 20,
-        "y": 1
+        "h": 6,
+        "w": 3,
+        "x": 21,
+        "y": 5
       },
       "id": 3,
       "options": {
@@ -636,9 +924,9 @@
       },
       "gridPos": {
         "h": 1,
-        "w": 12,
+        "w": 14,
         "x": 4,
-        "y": 4
+        "y": 10
       },
       "id": 6,
       "options": {
@@ -677,7 +965,7 @@
   ],
   "refresh": "1s",
   "schemaVersion": 39,
-  "tags": ["joustmania", "game", "per-player", "sensitivity"],
+  "tags": ["joustmania", "game", "per-player", "sensitivity", "presentation"],
   "templating": {
     "list": [
       {
@@ -713,6 +1001,6 @@
   "timezone": "",
   "title": "Player Insights",
   "uid": "player-insights",
-  "version": 2,
+  "version": 3,
   "weekStart": ""
 }


### PR DESCRIPTION
## Summary

Optimize the Player Insights dashboard for presentations and demos.

### New "Game Status" top row
Shows game-level context at a glance:
- **Players** - Alive/Total count with color coding
- **Death Threshold** - Current threshold gauge (lower = faster/harder)
- **Game Speed** - Percentage of base threshold (100% = normal speed)
- **Thresholds** - Mini trend showing warning/death lines over time

### Larger per-player panels
Better visibility from a distance:
| Panel | Before | After |
|-------|--------|-------|
| Acceleration gauge | h:4 | h:6 |
| Acceleration trend | h:3, w:12 | h:5, w:14 |
| Peak/Style stats | h:4 | h:6 |

### Simplified view
- Removed Signal (RSSI) gauge - less relevant for presentations
- Added "presentation" tag for easy discovery

## Screenshots
The dashboard now shows game state at the top, making it clear:
- How many players are alive
- How fast the game is running (threshold decreasing = speeding up)
- Individual player acceleration with dynamic threshold lines

## Test plan
- [ ] Start the stack with `docker compose up -d`
- [ ] Open Grafana at http://localhost:8080/grafana/
- [ ] Navigate to Player Insights dashboard
- [ ] Verify Game Status row appears at top
- [ ] Verify panels are larger and more readable

Closes #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)