### PR TITLE
feat(pairing): Add adapter load balancing to pairing daemon

### DIFF
--- a/scripts/pairing-daemon/psmove_pairing/adapter_manager.py
+++ b/scripts/pairing-daemon/psmove_pairing/adapter_manager.py
@@ -1,0 +1,104 @@
+"""Bluetooth adapter management for load-balanced pairing."""
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+
+from .utils import run_command
+
+logger = logging.getLogger("psmove-pairing")
+
+BLUETOOTH_DIR = Path("/var/lib/bluetooth")
+
+
+@dataclass
+class AdapterInfo:
+    """Information about a Bluetooth adapter."""
+
+    address: str
+    name: str
+    device_count: int
+
+
+class AdapterManager:
+    """Manages Bluetooth adapters and provides load-balanced selection."""
+
+    def __init__(self):
+        self._adapters: list[AdapterInfo] = []
+
+    async def refresh_adapters(self) -> list[AdapterInfo]:
+        """Refresh the list of available adapters and their device counts."""
+        self._adapters = []
+
+        # Get adapters from bluetoothctl
+        exit_code, output = await run_command(["bluetoothctl", "list"])
+        if exit_code != 0:
+            logger.error(f"Failed to list Bluetooth adapters: {output}")
+            return []
+
+        for line in output.strip().split("\n"):
+            if not line.strip():
+                continue
+            # Parse: "Controller AA:BB:CC:DD:EE:FF hostname [default]"
+            parts = line.split()
+            if len(parts) >= 2 and parts[0] == "Controller":
+                address = parts[1].upper()
+                name = parts[2] if len(parts) > 2 else address
+                device_count = self._count_devices_for_adapter(address)
+                self._adapters.append(AdapterInfo(address, name, device_count))
+                logger.debug(f"Adapter {address} ({name}): {device_count} devices")
+
+        return self._adapters
+
+    def _count_devices_for_adapter(self, adapter_address: str) -> int:
+        """Count the number of paired devices for an adapter."""
+        adapter_dir = BLUETOOTH_DIR / adapter_address
+        if not adapter_dir.exists():
+            return 0
+
+        count = 0
+        for entry in adapter_dir.iterdir():
+            # Device directories are named like "AA:BB:CC:DD:EE:FF" or "dev_AA_BB_CC_DD_EE_FF"
+            if entry.is_dir() and entry.name != "cache":
+                # Check if it looks like a MAC address (contains colons or underscores)
+                name = entry.name
+                if ":" in name or (name.startswith("dev_") and "_" in name):
+                    count += 1
+
+        return count
+
+    async def select_least_loaded_adapter(self) -> AdapterInfo | None:
+        """Select the adapter with the fewest paired devices.
+
+        Returns None if no adapters are available.
+        """
+        await self.refresh_adapters()
+
+        if not self._adapters:
+            logger.warning("No Bluetooth adapters found")
+            return None
+
+        # Sort by device count, then by address for deterministic ordering
+        sorted_adapters = sorted(
+            self._adapters, key=lambda a: (a.device_count, a.address)
+        )
+        selected = sorted_adapters[0]
+
+        logger.info(
+            f"Selected adapter {selected.address} ({selected.name}) "
+            f"with {selected.device_count} devices"
+        )
+
+        # Log all adapter loads for visibility
+        for adapter in sorted_adapters:
+            logger.debug(f"  {adapter.address}: {adapter.device_count} devices")
+
+        return selected
+
+    def get_adapter_by_address(self, address: str) -> AdapterInfo | None:
+        """Get adapter info by address."""
+        address_upper = address.upper()
+        for adapter in self._adapters:
+            if adapter.address == address_upper:
+                return adapter
+        return None

--- a/scripts/pairing-daemon/psmove_pairing/metrics.py
+++ b/scripts/pairing-daemon/psmove_pairing/metrics.py
@@ -15,6 +15,16 @@ pairing_failed_total = Counter(
     "psmove_pairing_failed_total",
     "Failed pairings",
 )
