### PR TITLE
refactor(menu): Extract button debounce logic into shared ButtonDebouncer class

### DIFF
--- a/services/menu/handlers/admin.py
+++ b/services/menu/handlers/admin.py
@@ -25,7 +25,7 @@ from opentelemetry import trace
 
 from lib.telemetry import SpanAttr
 from lib.types import Sound
-from services.menu.handlers.base import ControllerState
+from services.menu.handlers.base import ButtonDebouncer, ControllerState
 
 if TYPE_CHECKING:
     from services.menu.state_manager import StateManager
@@ -98,9 +98,8 @@ class AdminModeHandler:
             (255, 165, 0),  # Orange for force_all_start
         ]
 
-        # Button debouncing
-        self.last_button_time: dict[str, float] = {}
-        self.button_debounce_interval = 0.3  # seconds
+        # Button debouncing (300ms for admin mode)
+        self._debouncer = ButtonDebouncer(default_interval=0.3)
 
         # Background tasks (to prevent garbage collection)
         self._pending_tasks: set[asyncio.Task] = set()
@@ -273,27 +272,6 @@ class AdminModeHandler:
             and controller.triangle_pressed
         )
 
-    def _should_process_button(self, serial: str, button: str, current_time: float) -> bool:
-        """
-        Check if a button press should be processed (debouncing).
-
-        Args:
-            serial: Controller serial
-            button: Button name
-            current_time: Current timestamp
-
-        Returns:
-            True if button should be processed
-        """
-        key = f"{serial}:{button}"
-        last_time = self.last_button_time.get(key, 0)
-
-        if current_time - last_time < self.button_debounce_interval:
-            return False
-
-        self.last_button_time[key] = current_time
-        return True
-
     def _get_span_context(self):
         """Get the admin mode span context for child spans."""
         return self.session_span_context if self.session_span_context else None
@@ -406,15 +384,13 @@ class AdminModeHandler:
             serial: Controller serial number
             button: Button name (trigger, move, cross, circle, square, triangle, ps)
         """
-        current_time = time.time()
-
         # Check for admin mode timeout (60 seconds)
-        if current_time - self.entry_time > 60:
+        if time.time() - self.entry_time > 60:
             logger.info("Admin mode timed out after 60 seconds")
             await self._exit_to_connected(serial)
             return
 
-        if not self._should_process_button(serial, button, current_time):
+        if not self._debouncer.should_process(serial, button):
             return
 
         if button == "move":

--- a/services/menu/handlers/base.py
+++ b/services/menu/handlers/base.py
@@ -1,10 +1,68 @@
 """Base handler protocol for controller state handlers."""
 
+import time
 from enum import Enum
 from typing import TYPE_CHECKING, Protocol
 
 if TYPE_CHECKING:
     from services.menu.state_manager import StateManager
+
+
+class ButtonDebouncer:
+    """
+    Utility class for debouncing button presses.
+
+    Tracks the last press time for each button on each controller and
+    filters out presses that occur too quickly (within the debounce interval).
+    """
+
+    def __init__(self, default_interval: float = 0.1):
+        """
+        Initialize the debouncer.
+
+        Args:
+            default_interval: Default debounce interval in seconds (default 100ms)
+        """
+        self._last_press: dict[str, dict[str, float]] = {}
+        self.default_interval = default_interval
+
+    def should_process(self, serial: str, button: str, interval: float | None = None) -> bool:
+        """
+        Check if a button press should be processed.
+
+        Args:
+            serial: Controller serial number
+            button: Button name
+            interval: Optional override for debounce interval
+
+        Returns:
+            True if the button press should be processed, False if debounced
+        """
+        interval = interval if interval is not None else self.default_interval
+        current_time = time.time()
+
+        if serial not in self._last_press:
+            self._last_press[serial] = {}
+
+        last_press = self._last_press[serial].get(button, 0)
+        if current_time - last_press < interval:
+            return False
+
+        self._last_press[serial][button] = current_time
+        return True
+
+    def clear(self, serial: str | None = None) -> None:
+        """
+        Clear debounce state.
+
+        Args:
+            serial: If provided, clear only for this controller.
+                   If None, clear all state.
+        """
+        if serial is None:
+            self._last_press.clear()
+        else:
+            self._last_press.pop(serial, None)
 
 
 class ControllerState(Enum):

--- a/services/menu/handlers/connected.py
+++ b/services/menu/handlers/connected.py
@@ -3,10 +3,9 @@
 from __future__ import annotations
 
 import logging
-import time
 from typing import TYPE_CHECKING
 
-from services.menu.handlers.base import ControllerState
+from services.menu.handlers.base import ButtonDebouncer, ControllerState
 
 if TYPE_CHECKING:
     from services.menu.state_manager import StateManager
@@ -29,9 +28,7 @@ class ConnectedHandler:
     def __init__(self):
         """Initialize connected handler."""
         self._state_manager: StateManager | None = None
-
-        # Debounce tracking
-        self._last_button_press: dict[str, dict[str, float]] = {}
+        self._debouncer = ButtonDebouncer(default_interval=0.1)
 
     @property
     def state(self) -> ControllerState:
@@ -54,15 +51,13 @@ class ConnectedHandler:
             logger.error("StateManager not set")
             return
 
-        current_time = time.time()
-
         if button == "trigger":
-            if not self._should_process_button(serial, "trigger", current_time):
+            if not self._debouncer.should_process(serial, "trigger"):
                 return
             await self._handle_trigger(serial)
 
         elif button == "select":
-            if not self._should_process_button(serial, "select", current_time):
+            if not self._debouncer.should_process(serial, "select"):
                 return
             await self._handle_select(serial)
 
@@ -86,28 +81,6 @@ class ConnectedHandler:
         Called when a controller exits the connected state.
         """
         logger.debug(f"Controller {serial} exiting connected state")
