### PR TITLE
feat(pairing-daemon): Add test infrastructure and health checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,7 +164,7 @@ jobs:
   sonarcloud:
     name: SonarCloud Analysis
     runs-on: ubuntu-latest
-    needs: [service-checks, lib-tests]
+    needs: [service-checks, lib-tests, pairing-daemon-checks]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -203,6 +203,66 @@ jobs:
         with:
           args: >
             -Dsonar.python.coverage.reportPaths=${{ env.SONAR_COVERAGE_PATHS }}
+
+  # Pairing daemon tests (host service, not in Docker)
+  pairing-daemon-checks:
+    name: Pairing Daemon Checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            pairing:
+              - 'scripts/pairing-daemon/**'
+
+      - name: Install uv
+        if: steps.changes.outputs.pairing == 'true'
+        uses: astral-sh/setup-uv@v5
+
+      - name: Install system dependencies
+        if: steps.changes.outputs.pairing == 'true'
+        run: |
+          sudo apt-get update
+          # dbus-python needs libdbus-1-dev
+          sudo apt-get install -y libdbus-1-dev libglib2.0-dev pkg-config
+
+      - name: Lint
+        if: steps.changes.outputs.pairing == 'true'
+        run: |
+          uv tool install ruff
+          cd scripts/pairing-daemon
+          ruff check .
+
+      # Always run tests with coverage for SonarCloud (no path filter)
+      - name: Install uv for tests
+        uses: astral-sh/setup-uv@v5
+
+      - name: Install system dependencies for tests
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libdbus-1-dev libglib2.0-dev pkg-config
+
+      - name: Unit tests with coverage
+        run: |
+          cd scripts/pairing-daemon
+          uv sync --extra test
+          uv run pytest tests/ -v --tb=short \
+            --cov=psmove_pairing \
+            --cov-report=xml:coverage.xml \
+            --cov-report=term-missing
+          # Fix paths in coverage.xml for SonarCloud
+          sed -i 's|<source>.*</source>|<source>.</source>|g' coverage.xml
+          sed -i 's|filename="|filename="scripts/pairing-daemon/|g' coverage.xml
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-pairing-daemon
+          path: scripts/pairing-daemon/coverage.xml
+          retention-days: 1
 
   validate-protos:
     name: Validate Proto Files
@@ -485,6 +545,7 @@ jobs:
     needs:
       - lib-tests
       - service-checks
+      - pairing-daemon-checks
       - lint-dockerfiles
       - sonarcloud
       - validate-protos
@@ -506,6 +567,7 @@ jobs:
             echo "Job results:"
             echo "  lib-tests: ${{ needs.lib-tests.result }}"
             echo "  service-checks: ${{ needs.service-checks.result }}"
+            echo "  pairing-daemon-checks: ${{ needs.pairing-daemon-checks.result }}"
             echo "  lint-dockerfiles: ${{ needs.lint-dockerfiles.result }}"
             echo "  sonarcloud: ${{ needs.sonarcloud.result }}"
             echo "  validate-protos: ${{ needs.validate-protos.result }}"

--- a/scripts/pairing-daemon/psmove-pairing.service
+++ b/scripts/pairing-daemon/psmove-pairing.service
@@ -10,6 +10,10 @@ ExecStart=/opt/joustmania/scripts/pairing-daemon/venv/bin/python /opt/joustmania
 Restart=always
 RestartSec=10
 
+# Health check - verify daemon is responsive after startup
+# Waits 5s for startup, then checks /healthz endpoint
+ExecStartPost=/bin/sh -c 'sleep 5 && curl -sf http://localhost:8002/healthz || exit 1'
+
 # Environment
 Environment=POLL_INTERVAL=10
 Environment=DEBUG=0

--- a/scripts/pairing-daemon/psmove_pairing/adapter_manager.py
+++ b/scripts/pairing-daemon/psmove_pairing/adapter_manager.py
@@ -78,10 +78,7 @@ def get_hci_dict() -> dict[str, str]:
         try:
             proxy2 = _get_adapter_proxy(hci)
             interfaces = _get_node_interfaces(proxy2)
-            if (
-                "org.freedesktop.DBus.Properties" not in interfaces
-                or "org.bluez.Adapter1" not in interfaces
-            ):
+            if "org.freedesktop.DBus.Properties" not in interfaces or "org.bluez.Adapter1" not in interfaces:
                 continue
             addr = _get_adapter_attrib(proxy2, "Address")
             hci_dict[hci] = str(addr)
@@ -171,10 +168,7 @@ class AdapterManager:
         # Return first adapter with that count (deterministic ordering)
         for addr in sorted(self._bt_devices.keys()):
             if len(self._bt_devices[addr]) == min_count:
-                logger.info(
-                    f"Selected adapter {addr} with {min_count} devices "
-                    f"(of {len(self._bt_devices)} adapters)"
-                )
+                logger.info(f"Selected adapter {addr} with {min_count} devices (of {len(self._bt_devices)} adapters)")
                 return addr
 
         return ""
@@ -226,7 +220,4 @@ class AdapterManager:
             True if the controller is NOT paired to any adapter
         """
         controller_upper = controller_addr.upper()
-        for devices in self._bt_devices.values():
-            if controller_upper in [d.upper() for d in devices]:
-                return False
-        return True
+        return all(controller_upper not in [d.upper() for d in devices] for devices in self._bt_devices.values())

--- a/scripts/pairing-daemon/psmove_pairing/config.py
+++ b/scripts/pairing-daemon/psmove_pairing/config.py
@@ -34,9 +34,8 @@ def _find_psmove_bindings() -> str | None:
 
     # Check environment variable first
     env_path = os.getenv("PSMOVEAPI_BUILD_PATH")
-    if env_path and os.path.isdir(env_path):
-        if os.path.exists(os.path.join(env_path, "psmove.py")):
-            return env_path
+    if env_path and os.path.isdir(env_path) and os.path.exists(os.path.join(env_path, "psmove.py")):
+        return env_path
 
     # Common installation locations
     home = os.path.expanduser("~")

--- a/scripts/pairing-daemon/psmove_pairing/daemon.py
+++ b/scripts/pairing-daemon/psmove_pairing/daemon.py
@@ -2,6 +2,8 @@
 
 import asyncio
 import logging
+import shutil
+import time
 
 from opentelemetry import trace
 
@@ -12,6 +14,9 @@ from .utils import run_command
 
 logger = logging.getLogger("psmove-pairing")
 
+# Health check thresholds
+_HEALTH_STALENESS_THRESHOLD = 60.0  # seconds
+
 
 class PairingDaemon:
     """PS Move controller pairing daemon with async Bluetooth monitoring."""
@@ -21,7 +26,114 @@ class PairingDaemon:
         self.psmove = psmove_path
         self.usb_pairing = USBPairing(tracer, psmove_path)
         self.bt_monitor = BluetoothMonitor(tracer)
+
+        # Health tracking timestamps
+        self._last_usb_poll: float = 0.0
+        self._last_bt_monitor: float = 0.0
+        self._startup_time: float = time.time()
+
         logger.info(f"PairingDaemon initialized with psmove: {self.psmove}")
+
+    async def validate_prerequisites(self) -> bool:
+        """Validate that required tools are available.
+
+        Returns True if all prerequisites are met, False otherwise.
+        """
+        errors = []
+
+        # Check psmove binary
+        exit_code, output = await run_command([self.psmove, "list"])
+        if exit_code != 0:
+            errors.append(f"psmove binary failed: {output}")
+
+        # Check bluetoothctl
+        if not shutil.which("bluetoothctl"):
+            errors.append("bluetoothctl not found")
+        else:
+            exit_code, output = await run_command(["bluetoothctl", "show"])
+            if exit_code != 0:
+                errors.append(f"bluetoothctl failed: {output}")
+
+        # Check hciconfig (for Bluetooth monitoring)
+        if not shutil.which("hciconfig"):
+            errors.append("hciconfig not found")
+
+        # Check hcitool (for RSSI monitoring)
+        if not shutil.which("hcitool"):
+            errors.append("hcitool not found")
+
+        if errors:
+            for error in errors:
+                logger.error(f"Prerequisite check failed: {error}")
+            return False
+
+        logger.info("All prerequisites validated successfully")
+        return True
+
+    def is_healthy(self) -> bool:
+        """Check if daemon is healthy (loops running within threshold).
+
+        Returns True if both USB poll and Bluetooth monitor have run recently.
+        """
+        now = time.time()
+
+        # During startup, allow grace period
+        if now - self._startup_time < _HEALTH_STALENESS_THRESHOLD:
+            return True
+
+        # Check USB poll staleness
+        usb_stale = (now - self._last_usb_poll) > _HEALTH_STALENESS_THRESHOLD
+        # Check BT monitor staleness
+        bt_stale = (now - self._last_bt_monitor) > _HEALTH_STALENESS_THRESHOLD
+
+        if usb_stale:
+            logger.warning(f"USB poll loop stale: {now - self._last_usb_poll:.1f}s since last poll")
+        if bt_stale:
+            logger.warning(f"BT monitor loop stale: {now - self._last_bt_monitor:.1f}s since last monitor")
+
+        return not (usb_stale or bt_stale)
+
+    def get_health_status(self) -> dict:
+        """Get detailed health status for /healthz endpoint."""
+        now = time.time()
+        return {
+            "healthy": self.is_healthy(),
+            "uptime_seconds": now - self._startup_time,
+            "last_usb_poll_seconds_ago": now - self._last_usb_poll if self._last_usb_poll else None,
+            "last_bt_monitor_seconds_ago": now - self._last_bt_monitor if self._last_bt_monitor else None,
+            "usb_poll_count": self.usb_pairing.poll_count,
+            "bt_monitor_count": self.bt_monitor.monitor_count,
+        }
+
+    def update_usb_poll_timestamp(self) -> None:
+        """Update the last USB poll timestamp."""
+        self._last_usb_poll = time.time()
+
+    def update_bt_monitor_timestamp(self) -> None:
+        """Update the last Bluetooth monitor timestamp."""
+        self._last_bt_monitor = time.time()
+
+    async def _usb_poll_loop(self) -> None:
+        """USB polling loop with health tracking."""
+        logger.info(f"Starting USB poll loop (interval: {POLL_INTERVAL}s)")
+        while True:
+            try:
+                await self.usb_pairing.poll()
+                self.update_usb_poll_timestamp()
+            except Exception as e:
+                logger.error(f"Error during USB poll: {e}", exc_info=DEBUG)
+            await asyncio.sleep(POLL_INTERVAL)
+
+    async def _bt_monitor_loop(self) -> None:
+        """Bluetooth monitoring loop with health tracking."""
+        logger.info(f"Starting Bluetooth monitor loop (interval: {BT_MONITOR_INTERVAL}s)")
+        while True:
+            try:
+                await self.bt_monitor.monitor()
+                self.update_bt_monitor_timestamp()
+            except Exception as e:
+                logger.error(f"Error during Bluetooth monitor: {e}", exc_info=DEBUG)
+            await asyncio.sleep(BT_MONITOR_INTERVAL)
 
     async def run(self) -> None:
         """Main daemon loop with concurrent USB polling and Bluetooth monitoring."""
@@ -32,13 +144,12 @@ class PairingDaemon:
         logger.info(f"  debug mode: {DEBUG}")
         logger.info(f"  metrics port: {METRICS_PORT}")
 
-        # Verify psmove works
-        exit_code, _ = await run_command([self.psmove, "list"])
-        if exit_code != 0:
-            logger.warning("'psmove list' failed - check permissions/udev rules")
+        # Validate prerequisites
+        if not await self.validate_prerequisites():
+            logger.warning("Some prerequisites failed - daemon may not work correctly")
 
         # Run both loops concurrently
         await asyncio.gather(
-            self.usb_pairing.run_loop(),
-            self.bt_monitor.run_loop(),
+            self._usb_poll_loop(),
+            self._bt_monitor_loop(),
         )

--- a/scripts/pairing-daemon/psmove_pairing/usb_pairing.py
+++ b/scripts/pairing-daemon/psmove_pairing/usb_pairing.py
@@ -90,9 +90,7 @@ class USBPairing:
         pairing_usb_controllers.set(len(usb_controllers))
         return usb_controllers
 
-    def pair_controller_psmove(
-        self, move_index: int, serial: str, adapter_address: str
-    ) -> bool:
+    def pair_controller_psmove(self, move_index: int, serial: str, adapter_address: str) -> bool:
         """Pair a controller using psmove Python library's pair_custom().
 
         This directly specifies the target adapter, matching the original
@@ -132,10 +130,9 @@ class USBPairing:
                     logger.info(f"pair_custom() succeeded for {serial}")
                     span.set_status(Status(StatusCode.OK))
                     return True
-                else:
-                    logger.error(f"pair_custom() returned False for {serial}")
-                    span.set_status(Status(StatusCode.ERROR, "pair_custom failed"))
-                    return False
+                logger.error(f"pair_custom() returned False for {serial}")
+                span.set_status(Status(StatusCode.ERROR, "pair_custom failed"))
+                return False
 
             except Exception as e:
                 duration = time.time() - start_time
@@ -162,9 +159,7 @@ class USBPairing:
 
             if exit_code != 0:
                 logger.warning(f"Calibration returned non-zero: {exit_code}")
-                span.set_status(
-                    Status(StatusCode.ERROR, "Calibration returned non-zero")
-                )
+                span.set_status(Status(StatusCode.ERROR, "Calibration returned non-zero"))
             else:
                 span.set_status(Status(StatusCode.OK))
 
@@ -177,9 +172,7 @@ class USBPairing:
         BlueZ recognizes the newly paired controller.
         """
         logger.info("Restarting Bluetooth service...")
-        exit_code, output = await run_command(
-            ["sudo", "systemctl", "restart", "bluetooth"]
-        )
+        exit_code, output = await run_command(["sudo", "systemctl", "restart", "bluetooth"])
         if exit_code != 0:
             logger.warning(f"Failed to restart bluetooth: {output}")
         else:
@@ -227,9 +220,7 @@ class USBPairing:
                 span.set_attribute("adapter.hci", adapter.hci)
                 # Record metrics
                 pairing_adapter_selected_total.labels(adapter=adapter.address).inc()
-                pairing_adapter_device_count.labels(adapter=adapter.address).set(
-                    adapter.device_count
-                )
+                pairing_adapter_device_count.labels(adapter=adapter.address).set(adapter.device_count)
 
             # Pair controller to selected adapter using Python bindings
             if not self.pair_controller_psmove(move_index, serial, adapter_address):

--- a/scripts/pairing-daemon/psmove_pairing/utils.py
+++ b/scripts/pairing-daemon/psmove_pairing/utils.py
@@ -50,9 +50,7 @@ async def run_command(
         env: Additional environment variables to set (merged with current env)
     """
     try:
-        stderr = (
-            asyncio.subprocess.STDOUT if capture_stderr else asyncio.subprocess.DEVNULL
-        )
+        stderr = asyncio.subprocess.STDOUT if capture_stderr else asyncio.subprocess.DEVNULL
 
         # Merge additional env vars with current environment
         run_env = None