+pairing_adapter_selected_total = Counter(
+    "psmove_pairing_adapter_selected_total",
+    "Adapter selections for load-balanced pairing",
+    ["adapter"],
+)
+pairing_adapter_device_count = Gauge(
+    "psmove_pairing_adapter_device_count_at_selection",
+    "Device count on adapter when selected for pairing",
+    ["adapter"],
+)
 pairing_polls_total = Counter(
     "psmove_pairing_polls_total",
     "Total polling cycles",

--- a/scripts/pairing-daemon/psmove_pairing/usb_pairing.py
+++ b/scripts/pairing-daemon/psmove_pairing/usb_pairing.py
@@ -7,9 +7,12 @@ import time
 from opentelemetry import trace
 from opentelemetry.trace import Status, StatusCode
 
+from .adapter_manager import AdapterManager
 from .config import DEBUG, POLL_INTERVAL, PSMOVE_USB_IDS
 from .metrics import (
     calibration_duration_seconds,
+    pairing_adapter_device_count,
+    pairing_adapter_selected_total,
     pairing_attempts_total,
     pairing_duration_seconds,
     pairing_failed_total,
@@ -23,6 +26,7 @@ logger = logging.getLogger("psmove-pairing")
 
 # Span attribute constant (matches lib/telemetry.SpanAttr.CONTROLLER_SERIAL)
 _ATTR_CONTROLLER_SERIAL = "controller.serial"
+_ATTR_ADAPTER_ADDRESS = "adapter.address"
 
 
 class USBPairing:
@@ -32,6 +36,7 @@ class USBPairing:
         self.tracer = tracer
         self.psmove = psmove_path
         self.poll_count = 0
+        self.adapter_manager = AdapterManager()
 
     async def check_usb_controllers(self) -> bool:
         """Check if any PS Move controller is connected via USB."""
@@ -47,7 +52,9 @@ class USBPairing:
         if DEBUG:
             exit_code, output = await run_command([self.psmove, "list"])
         else:
-            exit_code, output = await run_command([self.psmove, "list"], capture_stderr=False)
+            exit_code, output = await run_command(
+                [self.psmove, "list"], capture_stderr=False
+            )
 
         if exit_code != 0:
             logger.debug(f"psmove list failed with exit code {exit_code}")
@@ -82,9 +89,15 @@ class USBPairing:
 
         # Check paired, trusted, and connected devices
         for device_type in ["Paired", "Trusted", "Connected"]:
-            exit_code, output = await run_command(["bluetoothctl", "devices", device_type])
-            if exit_code == 0 and (serial_upper in output.upper() or serial_nocolons in output.upper()):
-                logger.debug(f"Controller {serial_upper} found in {device_type} devices")
+            exit_code, output = await run_command(
+                ["bluetoothctl", "devices", device_type]
+            )
+            if exit_code == 0 and (
+                serial_upper in output.upper() or serial_nocolons in output.upper()
+            ):
+                logger.debug(
+                    f"Controller {serial_upper} found in {device_type} devices"
+                )
                 return True
 
         return False
@@ -96,17 +109,35 @@ class USBPairing:
             return False
 
         # Check if this controller shows Bluetooth mode (already paired)
-        return any(serial.upper() in line.upper() and "bluetooth" in line.lower() for line in output.split("\n"))
+        return any(
+            serial.upper() in line.upper() and "bluetooth" in line.lower()
+            for line in output.split("\n")
+        )
 
-    async def pair_controller(self, serial: str) -> bool:
-        """Pair a controller using psmove pair command."""
+    async def pair_controller(
+        self, serial: str, adapter_address: str | None = None
+    ) -> bool:
+        """Pair a controller using psmove pair command.
+
+        Args:
+            serial: Controller MAC address
+            adapter_address: Target Bluetooth adapter address for load balancing.
+                           If provided, sets PSMOVE_PREFER_BLUETOOTH_HOST_ADDRESS.
+        """
         logger.info(f"Pairing controller {serial}...")
 
         with self.tracer.start_as_current_span("pair_controller") as span:
             span.set_attribute(_ATTR_CONTROLLER_SERIAL, serial)
             start_time = time.time()
 
-            exit_code, output = await run_command([self.psmove, "pair"])
+            # Set adapter preference via environment variable if specified
+            env = None
+            if adapter_address:
+                env = {"PSMOVE_PREFER_BLUETOOTH_HOST_ADDRESS": adapter_address}
+                logger.info(f"Using adapter {adapter_address} for pairing")
+                span.set_attribute(_ATTR_ADAPTER_ADDRESS, adapter_address)
+
+            exit_code, output = await run_command([self.psmove, "pair"], env=env)
             duration = time.time() - start_time
             pairing_duration_seconds.observe(duration)
 
@@ -117,7 +148,14 @@ class USBPairing:
             span.set_attribute("pair.duration_seconds", duration)
 
             # Check for explicit failure indicators
-            failure_words = ["error", "failed", "cannot", "unable", "permission denied", "not found"]
+            failure_words = [
+                "error",
+                "failed",
+                "cannot",
+                "unable",
+                "permission denied",
+                "not found",
+            ]
             success_words = ["already", "set", "paired", "master"]
 
             pair_failed = False
@@ -138,14 +176,29 @@ class USBPairing:
             span.set_status(Status(StatusCode.OK))
             return True
 
-    async def trust_device(self, serial: str) -> bool:
-        """Trust the device in BlueZ."""
+    async def trust_device(
+        self, serial: str, adapter_address: str | None = None
+    ) -> bool:
+        """Trust the device in BlueZ.
+
+        Args:
+            serial: Controller MAC address
+            adapter_address: Target Bluetooth adapter address. If provided,
+                           uses bluetoothctl --adapter flag.
+        """
         logger.debug(f"Trusting device in BlueZ: {serial}")
 
         with self.tracer.start_as_current_span("trust_device") as span:
             span.set_attribute(_ATTR_CONTROLLER_SERIAL, serial)
 
-            exit_code, output = await run_command(["bluetoothctl", "trust", serial.upper()])
+            # Build command with optional adapter selection
+            cmd = ["bluetoothctl"]
+            if adapter_address:
+                cmd.extend(["--adapter", adapter_address])
+                span.set_attribute(_ATTR_ADAPTER_ADDRESS, adapter_address)
+            cmd.extend(["trust", serial.upper()])
+
+            exit_code, output = await run_command(cmd)
             span.set_attribute("trust.exit_code", exit_code)
 
             if exit_code != 0:
@@ -175,14 +228,16 @@ class USBPairing:
             # Calibration failure is not critical
             if exit_code != 0:
                 logger.warning(f"Calibration returned non-zero: {exit_code}")
-                span.set_status(Status(StatusCode.ERROR, "Calibration returned non-zero"))
+                span.set_status(
+                    Status(StatusCode.ERROR, "Calibration returned non-zero")
+                )
             else:
                 span.set_status(Status(StatusCode.OK))
 
             return exit_code == 0
 
     async def process_controller(self, serial: str) -> bool:
-        """Process a single USB-connected controller."""
+        """Process a single USB-connected controller with load-balanced adapter selection."""
         with self.tracer.start_as_current_span("process_controller") as span:
             span.set_attribute(_ATTR_CONTROLLER_SERIAL, serial)
 
@@ -195,7 +250,9 @@ class USBPairing:
 
             # Check if psmove thinks it's paired
             if await self.is_controller_already_paired_psmove(serial):
-                logger.info(f"Controller {serial} already paired (shows Bluetooth mode), skipping")
+                logger.info(
+                    f"Controller {serial} already paired (shows Bluetooth mode), skipping"
+                )
                 span.set_attribute("skipped", True)
                 span.set_attribute("skip_reason", "already_paired_psmove")
                 return False
@@ -204,20 +261,48 @@ class USBPairing:
             span.set_attribute("skipped", False)
             pairing_attempts_total.inc()
 
-            # Pair controller
-            if not await self.pair_controller(serial):
-                logger.error(f"Failed to pair {serial}")
+            # Select least-loaded adapter for load balancing
+            adapter = await self.adapter_manager.select_least_loaded_adapter()
+            adapter_address = adapter.address if adapter else None
+
+            if adapter:
+                logger.info(
+                    f"Load balancing: selected adapter {adapter.address} "
+                    f"({adapter.name}) with {adapter.device_count} existing devices"
+                )
+                span.set_attribute(_ATTR_ADAPTER_ADDRESS, adapter.address)
+                span.set_attribute("adapter.device_count", adapter.device_count)
+                # Record metrics for adapter selection
+                pairing_adapter_selected_total.labels(adapter=adapter.address).inc()
+                pairing_adapter_device_count.labels(adapter=adapter.address).set(
+                    adapter.device_count
+                )
+
+            # Pair controller to selected adapter
+            if not await self.pair_controller(serial, adapter_address):
+                logger.error(f"PAIRING FAILED: Controller {serial} could not be paired")
                 pairing_failed_total.inc()
                 span.set_status(Status(StatusCode.ERROR, "Pairing failed"))
                 return False
 
-            # Trust in BlueZ
-            await self.trust_device(serial)
+            # Trust in BlueZ on the same adapter
+            await self.trust_device(serial, adapter_address)
 
             # Calibrate
             await self.calibrate_controller(serial)
 
-            logger.info(f"Controller ready: {serial} - unplug USB and press PS button to connect")
+            # Success message with adapter info
+            if adapter:
+                logger.info(
+                    f"PAIRING SUCCESS: Controller {serial} paired to adapter "
+                    f"{adapter.address} ({adapter.name}) - unplug USB and press PS button"
+                )
+            else:
+                logger.info(
+                    f"PAIRING SUCCESS: Controller {serial} paired - "
+                    f"unplug USB and press PS button to connect"
+                )
+
             pairing_success_total.inc()
             span.set_status(Status(StatusCode.OK))
             return True

--- a/scripts/pairing-daemon/psmove_pairing/utils.py
+++ b/scripts/pairing-daemon/psmove_pairing/utils.py
@@ -37,15 +37,34 @@ def find_psmove_binary() -> str:
     sys.exit(1)
 
 
-async def run_command(cmd: list[str], capture_stderr: bool = True) -> tuple[int, str]:
-    """Run a subprocess command asynchronously and return exit code and output."""
+async def run_command(
+    cmd: list[str],
+    capture_stderr: bool = True,
+    env: dict[str, str] | None = None,
+) -> tuple[int, str]:
+    """Run a subprocess command asynchronously and return exit code and output.
+
+    Args:
+        cmd: Command and arguments to run
+        capture_stderr: Whether to capture stderr in output
+        env: Additional environment variables to set (merged with current env)
+    """
     try:
-        stderr = asyncio.subprocess.STDOUT if capture_stderr else asyncio.subprocess.DEVNULL
+        stderr = (
+            asyncio.subprocess.STDOUT if capture_stderr else asyncio.subprocess.DEVNULL
+        )
+
+        # Merge additional env vars with current environment
+        run_env = None
+        if env:
+            run_env = os.environ.copy()
+            run_env.update(env)
 
         proc = await asyncio.create_subprocess_exec(
             *cmd,
             stdout=asyncio.subprocess.PIPE,
             stderr=stderr,
+            env=run_env,
         )
         stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=60)
         output = stdout.decode("utf-8", errors="replace").strip()


### PR DESCRIPTION
## Summary

- Add `AdapterManager` class to track device counts per Bluetooth adapter
- Select least-loaded adapter for each new controller pairing
- Set `PSMOVE_PREFER_BLUETOOTH_HOST_ADDRESS` env var for `psmove pair`
- Use `bluetoothctl --adapter` flag for trust command
- Add metrics for adapter selection observability
- Improve logging with clear `PAIRING SUCCESS`/`PAIRING FAILED` messages

Fixes #306

## Background

When pairing PS Move controllers with multiple Bluetooth adapters, the psmoveapi's `psmove pair` command defaults to the first adapter unless `PSMOVE_PREFER_BLUETOOTH_HOST_ADDRESS` is set. This causes all controllers to be paired to a single adapter, exceeding its connection limit (~7 devices) while other adapters sit idle.

With 6 adapters and 30 controllers, this resulted in only ~14 controllers connecting because they were all trying to connect to the same overloaded adapter.

## Test plan

- [ ] Reset BlueZ database (`sudo rm -rf /var/lib/bluetooth/*`)
- [ ] Start pairing daemon (`sudo systemctl restart psmove-pairing`)
- [ ] Pair multiple controllers via USB
- [ ] Verify logs show different adapters being selected
- [ ] Verify controllers are distributed across adapters in `/var/lib/bluetooth/*/`
- [ ] Verify all controllers can connect via Bluetooth

🤖 Generated with [Claude Code](https://claude.com/claude-code)