-
-    def _should_process_button(self, serial: str, button: str, current_time: float) -> bool:
-        """
-        Check if button press should be processed (debouncing).
-
-        Args:
-            serial: Controller serial number
-            button: Button name
-            current_time: Current timestamp
-
-        Returns:
-            True if button press should be processed
-        """
-        if serial not in self._last_button_press:
-            self._last_button_press[serial] = {}
-
-        last_press = self._last_button_press[serial].get(button, 0)
-        if current_time - last_press < 0.1:  # 100ms debounce
-            return False
-
-        self._last_button_press[serial][button] = current_time
-        return True
 
     async def _handle_trigger(self, serial: str) -> None:
         """

--- a/services/menu/handlers/ready.py
+++ b/services/menu/handlers/ready.py
@@ -4,10 +4,9 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import time
 from typing import TYPE_CHECKING
 
-from services.menu.handlers.base import ControllerState
+from services.menu.handlers.base import ButtonDebouncer, ControllerState
 
 if TYPE_CHECKING:
     from services.menu.state_manager import StateManager
@@ -37,9 +36,7 @@ class ReadyHandler:
         """
         self._state_manager: StateManager | None = None
         self._start_game_callback = start_game_callback
-
-        # Debounce tracking
-        self._last_button_press: dict[str, dict[str, float]] = {}
+        self._debouncer = ButtonDebouncer(default_interval=0.1)
 
         # Prevent duplicate game start attempts (Issue #230)
         self._game_start_in_progress = False
@@ -65,15 +62,13 @@ class ReadyHandler:
             logger.error("StateManager not set")
             return
 
-        current_time = time.time()
-
         if button == "trigger":
-            if not self._should_process_button(serial, "trigger", current_time):
+            if not self._debouncer.should_process(serial, "trigger"):
                 return
             await self._handle_trigger(serial)
 
         elif button == "move":
-            if not self._should_process_button(serial, "move", current_time):
+            if not self._debouncer.should_process(serial, "move"):
                 return
             await self._handle_move(serial)
 
