### PR TITLE
chore: Rename dev-refactor branch to main

### DIFF
--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -5,11 +5,11 @@
 Never commit directly to the main checkout. Always use git worktrees:
 
 ```bash
-git worktree add ../JoustMania-issue-<NUMBER> -b fix/description origin/dev-refactor
+git worktree add ../JoustMania-issue-<NUMBER> -b fix/description origin/main
 cd ../JoustMania-issue-<NUMBER>
 # ... make changes ...
 git push -u origin fix/description
-gh pr create --base dev-refactor
+gh pr create --base main
 ```
 
 This keeps the main checkout clean for:
@@ -19,9 +19,9 @@ This keeps the main checkout clean for:
 
 ## Main Branch
 
-The main development branch is **`dev-refactor`** (not `master`).
+The main development branch is **`main`**.
 
-All PRs target `dev-refactor`.
+All PRs target `main`.
 
 ## Branch Naming
 
@@ -60,7 +60,7 @@ make lint
 
 ## Pull Requests
 
-1. Create via `gh pr create --base dev-refactor`
+1. Create via `gh pr create --base main`
 2. Include issue reference: `Fixes #123`
 3. Add test plan with checkboxes
 4. Wait for CI to pass

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   pull_request:
-    branches: [main, master, dev-refactor]
+    branches: [main]
   push:
-    branches: [main, master, dev-refactor]
+    branches: [main]
   workflow_dispatch:
 
 env:
@@ -12,7 +12,7 @@ env:
   # Repository name in lowercase for GHCR
   IMAGE_PREFIX: ghcr.io/watchmejoustmyflags/joustmania
   # Main branch - used for :latest Docker tag
-  MAIN_BRANCH: dev-refactor
+  MAIN_BRANCH: main
 
 jobs:
   # Build and test shared packages (proto, lib)
@@ -353,7 +353,7 @@ jobs:
         run: |
           docker buildx imagetools create \
             --tag ${{ env.IMAGE_PREFIX }}/builder:${{ github.sha }} \
-            ${{ env.IMAGE_PREFIX }}/builder:dev-refactor
+            ${{ env.IMAGE_PREFIX }}/builder:main
 
   build-psmove-builder:
     name: Build psmove-builder
@@ -400,7 +400,7 @@ jobs:
         run: |
           docker buildx imagetools create \
             --tag ${{ env.IMAGE_PREFIX }}/psmove-builder:${{ github.sha }} \
