### PR TITLE
refactor: Add OTEL test helpers to reduce patching boilerplate

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -61,3 +61,29 @@ make test      # Run full integration tests
 - Use `unittest.mock` for service dependencies
 - Controller Manager has a mock backend (`CONTROLLER_BACKEND=mock`)
 - Tests use `MockControllerManagerService`, `MockSettingsService`, etc.
+
+## Disabling OTEL in Tests
+
+Use the telemetry test helpers in `conftest.py` to disable OpenTelemetry:
+
+```python
+# conftest.py
+from lib.otel_metrics import disable_metrics_for_tests
+from lib.telemetry import disable_telemetry_for_tests
+
+disable_telemetry_for_tests()
+disable_metrics_for_tests()
+```
+
+This replaces manual `sys.modules` patching and environment variables. Benefits:
+- Single source of truth for test OTEL configuration
+- Consistent approach across all services
+- Metrics silently no-op instead of failing
+
+For tests that need to verify metric calls, use `@patch`:
+```python
+@patch("services.controller_manager.metrics.state_cache_hits_total")
+def test_cache_hit(self, mock_metric):
+    # ... test code
+    mock_metric.inc.assert_called_once()
+```

--- a/lib/otel_metrics.py
+++ b/lib/otel_metrics.py
@@ -42,6 +42,34 @@ _meter: metrics.Meter | None = None
 _initialized = False
 _pending_metrics: list[LabeledMetric] = []
 _init_lock = Lock()