@@ -120,28 +115,6 @@ class ReadyHandler:
         a game ends or fails.
         """
         self._game_start_in_progress = False
-
-    def _should_process_button(self, serial: str, button: str, current_time: float) -> bool:
-        """
-        Check if button press should be processed (debouncing).
-
-        Args:
-            serial: Controller serial number
-            button: Button name
-            current_time: Current timestamp
-
-        Returns:
-            True if button press should be processed
-        """
-        if serial not in self._last_button_press:
-            self._last_button_press[serial] = {}
-
-        last_press = self._last_button_press[serial].get(button, 0)
-        if current_time - last_press < 0.1:  # 100ms debounce
-            return False
-
-        self._last_button_press[serial][button] = current_time
-        return True
 
     async def _handle_trigger(self, serial: str) -> None:
         """

--- a/services/menu/tests/test_handlers.py
+++ b/services/menu/tests/test_handlers.py
@@ -1,12 +1,100 @@
 """Unit tests for controller state handlers."""
 
-from unittest.mock import AsyncMock, MagicMock, patch
+import time
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from services.menu.handlers.base import ControllerState
+from services.menu.handlers.base import ButtonDebouncer, ControllerState
 from services.menu.handlers.connected import ConnectedHandler
 from services.menu.handlers.ready import ReadyHandler
+
+
+class TestButtonDebouncer:
+    """Tests for ButtonDebouncer utility class."""
+
+    def test_first_press_always_processed(self):
+        """First button press should always be processed."""
+        debouncer = ButtonDebouncer(default_interval=0.1)
+        assert debouncer.should_process("serial1", "trigger") is True
+
+    def test_rapid_press_debounced(self):
+        """Rapid presses within interval should be debounced."""
+        debouncer = ButtonDebouncer(default_interval=0.1)
+
+        # First press passes
+        assert debouncer.should_process("serial1", "trigger") is True
+        # Immediate second press blocked
+        assert debouncer.should_process("serial1", "trigger") is False
+
+    def test_press_after_interval_processed(self):
+        """Press after interval should be processed."""
+        debouncer = ButtonDebouncer(default_interval=0.01)  # 10ms for fast test
+
+        assert debouncer.should_process("serial1", "trigger") is True
+
+        # Wait for interval to pass
+        time.sleep(0.015)
+
+        assert debouncer.should_process("serial1", "trigger") is True
+
+    def test_different_buttons_independent(self):
+        """Different buttons should have independent debounce state."""
+        debouncer = ButtonDebouncer(default_interval=0.1)
+
+        assert debouncer.should_process("serial1", "trigger") is True
+        assert debouncer.should_process("serial1", "move") is True  # Different button
+        assert debouncer.should_process("serial1", "trigger") is False  # Same button blocked
+
+    def test_different_controllers_independent(self):
+        """Different controllers should have independent debounce state."""
+        debouncer = ButtonDebouncer(default_interval=0.1)
+
+        assert debouncer.should_process("serial1", "trigger") is True
+        assert debouncer.should_process("serial2", "trigger") is True  # Different controller
+        assert debouncer.should_process("serial1", "trigger") is False  # Same controller blocked
+
+    def test_custom_interval_override(self):
+        """Custom interval override should be respected."""
+        debouncer = ButtonDebouncer(default_interval=0.01)
+
+        assert debouncer.should_process("serial1", "trigger") is True
+        time.sleep(0.015)  # Wait past default interval
+
+        # Use longer override interval - should still be blocked
+        assert debouncer.should_process("serial1", "trigger", interval=0.5) is False
+
+    def test_clear_single_controller(self):
+        """clear() with serial should clear only that controller."""
+        debouncer = ButtonDebouncer(default_interval=0.1)
+
+        debouncer.should_process("serial1", "trigger")
+        debouncer.should_process("serial2", "trigger")
+
+        debouncer.clear("serial1")
+
+        # serial1 cleared - can press again
+        assert debouncer.should_process("serial1", "trigger") is True
+        # serial2 not cleared - still blocked
+        assert debouncer.should_process("serial2", "trigger") is False
+
+    def test_clear_all(self):
+        """clear() without args should clear all state."""
+        debouncer = ButtonDebouncer(default_interval=0.1)
+
+        debouncer.should_process("serial1", "trigger")
+        debouncer.should_process("serial2", "trigger")
+
+        debouncer.clear()
+
+        # Both can press again
+        assert debouncer.should_process("serial1", "trigger") is True
+        assert debouncer.should_process("serial2", "trigger") is True
+
+    def test_default_interval(self):
+        """Default interval should be 100ms."""
+        debouncer = ButtonDebouncer()
+        assert debouncer.default_interval == 0.1
 
 
 class TestConnectedHandler:
