### PR TITLE
fix(audio): add audio group for /dev/snd device access

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -234,6 +234,9 @@ services:
     # Sound device access for real audio output
     devices:
       - /dev/snd:/dev/snd
+    # Add audio group (GID 29 on Raspberry Pi) for device access
+    group_add:
+      - "29"
     volumes:
       - ./services/audio/assets:/app/services/audio/assets:ro  # Audio files (read-only)
     # Ports exposed only within Docker network (no host binding)


### PR DESCRIPTION
## Summary

Fixes audio playback issue where the audio service couldn't access ALSA devices.

## Problem

The audio service was logging repeated errors:
```
ALSA lib pcm_dmix.c:999:(snd_pcm_dmix_open) unable to open slave
Playback error: Unknown error 524 [default]
```

Audio devices `/dev/snd/*` are owned by `root:audio` with 660 permissions, but the container wasn't part of the audio group.

## Solution

Added `group_add: ["29"]` to the audio service configuration to grant access to the audio group (GID 29 on Raspberry Pi).

This is more secure than using `privileged: true` (like controller-manager) since the audio service only needs audio device access.

## Test Plan

- [x] Verified audio group GID on Raspberry Pi: `getent group audio` → `audio:x:29`
- [x] Added group_add configuration to docker-compose.yml
- [ ] Rebuild and restart audio service: `docker compose up -d --build audio`
- [ ] Verify no more ALSA errors in logs: `docker compose logs audio`
- [ ] Test audio playback during game

## Related

Audio works on master branch, this regression was introduced during microservices refactoring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)