### PR TITLE
fix(otel): Use JSON encoding for Grafana Live Publisher

### DIFF
--- a/services/otel-collector/config.yaml
+++ b/services/otel-collector/config.yaml
@@ -59,6 +59,7 @@ exporters:
   # OTLP HTTP exporter to Grafana Live Publisher for real-time WebSocket streaming
   otlphttp/grafana-live:
     endpoint: "http://grafana-live-publisher:4318"
+    encoding: json
     tls:
       insecure: true
 


### PR DESCRIPTION
## Summary

- Add `encoding: json` to the OTLP HTTP exporter for Grafana Live Publisher

## Problem

The OTLP HTTP exporter defaults to protobuf encoding, but the grafana-live-publisher service only parses JSON. This caused continuous "invalid character" errors in the logs.

## Test plan

- [ ] Restart otel-collector after merging
- [ ] Verify no more "Failed to parse OTLP" errors in grafana-live-publisher logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)