@@ -48,22 +136,20 @@ class TestConnectedHandler:
         mock_state_manager.led.set_connected_color.assert_called_once_with("serial1", "JoustFFA")
 
     @pytest.mark.asyncio
-    @patch("services.menu.handlers.connected.time")
-    async def test_handle_button_trigger(self, mock_time, handler, mock_state_manager):
+    async def test_handle_button_trigger(self, handler, mock_state_manager):
         """Trigger press should transition to READY."""
-        mock_time.time.return_value = 100.0
         handler.set_state_manager(mock_state_manager)
+        handler._debouncer.should_process = MagicMock(return_value=True)
 
         await handler.handle_button("serial1", "trigger")
 
         mock_state_manager.transition_to.assert_called_once_with("serial1", ControllerState.READY)
 
     @pytest.mark.asyncio
-    @patch("services.menu.handlers.connected.time")
-    async def test_handle_button_select_cycles_game(self, mock_time, handler, mock_state_manager):
+    async def test_handle_button_select_cycles_game(self, handler, mock_state_manager):
         """Select button press should cycle game modes."""
-        mock_time.time.return_value = 100.0
         handler.set_state_manager(mock_state_manager)
+        handler._debouncer.should_process = MagicMock(return_value=True)
 
         await handler.handle_button("serial1", "select")
 
@@ -71,15 +157,13 @@ class TestConnectedHandler:
         mock_state_manager.settings.save_current_game.assert_called_once()
 
     @pytest.mark.asyncio
-    @patch("services.menu.handlers.connected.time")
-    async def test_handle_button_debounce(self, mock_time, handler, mock_state_manager):
+    async def test_handle_button_debounce(self, handler, mock_state_manager):
         """Rapid button presses should be debounced."""
         handler.set_state_manager(mock_state_manager)
+        # First call returns True, second returns False (debounced)
+        handler._debouncer.should_process = MagicMock(side_effect=[True, False])
 
-        mock_time.time.return_value = 100.0
         await handler.handle_button("serial1", "trigger")
-
-        mock_time.time.return_value = 100.05  # 50ms later
         await handler.handle_button("serial1", "trigger")
 
         assert mock_state_manager.transition_to.call_count == 1
@@ -135,11 +219,10 @@ class TestReadyHandler:
         start_game_callback.assert_called_once_with("serial1")
 
     @pytest.mark.asyncio
-    @patch("services.menu.handlers.ready.time")
-    async def test_handle_button_move_unreadies(self, mock_time, handler, mock_state_manager):
+    async def test_handle_button_move_unreadies(self, handler, mock_state_manager):
         """Move press should transition back to CONNECTED."""
-        mock_time.time.return_value = 100.0
         handler.set_state_manager(mock_state_manager)
+        handler._debouncer.should_process = MagicMock(return_value=True)
 
         await handler.handle_button("serial1", "move")
 


### PR DESCRIPTION
Fixes #266

## Summary
- Add `ButtonDebouncer` utility class to `handlers/base.py`
- Replace duplicated `_should_process_button` implementations in all 3 handlers
- ConnectedHandler and ReadyHandler use 100ms debounce (default)
- AdminModeHandler uses 300ms debounce

## Changes
| File | Change |
|------|--------|
| `handlers/base.py` | Add `ButtonDebouncer` class (~55 lines) |
| `handlers/connected.py` | Use `ButtonDebouncer`, remove 20 lines |
| `handlers/ready.py` | Use `ButtonDebouncer`, remove 20 lines |
| `handlers/admin.py` | Use `ButtonDebouncer`, remove 20 lines |
| `tests/test_handlers.py` | Add 9 tests for `ButtonDebouncer`, update handler tests |

Net result: ~40 fewer lines of code, single place to maintain debounce logic.

## Test plan
- [x] All 122 menu service tests pass
- [x] ButtonDebouncer has 9 dedicated unit tests covering all functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)