### PR TITLE
docs: Fix Quick Start to include setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,22 @@ A cloud-native refactor of the [original JoustMania](https://github.com/adangert
 
 ## Quick Start
 
+### With PS Move Controllers (Raspberry Pi / Linux)
+
 ```bash
 git clone https://github.com/WatchMeJoustMyFlags/JoustMania.git
 cd JoustMania
-docker compose up -d
+./setup.sh    # Install dependencies, Bluetooth config, pairing daemon
+```
+
+The setup script will guide you through installation and optionally enable autostart on boot.
+
+### Demo Mode (No Hardware)
+
+```bash
+git clone https://github.com/WatchMeJoustMyFlags/JoustMania.git
+cd JoustMania
+CONTROLLER_BACKEND=mock docker compose up -d
 ```
 
 **Open the dashboard:** http://localhost:8080
@@ -81,19 +93,9 @@ See [CONTRIBUTING.md](docs/CONTRIBUTING.md) for the full development guide.
 
 ## Mock Environment
 
-Test without hardware:
+For development without PS Move controllers, use mock mode (see Quick Start above).
 
-```bash
-CONTROLLER_BACKEND=mock docker compose up -d
-```
-
-See [Mock Environment Guide](services/controller_manager/MOCK_ENVIRONMENT.md) for details.
-
-## Hardware Setup
-
-For physical PS Move controllers, see [Hardware Setup Guide](docs/hardware-setup-guide.md).
-
-**Requirements:** PS Move controllers, USB Bluetooth adapter, Raspberry Pi or Linux
+See [Mock Environment Guide](services/controller_manager/MOCK_ENVIRONMENT.md) for simulating controllers and running integration tests.
 
 ## Documentation
 


### PR DESCRIPTION
## Summary

Fix the Quick Start section to correctly show the setup steps:

- **With PS Move Controllers**: Run `./setup.sh` which handles everything (dependencies, Bluetooth config, pairing daemon, optional autostart)
- **Demo Mode**: Use `CONTROLLER_BACKEND=mock` for testing without hardware

Also consolidates the Mock Environment section to reference Quick Start instead of duplicating the command.

## Changes

**Before:**
```bash
docker compose up -d
```

**After:**
```bash
# With PS Move Controllers (Raspberry Pi / Linux)
./setup.sh    # Install dependencies, Bluetooth config, pairing daemon
# Setup script guides through installation and optionally enables autostart

# Demo Mode (No Hardware)
CONTROLLER_BACKEND=mock docker compose up -d
```

## Test plan
- [ ] README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)