### PR TITLE
refactor: Unify active_effects and active_effect_types into single dict

### DIFF
--- a/services/controller_manager/effects_base.py
+++ b/services/controller_manager/effects_base.py
@@ -13,10 +13,19 @@ import colorsys
 import logging
 import math
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 
 from lib.clock import Clock, RealClock
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ActiveEffect:
+    """Tracks an active effect task and its type for a single controller."""
+
+    task: asyncio.Task
+    effect_type: int  # GameEffect enum value
 
 
 class ControllerEffectsBase(ABC):
@@ -35,8 +44,8 @@ class ControllerEffectsBase(ABC):
         Args:
             clock: Clock instance for time/sleep operations. Defaults to RealClock.
         """
-        # Track active effect tasks per controller: {serial: asyncio.Task}
-        self.active_effects: dict[str, asyncio.Task] = {}
+        # Track active effects per controller: {serial: ActiveEffect}
+        self.active_effects: dict[str, ActiveEffect] = {}
         self._clock = clock or RealClock()
 
     @abstractmethod
@@ -196,6 +205,6 @@ class ControllerEffectsBase(ABC):
             serial: Controller serial number
         """
         if serial in self.active_effects:
-            self.active_effects[serial].cancel()
+            self.active_effects[serial].task.cancel()
             del self.active_effects[serial]
             logger.debug(f"Cancelled effect for {serial}")

--- a/services/controller_manager/feedback_manager.py
+++ b/services/controller_manager/feedback_manager.py
@@ -20,7 +20,7 @@ from lib.colors import Colors
 from lib.telemetry import extract_trace_context, get_tracer
 from proto import controller_manager_pb2
 from services.controller_manager import metrics
-from services.controller_manager.effects_base import ControllerEffectsBase
+from services.controller_manager.effects_base import ActiveEffect, ControllerEffectsBase
 
 if TYPE_CHECKING:
     from services.controller_manager.backend import ControllerBackend
@@ -68,9 +68,6 @@ class FeedbackManager(ControllerEffectsBase):
 
         # Base colors per controller (for auto-restore after effects)
         self.base_colors: dict[str, tuple[int, int, int]] = {}
