### PR TITLE
fix: Set all audio devices to max volume on startup

### DIFF
--- a/scripts/setup/joustmania-start.sh
+++ b/scripts/setup/joustmania-start.sh
@@ -81,6 +81,16 @@ fi
 echo "Cleaning up..."
 docker compose down --remove-orphans || true
 
+# Set all audio devices to max volume
+echo "Setting audio volume..."
+for card in /proc/asound/card[0-9]*; do
+  card_num=$(basename "$card" | sed 's/card//')
+  amixer -c "$card_num" scontrols 2>/dev/null | sed -e "s/^Simple mixer control //" | while read ctrl; do
+    amixer -c "$card_num" set "$ctrl" 100% unmute 2>/dev/null
+  done
+done
+echo "Audio volume configured"
+
 # Start services (this must succeed)
 echo "Starting JoustMania..."
 exec docker compose up -d

--- a/scripts/setup/setup_host.sh
+++ b/scripts/setup/setup_host.sh
@@ -85,9 +85,15 @@ echo "  → Syncing Python dependencies..."
 cd "$HOMEDIR/JoustMania"
 uv sync --python "$PYTHON" || exit 1
 
-# Configure audio
+# Configure audio - set all devices to max volume
 echo "[7/9] Configuring audio (ALSA)..."
-amixer sset PCM,0 100% 2>/dev/null || echo "  → Could not set PCM volume (may not be available)"
+for card in /proc/asound/card[0-9]*; do
+  card_num=$(basename "$card" | sed 's/card//')
+  amixer -c "$card_num" scontrols 2>/dev/null | sed -e "s/^Simple mixer control //" | while read ctrl; do
+    amixer -c "$card_num" set "$ctrl" 100% unmute 2>/dev/null
+  done
+done
+echo "  → Audio volume configured"
 sudo alsactl store 2>/dev/null || echo "  → Could not store ALSA state"
 
 # Configure Bluetooth

--- a/scripts/setup/setup_runtime.sh
+++ b/scripts/setup/setup_runtime.sh
@@ -187,10 +187,16 @@ else
     echo -e "  → ${RED}Pairing daemon script not found${NC}"
 fi
 
-# Configure audio (optional, best effort)
+# Configure audio - set all devices to max volume
 echo ""
 echo "Configuring audio..."
-amixer sset PCM,0 100% 2>/dev/null && echo -e "  → ${GREEN}Audio configured${NC}" || echo "  → Audio config skipped (may not be available)"
+for card in /proc/asound/card[0-9]*; do
+  card_num=$(basename "$card" | sed 's/card//')
+  amixer -c "$card_num" scontrols 2>/dev/null | sed -e "s/^Simple mixer control //" | while read ctrl; do
+    amixer -c "$card_num" set "$ctrl" 100% unmute 2>/dev/null
+  done
+done
+echo -e "  → ${GREEN}Audio volume configured${NC}"
 
 # Summary
 echo ""


### PR DESCRIPTION
## Summary

- Replace single `amixer sset PCM,0 100%` with a loop over all ALSA cards and mixer controls, setting each to 100% and unmuting
- Applied to `joustmania-start.sh` (every boot), `setup_host.sh` (initial setup), and `setup_runtime.sh` (runtime setup)
- Handles missing audio hardware gracefully via `2>/dev/null`

Fixes #283

## Test plan

- [ ] Run `joustmania-start.sh` on a Pi with USB audio adapter — verify all controls show 100% (`amixer contents`)
- [ ] Run on a machine with no audio device — script completes without errors
- [ ] Run `setup_host.sh` and `setup_runtime.sh` — audio section completes successfully
- [ ] Verify `amixer` output after startup shows all controls at max

🤖 Generated with [Claude Code](https://claude.com/claude-code)