+_test_mode = False
+
+
+def disable_metrics_for_tests() -> None:
+    """
+    Disable OpenTelemetry metrics for unit tests.
+
+    Call this once in conftest.py to prevent OTLP connection attempts
+    and enable silent no-op behavior for all metrics during tests.
+
+    When test mode is enabled, all metric operations (set, inc, observe)
+    silently do nothing instead of trying to export to a collector.
+
+    Example:
+        # conftest.py
+        from lib.otel_metrics import disable_metrics_for_tests
+        disable_metrics_for_tests()
+    """
+    global _test_mode
+    _test_mode = True
+    # Note: We don't set _initialized=True here because the silent skip
+    # logic in _ensure_initialized() already handles uninitialized state.
+    # Setting _test_mode just provides a clearer signal for tests.
+
+
+def is_test_mode() -> bool:
+    """Check if metrics are in test mode (disabled for tests)."""
+    return _test_mode
 
 
 def init_metrics(

--- a/lib/telemetry.py
+++ b/lib/telemetry.py
@@ -37,6 +37,34 @@ logger = logging.getLogger(__name__)
 # Lazy initialization state
 _initialized = False
 _init_lock = threading.Lock()
+_test_mode = False
+
+
+def disable_telemetry_for_tests() -> None:
+    """
+    Disable OpenTelemetry tracing for unit tests.
+
+    Call this once in conftest.py to prevent OTLP connection attempts
+    during tests. This is cleaner than patching sys.modules.
+
+    Example:
+        # conftest.py
+        from lib.telemetry import disable_telemetry_for_tests
+        disable_telemetry_for_tests()
+    """
+    global _initialized, _test_mode
+    _test_mode = True
+    _initialized = True  # Prevent real initialization
+
+    # Set environment variables as backup for any code that checks them
+    os.environ["OTEL_SDK_DISABLED"] = "true"
+    os.environ["OTEL_TRACES_EXPORTER"] = "none"
+    os.environ["OTEL_METRICS_EXPORTER"] = "none"
+
+
+def is_test_mode() -> bool:
+    """Check if telemetry is in test mode (disabled for tests)."""
+    return _test_mode
 
 
 class SpanAttr:

--- a/services/audio/tests/conftest.py
+++ b/services/audio/tests/conftest.py
@@ -1,0 +1,10 @@
+"""
+Pytest fixtures for audio service tests.
+"""
+
+# Disable OpenTelemetry for tests - must be done before importing service modules
+from lib.otel_metrics import disable_metrics_for_tests
+from lib.telemetry import disable_telemetry_for_tests
+
+disable_telemetry_for_tests()
+disable_metrics_for_tests()

--- a/services/controller_manager/tests/conftest.py
+++ b/services/controller_manager/tests/conftest.py
@@ -2,14 +2,14 @@
 Pytest fixtures for controller_manager tests.
 """
 
-import os
-
 import pytest
 
-# Disable OpenTelemetry export during tests to prevent hanging on trace/metric export
-os.environ["OTEL_SDK_DISABLED"] = "true"
-os.environ["OTEL_TRACES_EXPORTER"] = "none"
-os.environ["OTEL_METRICS_EXPORTER"] = "none"
+# Disable OpenTelemetry for tests - must be done before importing service modules
+from lib.otel_metrics import disable_metrics_for_tests
+from lib.telemetry import disable_telemetry_for_tests
+
+disable_telemetry_for_tests()
+disable_metrics_for_tests()
 
 
 class FakeMove:

--- a/services/controller_manager/tests/test_button_detector.py
+++ b/services/controller_manager/tests/test_button_detector.py
@@ -5,16 +5,12 @@ Tests button state transition detection and event publishing.
 """
 
 import asyncio
-import sys
 from unittest.mock import MagicMock, patch
 
-# Mock prometheus_client before importing modules that use metrics
-sys.modules["prometheus_client"] = MagicMock()
-
-from lib.controller_constants import ButtonKey, ButtonTrackingKey  # noqa: E402
-from proto import controller_manager_pb2  # noqa: E402
-from services.controller_manager.button_detector import ButtonDetector  # noqa: E402
-from services.controller_manager.event_publisher import EventPublisher  # noqa: E402
+from lib.controller_constants import ButtonKey, ButtonTrackingKey
+from proto import controller_manager_pb2
+from services.controller_manager.button_detector import ButtonDetector
+from services.controller_manager.event_publisher import EventPublisher
 
 
 class TestButtonDetectorInitialization:

--- a/services/controller_manager/tests/test_discovery_loop.py
+++ b/services/controller_manager/tests/test_discovery_loop.py
@@ -4,35 +4,10 @@ Unit tests for DiscoveryLoop.
 Tests activity tracking and adaptive polling logic.
 """
 
-import sys
 import time
 from unittest.mock import MagicMock
 
-# Mock external dependencies before importing modules that use them
-# These must be mocked before any imports that use them
-mock_tracer = MagicMock()
-mock_tracer.start_as_current_span = MagicMock(return_value=MagicMock(__enter__=MagicMock(), __exit__=MagicMock()))
-
-sys.modules["prometheus_client"] = MagicMock()
-sys.modules["opentelemetry"] = MagicMock()
-sys.modules["opentelemetry.trace"] = MagicMock()
-sys.modules["opentelemetry.exporter"] = MagicMock()
-sys.modules["opentelemetry.exporter.otlp"] = MagicMock()
-sys.modules["opentelemetry.exporter.otlp.proto"] = MagicMock()
-sys.modules["opentelemetry.exporter.otlp.proto.grpc"] = MagicMock()
-sys.modules["opentelemetry.exporter.otlp.proto.grpc.trace_exporter"] = MagicMock()
-sys.modules["opentelemetry.sdk"] = MagicMock()
-sys.modules["opentelemetry.sdk.trace"] = MagicMock()
-sys.modules["opentelemetry.sdk.trace.export"] = MagicMock()
-sys.modules["opentelemetry.sdk.resources"] = MagicMock()
-
-# Mock lib.telemetry to return our mock tracer
-mock_telemetry = MagicMock()
-mock_telemetry.init_telemetry = MagicMock(return_value=mock_tracer)
-mock_telemetry.get_tracer = MagicMock(return_value=mock_tracer)
-sys.modules["lib.telemetry"] = mock_telemetry
-
-from lib.controller_constants import AxisKey, ButtonKey, StateKey  # noqa: E402
+from lib.controller_constants import AxisKey, ButtonKey, StateKey
 
 
 class TestActivityTracking:

--- a/services/game_coordinator/tests/conftest.py
+++ b/services/game_coordinator/tests/conftest.py
@@ -20,6 +20,13 @@ project_root = service_dir.parent.parent
 # Add paths for imports
 sys.path.insert(0, str(project_root))
 
+# Disable OpenTelemetry for tests - must be done before importing service modules
+from lib.otel_metrics import disable_metrics_for_tests  # noqa: E402
+from lib.telemetry import disable_telemetry_for_tests  # noqa: E402
+
+disable_telemetry_for_tests()
+disable_metrics_for_tests()
+
 # Import protobufs from proto package (must be after path setup)
 from proto import controller_manager_pb2, settings_pb2  # noqa: E402
 

--- a/services/menu/tests/conftest.py
+++ b/services/menu/tests/conftest.py
@@ -1,0 +1,10 @@
+"""
+Pytest fixtures for menu service tests.
+"""
+
+# Disable OpenTelemetry for tests - must be done before importing service modules
+from lib.otel_metrics import disable_metrics_for_tests
+from lib.telemetry import disable_telemetry_for_tests
+
+disable_telemetry_for_tests()
+disable_metrics_for_tests()

--- a/services/settings/tests/conftest.py
+++ b/services/settings/tests/conftest.py
@@ -1,0 +1,10 @@
+"""
+Pytest fixtures for settings service tests.
+"""
+
+# Disable OpenTelemetry for tests - must be done before importing service modules
+from lib.otel_metrics import disable_metrics_for_tests
+from lib.telemetry import disable_telemetry_for_tests
+
+disable_telemetry_for_tests()
+disable_metrics_for_tests()


### PR DESCRIPTION
## Summary

Adds centralized test helper functions to disable OpenTelemetry in unit tests, replacing scattered `sys.modules` patching and environment variable setup.

- `disable_telemetry_for_tests()` in `lib/telemetry.py`
- `disable_metrics_for_tests()` in `lib/otel_metrics.py`

## Changes

**New helper functions:**
- `lib/telemetry.py`: Added `disable_telemetry_for_tests()` and `is_test_mode()`
- `lib/otel_metrics.py`: Added `disable_metrics_for_tests()` and `is_test_mode()`

**Simplified test setup:**
- `controller_manager/tests/conftest.py`: Now uses helpers instead of 3 env vars
- `controller_manager/tests/test_discovery_loop.py`: Removed 13 `sys.modules` patches
- `controller_manager/tests/test_button_detector.py`: Removed `sys.modules` patch

**Added conftest.py to all services:**
- `menu/tests/conftest.py`
- `audio/tests/conftest.py`
- `settings/tests/conftest.py`
- `game_coordinator/tests/conftest.py` (updated)

**Documentation:**
- `.claude/rules/testing.md`: Added section on disabling OTEL in tests

## Benefits

1. **Single source of truth** - One helper function call vs scattered patches
2. **Consistent approach** - All services use the same pattern
3. **Less boilerplate** - From 13+ sys.modules patches to 2 function calls
4. **Easier maintenance** - Changes in one place propagate everywhere

Fixes #268

## Test plan

- [x] `make lint` passes
- [x] Controller manager unit tests pass (209 tests)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.ai/code)