### PR TITLE
fix(audio): Increase default master volume to 100%

### DIFF
--- a/services/audio/servicer.py
+++ b/services/audio/servicer.py
@@ -168,7 +168,7 @@ class AudioManager:
             self.music_player = MusicPlayer("background")
 
         self.current_music_file: str | None = None
-        self.master_volume: float = 0.7
+        self.master_volume: float = 1.0
         self.music_lock = threading.Lock()
         self.event_loop: asyncio.AbstractEventLoop | None = None  # Set from async context
 


### PR DESCRIPTION
## Summary

Increases the default `master_volume` from 0.7 (70%) to 1.0 (100%) for louder audio output.

## Test plan

- [x] Linting passes
- [ ] Manual test: audio plays at full volume by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)