-
-        # Track which GameEffect type is active per controller (for cancellability check)
-        self.active_effect_types: dict[str, int] = {}
 
         # Effects that can be cancelled by a base_color message
         self.cancellable_effects: set[int] = {
@@ -207,11 +204,14 @@ class FeedbackManager(ControllerEffectsBase):
             speed: Effect speed (1-10)
             restore_color: Color to restore to after effect (None = no restore)
         """
-        # Cancel any existing effect
+        # Cancel any existing effect, preserving the effect_type if already set
+        # (handle_game_effect sets effect_type before calling handler)
         existing_task = None
+        current_effect_type = 0
         async with self.effect_lock:
             if serial in self.active_effects:
-                existing_task = self.active_effects[serial]
+                current_effect_type = self.active_effects[serial].effect_type
+                existing_task = self.active_effects[serial].task
                 existing_task.cancel()
                 del self.active_effects[serial]
         # Await cancelled task outside lock to avoid deadlock with task's finally block
@@ -238,11 +238,10 @@ class FeedbackManager(ControllerEffectsBase):
             except asyncio.CancelledError:
                 raise
             finally:
-                # Clear effect active flag and effect type tracking
+                # Clear effect active flag
                 self.backend.set_effect_active(serial, False)
                 # Remove from active_effects so new base colors can be applied immediately
                 async with self.effect_lock:
-                    self.active_effect_types.pop(serial, None)
                     self.active_effects.pop(serial, None)
                 # Use current base_colors (may have changed during effect) if restore requested
                 current_restore = self.base_colors.get(serial) if restore_color else None
@@ -251,7 +250,7 @@ class FeedbackManager(ControllerEffectsBase):
 
         task = asyncio.create_task(effect_with_restore())
         async with self.effect_lock:
-            self.active_effects[serial] = task
+            self.active_effects[serial] = ActiveEffect(task=task, effect_type=current_effect_type)
 
     # =========================================================================
     # Individual effect handlers
@@ -261,7 +260,7 @@ class FeedbackManager(ControllerEffectsBase):
         """No-op - clear tracking."""
         # Note: async kept for interface consistency with other effect handlers
         async with self.effect_lock:
-            self.active_effect_types.pop(serial, None)
+            self.active_effects.pop(serial, None)
 
     async def _effect_player_warning(
         self, serial: str, restore_color: tuple | None, trace_context: Context | None = None, **_kwargs
@@ -309,7 +308,7 @@ class FeedbackManager(ControllerEffectsBase):
     async def _effect_player_respawn(self, serial: str, **_kwargs) -> None:
         """White during spawn protection."""
         async with self.effect_lock:
-            self.active_effect_types.pop(serial, None)
+            self.active_effects.pop(serial, None)
         await self.set_controller_color(serial, Colors.White.value)
         self.base_colors[serial] = Colors.White.value
 
@@ -345,7 +344,9 @@ class FeedbackManager(ControllerEffectsBase):
         phase_duration_ms = duration_ms if duration_ms > 0 else 750
         task = asyncio.create_task(self._countdown_sequence(serial, restore_color, trace_context, phase_duration_ms))
         async with self.effect_lock:
-            self.active_effects[serial] = task
+            self.active_effects[serial] = ActiveEffect(
+                task=task, effect_type=controller_manager_pb2.GAME_EFFECT_COUNTDOWN
+            )
 
     async def _effect_admin_enter(self, serial: str, **_kwargs) -> None:
         """White flash, then persistent white."""
@@ -355,7 +356,7 @@ class FeedbackManager(ControllerEffectsBase):
     async def _effect_admin_exit(self, serial: str, restore_color: tuple | None, **_kwargs) -> None:
         """Restore to base color (instant)."""
         async with self.effect_lock:
-            self.active_effect_types.pop(serial, None)
+            self.active_effects.pop(serial, None)
         if restore_color:
             await self.set_controller_color(serial, restore_color)
 
@@ -367,7 +368,7 @@ class FeedbackManager(ControllerEffectsBase):
             await self.set_controller_color(serial, Colors.Red20.value)
             await asyncio.sleep(0.15)
         async with self.effect_lock:
-            self.active_effect_types.pop(serial, None)
+            self.active_effects.pop(serial, None)
         if restore_color:
             await self.set_controller_color(serial, restore_color)
 
@@ -392,7 +393,7 @@ class FeedbackManager(ControllerEffectsBase):
         intensity = min(255, effect_speed * 50)
         await self.set_vibration(serial, intensity, effect_duration)
         async with self.effect_lock:
-            self.active_effect_types.pop(serial, None)
+            self.active_effects.pop(serial, None)
 
     async def _game_effect_pulse(
         self,
@@ -503,8 +504,16 @@ class FeedbackManager(ControllerEffectsBase):
 
             for target_serial in serials:
                 restore_color = self.base_colors.get(target_serial)
+                # Store effect_type; if there's already an ActiveEffect, update its type.
+                # The handler will replace the full ActiveEffect when it creates its task.
                 async with self.effect_lock:
-                    self.active_effect_types[target_serial] = effect
+                    if target_serial in self.active_effects:
+                        self.active_effects[target_serial].effect_type = effect
+                    else:
+                        # Placeholder with no-op task; handler will replace with real task
+                        done_task = asyncio.get_event_loop().create_future()
+                        done_task.set_result(None)
+                        self.active_effects[target_serial] = ActiveEffect(task=done_task, effect_type=effect)
 
                 await handler(
                     serial=target_serial,
@@ -526,10 +535,9 @@ class FeedbackManager(ControllerEffectsBase):
         task = None
         async with self.effect_lock:
             if serial in self.active_effects:
-                task = self.active_effects[serial]
+                task = self.active_effects[serial].task
                 task.cancel()
                 del self.active_effects[serial]
-                self.active_effect_types.pop(serial, None)
                 self.backend.set_effect_active(serial, False)
         # Await cancelled task outside lock to avoid deadlock with task's finally block
         if task:
@@ -549,12 +557,11 @@ class FeedbackManager(ControllerEffectsBase):
         task = None
         async with self.effect_lock:
             if serial in self.active_effects:
-                effect_type = self.active_effect_types.get(serial)
-                if effect_type in self.cancellable_effects:
-                    task = self.active_effects[serial]
+                active = self.active_effects[serial]
+                if active.effect_type in self.cancellable_effects:
+                    task = active.task
                     task.cancel()
                     del self.active_effects[serial]
-                    self.active_effect_types.pop(serial, None)
                     self.backend.set_effect_active(serial, False)
                     logger.debug(f"Cancelled cancellable effect for {serial}")
         # Await cancelled task outside lock to avoid deadlock with task's finally block
@@ -567,7 +574,7 @@ class FeedbackManager(ControllerEffectsBase):
     def clear_controller(self, serial: str) -> None:
         """Clear feedback state for a disconnected controller."""
         # Note: Keep base_colors[serial] so we can restore on reconnect
-        self.active_effect_types.pop(serial, None)
+        self.active_effects.pop(serial, None)
 
     def _get_battery_color(self, battery_percent: int) -> tuple[int, int, int]:
         """
@@ -648,7 +655,6 @@ class FeedbackManager(ControllerEffectsBase):
                 self.backend.set_effect_active(serial, False)
                 # Remove from active_effects so new base colors can be applied immediately
                 async with self.effect_lock:
-                    self.active_effect_types.pop(serial, None)
                     self.active_effects.pop(serial, None)
                 # Restore to base color
                 current_restore = self.base_colors.get(serial) if restore_color else None

--- a/services/controller_manager/servicer.py
+++ b/services/controller_manager/servicer.py
@@ -232,13 +232,12 @@ class ControllerManagerServicer(controller_manager_pb2_grpc.ControllerManagerSer
                             # Only cancel effect if it's marked as cancellable
                             async with self.feedback_manager.effect_lock:
                                 if serial in self.feedback_manager.active_effects:
-                                    effect_type = self.feedback_manager.active_effect_types.get(serial)
-                                    if effect_type in self.feedback_manager.cancellable_effects:
-                                        self.feedback_manager.active_effects[serial].cancel()
+                                    active = self.feedback_manager.active_effects[serial]
+                                    if active.effect_type in self.feedback_manager.cancellable_effects:
+                                        active.task.cancel()
                                         with contextlib.suppress(asyncio.CancelledError):
-                                            await self.feedback_manager.active_effects[serial]
+                                            await active.task
                                         del self.feedback_manager.active_effects[serial]
-                                        self.feedback_manager.active_effect_types.pop(serial, None)
                                         # Clear effect active flag
                                         self.backend.set_effect_active(serial, False)
                                         logger.debug(f"Cancelled cancellable effect for {serial}")
@@ -252,8 +251,11 @@ class ControllerManagerServicer(controller_manager_pb2_grpc.ControllerManagerSer
                                     await self.feedback_manager.set_controller_color(serial, color)
                                     logger.info(f"[ButtonStream] Applied base color for {serial}: {color}")
                                 else:
-                                    etype = self.feedback_manager.active_effect_types.get(serial, "unknown")
-                                    logger.warning(f"[ButtonStream] Base color for {serial} blocked by effect: {etype}")
+                                    active = self.feedback_manager.active_effects[serial]
+                                    logger.warning(
+                                        f"[ButtonStream] Base color for {serial} blocked by effect: "
+                                        f"{active.effect_type}"
+                                    )
 
                             logger.debug(f"[{subscriber_id}] Base color set: serial={serial}, rgb={color}")
 
@@ -428,13 +430,12 @@ class ControllerManagerServicer(controller_manager_pb2_grpc.ControllerManagerSer
                             # Only cancel effect if it's marked as cancellable
                             async with self.feedback_manager.effect_lock:
                                 if serial in self.feedback_manager.active_effects:
-                                    effect_type = self.feedback_manager.active_effect_types.get(serial)
-                                    if effect_type in self.feedback_manager.cancellable_effects:
-                                        self.feedback_manager.active_effects[serial].cancel()
+                                    active = self.feedback_manager.active_effects[serial]
+                                    if active.effect_type in self.feedback_manager.cancellable_effects:
+                                        active.task.cancel()
                                         with contextlib.suppress(asyncio.CancelledError):
-                                            await self.feedback_manager.active_effects[serial]
+                                            await active.task
                                         del self.feedback_manager.active_effects[serial]
-                                        self.feedback_manager.active_effect_types.pop(serial, None)
                                         # Clear effect active flag
                                         self.backend.set_effect_active(serial, False)
                                         logger.debug(f"Cancelled cancellable effect for {serial}")
@@ -448,9 +449,10 @@ class ControllerManagerServicer(controller_manager_pb2_grpc.ControllerManagerSer
                                     await self.feedback_manager.set_controller_color(serial, color)
                                     logger.info(f"[GameplayStream] Applied base color for {serial}: {color}")
                                 else:
-                                    etype = self.feedback_manager.active_effect_types.get(serial, "unknown")
+                                    active = self.feedback_manager.active_effects[serial]
                                     logger.warning(
-                                        f"[GameplayStream] Base color for {serial} blocked by effect: {etype}"
+                                        f"[GameplayStream] Base color for {serial} blocked by effect: "
+                                        f"{active.effect_type}"
                                     )
 
                             logger.debug(f"[{subscriber_id}] Base color set: serial={serial}, rgb={color}")

--- a/services/controller_manager/tests/test_effects_base.py
+++ b/services/controller_manager/tests/test_effects_base.py
@@ -13,7 +13,7 @@ import contextlib
 import pytest
 
 from lib.clock import FakeClock
-from services.controller_manager.effects_base import ControllerEffectsBase
+from services.controller_manager.effects_base import ActiveEffect, ControllerEffectsBase
 
 
 class MockEffectsController(ControllerEffectsBase):
@@ -240,7 +240,7 @@ class TestEffectManagement:
         """Active effects should be tracked in dict."""
         # Create task
         task = asyncio.create_task(effects._effect_flash("test_serial", (255, 0, 0), duration_ms=100, speed=5))
-        effects.active_effects["test_serial"] = task
+        effects.active_effects["test_serial"] = ActiveEffect(task=task, effect_type=0)
 
         await task
 
@@ -256,7 +256,7 @@ class TestEffectManagement:
 
         # Start long-running effect (10 seconds)
         task = asyncio.create_task(effects._effect_pulse("test", (255, 0, 0), duration_ms=10000, speed=1))
-        effects.active_effects["test"] = task
+        effects.active_effects["test"] = ActiveEffect(task=task, effect_type=0)
 
         # Let it start and block on first sleep
         await asyncio.sleep(0.01)

--- a/services/controller_manager/tests/test_feedback_manager_effects.py
+++ b/services/controller_manager/tests/test_feedback_manager_effects.py
@@ -94,8 +94,8 @@ class TestBaseColorDuringEffect:
             )
 
             # Get the actual background task that's running the effect
-            effect_task = feedback_manager.active_effects.get(serial)
-            assert effect_task is not None, "Effect task should be running"
+            active = feedback_manager.active_effects.get(serial)
+            assert active is not None, "Effect task should be running"
 
             # Give effect time to start
             await asyncio.sleep(0.02)
@@ -104,7 +104,7 @@ class TestBaseColorDuringEffect:
             feedback_manager.base_colors[serial] = lobby_color
 
             # 4. Wait for the actual effect task to complete
-            await effect_task
+            await active.task
 
         # 5. Verify controller shows NEW base_color (lobby), not old (team)
         final_color = mock_backend.get_current_color(serial)
@@ -134,8 +134,8 @@ class TestBaseColorDuringEffect:
             )
 
             # Get the actual background task
-            effect_task = feedback_manager.active_effects.get(serial)
-            assert effect_task is not None, "Effect task should be running"
+            active = feedback_manager.active_effects.get(serial)
+            assert active is not None, "Effect task should be running"
 
             await asyncio.sleep(0.02)
 
@@ -143,7 +143,7 @@ class TestBaseColorDuringEffect:
             feedback_manager.base_colors[serial] = lobby_color
 
             # 4. Wait for the actual effect task to complete
-            await effect_task
+            await active.task
 
         # 5. Should restore to the base_color that was set during effect
         final_color = mock_backend.get_current_color(serial)
@@ -183,9 +183,9 @@ class TestBaseColorDuringEffect:
             )
 
             # Get the actual background task
-            effect_task = feedback_manager.active_effects.get(serial)
-            if effect_task:
-                await effect_task
+            active = feedback_manager.active_effects.get(serial)
+            if active:
+                await active.task
 
         # After death, base_color should be black
         assert feedback_manager.base_colors[serial] == (0, 0, 0)
@@ -225,15 +225,15 @@ class TestEffectRestoreLogic:
         )
 
         # Get the actual background task
-        effect_task = feedback_manager.active_effects.get(serial)
-        assert effect_task is not None, "Effect task should be running"
+        active = feedback_manager.active_effects.get(serial)
+        assert active is not None, "Effect task should be running"
 
         # Update base_colors during effect
         await asyncio.sleep(0.02)
         feedback_manager.base_colors[serial] = new_color
 
         # Wait for effect to complete
-        await effect_task
+        await active.task
 
         # Should have restored to NEW color (read from base_colors at effect end)
         final_color = mock_backend.get_current_color(serial)
@@ -271,7 +271,7 @@ class TestEffectCancellation:
 
         # Verify warning effect is running (white flash active)
         assert serial in feedback_manager.active_effects, "Warning effect should be running"
-        warning_task = feedback_manager.active_effects[serial]
+        warning_task = feedback_manager.active_effects[serial].task
 
         # Small delay to let warning effect start
         await asyncio.sleep(0.01)
@@ -296,9 +296,9 @@ class TestEffectCancellation:
         )
 
         # Wait for death effect to complete
-        death_task = feedback_manager.active_effects.get(serial)
-        if death_task:
-            await death_task
+        active = feedback_manager.active_effects.get(serial)
+        if active:
+            await active.task
 
         # After death, should be black and base_color should be black
         assert mock_backend.get_current_color(serial) == (0, 0, 0)


### PR DESCRIPTION
## Summary
- Replaced two parallel dicts (`active_effects: dict[str, Task]` and `active_effect_types: dict[str, int]`) with a single `active_effects: dict[str, ActiveEffect]` using a new `ActiveEffect` dataclass
- Eliminates consistency risk of maintaining two dicts that must always be modified together
- Reduces code duplication at ~30 access sites across `feedback_manager.py` and `servicer.py`

Fixes #347

## Test plan
- [x] All 209 controller_manager unit tests pass
- [x] `make lint` passes
- [ ] Integration tests via `make test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)