### PR TITLE
chore: Remove stale TODOs and replace print with logger

### DIFF
--- a/services/controller_manager/bluetooth.py
+++ b/services/controller_manager/bluetooth.py
@@ -186,7 +186,7 @@ def enable_adapter(hci):
     if iface.Get("org.bluez.Adapter1", "Powered").real:
         return False
     try:
-        print("Enabling adapter")
+        logger.debug("Enabling adapter")
         iface.Set("org.bluez.Adapter1", "Powered", True)
         return True
     except dbus.exceptions.DBusException as e:

--- a/services/menu/process.py
+++ b/services/menu/process.py
@@ -230,10 +230,6 @@ class MenuProcess(Process):
         if self.check_game_start():
             self.request_game_start()
 
-        # TODO: Update controller display
-        # TODO: Handle game mode changes
-        # TODO: Handle admin controls
-
     def check_game_start(self) -> bool:
         """
         Check if game should start.


### PR DESCRIPTION
## Summary
- Remove three stale TODO comments from `services/menu/process.py` — all three functionalities (controller display updates, game mode changes, admin controls) are already fully implemented in the gRPC servicer architecture (`handlers/admin.py`, `handlers/connected.py`, `utils/led.py`)
- Replace `print("Enabling adapter")` with `logger.debug("Enabling adapter")` in `services/controller_manager/bluetooth.py` for logging consistency

Fixes #339
Fixes #340

## Test plan
- [x] `make lint` passes
- [x] Menu service unit tests pass (152 tests)
- [x] Controller manager unit tests pass (209 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)