-            ${{ env.IMAGE_PREFIX }}/psmove-builder:dev-refactor
+            ${{ env.IMAGE_PREFIX }}/psmove-builder:main
 
   docker-build:
     name: Build ${{ matrix.service }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Multiplayer motion-controlled party game system using PS Move controllers.
 
-**Main branch: `dev-refactor`** (not master)
+**Main branch: `main`**
 
 ## Quick Reference
 
@@ -31,7 +31,7 @@ uv run pytest
 **Always create a new worktree for changes.** Never commit directly to the main checkout directory.
 
 ```bash
-git worktree add ../JoustMania-issue-<NUMBER> -b fix/description origin/dev-refactor
+git worktree add ../JoustMania-issue-<NUMBER> -b fix/description origin/main
 cd ../JoustMania-issue-<NUMBER>
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@
 #
 # Notes:
 # - All images default to ghcr.io/watchmejoustmyflags/joustmania registry
-# - Use IMAGE_TAG to specify version (e.g., IMAGE_TAG=dev-refactor docker compose up)
+# - Use IMAGE_TAG to specify version (e.g., IMAGE_TAG=main docker compose up)
 # - Local builds tag images with GHCR names for consistency
 
 services:

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -54,7 +54,7 @@ Use git worktrees to isolate work on different issues:
 
 ```bash
 # Create worktree for an issue
-git worktree add ../JoustMania-issue-<NUMBER> -b issue-<NUMBER> origin/dev-refactor
+git worktree add ../JoustMania-issue-<NUMBER> -b issue-<NUMBER> origin/main
 
 # Work in the isolated directory
 cd ../JoustMania-issue-<NUMBER>

--- a/docs/DOCKER_WORKFLOW.md
+++ b/docs/DOCKER_WORKFLOW.md
@@ -75,9 +75,9 @@ ghcr.io/watchmejoustmyflags/joustmania/<service>:<tag>
 Controls which image tag to use. Defaults to `latest`.
 
 ```bash
-# Use dev-refactor branch images
-IMAGE_TAG=dev-refactor docker compose pull
-IMAGE_TAG=dev-refactor docker compose up -d
+# Use main branch images
+IMAGE_TAG=main docker compose pull
+IMAGE_TAG=main docker compose up -d
 ```
 
 ### BUILDER_IMAGE / PSMOVE_BUILDER_IMAGE
@@ -137,7 +137,7 @@ make test-debug
 
 # Test with prebuilt GHCR images
 make test-pulled
-IMAGE_TAG=dev-refactor make test-pulled
+IMAGE_TAG=main make test-pulled
 ```
 
 ### CI/CD Workflow

--- a/services/audio/Dockerfile
+++ b/services/audio/Dockerfile
@@ -11,7 +11,7 @@
 # - Fix: disable GCC auto-vectorization for ARM64 builds
 #
 # Phase 75: Builder images can be overridden for CI/CD
-# --build-arg BUILDER_IMAGE=ghcr.io/watchmejoustmyflags/joustmania/builder:dev-refactor
+# --build-arg BUILDER_IMAGE=ghcr.io/watchmejoustmyflags/joustmania/builder:main
 
 # Builder image - override with --build-arg for CI/CD
 ARG BUILDER_IMAGE=ghcr.io/watchmejoustmyflags/joustmania/builder:latest

--- a/services/controller_manager/Dockerfile
+++ b/services/controller_manager/Dockerfile
@@ -6,8 +6,8 @@
 #   docker build -t ghcr.io/watchmejoustmyflags/joustmania/builder:latest images/builder/
 #
 # Phase 75: Builder images can be overridden for CI/CD
-# --build-arg BUILDER_IMAGE=ghcr.io/watchmejoustmyflags/joustmania/builder:dev-refactor
-# --build-arg PSMOVE_BUILDER_IMAGE=ghcr.io/watchmejoustmyflags/joustmania/psmove-builder:dev-refactor
+# --build-arg BUILDER_IMAGE=ghcr.io/watchmejoustmyflags/joustmania/builder:main
+# --build-arg PSMOVE_BUILDER_IMAGE=ghcr.io/watchmejoustmyflags/joustmania/psmove-builder:main
 #
 # Build time: ~1-2 minutes (vs 10-15 minutes without pre-built psmoveapi)
 

--- a/services/game_coordinator/Dockerfile
+++ b/services/game_coordinator/Dockerfile
@@ -4,7 +4,7 @@
 # Build the builder first: docker build -t ghcr.io/watchmejoustmyflags/joustmania/builder:latest images/builder/
 #
 # Phase 75: Builder image can be overridden for CI/CD
-# --build-arg BUILDER_IMAGE=ghcr.io/watchmejoustmyflags/joustmania/builder:dev-refactor
+# --build-arg BUILDER_IMAGE=ghcr.io/watchmejoustmyflags/joustmania/builder:main
 
 # Builder image - override with --build-arg BUILDER_IMAGE=...
 ARG BUILDER_IMAGE=ghcr.io/watchmejoustmyflags/joustmania/builder:latest

--- a/services/menu/Dockerfile
+++ b/services/menu/Dockerfile
@@ -4,7 +4,7 @@
 # Build the builder first: docker build -t ghcr.io/watchmejoustmyflags/joustmania/builder:latest images/builder/
 #
 # Phase 75: Builder image can be overridden for CI/CD
-# --build-arg BUILDER_IMAGE=ghcr.io/watchmejoustmyflags/joustmania/builder:dev-refactor
+# --build-arg BUILDER_IMAGE=ghcr.io/watchmejoustmyflags/joustmania/builder:main
 
 # Builder image - override with --build-arg BUILDER_IMAGE=...
 ARG BUILDER_IMAGE=ghcr.io/watchmejoustmyflags/joustmania/builder:latest

--- a/services/settings/Dockerfile
+++ b/services/settings/Dockerfile
@@ -4,7 +4,7 @@
 # Build the builder first: docker build -t ghcr.io/watchmejoustmyflags/joustmania/builder:latest images/builder/
 #
 # Phase 75: Builder image can be overridden for CI/CD
-# --build-arg BUILDER_IMAGE=ghcr.io/watchmejoustmyflags/joustmania/builder:dev-refactor
+# --build-arg BUILDER_IMAGE=ghcr.io/watchmejoustmyflags/joustmania/builder:main
 
 # Builder image - override with --build-arg BUILDER_IMAGE=...
 ARG BUILDER_IMAGE=ghcr.io/watchmejoustmyflags/joustmania/builder:latest

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -83,7 +83,7 @@ make test TEST=test_ffa
 make test-pulled
 
 # Using specific image tag
-IMAGE_TAG=dev-refactor make test-pulled
+IMAGE_TAG=main make test-pulled
 
 # With pause for Jaeger inspection
 make test-debug
@@ -99,7 +99,7 @@ uv run --package joustmania-integration-tests pytest tests/integration/ -v
 USE_PREBUILT_IMAGES=true uv run --package joustmania-integration-tests pytest tests/integration/ -v
 
 # Using specific image tag
-USE_PREBUILT_IMAGES=true IMAGE_TAG=dev-refactor uv run --package joustmania-integration-tests pytest tests/integration/ -v
+USE_PREBUILT_IMAGES=true IMAGE_TAG=main uv run --package joustmania-integration-tests pytest tests/integration/ -v
 
 # With pause for Jaeger inspection
 PAUSE_BEFORE_TEARDOWN=1 uv run --package joustmania-integration-tests pytest tests/integration/ -v -s


### PR DESCRIPTION
## Summary

Renames the default branch from `dev-refactor` to `main` — the standard convention. The `dev-refactor` name is a legacy artifact from when the refactor was a side branch; now that it *is* the project, it should be called `main`.

- Update CI workflow triggers and `MAIN_BRANCH` env var
- Update builder image re-tag fallback references
- Update all documentation (CLAUDE.md, git-workflow rules, CONTRIBUTING, DOCKER_WORKFLOW, integration test README)
- Update Dockerfile comment examples (5 services)
- Update docker-compose.yml comment example
- Update legacy `claude.md` session continuity guide

Fixes #318

## Post-merge steps

After this PR is merged, rename the branch on GitHub:

```bash
gh api repos/WatchMeJoustMyFlags/JoustMania/branches/dev-refactor/rename -f new_name=main
```

This automatically updates the default branch setting, retargets open PRs, and sets up a redirect.

Contributors update their local clones with:
```bash
git fetch --prune && git branch -m dev-refactor main && git branch -u origin/main
```

## Test plan

- [x] `make lint` passes
- [x] `grep -r "dev-refactor" .` returns zero hits (excluding .git/)
- [ ] CI passes on this PR
- [ ] After merge: run `gh api` rename command
- [ ] After rename: verify `gh repo view --json defaultBranchRef` shows `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)