### PR TITLE
fix: Replace os.popen with subprocess.run to prevent shell injection

### DIFF
--- a/services/controller_manager/bluetooth.py
+++ b/services/controller_manager/bluetooth.py
@@ -4,6 +4,7 @@ This module handles interacting with Bluez over DBus for JoustMania
 
 import logging
 import os
+import subprocess
 from xml.etree import ElementTree
 
 import dbus
@@ -56,8 +57,6 @@ def get_connected_addresses(hci):
 
     Falls back to DBus Connected property if hcitool fails.
     """
-    import subprocess
-
     # Try hcitool con first - this shows actual HCI connections
     try:
         result = subprocess.run(
@@ -186,7 +185,7 @@ def enable_adapter(hci):
     if iface.Get("org.bluez.Adapter1", "Powered").real:
         return False
     try:
-        print("Enabling adapter")
+        logger.debug("Enabling adapter")
         iface.Set("org.bluez.Adapter1", "Powered", True)
         return True
     except dbus.exceptions.DBusException as e:
@@ -198,8 +197,23 @@ def enable_adapter(hci):
 
 
 def rfkill_unblock(hci):
-    hci_id = os.popen(f'rfkill list | grep {hci} | cut -d ":" -f 1').read().split("\n")[0]
-    os.popen(f"rfkill unblock {hci_id}").read()
+    """Unblock a Bluetooth adapter via rfkill."""
+    # Parse rfkill list output to find the ID for this HCI adapter
+    # Lines look like: "0: hci0: Bluetooth"
+    result = subprocess.run(["rfkill", "list"], capture_output=True, text=True, timeout=5.0)
+    hci_id = None
+    for line in result.stdout.splitlines():
+        if hci in line:
+            candidate = line.split(":")[0].strip()
+            if candidate.isdigit():
+                hci_id = candidate
+                break
+
+    if hci_id is None:
+        logger.warning(f"Could not find rfkill ID for {hci}")
+        return
+
+    subprocess.run(["rfkill", "unblock", hci_id], check=True, timeout=5.0)
 
 
 def disable_adapter(hci):


### PR DESCRIPTION
## Summary
- Replace `os.popen()` calls in `rfkill_unblock()` with `subprocess.run()` using argument lists, preventing shell injection via crafted HCI adapter names
- Move `subprocess` import to top-level (was local import in `get_connected_addresses()`)
- Replace `print("Enabling adapter")` with `logger.debug()` (fixes #340)

Fixes #324

## Test plan
- [x] `make lint` passes
- [x] `uv run pytest` passes (209 tests)
- [ ] Manual: verify rfkill unblock works on Raspberry Pi with real adapter

🤖 Generated with [Claude Code](https://claude.com/claude-code)