### PR TITLE
feat(dashboard): Add observability stack health monitoring

### DIFF
--- a/services/grafana/dashboards/service-health-overview.json
+++ b/services/grafana/dashboards/service-health-overview.json
@@ -41,7 +41,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "Number of healthy services",
+      "description": "Number of healthy application services",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -57,11 +57,11 @@
               },
               {
                 "color": "yellow",
-                "value": 5
+                "value": 3
               },
               {
                 "color": "green",
-                "value": 7
+                "value": 5
               }
             ]
           }
@@ -101,7 +101,7 @@
           "refId": "A"
         }
       ],
-      "title": "Services Up",
+      "title": "App Services Up",
       "type": "stat"
     },
     {
@@ -317,7 +317,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "Status of all JoustMania services",
+      "description": "Status of all JoustMania application services",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -395,7 +395,7 @@
           "refId": "A"
         }
       ],
-      "title": "Service Availability",
+      "title": "Application Services",
       "transformations": [
         {
           "id": "organize",
@@ -403,11 +403,183 @@
             "excludeByName": {
               "Time": true,
               "__name__": true,
-              "instance": true
+              "instance": true,
+              "service": true
             },
             "renameByName": {
               "Value": "Status",
               "job": "Service"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Number of healthy observability components",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 3
+              },
+              {
+                "color": "green",
+                "value": 5
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 4
+      },
+      "id": 11,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.2.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "count(up{job=~\"prometheus|grafana|loki|victoria-metrics|otel-collector|node\"} == 1)",
+          "legendFormat": "Observability",
+          "refId": "A"
+        }
+      ],
+      "title": "Observability Up",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Status of observability stack components",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "color-background"
+            },
+            "inspect": false
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "red",
+                  "index": 0,
+                  "text": "DOWN"
+                },
+                "1": {
+                  "color": "green",
+                  "index": 1,
+                  "text": "UP"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 20,
+        "x": 4,
+        "y": 4
+      },
+      "id": 12,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "10.2.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "up{job=~\"prometheus|grafana|loki|victoria-metrics|otel-collector|node\"}",
+          "format": "table",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Observability Stack",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true,
+              "collector": true,
+              "instance": true
+            },
+            "renameByName": {
+              "Value": "Status",
+              "job": "Component"
             }
           }
         }
@@ -479,7 +651,7 @@
         "h": 6,
         "w": 12,
         "x": 0,
-        "y": 4
+        "y": 8
       },
       "id": 6,
       "options": {
@@ -571,7 +743,7 @@
         "h": 6,
         "w": 12,
         "x": 12,
-        "y": 4
+        "y": 8
       },
       "id": 7,
       "options": {
@@ -663,7 +835,7 @@
         "h": 6,
         "w": 8,
         "x": 0,
-        "y": 10
+        "y": 14
       },
       "id": 8,
       "options": {
@@ -756,7 +928,7 @@
         "h": 6,
         "w": 8,
         "x": 8,
-        "y": 10
+        "y": 14
       },
       "id": 9,
       "options": {
@@ -848,7 +1020,7 @@
         "h": 6,
         "w": 8,
         "x": 16,
-        "y": 10
+        "y": 14
       },
       "id": 10,
       "options": {

--- a/services/prometheus/prometheus.yml
+++ b/services/prometheus/prometheus.yml
@@ -25,38 +25,62 @@ scrape_configs:
         regex: (.+)
         replacement: $1
 
-  # Menu Service (still uses prometheus_client pull)
+  # Controller Manager Service
+  - job_name: 'controller-manager'
+    static_configs:
+      - targets: ['controller-manager:8000']
+        labels:
+          service: 'controller-manager'
+
+  # Game Coordinator Service
+  - job_name: 'game-coordinator'
+    static_configs:
+      - targets: ['game-coordinator:8000']
+        labels:
+          service: 'game-coordinator'
+
+  # Menu Service
   - job_name: 'menu'
     static_configs:
       - targets: ['menu:8000']
         labels:
           service: 'menu'
 
-  # Settings Service (still uses prometheus_client pull)
+  # Settings Service
   - job_name: 'settings'
     static_configs:
       - targets: ['settings:8000']
         labels:
           service: 'settings'
 
-  # WebUI Service (still uses prometheus_client pull)
-  - job_name: 'webui'
-    static_configs:
-      - targets: ['webui:8000']
-        labels:
-          service: 'webui'
-
-  # Audio Service (still uses prometheus_client pull)
+  # Audio Service
   - job_name: 'audio'
     static_configs:
       - targets: ['audio:8000']
         labels:
           service: 'audio'
 
+  # --- Observability Stack ---
+
   # Prometheus itself
   - job_name: 'prometheus'
     static_configs:
       - targets: ['localhost:9090']
+
+  # Grafana
+  - job_name: 'grafana'
+    static_configs:
+      - targets: ['grafana:3000']
+
+  # Loki
+  - job_name: 'loki'
+    static_configs:
+      - targets: ['loki:3100']
+
+  # VictoriaMetrics
+  - job_name: 'victoria-metrics'
+    static_configs:
+      - targets: ['victoria-metrics:8428']
 
   # Node Exporter (host metrics - CPU, memory, disk, temperature)
   - job_name: 'node'


### PR DESCRIPTION
## Summary
- Add Prometheus scrape jobs for controller-manager and game-coordinator services
- Add scrape jobs for observability components: grafana, loki, victoria-metrics
- Remove stale webui scrape job (service no longer exists)
- Add new dashboard row showing observability stack health

## Changes

**Prometheus config (`services/prometheus/prometheus.yml`):**
- Added `controller-manager` job (port 8000)
- Added `game-coordinator` job (port 8000)
- Added `grafana` job (port 3000)
- Added `loki` job (port 3100)
- Added `victoria-metrics` job (port 8428)
- Removed `webui` job (service doesn't exist in docker-compose)

**Dashboard (`services/grafana/dashboards/service-health-overview.json`):**
- Renamed "Services Up" to "App Services Up" for clarity
- Added "Observability Up" stat showing healthy observability components
- Added "Observability Stack" table showing status of: prometheus, grafana, loki, victoria-metrics, otel-collector, node-exporter

## Test plan
- [ ] Deploy and verify all services appear in Prometheus targets (`/prometheus/targets`)
- [ ] Check service health dashboard shows both app services and observability stack
- [ ] Verify "Observability Up" stat shows correct count (6 components)

🤖 Generated with [Claude Code](https://claude.com/claude-code)