--- a/scripts/pairing-daemon/psmove_pairing_daemon.py
+++ b/scripts/pairing-daemon/psmove_pairing_daemon.py
@@ -20,14 +20,23 @@ Environment:
   DEBUG         - set to 1 for verbose logging
   METRICS_PORT  - port for Prometheus metrics (default: 8002)
   OTEL_EXPORTER_OTLP_ENDPOINT - OTLP collector endpoint (default: http://localhost:4317)
+
+Endpoints:
+  GET /metrics  - Prometheus metrics
+  GET /healthz  - Health check (200 if healthy, 503 if unhealthy)
 """
 
 import asyncio
+import json
 import logging
 
-from prometheus_client import start_http_server
+from prometheus_client import REGISTRY, MetricsHandler
+
 from psmove_pairing import PairingDaemon, find_psmove_binary, init_telemetry
 from psmove_pairing.config import DEBUG, METRICS_PORT
+
+# Global daemon reference for health checks
+_daemon: PairingDaemon | None = None
 
 # Logging setup
 logging.basicConfig(
@@ -38,11 +47,63 @@ logging.basicConfig(
 logger = logging.getLogger("psmove-pairing")
 
 
+class HealthHandler(MetricsHandler):
+    """HTTP handler that adds /healthz endpoint to prometheus metrics."""
+
+    def do_GET(self):
+        """Handle GET requests."""
+        if self.path == "/healthz" or self.path == "/healthz/":
+            self._handle_healthz()
+        elif self.path == "/health" or self.path == "/health/":
+            # Alias for /healthz
+            self._handle_healthz()
+        else:
+            # Delegate to prometheus metrics handler
+            super().do_GET()
+
+    def _handle_healthz(self):
+        """Handle health check request."""
+        global _daemon
+
+        if _daemon is None:
+            self.send_response(503)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps({"healthy": False, "error": "daemon not started"}).encode())
+            return
+
+        status = _daemon.get_health_status()
+        if status["healthy"]:
+            self.send_response(200)
+        else:
+            self.send_response(503)
+
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps(status).encode())
+
+
+def start_http_server_with_health(port: int) -> None:
+    """Start HTTP server with both metrics and health endpoints."""
+    from http.server import HTTPServer
+    from threading import Thread
+
+    def handler(*args, **kwargs):
+        return HealthHandler(*args, registry=REGISTRY, **kwargs)
+
+    server = HTTPServer(("", port), handler)
+    thread = Thread(target=server.serve_forever)
+    thread.daemon = True
+    thread.start()
+
+
 def main() -> None:
     """Entry point."""
-    # Start Prometheus metrics server
-    logger.info(f"Starting metrics server on port {METRICS_PORT}")
-    start_http_server(METRICS_PORT)
+    global _daemon
+
+    # Start HTTP server with metrics and health endpoints
+    logger.info(f"Starting HTTP server on port {METRICS_PORT} (metrics + healthz)")
+    start_http_server_with_health(METRICS_PORT)
 
     # Initialize OpenTelemetry
     tracer = init_telemetry()
@@ -51,8 +112,8 @@ def main() -> None:
     psmove_path = find_psmove_binary()
 
     # Create and run daemon
-    daemon = PairingDaemon(tracer, psmove_path)
-    asyncio.run(daemon.run())
+    _daemon = PairingDaemon(tracer, psmove_path)
+    asyncio.run(_daemon.run())
 
 
 if __name__ == "__main__":

--- a/scripts/pairing-daemon/pyproject.toml
+++ b/scripts/pairing-daemon/pyproject.toml
@@ -1,0 +1,71 @@
+[project]
+name = "psmove-pairing"
+version = "1.0.0"
+description = "PS Move controller pairing daemon for JoustMania"
+requires-python = ">=3.9,<3.13"
+dependencies = [
+    # Prometheus metrics (pull model)
+    "prometheus-client>=0.17.0",
+
+    # OpenTelemetry tracing
+    "opentelemetry-api>=1.20.0",
+    "opentelemetry-sdk>=1.20.0",
+    "opentelemetry-exporter-otlp-proto-grpc>=1.20.0",
+
+    # DBus for BlueZ adapter management
+    "dbus-python>=1.2.0; sys_platform == 'linux'",
+
+    # NOTE: psmove/psmoveapi must be built from source (not on PyPI)
+    # See: https://github.com/thp/psmoveapi for build instructions
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest>=8.0.0",
+    "pytest-asyncio>=0.23.0",
+    "pytest-cov>=4.1.0",
+]
+
+[project.scripts]
+psmove-pairing = "psmove_pairing_daemon:main"
+
+[build-system]
+requires = ["setuptools>=45", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+py-modules = ["psmove_pairing_daemon"]
+packages = ["psmove_pairing"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
+testpaths = ["tests"]
+
+# ruff - Linting configuration
+[tool.ruff]
+line-length = 120
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "N", "UP", "ASYNC", "B", "C4", "RET", "SIM", "ARG"]
+ignore = ["ANN"]
+
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = ["F401"]  # Unused imports OK in __init__
+"psmove_pairing_daemon.py" = ["N802"]  # HTTP handler do_GET is from parent class
+"tests/*.py" = ["ARG001", "ARG002", "E402", "SIM105", "SIM117", "F841"]  # Test fixtures, test patterns
+
+[tool.ruff.lint.isort]
+known-first-party = ["psmove_pairing"]
+
+[tool.coverage.run]
+source = ["psmove_pairing"]
+branch = true
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "if __name__ == .__main__.:",
+    "raise NotImplementedError",
+]

--- a/scripts/pairing-daemon/tests/__init__.py
+++ b/scripts/pairing-daemon/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for PS Move pairing daemon."""

--- a/scripts/pairing-daemon/tests/conftest.py
+++ b/scripts/pairing-daemon/tests/conftest.py
@@ -1,0 +1,163 @@
+"""
+Pytest fixtures for pairing daemon tests.
+
+Mocks psmove module, DBus, and provides test utilities.
+"""
+
+import os
+import sys
+
+# Disable OTEL before importing modules that use it
+os.environ["OTEL_SDK_DISABLED"] = "true"
+os.environ["OTEL_TRACES_EXPORTER"] = "none"
+os.environ["OTEL_METRICS_EXPORTER"] = "none"
+
+# Mock psmove module before it gets imported
+from unittest.mock import MagicMock
+
+mock_psmove = MagicMock()
+mock_psmove.Conn_USB = 1
+mock_psmove.Conn_Bluetooth = 2
+mock_psmove.count_connected.return_value = 0
+sys.modules["psmove"] = mock_psmove
+
+# Mock dbus module for AdapterManager
+mock_dbus = MagicMock()
+mock_dbus.SystemBus.return_value = MagicMock()
+sys.modules["dbus"] = mock_dbus
+sys.modules["dbus.exceptions"] = MagicMock()
+
+import pytest
+
+
+class MockCommandRunner:
+    """Mock for run_command() that returns predefined outputs.
+
+    Usage:
+        runner = MockCommandRunner()
+        runner.add_response(["lsusb"], (0, "Bus 001 Device 003: ID 054c:03d5 Sony Corp."))
+
+        with patch("psmove_pairing.usb_pairing.run_command", runner):
+            result = await check_usb_controllers()
+    """
+
+    def __init__(self):
+        self.responses: dict[tuple[str, ...], tuple[int, str]] = {}
+        self.default_response: tuple[int, str] = (0, "")
+        self.calls: list[list[str]] = []
+
+    def add_response(self, cmd: list[str], response: tuple[int, str]) -> None:
+        """Add a response for a specific command."""
+        self.responses[tuple(cmd)] = response
+
+    def add_prefix_response(self, cmd_prefix: list[str], response: tuple[int, str]) -> None:
+        """Add a response that matches commands starting with the given prefix."""
+        key = ("__PREFIX__", *cmd_prefix)
+        self.responses[key] = response
+
+    async def __call__(self, cmd: list[str], capture_stderr: bool = True, **kwargs) -> tuple[int, str]:
+        """Return mocked response for command."""
+        self.calls.append(cmd)
+
+        # Exact match
+        key = tuple(cmd)
+        if key in self.responses:
+            return self.responses[key]
+
+        # Prefix match
+        for resp_key, response in self.responses.items():
+            if resp_key and resp_key[0] == "__PREFIX__":
+                prefix = resp_key[1:]
+                if tuple(cmd[: len(prefix)]) == prefix:
+                    return response
+
+        return self.default_response
+
+
+@pytest.fixture
+def mock_runner():
+    """Provide a MockCommandRunner for tests."""
+    return MockCommandRunner()
+
+
+@pytest.fixture
+def mock_tracer():
+    """Provide a mock OpenTelemetry tracer."""
+    tracer = MagicMock()
+    span = MagicMock()
+    span.__enter__ = MagicMock(return_value=span)
+    span.__exit__ = MagicMock(return_value=False)
+    tracer.start_as_current_span.return_value = span
+    return tracer
+
+
+@pytest.fixture
+def mock_psmove_module():
+    """Provide a configurable mock psmove module."""
+    return mock_psmove
+
+
+# Sample command outputs for testing
+SAMPLE_LSUSB_NO_PSMOVE = """\
+Bus 001 Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub
+Bus 002 Device 001: ID 1d6b:0003 Linux Foundation 3.0 root hub
+"""
+
+SAMPLE_LSUSB_WITH_PSMOVE = """\
+Bus 001 Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub
+Bus 001 Device 003: ID 054c:03d5 Sony Corp. Motion Controller
+Bus 002 Device 001: ID 1d6b:0003 Linux Foundation 3.0 root hub
+"""
+
+SAMPLE_HCICONFIG = """\
+hci0:   Type: Primary  Bus: USB
+        BD Address: DC:A6:32:AA:BB:CC  ACL MTU: 1021:8  SCO MTU: 64:1
+        UP RUNNING PSCAN ISCAN
+        RX bytes:123456 acl:7890 sco:0 events:1234 errors:0
+        TX bytes:123456 acl:7890 sco:0 commands:567 errors:0
+
+hci1:   Type: Primary  Bus: USB
+        BD Address: 00:1A:7D:DD:EE:FF  ACL MTU: 310:10  SCO MTU: 64:8
+        UP RUNNING PSCAN ISCAN
+        RX bytes:654321 acl:8901 sco:0 events:2345 errors:0
+        TX bytes:654321 acl:8901 sco:0 commands:678 errors:0
+"""
+
+SAMPLE_HCITOOL_CON = """\
+Connections:
+        < ACL 00:06:F7:AA:BB:CC handle 256 state 1 lm MASTER
+        < ACL 00:06:F7:DD:EE:FF handle 257 state 1 lm MASTER
+"""
+
+SAMPLE_HCITOOL_CON_EMPTY = """\
+Connections:
+"""
+
+SAMPLE_HCITOOL_RSSI = """\
+RSSI return value: -45
+"""
+
+
+@pytest.fixture
+def sample_lsusb_no_psmove():
+    return SAMPLE_LSUSB_NO_PSMOVE
+
+
+@pytest.fixture
+def sample_lsusb_with_psmove():
+    return SAMPLE_LSUSB_WITH_PSMOVE
+
+
+@pytest.fixture
+def sample_hciconfig():
+    return SAMPLE_HCICONFIG
+
+
+@pytest.fixture
+def sample_hcitool_con():
+    return SAMPLE_HCITOOL_CON
+
+
+@pytest.fixture
+def sample_hcitool_rssi():
+    return SAMPLE_HCITOOL_RSSI

--- a/scripts/pairing-daemon/tests/test_bluetooth_monitor.py
+++ b/scripts/pairing-daemon/tests/test_bluetooth_monitor.py
@@ -1,0 +1,188 @@
+"""Tests for psmove_pairing.bluetooth_monitor module."""
+
+from unittest.mock import patch
+
+import pytest
+
+from psmove_pairing.bluetooth_monitor import BluetoothMonitor
+
+from .conftest import (
+    SAMPLE_HCICONFIG,
+    SAMPLE_HCITOOL_CON,
+    SAMPLE_HCITOOL_CON_EMPTY,
+    SAMPLE_HCITOOL_RSSI,
+    MockCommandRunner,
+)
+
+
+@pytest.fixture
+def bt_monitor(mock_tracer):
+    """Provide BluetoothMonitor instance for tests."""
+    return BluetoothMonitor(mock_tracer)
+
+
+class TestGetBluetoothAdapters:
+    """Tests for get_bluetooth_adapters()."""
+
+    @pytest.mark.asyncio
+    async def test_parses_multiple_adapters(self, bt_monitor):
+        """Test parsing multiple HCI adapters."""
+        runner = MockCommandRunner()
+        runner.add_response(["hciconfig", "-a"], (0, SAMPLE_HCICONFIG))
+
+        with patch("psmove_pairing.bluetooth_monitor.run_command", runner):
+            adapters = await bt_monitor.get_bluetooth_adapters()
+            assert len(adapters) == 2
+            assert "hci0" in adapters
+            assert "hci1" in adapters
+
+    @pytest.mark.asyncio
+    async def test_single_adapter(self, bt_monitor):
+        """Test parsing single HCI adapter."""
+        single_adapter = """\
+hci0:   Type: Primary  Bus: USB
+        BD Address: DC:A6:32:AA:BB:CC  ACL MTU: 1021:8  SCO MTU: 64:1
+        UP RUNNING PSCAN ISCAN
+"""
+        runner = MockCommandRunner()
+        runner.add_response(["hciconfig", "-a"], (0, single_adapter))
+
+        with patch("psmove_pairing.bluetooth_monitor.run_command", runner):
+            adapters = await bt_monitor.get_bluetooth_adapters()
+            assert adapters == ["hci0"]
+
+    @pytest.mark.asyncio
+    async def test_no_adapters(self, bt_monitor):
+        """Test when no adapters are available."""
+        runner = MockCommandRunner()
+        runner.add_response(["hciconfig", "-a"], (0, ""))
+
+        with patch("psmove_pairing.bluetooth_monitor.run_command", runner):
+            adapters = await bt_monitor.get_bluetooth_adapters()
+            assert adapters == []
+
+    @pytest.mark.asyncio
+    async def test_hciconfig_failure(self, bt_monitor):
+        """Test handling hciconfig command failure."""
+        runner = MockCommandRunner()
+        runner.add_response(["hciconfig", "-a"], (1, "command not found"))
+
+        with patch("psmove_pairing.bluetooth_monitor.run_command", runner):
+            adapters = await bt_monitor.get_bluetooth_adapters()
+            assert adapters == []
+
+
+class TestGetAdapterConnections:
+    """Tests for get_adapter_connections()."""
+
+    @pytest.mark.asyncio
+    async def test_parses_connections(self, bt_monitor):
+        """Test parsing connected devices from hcitool."""
+        runner = MockCommandRunner()
+        runner.add_response(["hcitool", "-i", "hci0", "con"], (0, SAMPLE_HCITOOL_CON))
+
+        with patch("psmove_pairing.bluetooth_monitor.run_command", runner):
+            connections = await bt_monitor.get_adapter_connections("hci0")
+            assert len(connections) == 2
+            assert "00:06:f7:aa:bb:cc" in connections
+            assert "00:06:f7:dd:ee:ff" in connections
+
+    @pytest.mark.asyncio
+    async def test_no_connections(self, bt_monitor):
+        """Test when no devices are connected."""
+        runner = MockCommandRunner()
+        runner.add_response(["hcitool", "-i", "hci0", "con"], (0, SAMPLE_HCITOOL_CON_EMPTY))
+
+        with patch("psmove_pairing.bluetooth_monitor.run_command", runner):
+            connections = await bt_monitor.get_adapter_connections("hci0")
+            assert connections == []
+
+    @pytest.mark.asyncio
+    async def test_hcitool_failure(self, bt_monitor):
+        """Test handling hcitool command failure."""
+        runner = MockCommandRunner()
+        runner.add_response(["hcitool", "-i", "hci0", "con"], (1, "error"))
+
+        with patch("psmove_pairing.bluetooth_monitor.run_command", runner):
+            connections = await bt_monitor.get_adapter_connections("hci0")
+            assert connections == []
+
+    @pytest.mark.asyncio
+    async def test_lowercase_mac_addresses(self, bt_monitor):
+        """Test that MAC addresses are returned in lowercase."""
+        uppercase_output = """\
+Connections:
+        < ACL 00:06:F7:AA:BB:CC handle 256 state 1 lm MASTER
+"""
+        runner = MockCommandRunner()
+        runner.add_response(["hcitool", "-i", "hci0", "con"], (0, uppercase_output))
+
+        with patch("psmove_pairing.bluetooth_monitor.run_command", runner):
+            connections = await bt_monitor.get_adapter_connections("hci0")
+            assert connections[0] == "00:06:f7:aa:bb:cc"
+
+
+class TestGetRSSI:
+    """Tests for get_rssi()."""
+
+    @pytest.mark.asyncio
+    async def test_parses_rssi(self, bt_monitor):
+        """Test parsing RSSI value."""
+        runner = MockCommandRunner()
+        runner.add_response(["hcitool", "-i", "hci0", "rssi", "00:06:f7:aa:bb:cc"], (0, SAMPLE_HCITOOL_RSSI))
+
+        with patch("psmove_pairing.bluetooth_monitor.run_command", runner):
+            rssi = await bt_monitor.get_rssi("hci0", "00:06:f7:aa:bb:cc")
+            assert rssi == -45
+
+    @pytest.mark.asyncio
+    async def test_negative_rssi(self, bt_monitor):
+        """Test parsing negative RSSI value."""
+        runner = MockCommandRunner()
+        runner.add_response(["hcitool", "-i", "hci0", "rssi", "00:06:f7:aa:bb:cc"], (0, "RSSI return value: -72"))
+
+        with patch("psmove_pairing.bluetooth_monitor.run_command", runner):
+            rssi = await bt_monitor.get_rssi("hci0", "00:06:f7:aa:bb:cc")
+            assert rssi == -72
+
+    @pytest.mark.asyncio
+    async def test_hcitool_rssi_failure(self, bt_monitor):
+        """Test handling hcitool rssi command failure."""
+        runner = MockCommandRunner()
+        runner.add_response(["hcitool", "-i", "hci0", "rssi", "00:06:f7:aa:bb:cc"], (1, "error"))
+
+        with patch("psmove_pairing.bluetooth_monitor.run_command", runner):
+            rssi = await bt_monitor.get_rssi("hci0", "00:06:f7:aa:bb:cc")
+            assert rssi is None
+
+
+class TestMonitor:
+    """Tests for monitor()."""
+
+    @pytest.mark.asyncio
+    async def test_monitor_increments_count(self, bt_monitor):
+        """Test that monitor count is incremented."""
+        runner = MockCommandRunner()
+        runner.add_response(["hciconfig", "-a"], (0, ""))
+
+        with patch("psmove_pairing.bluetooth_monitor.run_command", runner):
+            initial_count = bt_monitor.monitor_count
+            await bt_monitor.monitor()
+            assert bt_monitor.monitor_count == initial_count + 1
+
+    @pytest.mark.asyncio
+    async def test_monitor_full_flow(self, bt_monitor):
+        """Test complete monitoring flow with adapters and connections."""
+        single_adapter = "hci0:   Type: Primary  Bus: USB\n"
+        single_connection = """\
+Connections:
+        < ACL 00:06:f7:aa:bb:cc handle 256 state 1 lm MASTER
+"""
+        runner = MockCommandRunner()
+        runner.add_response(["hciconfig", "-a"], (0, single_adapter))
+        runner.add_response(["hcitool", "-i", "hci0", "con"], (0, single_connection))
+        runner.add_response(["hcitool", "-i", "hci0", "rssi", "00:06:f7:aa:bb:cc"], (0, "RSSI return value: -50"))
+
+        with patch("psmove_pairing.bluetooth_monitor.run_command", runner):
+            await bt_monitor.monitor()
+            assert ("00:06:f7:aa:bb:cc", "hci0") in bt_monitor._known_devices

--- a/scripts/pairing-daemon/tests/test_daemon.py
+++ b/scripts/pairing-daemon/tests/test_daemon.py
@@ -1,0 +1,171 @@
+"""Tests for psmove_pairing.daemon module."""
+
+import time
+from unittest.mock import patch
+
+import pytest
+
+from psmove_pairing.daemon import _HEALTH_STALENESS_THRESHOLD, PairingDaemon
+
+from .conftest import MockCommandRunner
+
+
+@pytest.fixture
+def daemon(mock_tracer):
+    """Provide PairingDaemon instance for tests."""
+    return PairingDaemon(mock_tracer, "/usr/bin/psmove")
+
+
+class TestValidatePrerequisites:
+    """Tests for validate_prerequisites()."""
+
+    @pytest.mark.asyncio
+    async def test_all_prerequisites_pass(self, daemon):
+        """Test when all prerequisites are available."""
+        runner = MockCommandRunner()
+        runner.add_response(["/usr/bin/psmove", "list"], (0, "Controller 0: ..."))
+        runner.add_response(["bluetoothctl", "show"], (0, "Controller ..."))
+
+        with patch("psmove_pairing.daemon.run_command", runner):
+            with patch("psmove_pairing.daemon.shutil.which", return_value="/usr/bin/bluetoothctl"):
+                result = await daemon.validate_prerequisites()
+                assert result is True
+
+    @pytest.mark.asyncio
+    async def test_psmove_fails(self, daemon):
+        """Test when psmove binary fails."""
+        runner = MockCommandRunner()
+        runner.add_response(["/usr/bin/psmove", "list"], (1, "error"))
+        runner.add_response(["bluetoothctl", "show"], (0, "Controller ..."))
+
+        with patch("psmove_pairing.daemon.run_command", runner):
+            with patch("psmove_pairing.daemon.shutil.which", return_value="/usr/bin/tool"):
+                result = await daemon.validate_prerequisites()
+                assert result is False
+
+    @pytest.mark.asyncio
+    async def test_bluetoothctl_not_found(self, daemon):
+        """Test when bluetoothctl is not found."""
+        runner = MockCommandRunner()
+        runner.add_response(["/usr/bin/psmove", "list"], (0, "ok"))
+
+        def mock_which(cmd):
+            if cmd == "bluetoothctl":
+                return None
+            return f"/usr/bin/{cmd}"
+
+        with patch("psmove_pairing.daemon.run_command", runner):
+            with patch("psmove_pairing.daemon.shutil.which", side_effect=mock_which):
+                result = await daemon.validate_prerequisites()
+                assert result is False
+
+
+class TestIsHealthy:
+    """Tests for is_healthy()."""
+
+    def test_healthy_during_startup(self, daemon):
+        """Test that daemon is healthy during startup grace period."""
+        assert daemon.is_healthy() is True
+
+    def test_healthy_after_polls(self, daemon):
+        """Test daemon is healthy after both loops have run."""
+        daemon.update_usb_poll_timestamp()
+        daemon.update_bt_monitor_timestamp()
+        daemon._startup_time = time.time() - _HEALTH_STALENESS_THRESHOLD - 10
+        assert daemon.is_healthy() is True
+
+    def test_unhealthy_when_usb_stale(self, daemon):
+        """Test daemon is unhealthy when USB poll is stale."""
+        daemon._startup_time = time.time() - _HEALTH_STALENESS_THRESHOLD - 10
+        daemon.update_bt_monitor_timestamp()
+        daemon._last_usb_poll = time.time() - _HEALTH_STALENESS_THRESHOLD - 10
+        assert daemon.is_healthy() is False
+
+    def test_unhealthy_when_bt_stale(self, daemon):
+        """Test daemon is unhealthy when Bluetooth monitor is stale."""
+        daemon._startup_time = time.time() - _HEALTH_STALENESS_THRESHOLD - 10
+        daemon.update_usb_poll_timestamp()
+        daemon._last_bt_monitor = time.time() - _HEALTH_STALENESS_THRESHOLD - 10
+        assert daemon.is_healthy() is False
+
+
+class TestGetHealthStatus:
+    """Tests for get_health_status()."""
+
+    def test_status_includes_all_fields(self, daemon):
+        """Test health status includes all expected fields."""
+        status = daemon.get_health_status()
+        assert "healthy" in status
+        assert "uptime_seconds" in status
+        assert "last_usb_poll_seconds_ago" in status
+        assert "last_bt_monitor_seconds_ago" in status
+        assert "usb_poll_count" in status
+        assert "bt_monitor_count" in status
+
+    def test_status_reflects_health(self, daemon):
+        """Test health status reflects actual health."""
+        daemon.update_usb_poll_timestamp()
+        daemon.update_bt_monitor_timestamp()
+        status = daemon.get_health_status()
+        assert status["healthy"] is True
+
+    def test_status_tracks_poll_counts(self, daemon):
+        """Test health status tracks poll counts."""
+        initial_status = daemon.get_health_status()
+        assert initial_status["usb_poll_count"] == 0
+        assert initial_status["bt_monitor_count"] == 0
+
+
+class TestTimestampUpdates:
+    """Tests for timestamp update methods."""
+
+    def test_update_usb_poll_timestamp(self, daemon):
+        """Test USB poll timestamp is updated."""
+        assert daemon._last_usb_poll == 0.0
+        daemon.update_usb_poll_timestamp()
+        assert daemon._last_usb_poll > 0
+
+    def test_update_bt_monitor_timestamp(self, daemon):
+        """Test Bluetooth monitor timestamp is updated."""
+        assert daemon._last_bt_monitor == 0.0
+        daemon.update_bt_monitor_timestamp()
+        assert daemon._last_bt_monitor > 0
+
+
+class TestRun:
+    """Tests for run()."""
+
+    @pytest.mark.asyncio
+    async def test_run_starts_both_loops(self, daemon):
+        """Test that run starts both USB and BT loops."""
+        import asyncio
+
+        usb_loop_started = False
+        bt_loop_started = False
+
+        async def mock_usb_loop():
+            nonlocal usb_loop_started
+            usb_loop_started = True
+            raise asyncio.CancelledError()
+
+        async def mock_bt_loop():
+            nonlocal bt_loop_started
+            bt_loop_started = True
+            raise asyncio.CancelledError()
+
+        daemon._usb_poll_loop = mock_usb_loop
+        daemon._bt_monitor_loop = mock_bt_loop
+
+        runner = MockCommandRunner()
+        runner.add_response(["/usr/bin/psmove", "list"], (0, "ok"))
+        runner.add_response(["bluetoothctl", "show"], (0, "ok"))
+
+        with patch("psmove_pairing.daemon.run_command", runner):
+            with patch("psmove_pairing.daemon.shutil.which", return_value="/usr/bin/tool"):
+                try:
+                    await daemon.run()
+                except asyncio.CancelledError:
+                    pass
+
+        assert usb_loop_started
+        assert bt_loop_started

--- a/scripts/pairing-daemon/tests/test_usb_pairing.py
+++ b/scripts/pairing-daemon/tests/test_usb_pairing.py
@@ -1,0 +1,238 @@
+"""Tests for psmove_pairing.usb_pairing module."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from psmove_pairing.usb_pairing import USBPairing
+
+from .conftest import (
+    SAMPLE_LSUSB_NO_PSMOVE,
+    SAMPLE_LSUSB_WITH_PSMOVE,
+    MockCommandRunner,
+)
+
+
+@pytest.fixture
+def usb_pairing(mock_tracer):
+    """Provide USBPairing instance for tests."""
+    return USBPairing(mock_tracer, "/usr/bin/psmove")
+
+
+class TestCheckUSBControllers:
+    """Tests for check_usb_controllers()."""
+
+    @pytest.mark.asyncio
+    async def test_detects_psmove(self, usb_pairing):
+        """Test detecting PS Move via lsusb."""
+        runner = MockCommandRunner()
+        runner.add_response(["lsusb"], (0, SAMPLE_LSUSB_WITH_PSMOVE))
+
+        with patch("psmove_pairing.usb_pairing.run_command", runner):
+            result = await usb_pairing.check_usb_controllers()
+            assert result is True
+
+    @pytest.mark.asyncio
+    async def test_no_psmove_detected(self, usb_pairing):
+        """Test when no PS Move is connected."""
+        runner = MockCommandRunner()
+        runner.add_response(["lsusb"], (0, SAMPLE_LSUSB_NO_PSMOVE))
+
+        with patch("psmove_pairing.usb_pairing.run_command", runner):
+            result = await usb_pairing.check_usb_controllers()
+            assert result is False
+
+    @pytest.mark.asyncio
+    async def test_lsusb_failure(self, usb_pairing):
+        """Test handling lsusb command failure."""
+        runner = MockCommandRunner()
+        runner.add_response(["lsusb"], (1, "command not found"))
+
+        with patch("psmove_pairing.usb_pairing.run_command", runner):
+            result = await usb_pairing.check_usb_controllers()
+            assert result is False
+
+    @pytest.mark.asyncio
+    async def test_case_insensitive_match(self, usb_pairing):
+        """Test that USB ID matching is case-insensitive."""
+        lsusb_upper = "Bus 001 Device 003: ID 054C:03D5 Sony Corp. Motion Controller"
+        runner = MockCommandRunner()
+        runner.add_response(["lsusb"], (0, lsusb_upper))
+
+        with patch("psmove_pairing.usb_pairing.run_command", runner):
+            result = await usb_pairing.check_usb_controllers()
+            assert result is True
+
+
+class TestGetUSBControllersPsmove:
+    """Tests for get_usb_controllers_psmove()."""
+
+    def test_no_controllers_connected(self, usb_pairing, mock_psmove_module):
+        """Test when no controllers are connected."""
+        mock_psmove_module.count_connected.return_value = 0
+
+        controllers = usb_pairing.get_usb_controllers_psmove()
+        assert controllers == []
+
+    def test_usb_controller_detected(self, usb_pairing, mock_psmove_module):
+        """Test when USB controller is detected."""
+        mock_psmove_module.count_connected.return_value = 1
+
+        mock_move = MagicMock()
+        mock_move.connection_type = mock_psmove_module.Conn_USB
+        mock_move.get_serial.return_value = "aa:bb:cc:dd:ee:ff"
+        mock_psmove_module.PSMove.return_value = mock_move
+
+        controllers = usb_pairing.get_usb_controllers_psmove()
+        assert len(controllers) == 1
+        assert controllers[0] == (0, "AA:BB:CC:DD:EE:FF")
+
+    def test_bluetooth_controller_excluded(self, usb_pairing, mock_psmove_module):
+        """Test that Bluetooth controllers are excluded."""
+        mock_psmove_module.count_connected.return_value = 1
+
+        mock_move = MagicMock()
+        mock_move.connection_type = mock_psmove_module.Conn_Bluetooth
+        mock_psmove_module.PSMove.return_value = mock_move
+
+        controllers = usb_pairing.get_usb_controllers_psmove()
+        assert controllers == []
+
+
+class TestPairControllerPsmove:
+    """Tests for pair_controller_psmove()."""
+
+    def test_successful_pairing(self, usb_pairing, mock_psmove_module):
+        """Test successful pairing via pair_custom."""
+        mock_move = MagicMock()
+        mock_move.connection_type = mock_psmove_module.Conn_USB
+        mock_move.pair_custom.return_value = True
+        mock_psmove_module.PSMove.return_value = mock_move
+
+        result = usb_pairing.pair_controller_psmove(0, "AA:BB:CC:DD:EE:FF", "11:22:33:44:55:66")
+        assert result is True
+        mock_move.pair_custom.assert_called_once_with("11:22:33:44:55:66")
+
+    def test_pairing_failure(self, usb_pairing, mock_psmove_module):
+        """Test pairing failure."""
+        mock_move = MagicMock()
+        mock_move.connection_type = mock_psmove_module.Conn_USB
+        mock_move.pair_custom.return_value = False
+        mock_psmove_module.PSMove.return_value = mock_move
+
+        result = usb_pairing.pair_controller_psmove(0, "AA:BB:CC:DD:EE:FF", "11:22:33:44:55:66")
+        assert result is False
+
+    def test_not_usb_connected(self, usb_pairing, mock_psmove_module):
+        """Test when controller is not USB connected."""
+        mock_move = MagicMock()
+        mock_move.connection_type = mock_psmove_module.Conn_Bluetooth
+        mock_psmove_module.PSMove.return_value = mock_move
+
+        result = usb_pairing.pair_controller_psmove(0, "AA:BB:CC:DD:EE:FF", "11:22:33:44:55:66")
+        assert result is False
+
+    def test_exception_handling(self, usb_pairing, mock_psmove_module):
+        """Test exception handling during pairing."""
+        mock_psmove_module.PSMove.side_effect = RuntimeError("Hardware error")
+
+        result = usb_pairing.pair_controller_psmove(0, "AA:BB:CC:DD:EE:FF", "11:22:33:44:55:66")
+        assert result is False
+
+
+class TestCalibrateController:
+    """Tests for calibrate_controller()."""
+
+    @pytest.mark.asyncio
+    async def test_successful_calibration(self, usb_pairing):
+        """Test successful calibration."""
+        runner = MockCommandRunner()
+        runner.add_response(["/usr/bin/psmove", "calibrate"], (0, "Calibration complete"))
+
+        with patch("psmove_pairing.usb_pairing.run_command", runner):
+            result = await usb_pairing.calibrate_controller("00:06:F7:AA:BB:CC")
+            assert result is True
+
+    @pytest.mark.asyncio
+    async def test_calibration_failure(self, usb_pairing):
+        """Test calibration failure (non-critical)."""
+        runner = MockCommandRunner()
+        runner.add_response(["/usr/bin/psmove", "calibrate"], (1, "Calibration failed"))
+
+        with patch("psmove_pairing.usb_pairing.run_command", runner):
+            result = await usb_pairing.calibrate_controller("00:06:F7:AA:BB:CC")
+            assert result is False
+
+
+class TestRestartBluetooth:
+    """Tests for restart_bluetooth()."""
+
+    @pytest.mark.asyncio
+    async def test_successful_restart(self, usb_pairing):
+        """Test successful Bluetooth restart."""
+        runner = MockCommandRunner()
+        runner.add_response(["sudo", "systemctl", "restart", "bluetooth"], (0, ""))
+
+        with patch("psmove_pairing.usb_pairing.run_command", runner):
+            with patch("asyncio.sleep", return_value=None):
+                await usb_pairing.restart_bluetooth()
+                assert ["sudo", "systemctl", "restart", "bluetooth"] in runner.calls
+
+    @pytest.mark.asyncio
+    async def test_restart_failure_logged(self, usb_pairing):
+        """Test that restart failure is logged but doesn't raise."""
+        runner = MockCommandRunner()
+        runner.add_response(["sudo", "systemctl", "restart", "bluetooth"], (1, "Permission denied"))
+
+        with patch("psmove_pairing.usb_pairing.run_command", runner):
+            # Should not raise
+            await usb_pairing.restart_bluetooth()
+
+
+class TestProcessController:
+    """Tests for process_controller()."""
+
+    @pytest.mark.asyncio
+    async def test_skip_already_paired(self, usb_pairing):
+        """Test skipping controller already paired."""
+        usb_pairing.adapter_manager.refresh_adapters = MagicMock()
+        usb_pairing.adapter_manager.check_if_not_paired = MagicMock(return_value=False)
+
+        result = await usb_pairing.process_controller(0, "00:06:F7:AA:BB:CC")
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_no_adapters_available(self, usb_pairing):
+        """Test when no Bluetooth adapters are available."""
+        usb_pairing.adapter_manager.refresh_adapters = MagicMock()
+        usb_pairing.adapter_manager.check_if_not_paired = MagicMock(return_value=True)
+        usb_pairing.adapter_manager.get_lowest_bt_device = MagicMock(return_value="")
+
+        result = await usb_pairing.process_controller(0, "00:06:F7:AA:BB:CC")
+        assert result is False
+
+
+class TestPoll:
+    """Tests for poll()."""
+
+    @pytest.mark.asyncio
+    async def test_poll_increments_count(self, usb_pairing):
+        """Test that poll count is incremented."""
+        runner = MockCommandRunner()
+        runner.add_response(["lsusb"], (0, SAMPLE_LSUSB_NO_PSMOVE))
+
+        with patch("psmove_pairing.usb_pairing.run_command", runner):
+            initial_count = usb_pairing.poll_count
+            await usb_pairing.poll()
+            assert usb_pairing.poll_count == initial_count + 1
+
+    @pytest.mark.asyncio
+    async def test_poll_skips_when_no_usb(self, usb_pairing):
+        """Test that poll skips psmove when no USB PS Move detected."""
+        runner = MockCommandRunner()
+        runner.add_response(["lsusb"], (0, SAMPLE_LSUSB_NO_PSMOVE))
+
+        with patch("psmove_pairing.usb_pairing.run_command", runner):
+            await usb_pairing.poll()
+            assert len(runner.calls) == 1
+            assert runner.calls[0] == ["lsusb"]

--- a/scripts/pairing-daemon/tests/test_utils.py
+++ b/scripts/pairing-daemon/tests/test_utils.py
@@ -1,0 +1,107 @@
+"""Tests for psmove_pairing.utils module."""
+
+import os
+import tempfile
+from unittest.mock import patch
+
+import pytest
+
+from psmove_pairing.utils import find_psmove_binary, run_command
+
+
+class TestRunCommand:
+    """Tests for run_command()."""
+
+    @pytest.mark.asyncio
+    async def test_successful_command(self):
+        """Test successful command execution."""
+        exit_code, output = await run_command(["echo", "hello"])
+        assert exit_code == 0
+        assert output == "hello"
+
+    @pytest.mark.asyncio
+    async def test_failed_command(self):
+        """Test command that returns non-zero exit code."""
+        exit_code, output = await run_command(["false"])
+        assert exit_code == 1
+
+    @pytest.mark.asyncio
+    async def test_command_with_stderr(self):
+        """Test that stderr is captured by default."""
+        exit_code, output = await run_command(["sh", "-c", "echo error >&2"])
+        assert exit_code == 0
+        assert "error" in output
+
+    @pytest.mark.asyncio
+    async def test_command_without_stderr(self):
+        """Test that stderr can be suppressed."""
+        exit_code, output = await run_command(["sh", "-c", "echo error >&2"], capture_stderr=False)
+        assert exit_code == 0
+        assert output == ""
+
+    @pytest.mark.asyncio
+    async def test_timeout_handling(self):
+        """Test that commands time out properly."""
+        with patch("psmove_pairing.utils.asyncio.wait_for", side_effect=TimeoutError):
+            exit_code, output = await run_command(["sleep", "100"])
+            assert exit_code == -1
+            assert output == "timeout"
+
+    @pytest.mark.asyncio
+    async def test_exception_handling(self):
+        """Test that exceptions are handled gracefully."""
+        with patch("psmove_pairing.utils.asyncio.create_subprocess_exec", side_effect=OSError("mock error")):
+            exit_code, output = await run_command(["nonexistent-command"])
+            assert exit_code == -1
+            assert "mock error" in output
+
+    @pytest.mark.asyncio
+    async def test_multiline_output(self):
+        """Test command with multiline output."""
+        exit_code, output = await run_command(["printf", "line1\nline2\nline3"])
+        assert exit_code == 0
+        assert "line1" in output
+        assert "line2" in output
+        assert "line3" in output
+
+    @pytest.mark.asyncio
+    async def test_with_env_vars(self):
+        """Test command with additional environment variables."""
+        exit_code, output = await run_command(["sh", "-c", "echo $TEST_VAR"], env={"TEST_VAR": "hello"})
+        assert exit_code == 0
+        assert output == "hello"
+
+
+class TestFindPsmoveBinary:
+    """Tests for find_psmove_binary()."""
+
+    def test_env_var_takes_precedence(self):
+        """Test that PSMOVE_PATH environment variable takes precedence."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix="psmove", delete=False) as f:
+            f.write("#!/bin/bash\nexit 0\n")
+            temp_path = f.name
+
+        try:
+            os.chmod(temp_path, 0o755)
+            with patch.dict(os.environ, {"PSMOVE_PATH": temp_path}):
+                with patch("psmove_pairing.utils.PSMOVE_PATH", temp_path):
+                    result = find_psmove_binary()
+                    assert result == temp_path
+        finally:
+            os.unlink(temp_path)
+
+    def test_path_lookup(self):
+        """Test that shutil.which is used for PATH lookup."""
+        with patch("psmove_pairing.utils.PSMOVE_PATH", ""):
+            with patch("psmove_pairing.utils.shutil.which", return_value="/usr/bin/psmove"):
+                result = find_psmove_binary()
+                assert result == "/usr/bin/psmove"
+
+    def test_exits_when_not_found(self):
+        """Test that sys.exit is called when binary not found."""
+        with patch("psmove_pairing.utils.PSMOVE_PATH", ""):
+            with patch("psmove_pairing.utils.shutil.which", return_value=None):
+                with patch("psmove_pairing.utils.os.path.isfile", return_value=False):
+                    with patch("psmove_pairing.utils.sys.exit") as mock_exit:
+                        find_psmove_binary()
+                        mock_exit.assert_called_once_with(1)

--- a/scripts/pairing-daemon/uv.lock
+++ b/scripts/pairing-daemon/uv.lock
@@ -1,0 +1,570 @@
+version = 1
+revision = 3
+requires-python = ">=3.9, <3.13"
+resolution-markers = [
+    "python_full_version >= '3.10'",
+    "python_full_version < '3.10'",
+]
+
+[[package]]
+name = "backports-asyncio-runner"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893, upload-time = "2025-07-02T02:27:15.685Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313, upload-time = "2025-07-02T02:27:14.263Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "coverage"
+version = "7.10.7"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/51/26/d22c300112504f5f9a9fd2297ce33c35f3d353e4aeb987c8419453b2a7c2/coverage-7.10.7.tar.gz", hash = "sha256:f4ab143ab113be368a3e9b795f9cd7906c5ef407d6173fe9675a902e1fffc239", size = 827704, upload-time = "2025-09-21T20:03:56.815Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/6c/3a3f7a46888e69d18abe3ccc6fe4cb16cccb1e6a2f99698931dafca489e6/coverage-7.10.7-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:fc04cc7a3db33664e0c2d10eb8990ff6b3536f6842c9590ae8da4c614b9ed05a", size = 217987, upload-time = "2025-09-21T20:00:57.218Z" },
+    { url = "https://files.pythonhosted.org/packages/03/94/952d30f180b1a916c11a56f5c22d3535e943aa22430e9e3322447e520e1c/coverage-7.10.7-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e201e015644e207139f7e2351980feb7040e6f4b2c2978892f3e3789d1c125e5", size = 218388, upload-time = "2025-09-21T20:01:00.081Z" },
+    { url = "https://files.pythonhosted.org/packages/50/2b/9e0cf8ded1e114bcd8b2fd42792b57f1c4e9e4ea1824cde2af93a67305be/coverage-7.10.7-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:240af60539987ced2c399809bd34f7c78e8abe0736af91c3d7d0e795df633d17", size = 245148, upload-time = "2025-09-21T20:01:01.768Z" },
+    { url = "https://files.pythonhosted.org/packages/19/20/d0384ac06a6f908783d9b6aa6135e41b093971499ec488e47279f5b846e6/coverage-7.10.7-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:8421e088bc051361b01c4b3a50fd39a4b9133079a2229978d9d30511fd05231b", size = 246958, upload-time = "2025-09-21T20:01:03.355Z" },
+    { url = "https://files.pythonhosted.org/packages/60/83/5c283cff3d41285f8eab897651585db908a909c572bdc014bcfaf8a8b6ae/coverage-7.10.7-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6be8ed3039ae7f7ac5ce058c308484787c86e8437e72b30bf5e88b8ea10f3c87", size = 248819, upload-time = "2025-09-21T20:01:04.968Z" },
+    { url = "https://files.pythonhosted.org/packages/60/22/02eb98fdc5ff79f423e990d877693e5310ae1eab6cb20ae0b0b9ac45b23b/coverage-7.10.7-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e28299d9f2e889e6d51b1f043f58d5f997c373cc12e6403b90df95b8b047c13e", size = 245754, upload-time = "2025-09-21T20:01:06.321Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/bc/25c83bcf3ad141b32cd7dc45485ef3c01a776ca3aa8ef0a93e77e8b5bc43/coverage-7.10.7-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:c4e16bd7761c5e454f4efd36f345286d6f7c5fa111623c355691e2755cae3b9e", size = 246860, upload-time = "2025-09-21T20:01:07.605Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/b7/95574702888b58c0928a6e982038c596f9c34d52c5e5107f1eef729399b5/coverage-7.10.7-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:b1c81d0e5e160651879755c9c675b974276f135558cf4ba79fee7b8413a515df", size = 244877, upload-time = "2025-09-21T20:01:08.829Z" },
+    { url = "https://files.pythonhosted.org/packages/47/b6/40095c185f235e085df0e0b158f6bd68cc6e1d80ba6c7721dc81d97ec318/coverage-7.10.7-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:606cc265adc9aaedcc84f1f064f0e8736bc45814f15a357e30fca7ecc01504e0", size = 245108, upload-time = "2025-09-21T20:01:10.527Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/50/4aea0556da7a4b93ec9168420d170b55e2eb50ae21b25062513d020c6861/coverage-7.10.7-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:10b24412692df990dbc34f8fb1b6b13d236ace9dfdd68df5b28c2e39cafbba13", size = 245752, upload-time = "2025-09-21T20:01:11.857Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/28/ea1a84a60828177ae3b100cb6723838523369a44ec5742313ed7db3da160/coverage-7.10.7-cp310-cp310-win32.whl", hash = "sha256:b51dcd060f18c19290d9b8a9dd1e0181538df2ce0717f562fff6cf74d9fc0b5b", size = 220497, upload-time = "2025-09-21T20:01:13.459Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/1a/a81d46bbeb3c3fd97b9602ebaa411e076219a150489bcc2c025f151bd52d/coverage-7.10.7-cp310-cp310-win_amd64.whl", hash = "sha256:3a622ac801b17198020f09af3eaf45666b344a0d69fc2a6ffe2ea83aeef1d807", size = 221392, upload-time = "2025-09-21T20:01:14.722Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/5d/c1a17867b0456f2e9ce2d8d4708a4c3a089947d0bec9c66cdf60c9e7739f/coverage-7.10.7-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a609f9c93113be646f44c2a0256d6ea375ad047005d7f57a5c15f614dc1b2f59", size = 218102, upload-time = "2025-09-21T20:01:16.089Z" },
+    { url = "https://files.pythonhosted.org/packages/54/f0/514dcf4b4e3698b9a9077f084429681bf3aad2b4a72578f89d7f643eb506/coverage-7.10.7-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:65646bb0359386e07639c367a22cf9b5bf6304e8630b565d0626e2bdf329227a", size = 218505, upload-time = "2025-09-21T20:01:17.788Z" },
+    { url = "https://files.pythonhosted.org/packages/20/f6/9626b81d17e2a4b25c63ac1b425ff307ecdeef03d67c9a147673ae40dc36/coverage-7.10.7-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:5f33166f0dfcce728191f520bd2692914ec70fac2713f6bf3ce59c3deacb4699", size = 248898, upload-time = "2025-09-21T20:01:19.488Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/ef/bd8e719c2f7417ba03239052e099b76ea1130ac0cbb183ee1fcaa58aaff3/coverage-7.10.7-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:35f5e3f9e455bb17831876048355dca0f758b6df22f49258cb5a91da23ef437d", size = 250831, upload-time = "2025-09-21T20:01:20.817Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/b6/bf054de41ec948b151ae2b79a55c107f5760979538f5fb80c195f2517718/coverage-7.10.7-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4da86b6d62a496e908ac2898243920c7992499c1712ff7c2b6d837cc69d9467e", size = 252937, upload-time = "2025-09-21T20:01:22.171Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/e5/3860756aa6f9318227443c6ce4ed7bf9e70bb7f1447a0353f45ac5c7974b/coverage-7.10.7-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6b8b09c1fad947c84bbbc95eca841350fad9cbfa5a2d7ca88ac9f8d836c92e23", size = 249021, upload-time = "2025-09-21T20:01:23.907Z" },
+    { url = "https://files.pythonhosted.org/packages/26/0f/bd08bd042854f7fd07b45808927ebcce99a7ed0f2f412d11629883517ac2/coverage-7.10.7-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:4376538f36b533b46f8971d3a3e63464f2c7905c9800db97361c43a2b14792ab", size = 250626, upload-time = "2025-09-21T20:01:25.721Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a7/4777b14de4abcc2e80c6b1d430f5d51eb18ed1d75fca56cbce5f2db9b36e/coverage-7.10.7-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:121da30abb574f6ce6ae09840dae322bef734480ceafe410117627aa54f76d82", size = 248682, upload-time = "2025-09-21T20:01:27.105Z" },
+    { url = "https://files.pythonhosted.org/packages/34/72/17d082b00b53cd45679bad682fac058b87f011fd8b9fe31d77f5f8d3a4e4/coverage-7.10.7-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:88127d40df529336a9836870436fc2751c339fbaed3a836d42c93f3e4bd1d0a2", size = 248402, upload-time = "2025-09-21T20:01:28.629Z" },
+    { url = "https://files.pythonhosted.org/packages/81/7a/92367572eb5bdd6a84bfa278cc7e97db192f9f45b28c94a9ca1a921c3577/coverage-7.10.7-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ba58bbcd1b72f136080c0bccc2400d66cc6115f3f906c499013d065ac33a4b61", size = 249320, upload-time = "2025-09-21T20:01:30.004Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/88/a23cc185f6a805dfc4fdf14a94016835eeb85e22ac3a0e66d5e89acd6462/coverage-7.10.7-cp311-cp311-win32.whl", hash = "sha256:972b9e3a4094b053a4e46832b4bc829fc8a8d347160eb39d03f1690316a99c14", size = 220536, upload-time = "2025-09-21T20:01:32.184Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/ef/0b510a399dfca17cec7bc2f05ad8bd78cf55f15c8bc9a73ab20c5c913c2e/coverage-7.10.7-cp311-cp311-win_amd64.whl", hash = "sha256:a7b55a944a7f43892e28ad4bc0561dfd5f0d73e605d1aa5c3c976b52aea121d2", size = 221425, upload-time = "2025-09-21T20:01:33.557Z" },
+    { url = "https://files.pythonhosted.org/packages/51/7f/023657f301a276e4ba1850f82749bc136f5a7e8768060c2e5d9744a22951/coverage-7.10.7-cp311-cp311-win_arm64.whl", hash = "sha256:736f227fb490f03c6488f9b6d45855f8e0fd749c007f9303ad30efab0e73c05a", size = 220103, upload-time = "2025-09-21T20:01:34.929Z" },
+    { url = "https://files.pythonhosted.org/packages/13/e4/eb12450f71b542a53972d19117ea5a5cea1cab3ac9e31b0b5d498df1bd5a/coverage-7.10.7-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7bb3b9ddb87ef7725056572368040c32775036472d5a033679d1fa6c8dc08417", size = 218290, upload-time = "2025-09-21T20:01:36.455Z" },
+    { url = "https://files.pythonhosted.org/packages/37/66/593f9be12fc19fb36711f19a5371af79a718537204d16ea1d36f16bd78d2/coverage-7.10.7-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:18afb24843cbc175687225cab1138c95d262337f5473512010e46831aa0c2973", size = 218515, upload-time = "2025-09-21T20:01:37.982Z" },
+    { url = "https://files.pythonhosted.org/packages/66/80/4c49f7ae09cafdacc73fbc30949ffe77359635c168f4e9ff33c9ebb07838/coverage-7.10.7-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:399a0b6347bcd3822be369392932884b8216d0944049ae22925631a9b3d4ba4c", size = 250020, upload-time = "2025-09-21T20:01:39.617Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/90/a64aaacab3b37a17aaedd83e8000142561a29eb262cede42d94a67f7556b/coverage-7.10.7-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:314f2c326ded3f4b09be11bc282eb2fc861184bc95748ae67b360ac962770be7", size = 252769, upload-time = "2025-09-21T20:01:41.341Z" },
+    { url = "https://files.pythonhosted.org/packages/98/2e/2dda59afd6103b342e096f246ebc5f87a3363b5412609946c120f4e7750d/coverage-7.10.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c41e71c9cfb854789dee6fc51e46743a6d138b1803fab6cb860af43265b42ea6", size = 253901, upload-time = "2025-09-21T20:01:43.042Z" },
+    { url = "https://files.pythonhosted.org/packages/53/dc/8d8119c9051d50f3119bb4a75f29f1e4a6ab9415cd1fa8bf22fcc3fb3b5f/coverage-7.10.7-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bc01f57ca26269c2c706e838f6422e2a8788e41b3e3c65e2f41148212e57cd59", size = 250413, upload-time = "2025-09-21T20:01:44.469Z" },
+    { url = "https://files.pythonhosted.org/packages/98/b3/edaff9c5d79ee4d4b6d3fe046f2b1d799850425695b789d491a64225d493/coverage-7.10.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a6442c59a8ac8b85812ce33bc4d05bde3fb22321fa8294e2a5b487c3505f611b", size = 251820, upload-time = "2025-09-21T20:01:45.915Z" },
+    { url = "https://files.pythonhosted.org/packages/11/25/9a0728564bb05863f7e513e5a594fe5ffef091b325437f5430e8cfb0d530/coverage-7.10.7-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:78a384e49f46b80fb4c901d52d92abe098e78768ed829c673fbb53c498bef73a", size = 249941, upload-time = "2025-09-21T20:01:47.296Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/fd/ca2650443bfbef5b0e74373aac4df67b08180d2f184b482c41499668e258/coverage-7.10.7-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:5e1e9802121405ede4b0133aa4340ad8186a1d2526de5b7c3eca519db7bb89fb", size = 249519, upload-time = "2025-09-21T20:01:48.73Z" },
+    { url = "https://files.pythonhosted.org/packages/24/79/f692f125fb4299b6f963b0745124998ebb8e73ecdfce4ceceb06a8c6bec5/coverage-7.10.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:d41213ea25a86f69efd1575073d34ea11aabe075604ddf3d148ecfec9e1e96a1", size = 251375, upload-time = "2025-09-21T20:01:50.529Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/75/61b9bbd6c7d24d896bfeec57acba78e0f8deac68e6baf2d4804f7aae1f88/coverage-7.10.7-cp312-cp312-win32.whl", hash = "sha256:77eb4c747061a6af8d0f7bdb31f1e108d172762ef579166ec84542f711d90256", size = 220699, upload-time = "2025-09-21T20:01:51.941Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/f3/3bf7905288b45b075918d372498f1cf845b5b579b723c8fd17168018d5f5/coverage-7.10.7-cp312-cp312-win_amd64.whl", hash = "sha256:f51328ffe987aecf6d09f3cd9d979face89a617eacdaea43e7b3080777f647ba", size = 221512, upload-time = "2025-09-21T20:01:53.481Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/44/3e32dbe933979d05cf2dac5e697c8599cfe038aaf51223ab901e208d5a62/coverage-7.10.7-cp312-cp312-win_arm64.whl", hash = "sha256:bda5e34f8a75721c96085903c6f2197dc398c20ffd98df33f866a9c8fd95f4bf", size = 220147, upload-time = "2025-09-21T20:01:55.2Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/ad/d1c25053764b4c42eb294aae92ab617d2e4f803397f9c7c8295caa77a260/coverage-7.10.7-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:fff7b9c3f19957020cac546c70025331113d2e61537f6e2441bc7657913de7d3", size = 217978, upload-time = "2025-09-21T20:03:30.362Z" },
+    { url = "https://files.pythonhosted.org/packages/52/2f/b9f9daa39b80ece0b9548bbb723381e29bc664822d9a12c2135f8922c22b/coverage-7.10.7-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:bc91b314cef27742da486d6839b677b3f2793dfe52b51bbbb7cf736d5c29281c", size = 218370, upload-time = "2025-09-21T20:03:32.147Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/6e/30d006c3b469e58449650642383dddf1c8fb63d44fdf92994bfd46570695/coverage-7.10.7-cp39-cp39-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:567f5c155eda8df1d3d439d40a45a6a5f029b429b06648235f1e7e51b522b396", size = 244802, upload-time = "2025-09-21T20:03:33.919Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/49/8a070782ce7e6b94ff6a0b6d7c65ba6bc3091d92a92cef4cd4eb0767965c/coverage-7.10.7-cp39-cp39-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2af88deffcc8a4d5974cf2d502251bc3b2db8461f0b66d80a449c33757aa9f40", size = 246625, upload-time = "2025-09-21T20:03:36.09Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/92/1c1c5a9e8677ce56d42b97bdaca337b2d4d9ebe703d8c174ede52dbabd5f/coverage-7.10.7-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7315339eae3b24c2d2fa1ed7d7a38654cba34a13ef19fbcb9425da46d3dc594", size = 248399, upload-time = "2025-09-21T20:03:38.342Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/54/b140edee7257e815de7426d5d9846b58505dffc29795fff2dfb7f8a1c5a0/coverage-7.10.7-cp39-cp39-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:912e6ebc7a6e4adfdbb1aec371ad04c68854cd3bf3608b3514e7ff9062931d8a", size = 245142, upload-time = "2025-09-21T20:03:40.591Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/9e/6d6b8295940b118e8b7083b29226c71f6154f7ff41e9ca431f03de2eac0d/coverage-7.10.7-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:f49a05acd3dfe1ce9715b657e28d138578bc40126760efb962322c56e9ca344b", size = 246284, upload-time = "2025-09-21T20:03:42.355Z" },
+    { url = "https://files.pythonhosted.org/packages/db/e5/5e957ca747d43dbe4d9714358375c7546cb3cb533007b6813fc20fce37ad/coverage-7.10.7-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:cce2109b6219f22ece99db7644b9622f54a4e915dad65660ec435e89a3ea7cc3", size = 244353, upload-time = "2025-09-21T20:03:44.218Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/45/540fc5cc92536a1b783b7ef99450bd55a4b3af234aae35a18a339973ce30/coverage-7.10.7-cp39-cp39-musllinux_1_2_riscv64.whl", hash = "sha256:f3c887f96407cea3916294046fc7dab611c2552beadbed4ea901cbc6a40cc7a0", size = 244430, upload-time = "2025-09-21T20:03:46.065Z" },
+    { url = "https://files.pythonhosted.org/packages/75/0b/8287b2e5b38c8fe15d7e3398849bb58d382aedc0864ea0fa1820e8630491/coverage-7.10.7-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:635adb9a4507c9fd2ed65f39693fa31c9a3ee3a8e6dc64df033e8fdf52a7003f", size = 245311, upload-time = "2025-09-21T20:03:48.19Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/1d/29724999984740f0c86d03e6420b942439bf5bd7f54d4382cae386a9d1e9/coverage-7.10.7-cp39-cp39-win32.whl", hash = "sha256:5a02d5a850e2979b0a014c412573953995174743a3f7fa4ea5a6e9a3c5617431", size = 220500, upload-time = "2025-09-21T20:03:50.024Z" },
+    { url = "https://files.pythonhosted.org/packages/43/11/4b1e6b129943f905ca54c339f343877b55b365ae2558806c1be4f7476ed5/coverage-7.10.7-cp39-cp39-win_amd64.whl", hash = "sha256:c134869d5ffe34547d14e174c866fd8fe2254918cc0a95e99052903bc1543e07", size = 221408, upload-time = "2025-09-21T20:03:51.803Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/16/114df1c291c22cac3b0c127a73e0af5c12ed7bbb6558d310429a0ae24023/coverage-7.10.7-py3-none-any.whl", hash = "sha256:f7941f6f2fe6dd6807a1208737b8a0cbcf1cc6d7b07d24998ad2d63590868260", size = 209952, upload-time = "2025-09-21T20:03:53.918Z" },
+]
+
+[package.optional-dependencies]
+toml = [
+    { name = "tomli", marker = "python_full_version < '3.10'" },
+]
+
+[[package]]
+name = "coverage"
+version = "7.13.3"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/11/43/3e4ac666cc35f231fa70c94e9f38459299de1a152813f9d2f60fc5f3ecaf/coverage-7.13.3.tar.gz", hash = "sha256:f7f6182d3dfb8802c1747eacbfe611b669455b69b7c037484bb1efbbb56711ac", size = 826832, upload-time = "2026-02-03T14:02:30.944Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/07/1c8099563a8a6c389a31c2d0aa1497cee86d6248bb4b9ba5e779215db9f9/coverage-7.13.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0b4f345f7265cdbdb5ec2521ffff15fa49de6d6c39abf89fc7ad68aa9e3a55f0", size = 219143, upload-time = "2026-02-03T13:59:40.459Z" },
+    { url = "https://files.pythonhosted.org/packages/69/39/a892d44af7aa092cab70e0cc5cdbba18eeccfe1d6930695dab1742eef9e9/coverage-7.13.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:96c3be8bae9d0333e403cc1a8eb078a7f928b5650bae94a18fb4820cc993fb9b", size = 219663, upload-time = "2026-02-03T13:59:41.951Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/25/9669dcf4c2bb4c3861469e6db20e52e8c11908cf53c14ec9b12e9fd4d602/coverage-7.13.3-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:d6f4a21328ea49d38565b55599e1c02834e76583a6953e5586d65cb1efebd8f8", size = 246424, upload-time = "2026-02-03T13:59:43.418Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/68/d9766c4e298aca62ea5d9543e1dd1e4e1439d7284815244d8b7db1840bfb/coverage-7.13.3-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fc970575799a9d17d5c3fafd83a0f6ccf5d5117cdc9ad6fbd791e9ead82418b0", size = 248228, upload-time = "2026-02-03T13:59:44.816Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/e2/eea6cb4a4bd443741adf008d4cccec83a1f75401df59b6559aca2bdd9710/coverage-7.13.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:87ff33b652b3556b05e204ae20793d1f872161b0fa5ec8a9ac76f8430e152ed6", size = 250103, upload-time = "2026-02-03T13:59:46.271Z" },
+    { url = "https://files.pythonhosted.org/packages/db/77/664280ecd666c2191610842177e2fab9e5dbdeef97178e2078fed46a3d2c/coverage-7.13.3-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7df8759ee57b9f3f7b66799b7660c282f4375bef620ade1686d6a7b03699e75f", size = 247107, upload-time = "2026-02-03T13:59:48.53Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/df/2a672eab99e0d0eba52d8a63e47dc92245eee26954d1b2d3c8f7d372151f/coverage-7.13.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:f45c9bcb16bee25a798ccba8a2f6a1251b19de6a0d617bb365d7d2f386c4e20e", size = 248143, upload-time = "2026-02-03T13:59:50.027Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/dc/a104e7a87c13e57a358b8b9199a8955676e1703bb372d79722b54978ae45/coverage-7.13.3-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:318b2e4753cbf611061e01b6cc81477e1cdfeb69c36c4a14e6595e674caadb56", size = 246148, upload-time = "2026-02-03T13:59:52.025Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/89/e113d3a58dc20b03b7e59aed1e53ebc9ca6167f961876443e002b10e3ae9/coverage-7.13.3-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:24db3959de8ee394eeeca89ccb8ba25305c2da9a668dd44173394cbd5aa0777f", size = 246414, upload-time = "2026-02-03T13:59:53.859Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/60/a3fd0a6e8d89b488396019a2268b6a1f25ab56d6d18f3be50f35d77b47dc/coverage-7.13.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:be14d0622125edef21b3a4d8cd2d138c4872bf6e38adc90fd92385e3312f406a", size = 247023, upload-time = "2026-02-03T13:59:55.454Z" },
+    { url = "https://files.pythonhosted.org/packages/19/fa/de4840bb939dbb22ba0648a6d8069fa91c9cf3b3fca8b0d1df461e885b3d/coverage-7.13.3-cp310-cp310-win32.whl", hash = "sha256:53be4aab8ddef18beb6188f3a3fdbf4d1af2277d098d4e618be3a8e6c88e74be", size = 221751, upload-time = "2026-02-03T13:59:57.383Z" },
+    { url = "https://files.pythonhosted.org/packages/de/87/233ff8b7ef62fb63f58c78623b50bef69681111e0c4d43504f422d88cda4/coverage-7.13.3-cp310-cp310-win_amd64.whl", hash = "sha256:bfeee64ad8b4aae3233abb77eb6b52b51b05fa89da9645518671b9939a78732b", size = 222686, upload-time = "2026-02-03T13:59:58.825Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/09/1ac74e37cf45f17eb41e11a21854f7f92a4c2d6c6098ef4a1becb0c6d8d3/coverage-7.13.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5907605ee20e126eeee2abe14aae137043c2c8af2fa9b38d2ab3b7a6b8137f73", size = 219276, upload-time = "2026-02-03T14:00:00.296Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/cb/71908b08b21beb2c437d0d5870c4ec129c570ca1b386a8427fcdb11cf89c/coverage-7.13.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a88705500988c8acad8b8fd86c2a933d3aa96bec1ddc4bc5cb256360db7bbd00", size = 219776, upload-time = "2026-02-03T14:00:02.414Z" },
+    { url = "https://files.pythonhosted.org/packages/09/85/c4f3dd69232887666a2c0394d4be21c60ea934d404db068e6c96aa59cd87/coverage-7.13.3-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:7bbb5aa9016c4c29e3432e087aa29ebee3f8fda089cfbfb4e6d64bd292dcd1c2", size = 250196, upload-time = "2026-02-03T14:00:04.197Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/cc/560ad6f12010344d0778e268df5ba9aa990aacccc310d478bf82bf3d302c/coverage-7.13.3-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0c2be202a83dde768937a61cdc5d06bf9fb204048ca199d93479488e6247656c", size = 252111, upload-time = "2026-02-03T14:00:05.639Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/66/3193985fb2c58e91f94cfbe9e21a6fdf941e9301fe2be9e92c072e9c8f8c/coverage-7.13.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0f45e32ef383ce56e0ca099b2e02fcdf7950be4b1b56afaab27b4ad790befe5b", size = 254217, upload-time = "2026-02-03T14:00:07.738Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/78/f0f91556bf1faa416792e537c523c5ef9db9b1d32a50572c102b3d7c45b3/coverage-7.13.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6ed2e787249b922a93cd95c671cc9f4c9797a106e81b455c83a9ddb9d34590c0", size = 250318, upload-time = "2026-02-03T14:00:09.224Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/aa/fc654e45e837d137b2c1f3a2cc09b4aea1e8b015acd2f774fa0f3d2ddeba/coverage-7.13.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:05dd25b21afffe545e808265897c35f32d3e4437663923e0d256d9ab5031fb14", size = 251909, upload-time = "2026-02-03T14:00:10.712Z" },
+    { url = "https://files.pythonhosted.org/packages/73/4d/ab53063992add8a9ca0463c9d92cce5994a29e17affd1c2daa091b922a93/coverage-7.13.3-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:46d29926349b5c4f1ea4fca95e8c892835515f3600995a383fa9a923b5739ea4", size = 249971, upload-time = "2026-02-03T14:00:12.402Z" },
+    { url = "https://files.pythonhosted.org/packages/29/25/83694b81e46fcff9899694a1b6f57573429cdd82b57932f09a698f03eea5/coverage-7.13.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:fae6a21537519c2af00245e834e5bf2884699cc7c1055738fd0f9dc37a3644ad", size = 249692, upload-time = "2026-02-03T14:00:13.868Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/ef/d68fc304301f4cb4bf6aefa0045310520789ca38dabdfba9dbecd3f37919/coverage-7.13.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:c672d4e2f0575a4ca2bf2aa0c5ced5188220ab806c1bb6d7179f70a11a017222", size = 250597, upload-time = "2026-02-03T14:00:15.461Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/85/240ad396f914df361d0f71e912ddcedb48130c71b88dc4193fe3c0306f00/coverage-7.13.3-cp311-cp311-win32.whl", hash = "sha256:fcda51c918c7a13ad93b5f89a58d56e3a072c9e0ba5c231b0ed81404bf2648fb", size = 221773, upload-time = "2026-02-03T14:00:17.462Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/71/165b3a6d3d052704a9ab52d11ea64ef3426745de517dda44d872716213a7/coverage-7.13.3-cp311-cp311-win_amd64.whl", hash = "sha256:d1a049b5c51b3b679928dd35e47c4a2235e0b6128b479a7596d0ef5b42fa6301", size = 222711, upload-time = "2026-02-03T14:00:19.449Z" },
+    { url = "https://files.pythonhosted.org/packages/51/d0/0ddc9c5934cdd52639c5df1f1eb0fdab51bb52348f3a8d1c7db9c600d93a/coverage-7.13.3-cp311-cp311-win_arm64.whl", hash = "sha256:79f2670c7e772f4917895c3d89aad59e01f3dbe68a4ed2d0373b431fad1dcfba", size = 221377, upload-time = "2026-02-03T14:00:20.968Z" },
+    { url = "https://files.pythonhosted.org/packages/94/44/330f8e83b143f6668778ed61d17ece9dc48459e9e74669177de02f45fec5/coverage-7.13.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ed48b4170caa2c4420e0cd27dc977caaffc7eecc317355751df8373dddcef595", size = 219441, upload-time = "2026-02-03T14:00:22.585Z" },
+    { url = "https://files.pythonhosted.org/packages/08/e7/29db05693562c2e65bdf6910c0af2fd6f9325b8f43caf7a258413f369e30/coverage-7.13.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8f2adf4bcffbbec41f366f2e6dffb9d24e8172d16e91da5799c9b7ed6b5716e6", size = 219801, upload-time = "2026-02-03T14:00:24.186Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ae/7f8a78249b02b0818db46220795f8ac8312ea4abd1d37d79ea81db5cae81/coverage-7.13.3-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:01119735c690786b6966a1e9f098da4cd7ca9174c4cfe076d04e653105488395", size = 251306, upload-time = "2026-02-03T14:00:25.798Z" },
+    { url = "https://files.pythonhosted.org/packages/62/71/a18a53d1808e09b2e9ebd6b47dad5e92daf4c38b0686b4c4d1b2f3e42b7f/coverage-7.13.3-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:8bb09e83c603f152d855f666d70a71765ca8e67332e5829e62cb9466c176af23", size = 254051, upload-time = "2026-02-03T14:00:27.474Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/0a/eb30f6455d04c5a3396d0696cad2df0269ae7444bb322f86ffe3376f7bf9/coverage-7.13.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b607a40cba795cfac6d130220d25962931ce101f2f478a29822b19755377fb34", size = 255160, upload-time = "2026-02-03T14:00:29.024Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/7e/a45baac86274ce3ed842dbb84f14560c673ad30535f397d89164ec56c5df/coverage-7.13.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:44f14a62f5da2e9aedf9080e01d2cda61df39197d48e323538ec037336d68da8", size = 251709, upload-time = "2026-02-03T14:00:30.641Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/df/dd0dc12f30da11349993f3e218901fdf82f45ee44773596050c8f5a1fb25/coverage-7.13.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:debf29e0b157769843dff0981cc76f79e0ed04e36bb773c6cac5f6029054bd8a", size = 253083, upload-time = "2026-02-03T14:00:32.14Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/32/fc764c8389a8ce95cb90eb97af4c32f392ab0ac23ec57cadeefb887188d3/coverage-7.13.3-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:824bb95cd71604031ae9a48edb91fd6effde669522f960375668ed21b36e3ec4", size = 251227, upload-time = "2026-02-03T14:00:34.721Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/ca/d025e9da8f06f24c34d2da9873957cfc5f7e0d67802c3e34d0caa8452130/coverage-7.13.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:8f1010029a5b52dc427c8e2a8dbddb2303ddd180b806687d1acd1bb1d06649e7", size = 250794, upload-time = "2026-02-03T14:00:36.278Z" },
+    { url = "https://files.pythonhosted.org/packages/45/c7/76bf35d5d488ec8f68682eb8e7671acc50a6d2d1c1182de1d2b6d4ffad3b/coverage-7.13.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:cd5dee4fd7659d8306ffa79eeaaafd91fa30a302dac3af723b9b469e549247e0", size = 252671, upload-time = "2026-02-03T14:00:38.368Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/10/1921f1a03a7c209e1cb374f81a6b9b68b03cdb3ecc3433c189bc90e2a3d5/coverage-7.13.3-cp312-cp312-win32.whl", hash = "sha256:f7f153d0184d45f3873b3ad3ad22694fd73aadcb8cdbc4337ab4b41ea6b4dff1", size = 221986, upload-time = "2026-02-03T14:00:40.442Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/7c/f5d93297f8e125a80c15545edc754d93e0ed8ba255b65e609b185296af01/coverage-7.13.3-cp312-cp312-win_amd64.whl", hash = "sha256:03a6e5e1e50819d6d7436f5bc40c92ded7e484e400716886ac921e35c133149d", size = 222793, upload-time = "2026-02-03T14:00:42.106Z" },
+    { url = "https://files.pythonhosted.org/packages/43/59/c86b84170015b4555ebabca8649bdf9f4a1f737a73168088385ed0f947c4/coverage-7.13.3-cp312-cp312-win_arm64.whl", hash = "sha256:51c4c42c0e7d09a822b08b6cf79b3c4db8333fffde7450da946719ba0d45730f", size = 221410, upload-time = "2026-02-03T14:00:43.726Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/fb/70af542d2d938c778c9373ce253aa4116dbe7c0a5672f78b2b2ae0e1b94b/coverage-7.13.3-py3-none-any.whl", hash = "sha256:90a8af9dba6429b2573199622d72e0ebf024d6276f16abce394ad4d181bb0910", size = 211237, upload-time = "2026-02-03T14:02:27.986Z" },
+]
+
+[package.optional-dependencies]
+toml = [
+    { name = "tomli", marker = "python_full_version >= '3.10' and python_full_version <= '3.11'" },
+]
+
+[[package]]
+name = "dbus-python"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/24/63118050c7dd7be04b1ccd60eab53fef00abe844442e1b6dec92dae505d6/dbus-python-1.4.0.tar.gz", hash = "sha256:991666e498f60dbf3e49b8b7678f5559b8a65034fdf61aae62cdecdb7d89c770", size = 232490, upload-time = "2025-03-13T19:57:54.212Z" }
+
+[[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "googleapis-common-protos"
+version = "1.72.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e5/7b/adfd75544c415c487b33061fe7ae526165241c1ea133f9a9125a56b39fd8/googleapis_common_protos-1.72.0.tar.gz", hash = "sha256:e55a601c1b32b52d7a3e65f43563e2aa61bcd737998ee672ac9b951cd49319f5", size = 147433, upload-time = "2025-11-06T18:29:24.087Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/ab/09169d5a4612a5f92490806649ac8d41e3ec9129c636754575b3553f4ea4/googleapis_common_protos-1.72.0-py3-none-any.whl", hash = "sha256:4299c5a82d5ae1a9702ada957347726b167f9f8d1fc352477702a1e851ff4038", size = 297515, upload-time = "2025-11-06T18:29:13.14Z" },
+]
+
+[[package]]
+name = "grpcio"
+version = "1.78.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/8a/3d098f35c143a89520e568e6539cc098fcd294495910e359889ce8741c84/grpcio-1.78.0.tar.gz", hash = "sha256:7382b95189546f375c174f53a5fa873cef91c4b8005faa05cc5b3beea9c4f1c5", size = 12852416, upload-time = "2026-02-06T09:57:18.093Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/a8/690a085b4d1fe066130de97a87de32c45062cf2ecd218df9675add895550/grpcio-1.78.0-cp310-cp310-linux_armv7l.whl", hash = "sha256:7cc47943d524ee0096f973e1081cb8f4f17a4615f2116882a5f1416e4cfe92b5", size = 5946986, upload-time = "2026-02-06T09:54:34.043Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/1b/e5213c5c0ced9d2d92778d30529ad5bb2dcfb6c48c4e2d01b1f302d33d64/grpcio-1.78.0-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:c3f293fdc675ccba4db5a561048cca627b5e7bd1c8a6973ffedabe7d116e22e2", size = 11816533, upload-time = "2026-02-06T09:54:37.04Z" },
+    { url = "https://files.pythonhosted.org/packages/18/37/1ba32dccf0a324cc5ace744c44331e300b000a924bf14840f948c559ede7/grpcio-1.78.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:10a9a644b5dd5aec3b82b5b0b90d41c0fa94c85ef42cb42cf78a23291ddb5e7d", size = 6519964, upload-time = "2026-02-06T09:54:40.268Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/f5/c0e178721b818072f2e8b6fde13faaba942406c634009caf065121ce246b/grpcio-1.78.0-cp310-cp310-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:4c5533d03a6cbd7f56acfc9cfb44ea64f63d29091e40e44010d34178d392d7eb", size = 7198058, upload-time = "2026-02-06T09:54:42.389Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/b2/40d43c91ae9cd667edc960135f9f08e58faa1576dc95af29f66ec912985f/grpcio-1.78.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ff870aebe9a93a85283837801d35cd5f8814fe2ad01e606861a7fb47c762a2b7", size = 6727212, upload-time = "2026-02-06T09:54:44.91Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/88/9da42eed498f0efcfcd9156e48ae63c0cde3bea398a16c99fb5198c885b6/grpcio-1.78.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:391e93548644e6b2726f1bb84ed60048d4bcc424ce5e4af0843d28ca0b754fec", size = 7300845, upload-time = "2026-02-06T09:54:47.562Z" },
+    { url = "https://files.pythonhosted.org/packages/23/3f/1c66b7b1b19a8828890e37868411a6e6925df5a9030bfa87ab318f34095d/grpcio-1.78.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:df2c8f3141f7cbd112a6ebbd760290b5849cda01884554f7c67acc14e7b1758a", size = 8284605, upload-time = "2026-02-06T09:54:50.475Z" },
+    { url = "https://files.pythonhosted.org/packages/94/c4/ca1bd87394f7b033e88525384b4d1e269e8424ab441ea2fba1a0c5b50986/grpcio-1.78.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:bd8cb8026e5f5b50498a3c4f196f57f9db344dad829ffae16b82e4fdbaea2813", size = 7726672, upload-time = "2026-02-06T09:54:53.11Z" },
+    { url = "https://files.pythonhosted.org/packages/41/09/f16e487d4cc65ccaf670f6ebdd1a17566b965c74fc3d93999d3b2821e052/grpcio-1.78.0-cp310-cp310-win32.whl", hash = "sha256:f8dff3d9777e5d2703a962ee5c286c239bf0ba173877cc68dc02c17d042e29de", size = 4076715, upload-time = "2026-02-06T09:54:55.549Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/32/4ce60d94e242725fd3bcc5673c04502c82a8e87b21ea411a63992dc39f8f/grpcio-1.78.0-cp310-cp310-win_amd64.whl", hash = "sha256:94f95cf5d532d0e717eed4fc1810e8e6eded04621342ec54c89a7c2f14b581bf", size = 4799157, upload-time = "2026-02-06T09:54:59.838Z" },
+    { url = "https://files.pythonhosted.org/packages/86/c7/d0b780a29b0837bf4ca9580904dfb275c1fc321ded7897d620af7047ec57/grpcio-1.78.0-cp311-cp311-linux_armv7l.whl", hash = "sha256:2777b783f6c13b92bd7b716667452c329eefd646bfb3f2e9dabea2e05dbd34f6", size = 5951525, upload-time = "2026-02-06T09:55:01.989Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/b1/96920bf2ee61df85a9503cb6f733fe711c0ff321a5a697d791b075673281/grpcio-1.78.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:9dca934f24c732750389ce49d638069c3892ad065df86cb465b3fa3012b70c9e", size = 11830418, upload-time = "2026-02-06T09:55:04.462Z" },
+    { url = "https://files.pythonhosted.org/packages/83/0c/7c1528f098aeb75a97de2bae18c530f56959fb7ad6c882db45d9884d6edc/grpcio-1.78.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:459ab414b35f4496138d0ecd735fed26f1318af5e52cb1efbc82a09f0d5aa911", size = 6524477, upload-time = "2026-02-06T09:55:07.111Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/52/e7c1f3688f949058e19a011c4e0dec973da3d0ae5e033909677f967ae1f4/grpcio-1.78.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:082653eecbdf290e6e3e2c276ab2c54b9e7c299e07f4221872380312d8cf395e", size = 7198266, upload-time = "2026-02-06T09:55:10.016Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/61/8ac32517c1e856677282c34f2e7812d6c328fa02b8f4067ab80e77fdc9c9/grpcio-1.78.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:85f93781028ec63f383f6bc90db785a016319c561cc11151fbb7b34e0d012303", size = 6730552, upload-time = "2026-02-06T09:55:12.207Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/98/b8ee0158199250220734f620b12e4a345955ac7329cfd908d0bf0fda77f0/grpcio-1.78.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:f12857d24d98441af6a1d5c87442d624411db486f7ba12550b07788f74b67b04", size = 7304296, upload-time = "2026-02-06T09:55:15.044Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/0f/7b72762e0d8840b58032a56fdbd02b78fc645b9fa993d71abf04edbc54f4/grpcio-1.78.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:5397fff416b79e4b284959642a4e95ac4b0f1ece82c9993658e0e477d40551ec", size = 8288298, upload-time = "2026-02-06T09:55:17.276Z" },
+    { url = "https://files.pythonhosted.org/packages/24/ae/ae4ce56bc5bb5caa3a486d60f5f6083ac3469228faa734362487176c15c5/grpcio-1.78.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:fbe6e89c7ffb48518384068321621b2a69cab509f58e40e4399fdd378fa6d074", size = 7730953, upload-time = "2026-02-06T09:55:19.545Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/6e/8052e3a28eb6a820c372b2eb4b5e32d195c661e137d3eca94d534a4cfd8a/grpcio-1.78.0-cp311-cp311-win32.whl", hash = "sha256:6092beabe1966a3229f599d7088b38dfc8ffa1608b5b5cdda31e591e6500f856", size = 4076503, upload-time = "2026-02-06T09:55:21.521Z" },
+    { url = "https://files.pythonhosted.org/packages/08/62/f22c98c5265dfad327251fa2f840b591b1df5f5e15d88b19c18c86965b27/grpcio-1.78.0-cp311-cp311-win_amd64.whl", hash = "sha256:1afa62af6e23f88629f2b29ec9e52ec7c65a7176c1e0a83292b93c76ca882558", size = 4799767, upload-time = "2026-02-06T09:55:24.107Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/f4/7384ed0178203d6074446b3c4f46c90a22ddf7ae0b3aee521627f54cfc2a/grpcio-1.78.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:f9ab915a267fc47c7e88c387a3a28325b58c898e23d4995f765728f4e3dedb97", size = 5913985, upload-time = "2026-02-06T09:55:26.832Z" },
+    { url = "https://files.pythonhosted.org/packages/81/ed/be1caa25f06594463f685b3790b320f18aea49b33166f4141bfdc2bfb236/grpcio-1.78.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:3f8904a8165ab21e07e58bf3e30a73f4dffc7a1e0dbc32d51c61b5360d26f43e", size = 11811853, upload-time = "2026-02-06T09:55:29.224Z" },
+    { url = "https://files.pythonhosted.org/packages/24/a7/f06d151afc4e64b7e3cc3e872d331d011c279aaab02831e40a81c691fb65/grpcio-1.78.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:859b13906ce098c0b493af92142ad051bf64c7870fa58a123911c88606714996", size = 6475766, upload-time = "2026-02-06T09:55:31.825Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/a8/4482922da832ec0082d0f2cc3a10976d84a7424707f25780b82814aafc0a/grpcio-1.78.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:b2342d87af32790f934a79c3112641e7b27d63c261b8b4395350dad43eff1dc7", size = 7170027, upload-time = "2026-02-06T09:55:34.7Z" },
+    { url = "https://files.pythonhosted.org/packages/54/bf/f4a3b9693e35d25b24b0b39fa46d7d8a3c439e0a3036c3451764678fec20/grpcio-1.78.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:12a771591ae40bc65ba67048fa52ef4f0e6db8279e595fd349f9dfddeef571f9", size = 6690766, upload-time = "2026-02-06T09:55:36.902Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/b9/521875265cc99fe5ad4c5a17010018085cae2810a928bf15ebe7d8bcd9cc/grpcio-1.78.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:185dea0d5260cbb2d224c507bf2a5444d5abbb1fa3594c1ed7e4c709d5eb8383", size = 7266161, upload-time = "2026-02-06T09:55:39.824Z" },
+    { url = "https://files.pythonhosted.org/packages/05/86/296a82844fd40a4ad4a95f100b55044b4f817dece732bf686aea1a284147/grpcio-1.78.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:51b13f9aed9d59ee389ad666b8c2214cc87b5de258fa712f9ab05f922e3896c6", size = 8253303, upload-time = "2026-02-06T09:55:42.353Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/e4/ea3c0caf5468537f27ad5aab92b681ed7cc0ef5f8c9196d3fd42c8c2286b/grpcio-1.78.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fd5f135b1bd58ab088930b3c613455796dfa0393626a6972663ccdda5b4ac6ce", size = 7698222, upload-time = "2026-02-06T09:55:44.629Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/47/7f05f81e4bb6b831e93271fb12fd52ba7b319b5402cbc101d588f435df00/grpcio-1.78.0-cp312-cp312-win32.whl", hash = "sha256:94309f498bcc07e5a7d16089ab984d42ad96af1d94b5a4eb966a266d9fcabf68", size = 4066123, upload-time = "2026-02-06T09:55:47.644Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/e7/d6914822c88aa2974dbbd10903d801a28a19ce9cd8bad7e694cbbcf61528/grpcio-1.78.0-cp312-cp312-win_amd64.whl", hash = "sha256:9566fe4ababbb2610c39190791e5b829869351d14369603702e890ef3ad2d06e", size = 4797657, upload-time = "2026-02-06T09:55:49.86Z" },
+    { url = "https://files.pythonhosted.org/packages/58/6c/40a4bba2c753ea8eeb8d776a31e9c54f4e506edf36db93a3db5456725294/grpcio-1.78.0-cp39-cp39-linux_armv7l.whl", hash = "sha256:86f85dd7c947baa707078a236288a289044836d4b640962018ceb9cd1f899af5", size = 5947902, upload-time = "2026-02-06T09:56:48.469Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/4c/ed7664a37a7008be41204c77e0d88bbc4ac531bcf0c27668cd066f9ff6e2/grpcio-1.78.0-cp39-cp39-macosx_11_0_universal2.whl", hash = "sha256:de8cb00d1483a412a06394b8303feec5dcb3b55f81d83aa216dbb6a0b86a94f5", size = 11824772, upload-time = "2026-02-06T09:56:51.264Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/5b/45a5c23ba3c4a0f51352366d9b25369a2a51163ab1c93482cb8408726617/grpcio-1.78.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e888474dee2f59ff68130f8a397792d8cb8e17e6b3434339657ba4ee90845a8c", size = 6521579, upload-time = "2026-02-06T09:56:54.967Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/e3/392e647d918004231e3d1c780ed125c48939bfc8f845adb8b5820410da3e/grpcio-1.78.0-cp39-cp39-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:86ce2371bfd7f212cf60d8517e5e854475c2c43ce14aa910e136ace72c6db6c1", size = 7199330, upload-time = "2026-02-06T09:56:57.611Z" },
+    { url = "https://files.pythonhosted.org/packages/68/2f/42a52d78bdbdb3f1310ed690a3511cd004740281ca75d300b7bd6d9d3de3/grpcio-1.78.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b0c689c02947d636bc7fab3e30cc3a3445cca99c834dfb77cd4a6cabfc1c5597", size = 6726696, upload-time = "2026-02-06T09:57:00.357Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/83/b3d932a4fbb2dce3056f6df2926fc2d3ddc5d5acbafbec32c84033cf3f23/grpcio-1.78.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:ce7599575eeb25c0f4dc1be59cada6219f3b56176f799627f44088b21381a28a", size = 7299076, upload-time = "2026-02-06T09:57:04.124Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/d9/70ea1be55efaf91fd19f7258b1292772a8226cf1b0e237717fba671073cb/grpcio-1.78.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:684083fd383e9dc04c794adb838d4faea08b291ce81f64ecd08e4577c7398adf", size = 8284493, upload-time = "2026-02-06T09:57:06.746Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/2f/3dddccf49e3e75564655b84175fca092d3efd81d2979fc89c4b1c1d879dc/grpcio-1.78.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:ab399ef5e3cd2a721b1038a0f3021001f19c5ab279f145e1146bb0b9f1b2b12c", size = 7724340, upload-time = "2026-02-06T09:57:09.453Z" },
+    { url = "https://files.pythonhosted.org/packages/79/ae/dfdb3183141db787a9363078a98764675996a7c2448883153091fd7c8527/grpcio-1.78.0-cp39-cp39-win32.whl", hash = "sha256:f3d6379493e18ad4d39537a82371c5281e153e963cecb13f953ebac155756525", size = 4077641, upload-time = "2026-02-06T09:57:11.881Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/aa/694b2f505345cfdd234cffb2525aa379a81695e6c02fd40d7e9193e871c6/grpcio-1.78.0-cp39-cp39-win_amd64.whl", hash = "sha256:5361a0630a7fdb58a6a97638ab70e1dae2893c4d08d7aba64ded28bb9e7a29df", size = 4799428, upload-time = "2026-02-06T09:57:14.493Z" },
+]
+
+[[package]]
+name = "importlib-metadata"
+version = "8.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zipp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/5e/f8e9a1d23b9c20a551a8a02ea3637b4642e22c2626e3a13a9a29cdea99eb/importlib_metadata-8.7.1-py3-none-any.whl", hash = "sha256:5a1f80bf1daa489495071efbb095d75a634cf28a8bc299581244063b53176151", size = 27865, upload-time = "2025-12-21T10:00:18.329Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.39.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-metadata" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/97/b9/3161be15bb8e3ad01be8be5a968a9237c3027c5be504362ff800fca3e442/opentelemetry_api-1.39.1.tar.gz", hash = "sha256:fbde8c80e1b937a2c61f20347e91c0c18a1940cecf012d62e65a7caf08967c9c", size = 65767, upload-time = "2025-12-11T13:32:39.182Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cf/df/d3f1ddf4bb4cb50ed9b1139cc7b1c54c34a1e7ce8fd1b9a37c0d1551a6bd/opentelemetry_api-1.39.1-py3-none-any.whl", hash = "sha256:2edd8463432a7f8443edce90972169b195e7d6a05500cd29e6d13898187c9950", size = 66356, upload-time = "2025-12-11T13:32:17.304Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-common"
+version = "1.39.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-proto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/9d/22d241b66f7bbde88a3bfa6847a351d2c46b84de23e71222c6aae25c7050/opentelemetry_exporter_otlp_proto_common-1.39.1.tar.gz", hash = "sha256:763370d4737a59741c89a67b50f9e39271639ee4afc999dadfe768541c027464", size = 20409, upload-time = "2025-12-11T13:32:40.885Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8c/02/ffc3e143d89a27ac21fd557365b98bd0653b98de8a101151d5805b5d4c33/opentelemetry_exporter_otlp_proto_common-1.39.1-py3-none-any.whl", hash = "sha256:08f8a5862d64cc3435105686d0216c1365dc5701f86844a8cd56597d0c764fde", size = 18366, upload-time = "2025-12-11T13:32:20.2Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-grpc"
+version = "1.39.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "grpcio" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/53/48/b329fed2c610c2c32c9366d9dc597202c9d1e58e631c137ba15248d8850f/opentelemetry_exporter_otlp_proto_grpc-1.39.1.tar.gz", hash = "sha256:772eb1c9287485d625e4dbe9c879898e5253fea111d9181140f51291b5fec3ad", size = 24650, upload-time = "2025-12-11T13:32:41.429Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/a3/cc9b66575bd6597b98b886a2067eea2693408d2d5f39dad9ab7fc264f5f3/opentelemetry_exporter_otlp_proto_grpc-1.39.1-py3-none-any.whl", hash = "sha256:fa1c136a05c7e9b4c09f739469cbdb927ea20b34088ab1d959a849b5cc589c18", size = 19766, upload-time = "2025-12-11T13:32:21.027Z" },
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "1.39.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/1d/f25d76d8260c156c40c97c9ed4511ec0f9ce353f8108ca6e7561f82a06b2/opentelemetry_proto-1.39.1.tar.gz", hash = "sha256:6c8e05144fc0d3ed4d22c2289c6b126e03bcd0e6a7da0f16cedd2e1c2772e2c8", size = 46152, upload-time = "2025-12-11T13:32:48.681Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/95/b40c96a7b5203005a0b03d8ce8cd212ff23f1793d5ba289c87a097571b18/opentelemetry_proto-1.39.1-py3-none-any.whl", hash = "sha256:22cdc78efd3b3765d09e68bfbd010d4fc254c9818afd0b6b423387d9dee46007", size = 72535, upload-time = "2025-12-11T13:32:33.866Z" },
+]
+
+[[package]]
+name = "opentelemetry-sdk"
+version = "1.39.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/fb/c76080c9ba07e1e8235d24cdcc4d125ef7aa3edf23eb4e497c2e50889adc/opentelemetry_sdk-1.39.1.tar.gz", hash = "sha256:cf4d4563caf7bff906c9f7967e2be22d0d6b349b908be0d90fb21c8e9c995cc6", size = 171460, upload-time = "2025-12-11T13:32:49.369Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/98/e91cf858f203d86f4eccdf763dcf01cf03f1dae80c3750f7e635bfa206b6/opentelemetry_sdk-1.39.1-py3-none-any.whl", hash = "sha256:4d5482c478513ecb0a5d938dcc61394e647066e0cc2676bee9f3af3f3f45f01c", size = 132565, upload-time = "2025-12-11T13:32:35.069Z" },
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.60b1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/df/553f93ed38bf22f4b999d9be9c185adb558982214f33eae539d3b5cd0858/opentelemetry_semantic_conventions-0.60b1.tar.gz", hash = "sha256:87c228b5a0669b748c76d76df6c364c369c28f1c465e50f661e39737e84bc953", size = 137935, upload-time = "2025-12-11T13:32:50.487Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/5e/5958555e09635d09b75de3c4f8b9cae7335ca545d77392ffe7331534c402/opentelemetry_semantic_conventions-0.60b1-py3-none-any.whl", hash = "sha256:9fa8c8b0c110da289809292b0591220d3a7b53c1526a23021e977d68597893fb", size = 219982, upload-time = "2025-12-11T13:32:36.955Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "prometheus-client"
+version = "0.24.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f0/58/a794d23feb6b00fc0c72787d7e87d872a6730dd9ed7c7b3e954637d8f280/prometheus_client-0.24.1.tar.gz", hash = "sha256:7e0ced7fbbd40f7b84962d5d2ab6f17ef88a72504dcf7c0b40737b43b2a461f9", size = 85616, upload-time = "2026-01-14T15:26:26.965Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/c3/24a2f845e3917201628ecaba4f18bab4d18a337834c1df2a159ee9d22a42/prometheus_client-0.24.1-py3-none-any.whl", hash = "sha256:150db128af71a5c2482b36e588fc8a6b95e498750da4b17065947c16070f4055", size = 64057, upload-time = "2026-01-14T15:26:24.42Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "6.33.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/25/7c72c307aafc96fa87062aa6291d9f7c94836e43214d43722e86037aac02/protobuf-6.33.5.tar.gz", hash = "sha256:6ddcac2a081f8b7b9642c09406bc6a4290128fce5f471cddd165960bb9119e5c", size = 444465, upload-time = "2026-01-29T21:51:33.494Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b1/79/af92d0a8369732b027e6d6084251dd8e782c685c72da161bd4a2e00fbabb/protobuf-6.33.5-cp310-abi3-win32.whl", hash = "sha256:d71b040839446bac0f4d162e758bea99c8251161dae9d0983a3b88dee345153b", size = 425769, upload-time = "2026-01-29T21:51:21.751Z" },
+    { url = "https://files.pythonhosted.org/packages/55/75/bb9bc917d10e9ee13dee8607eb9ab963b7cf8be607c46e7862c748aa2af7/protobuf-6.33.5-cp310-abi3-win_amd64.whl", hash = "sha256:3093804752167bcab3998bec9f1048baae6e29505adaf1afd14a37bddede533c", size = 437118, upload-time = "2026-01-29T21:51:24.022Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/6b/e48dfc1191bc5b52950246275bf4089773e91cb5ba3592621723cdddca62/protobuf-6.33.5-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:a5cb85982d95d906df1e2210e58f8e4f1e3cdc088e52c921a041f9c9a0386de5", size = 427766, upload-time = "2026-01-29T21:51:25.413Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/b1/c79468184310de09d75095ed1314b839eb2f72df71097db9d1404a1b2717/protobuf-6.33.5-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:9b71e0281f36f179d00cbcb119cb19dec4d14a81393e5ea220f64b286173e190", size = 324638, upload-time = "2026-01-29T21:51:26.423Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/f5/65d838092fd01c44d16037953fd4c2cc851e783de9b8f02b27ec4ffd906f/protobuf-6.33.5-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:8afa18e1d6d20af15b417e728e9f60f3aa108ee76f23c3b2c07a2c3b546d3afd", size = 339411, upload-time = "2026-01-29T21:51:27.446Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/53/a9443aa3ca9ba8724fdfa02dd1887c1bcd8e89556b715cfbacca6b63dbec/protobuf-6.33.5-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:cbf16ba3350fb7b889fca858fb215967792dc125b35c7976ca4818bee3521cf0", size = 323465, upload-time = "2026-01-29T21:51:28.925Z" },
+    { url = "https://files.pythonhosted.org/packages/08/60/84d5f6dcda9165e4d6a56ac8433c9f40a8906bf2966150b8a0cfde097d78/protobuf-6.33.5-cp39-cp39-win32.whl", hash = "sha256:a3157e62729aafb8df6da2c03aa5c0937c7266c626ce11a278b6eb7963c4e37c", size = 425892, upload-time = "2026-01-29T21:51:30.382Z" },
+    { url = "https://files.pythonhosted.org/packages/68/19/33d7dc2dc84439587fa1e21e1c0026c01ad2af0a62f58fd54002a7546307/protobuf-6.33.5-cp39-cp39-win_amd64.whl", hash = "sha256:8f04fa32763dcdb4973d537d6b54e615cc61108c7cb38fe59310c3192d29510a", size = 437137, upload-time = "2026-01-29T21:51:31.456Z" },
+    { url = "https://files.pythonhosted.org/packages/57/bf/2086963c69bdac3d7cff1cc7ff79b8ce5ea0bec6797a017e1be338a46248/protobuf-6.33.5-py3-none-any.whl", hash = "sha256:69915a973dd0f60f31a08b8318b73eab2bd6a392c79184b3612226b0a3f8ec02", size = 170687, upload-time = "2026-01-29T21:51:32.557Z" },
+]
+
+[[package]]
+name = "psmove-pairing"
+version = "1.0.0"
+source = { editable = "." }
+dependencies = [
+    { name = "dbus-python", marker = "sys_platform == 'linux'" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-grpc" },
+    { name = "opentelemetry-sdk" },
+    { name = "prometheus-client" },
+]
+
+[package.optional-dependencies]
+test = [
+    { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pytest", version = "9.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pytest-asyncio", version = "1.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pytest-asyncio", version = "1.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pytest-cov" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "dbus-python", marker = "sys_platform == 'linux'", specifier = ">=1.2.0" },
+    { name = "opentelemetry-api", specifier = ">=1.20.0" },
+    { name = "opentelemetry-exporter-otlp-proto-grpc", specifier = ">=1.20.0" },
+    { name = "opentelemetry-sdk", specifier = ">=1.20.0" },
+    { name = "prometheus-client", specifier = ">=0.17.0" },
+    { name = "pytest", marker = "extra == 'test'", specifier = ">=8.0.0" },
+    { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.23.0" },
+    { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=4.1.0" },
+]
+provides-extras = ["test"]
+
+[[package]]
+name = "pygments"
+version = "2.19.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "8.4.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+dependencies = [
+    { name = "colorama", marker = "python_full_version < '3.10' and sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.10'" },
+    { name = "iniconfig", version = "2.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "packaging", marker = "python_full_version < '3.10'" },
+    { name = "pluggy", marker = "python_full_version < '3.10'" },
+    { name = "pygments", marker = "python_full_version < '3.10'" },
+    { name = "tomli", marker = "python_full_version < '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+dependencies = [
+    { name = "colorama", marker = "python_full_version >= '3.10' and sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version == '3.10.*'" },
+    { name = "iniconfig", version = "2.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "packaging", marker = "python_full_version >= '3.10'" },
+    { name = "pluggy", marker = "python_full_version >= '3.10'" },
+    { name = "pygments", marker = "python_full_version >= '3.10'" },
+    { name = "tomli", marker = "python_full_version == '3.10.*'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+dependencies = [
+    { name = "backports-asyncio-runner", marker = "python_full_version < '3.10'" },
+    { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/86/9e3c5f48f7b7b638b216e4b9e645f54d199d7abbbab7a64a13b4e12ba10f/pytest_asyncio-1.2.0.tar.gz", hash = "sha256:c609a64a2a8768462d0c99811ddb8bd2583c33fd33cf7f21af1c142e824ffb57", size = 50119, upload-time = "2025-09-12T07:33:53.816Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/93/2fa34714b7a4ae72f2f8dad66ba17dd9a2c793220719e736dda28b7aec27/pytest_asyncio-1.2.0-py3-none-any.whl", hash = "sha256:8e17ae5e46d8e7efe51ab6494dd2010f4ca8dae51652aa3c8d55acf50bfb2e99", size = 15095, upload-time = "2025-09-12T07:33:52.639Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+dependencies = [
+    { name = "backports-asyncio-runner", marker = "python_full_version == '3.10.*'" },
+    { name = "pytest", version = "9.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
+name = "pytest-cov"
+version = "7.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage", version = "7.10.7", source = { registry = "https://pypi.org/simple" }, extra = ["toml"], marker = "python_full_version < '3.10'" },
+    { name = "coverage", version = "7.13.3", source = { registry = "https://pypi.org/simple" }, extra = ["toml"], marker = "python_full_version >= '3.10'" },
+    { name = "pluggy" },
+    { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pytest", version = "9.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/f7/c933acc76f5208b3b00089573cf6a2bc26dc80a8aece8f52bb7d6b1855ca/pytest_cov-7.0.0.tar.gz", hash = "sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1", size = 54328, upload-time = "2025-09-09T10:57:02.113Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ee/49/1377b49de7d0c1ce41292161ea0f721913fa8722c19fb9c1e3aa0367eecb/pytest_cov-7.0.0-py3-none-any.whl", hash = "sha256:3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861", size = 22424, upload-time = "2025-09-09T10:57:00.695Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/30/31573e9457673ab10aa432461bee537ce6cef177667deca369efb79df071/tomli-2.4.0.tar.gz", hash = "sha256:aa89c3f6c277dd275d8e243ad24f3b5e701491a860d5121f2cdd399fbb31fc9c", size = 17477, upload-time = "2026-01-11T11:22:38.165Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/d9/3dc2289e1f3b32eb19b9785b6a006b28ee99acb37d1d47f78d4c10e28bf8/tomli-2.4.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b5ef256a3fd497d4973c11bf142e9ed78b150d36f5773f1ca6088c230ffc5867", size = 153663, upload-time = "2026-01-11T11:21:45.27Z" },
+    { url = "https://files.pythonhosted.org/packages/51/32/ef9f6845e6b9ca392cd3f64f9ec185cc6f09f0a2df3db08cbe8809d1d435/tomli-2.4.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5572e41282d5268eb09a697c89a7bee84fae66511f87533a6f88bd2f7b652da9", size = 148469, upload-time = "2026-01-11T11:21:46.873Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/c2/506e44cce89a8b1b1e047d64bd495c22c9f71f21e05f380f1a950dd9c217/tomli-2.4.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:551e321c6ba03b55676970b47cb1b73f14a0a4dce6a3e1a9458fd6d921d72e95", size = 236039, upload-time = "2026-01-11T11:21:48.503Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/40/e1b65986dbc861b7e986e8ec394598187fa8aee85b1650b01dd925ca0be8/tomli-2.4.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5e3f639a7a8f10069d0e15408c0b96a2a828cfdec6fca05296ebcdcc28ca7c76", size = 243007, upload-time = "2026-01-11T11:21:49.456Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/6f/6e39ce66b58a5b7ae572a0f4352ff40c71e8573633deda43f6a379d56b3e/tomli-2.4.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1b168f2731796b045128c45982d3a4874057626da0e2ef1fdd722848b741361d", size = 240875, upload-time = "2026-01-11T11:21:50.755Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/ad/cb089cb190487caa80204d503c7fd0f4d443f90b95cf4ef5cf5aa0f439b0/tomli-2.4.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:133e93646ec4300d651839d382d63edff11d8978be23da4cc106f5a18b7d0576", size = 246271, upload-time = "2026-01-11T11:21:51.81Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/63/69125220e47fd7a3a27fd0de0c6398c89432fec41bc739823bcc66506af6/tomli-2.4.0-cp311-cp311-win32.whl", hash = "sha256:b6c78bdf37764092d369722d9946cb65b8767bfa4110f902a1b2542d8d173c8a", size = 96770, upload-time = "2026-01-11T11:21:52.647Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/0d/a22bb6c83f83386b0008425a6cd1fa1c14b5f3dd4bad05e98cf3dbbf4a64/tomli-2.4.0-cp311-cp311-win_amd64.whl", hash = "sha256:d3d1654e11d724760cdb37a3d7691f0be9db5fbdaef59c9f532aabf87006dbaa", size = 107626, upload-time = "2026-01-11T11:21:53.459Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/6d/77be674a3485e75cacbf2ddba2b146911477bd887dda9d8c9dfb2f15e871/tomli-2.4.0-cp311-cp311-win_arm64.whl", hash = "sha256:cae9c19ed12d4e8f3ebf46d1a75090e4c0dc16271c5bce1c833ac168f08fb614", size = 94842, upload-time = "2026-01-11T11:21:54.831Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/43/7389a1869f2f26dba52404e1ef13b4784b6b37dac93bac53457e3ff24ca3/tomli-2.4.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:920b1de295e72887bafa3ad9f7a792f811847d57ea6b1215154030cf131f16b1", size = 154894, upload-time = "2026-01-11T11:21:56.07Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/05/2f9bf110b5294132b2edf13fe6ca6ae456204f3d749f623307cbb7a946f2/tomli-2.4.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7d6d9a4aee98fac3eab4952ad1d73aee87359452d1c086b5ceb43ed02ddb16b8", size = 149053, upload-time = "2026-01-11T11:21:57.467Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/41/1eda3ca1abc6f6154a8db4d714a4d35c4ad90adc0bcf700657291593fbf3/tomli-2.4.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:36b9d05b51e65b254ea6c2585b59d2c4cb91c8a3d91d0ed0f17591a29aaea54a", size = 243481, upload-time = "2026-01-11T11:21:58.661Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/6d/02ff5ab6c8868b41e7d4b987ce2b5f6a51d3335a70aa144edd999e055a01/tomli-2.4.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1c8a885b370751837c029ef9bc014f27d80840e48bac415f3412e6593bbc18c1", size = 251720, upload-time = "2026-01-11T11:22:00.178Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/57/0405c59a909c45d5b6f146107c6d997825aa87568b042042f7a9c0afed34/tomli-2.4.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8768715ffc41f0008abe25d808c20c3d990f42b6e2e58305d5da280ae7d1fa3b", size = 247014, upload-time = "2026-01-11T11:22:01.238Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/0e/2e37568edd944b4165735687cbaf2fe3648129e440c26d02223672ee0630/tomli-2.4.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7b438885858efd5be02a9a133caf5812b8776ee0c969fea02c45e8e3f296ba51", size = 251820, upload-time = "2026-01-11T11:22:02.727Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/1c/ee3b707fdac82aeeb92d1a113f803cf6d0f37bdca0849cb489553e1f417a/tomli-2.4.0-cp312-cp312-win32.whl", hash = "sha256:0408e3de5ec77cc7f81960c362543cbbd91ef883e3138e81b729fc3eea5b9729", size = 97712, upload-time = "2026-01-11T11:22:03.777Z" },
+    { url = "https://files.pythonhosted.org/packages/69/13/c07a9177d0b3bab7913299b9278845fc6eaaca14a02667c6be0b0a2270c8/tomli-2.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:685306e2cc7da35be4ee914fd34ab801a6acacb061b6a7abca922aaf9ad368da", size = 108296, upload-time = "2026-01-11T11:22:04.86Z" },
+    { url = "https://files.pythonhosted.org/packages/18/27/e267a60bbeeee343bcc279bb9e8fbed0cbe224bc7b2a3dc2975f22809a09/tomli-2.4.0-cp312-cp312-win_arm64.whl", hash = "sha256:5aa48d7c2356055feef06a43611fc401a07337d5b006be13a30f6c58f869e3c3", size = 94553, upload-time = "2026-01-11T11:22:05.854Z" },
+    { url = "https://files.pythonhosted.org/packages/23/d1/136eb2cb77520a31e1f64cbae9d33ec6df0d78bdf4160398e86eec8a8754/tomli-2.4.0-py3-none-any.whl", hash = "sha256:1f776e7d669ebceb01dee46484485f43a4048746235e683bcdffacdf1fb4785a", size = 14477, upload-time = "2026-01-11T11:22:37.446Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "zipp"
+version = "3.23.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/02/0f2892c661036d50ede074e376733dca2ae7c6eb617489437771209d4180/zipp-3.23.0.tar.gz", hash = "sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166", size = 25547, upload-time = "2025-06-08T17:06:39.4Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/54/647ade08bf0db230bfea292f893923872fd20be6ac6f53b2b936ba839d75/zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e", size = 10276, upload-time = "2025-06-08T17:06:38.034Z" },
+]


### PR DESCRIPTION
## Summary

Implements Phase 1 and Phase 2 of the pairing daemon improvement plan from issue #313.

### Testing Infrastructure (Phase 1)
- Added `pyproject.toml` with pytest, pytest-asyncio, pytest-cov dependencies
- Created comprehensive test suite with 56 tests covering:
  - `test_utils.py`: `run_command()`, `find_psmove_binary()`
  - `test_usb_pairing.py`: USB detection, pairing via psmove bindings, calibration
  - `test_bluetooth_monitor.py`: hciconfig/hcitool output parsing
  - `test_daemon.py`: Health checks, prerequisites validation, loop management
- Created `MockCommandRunner` fixture for mocking shell commands
- Added conftest.py that mocks `psmove` and `dbus` modules before import

### Health Checks (Phase 2)
- Added startup validation for psmove binary and bluetoothctl
- Added liveness tracking with 60-second staleness threshold
- Added `/healthz` endpoint on the metrics HTTP server (port 8002)
- Updated systemd service with `ExecStartPost` health check

### CI Integration
- Added `pairing-daemon-checks` job to CI workflow
- Installs dbus dependencies needed for tests

## Test plan

- [x] All 56 unit tests pass locally
- [x] Ruff check passes
- [x] Ruff format passes
- [ ] CI passes
- [ ] Manual verification on Pi with actual hardware

## Related

Fixes #313

🤖 Generated with [Claude Code](https://claude.com/claude-code)