### PR TITLE
feat: Add gRPC client metrics interceptors

### DIFF
--- a/lib/grpc_metrics.py
+++ b/lib/grpc_metrics.py
@@ -1,0 +1,173 @@
+"""
+Async gRPC client interceptors for recording latency and error metrics.
+
+Records per-RPC histogram latency and error counters for all outbound gRPC calls.
+Metrics are exported via OpenTelemetry to the OTEL Collector for Prometheus scraping.
+
+Usage:
+    from lib.grpc_metrics import get_metrics_interceptors
+
+    interceptors = get_metrics_interceptors()
+    channel = grpc.aio.insecure_channel("service:50051", interceptors=interceptors)
+"""
+
+import time
+from collections.abc import Callable
+from typing import Any
+
+import grpc
+import grpc.aio
+
+from lib.otel_metrics import Counter, Histogram
+
+# Module-level metrics using the project's OTEL push metrics helpers.
+# These are lazily initialized when init_metrics() is called in each service.
+grpc_client_request_duration_seconds = Histogram(
+    "grpc_client_request_duration_seconds",
+    "Duration of outbound gRPC client calls in seconds",
+    labelnames=["service", "method"],
+    buckets=[0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0],
+)
+
+grpc_client_errors_total = Counter(
+    "grpc_client_errors_total",
+    "Total outbound gRPC client errors",
+    labelnames=["service", "method", "code"],
+)
+
+
+def _parse_method(method: str | bytes) -> tuple[str, str]:
+    """Parse a gRPC method string into (service_name, method_name).
+
+    gRPC methods follow the format ``/pkg.ServiceName/MethodName``.
+
+    Args:
+        method: The full gRPC method path, e.g. ``/pkg.ServiceName/MethodName``.
+                May be bytes (decoded to str automatically).
+
+    Returns:
+        Tuple of (service_name, method_name). Falls back to ("unknown", method)
+        when the format is unexpected.
+    """
+    if isinstance(method, bytes):
+        method = method.decode("utf-8")
+
+    # Strip leading slash if present
+    path = method.lstrip("/")
+
+    # Expect "pkg.ServiceName/MethodName"
+    parts = path.split("/")
+    if len(parts) == 2:
+        # Extract just the service name (after the last dot in the package-qualified name)
+        service_part = parts[0]
+        service_name = service_part.rsplit(".", 1)[-1] if "." in service_part else service_part
+        return (service_name, parts[1])
+
+    return ("unknown", method)
+
+
+class MetricsUnaryUnaryInterceptor(grpc.aio.UnaryUnaryClientInterceptor):
+    """Async unary-unary client interceptor that records latency and error metrics."""
+
+    async def intercept_unary_unary(
+        self,
+        continuation: Callable,
+        client_call_details: grpc.aio.ClientCallDetails,
+        request: Any,
+    ) -> Any:
+        service, method = _parse_method(client_call_details.method)
+        start = time.monotonic()
+        try:
+            response = await continuation(client_call_details, request)
+            duration = time.monotonic() - start
+            grpc_client_request_duration_seconds.labels(service=service, method=method).observe(duration)
+            return response
+        except grpc.aio.AioRpcError as e:
+            duration = time.monotonic() - start
+            grpc_client_request_duration_seconds.labels(service=service, method=method).observe(duration)
+            grpc_client_errors_total.labels(service=service, method=method, code=e.code().name).inc()
+            raise
+
+
+class MetricsUnaryStreamInterceptor(grpc.aio.UnaryStreamClientInterceptor):
+    """Async unary-stream client interceptor that records latency and error metrics."""
+
+    async def intercept_unary_stream(
+        self,
+        continuation: Callable,
+        client_call_details: grpc.aio.ClientCallDetails,
+        request: Any,
+    ) -> Any:
+        service, method = _parse_method(client_call_details.method)
+        start = time.monotonic()
+        try:
+            response = await continuation(client_call_details, request)
+            duration = time.monotonic() - start
+            grpc_client_request_duration_seconds.labels(service=service, method=method).observe(duration)
+            return response
+        except grpc.aio.AioRpcError as e:
+            duration = time.monotonic() - start
+            grpc_client_request_duration_seconds.labels(service=service, method=method).observe(duration)
+            grpc_client_errors_total.labels(service=service, method=method, code=e.code().name).inc()
+            raise
+
+
+class MetricsStreamUnaryInterceptor(grpc.aio.StreamUnaryClientInterceptor):
+    """Async stream-unary client interceptor that records latency and error metrics."""
+
+    async def intercept_stream_unary(
+        self,
+        continuation: Callable,
+        client_call_details: grpc.aio.ClientCallDetails,
+        request_iterator: Any,
+    ) -> Any:
+        service, method = _parse_method(client_call_details.method)
+        start = time.monotonic()
+        try:
+            response = await continuation(client_call_details, request_iterator)
+            duration = time.monotonic() - start
+            grpc_client_request_duration_seconds.labels(service=service, method=method).observe(duration)
+            return response
+        except grpc.aio.AioRpcError as e:
+            duration = time.monotonic() - start
+            grpc_client_request_duration_seconds.labels(service=service, method=method).observe(duration)
+            grpc_client_errors_total.labels(service=service, method=method, code=e.code().name).inc()
+            raise
+
+
+class MetricsStreamStreamInterceptor(grpc.aio.StreamStreamClientInterceptor):
+    """Async stream-stream client interceptor that records latency and error metrics."""
+
+    async def intercept_stream_stream(
+        self,
+        continuation: Callable,
+        client_call_details: grpc.aio.ClientCallDetails,
+        request_iterator: Any,
+    ) -> Any:
+        service, method = _parse_method(client_call_details.method)
+        start = time.monotonic()
+        try:
+            response = await continuation(client_call_details, request_iterator)
+            duration = time.monotonic() - start
+            grpc_client_request_duration_seconds.labels(service=service, method=method).observe(duration)
+            return response
+        except grpc.aio.AioRpcError as e:
+            duration = time.monotonic() - start
+            grpc_client_request_duration_seconds.labels(service=service, method=method).observe(duration)
+            grpc_client_errors_total.labels(service=service, method=method, code=e.code().name).inc()
+            raise
+
+
+def get_metrics_interceptors() -> list:
+    """Return all 4 metrics interceptors for async gRPC clients.
+
+    Returns:
+        List of interceptors covering all RPC patterns (unary-unary,
+        unary-stream, stream-unary, stream-stream).
+    """
+    return [
+        MetricsUnaryUnaryInterceptor(),
+        MetricsUnaryStreamInterceptor(),
+        MetricsStreamUnaryInterceptor(),
+        MetricsStreamStreamInterceptor(),
+    ]

--- a/lib/grpc_utils.py
+++ b/lib/grpc_utils.py
@@ -117,11 +117,12 @@ def create_channel(
     address: str,
     options: list[tuple[str, Any]] | None = None,
     enable_tracing: bool = True,
+    enable_metrics: bool = True,
     enable_compression: bool | None = None,
     **kwargs,
 ) -> grpc.aio.Channel:
     """
-    Create an async gRPC channel with standard JoustMania options and tracing.
+    Create an async gRPC channel with standard JoustMania options, metrics, and tracing.
 
     Args:
         address: Target address in format "host:port"
@@ -129,18 +130,21 @@ def create_channel(
         enable_tracing: Whether to add OpenTelemetry tracing interceptors (default: True).
                        When enabled, all RPC calls through this channel will create
                        spans and propagate trace context to downstream services.
+        enable_metrics: Whether to add gRPC client metrics interceptors (default: True).
+                       When enabled, all RPC calls record latency histograms and error
+                       counters via OpenTelemetry.
         enable_compression: Whether to enable Gzip compression (default: auto-detect).
                            When None, compression is automatically disabled for local
                            addresses (localhost, 127.x.x.x) to reduce CPU overhead.
         **kwargs: Additional arguments passed to grpc.aio.insecure_channel
 
     Returns:
-        Configured async gRPC channel with optional tracing interceptors
+        Configured async gRPC channel with optional metrics and tracing interceptors
 
     Example:
         >>> channel = create_channel("localhost:50051")
         >>> stub = MyServiceStub(channel)
-        >>> # All calls through stub will now be traced (compression auto-disabled for localhost)
+        >>> # All calls through stub will now be traced and metered
     """
     if options is None:
         # Auto-detect compression setting based on address if not explicitly specified
@@ -148,10 +152,19 @@ def create_channel(
             enable_compression = not is_local_address(address)
         options = get_optimized_channel_options(enable_compression=enable_compression)
 
+    # Build interceptor list: metrics outermost (first) so they measure full
+    # call time including tracing overhead, then tracing interceptors.
+    interceptors = []
+    if enable_metrics:
+        from lib.grpc_metrics import get_metrics_interceptors
+
+        interceptors.extend(get_metrics_interceptors())
     if enable_tracing:
         from lib.grpc_tracing import get_tracing_interceptors
 
-        interceptors = get_tracing_interceptors()
+        interceptors.extend(get_tracing_interceptors())
+
+    if interceptors:
         return grpc.aio.insecure_channel(address, options=options, interceptors=interceptors, **kwargs)
 
     return grpc.aio.insecure_channel(address, options=options, **kwargs)

--- a/lib/tests/test_grpc_metrics.py
+++ b/lib/tests/test_grpc_metrics.py
@@ -1,0 +1,238 @@
+"""Unit tests for the gRPC client metrics interceptors."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import grpc
+import grpc.aio
+import pytest
+
+from lib.grpc_metrics import (
+    MetricsStreamStreamInterceptor,
+    MetricsStreamUnaryInterceptor,
+    MetricsUnaryStreamInterceptor,
+    MetricsUnaryUnaryInterceptor,
+    _parse_method,
+    get_metrics_interceptors,
+)
+from lib.otel_metrics import disable_metrics_for_tests
+
+# Disable OTEL metrics to prevent connection attempts during tests.
+# This is safe to call after imports because the module-level metrics
+# in grpc_metrics.py use lazy initialization and silently no-op when
+# not initialized.
+disable_metrics_for_tests()
+
+
+class TestParseMethod:
+    """Tests for the _parse_method helper."""
+
+    def test_standard_format(self):
+        """Test standard /pkg.ServiceName/MethodName format."""
+        service, method = _parse_method("/pkg.ServiceName/MethodName")
+        assert service == "ServiceName"
+        assert method == "MethodName"
+
+    def test_bytes_input(self):
+        """Test that bytes input is decoded and parsed correctly."""
+        service, method = _parse_method(b"/pkg.ServiceName/MethodName")
+        assert service == "ServiceName"
+        assert method == "MethodName"
+
+    def test_no_leading_slash(self):
+        """Test that input without leading slash still parses correctly."""
+        service, method = _parse_method("pkg.ServiceName/MethodName")
+        assert service == "ServiceName"
+        assert method == "MethodName"
+
+    def test_no_package_prefix(self):
+        """Test service name without package prefix."""
+        service, method = _parse_method("/ServiceName/MethodName")
+        assert service == "ServiceName"
+        assert method == "MethodName"
+
+    def test_fallback_unexpected_format(self):
+        """Test fallback for unexpected format returns ('unknown', original_method)."""
+        service, method = _parse_method("just-a-string")
+        assert service == "unknown"
+        assert method == "just-a-string"
+
+    def test_deeply_nested_package(self):
+        """Test deeply nested package name extracts only service name."""
+        service, method = _parse_method("/com.example.api.v1.SettingsService/GetSetting")
+        assert service == "SettingsService"
+        assert method == "GetSetting"
+
+    def test_bytes_no_leading_slash(self):
+        """Test bytes input without leading slash."""
+        service, method = _parse_method(b"pkg.SvcName/DoThing")
+        assert service == "SvcName"
+        assert method == "DoThing"
+
+
+class TestMetricsUnaryUnaryInterceptor:
+    """Tests for the unary-unary metrics interceptor."""
+
+    @pytest.mark.asyncio
+    async def test_records_duration_on_success(self):
+        """Test that duration histogram is recorded on a successful call."""
+        interceptor = MetricsUnaryUnaryInterceptor()
+
+        # Mock the continuation (the actual gRPC call)
+        mock_response = MagicMock()
+        continuation = AsyncMock(return_value=mock_response)
+
+        # Mock call details
+        call_details = MagicMock(spec=grpc.aio.ClientCallDetails)
+        call_details.method = "/pkg.SettingsService/GetSetting"
+
+        request = MagicMock()
+
+        with patch("lib.grpc_metrics.grpc_client_request_duration_seconds") as mock_histogram:
+            mock_labeled = MagicMock()
+            mock_histogram.labels.return_value = mock_labeled
+
+            result = await interceptor.intercept_unary_unary(continuation, call_details, request)
+
+            assert result == mock_response
+            mock_histogram.labels.assert_called_once_with(service="SettingsService", method="GetSetting")
+            mock_labeled.observe.assert_called_once()
+            # Duration should be a positive float
+            observed_value = mock_labeled.observe.call_args[0][0]
+            assert observed_value >= 0
+
+    @pytest.mark.asyncio
+    async def test_records_error_counter_on_rpc_error(self):
+        """Test that error counter is incremented on AioRpcError and exception is re-raised."""
+        interceptor = MetricsUnaryUnaryInterceptor()
+
+        # Create a mock AioRpcError
+        mock_error = grpc.aio.AioRpcError(
+            code=grpc.StatusCode.UNAVAILABLE,
+            initial_metadata=grpc.aio.Metadata(),
+            trailing_metadata=grpc.aio.Metadata(),
+            details="Service unavailable",
+            debug_error_string=None,
+        )
+        continuation = AsyncMock(side_effect=mock_error)
+
+        call_details = MagicMock(spec=grpc.aio.ClientCallDetails)
+        call_details.method = "/pkg.GameCoordinator/StartGame"
+
+        request = MagicMock()
+
+        with (
+            patch("lib.grpc_metrics.grpc_client_request_duration_seconds") as mock_histogram,
+            patch("lib.grpc_metrics.grpc_client_errors_total") as mock_counter,
+        ):
+            mock_labeled_hist = MagicMock()
+            mock_histogram.labels.return_value = mock_labeled_hist
+            mock_labeled_counter = MagicMock()
+            mock_counter.labels.return_value = mock_labeled_counter
+
+            with pytest.raises(grpc.aio.AioRpcError):
+                await interceptor.intercept_unary_unary(continuation, call_details, request)
+
+            # Duration should still be recorded
+            mock_histogram.labels.assert_called_once_with(service="GameCoordinator", method="StartGame")
+            mock_labeled_hist.observe.assert_called_once()
+
+            # Error counter should be incremented with the status code name
+            mock_counter.labels.assert_called_once_with(
+                service="GameCoordinator", method="StartGame", code="UNAVAILABLE"
+            )
+            mock_labeled_counter.inc.assert_called_once()
+
+
+class TestMetricsUnaryStreamInterceptor:
+    """Tests for the unary-stream metrics interceptor."""
+
+    @pytest.mark.asyncio
+    async def test_records_duration_on_success(self):
+        """Test that duration is recorded for unary-stream calls."""
+        interceptor = MetricsUnaryStreamInterceptor()
+
+        mock_response = MagicMock()
+        continuation = AsyncMock(return_value=mock_response)
+
+        call_details = MagicMock(spec=grpc.aio.ClientCallDetails)
+        call_details.method = "/pkg.MenuService/StreamMenuEvents"
+
+        with patch("lib.grpc_metrics.grpc_client_request_duration_seconds") as mock_histogram:
+            mock_labeled = MagicMock()
+            mock_histogram.labels.return_value = mock_labeled
+
+            result = await interceptor.intercept_unary_stream(continuation, call_details, MagicMock())
+
+            assert result == mock_response
+            mock_histogram.labels.assert_called_once_with(service="MenuService", method="StreamMenuEvents")
+            mock_labeled.observe.assert_called_once()
+
+
+class TestMetricsStreamUnaryInterceptor:
+    """Tests for the stream-unary metrics interceptor."""
+
+    @pytest.mark.asyncio
+    async def test_records_duration_on_success(self):
+        """Test that duration is recorded for stream-unary calls."""
+        interceptor = MetricsStreamUnaryInterceptor()
+
+        mock_response = MagicMock()
+        continuation = AsyncMock(return_value=mock_response)
+
+        call_details = MagicMock(spec=grpc.aio.ClientCallDetails)
+        call_details.method = "/pkg.AudioService/PlaySound"
+
+        with patch("lib.grpc_metrics.grpc_client_request_duration_seconds") as mock_histogram:
+            mock_labeled = MagicMock()
+            mock_histogram.labels.return_value = mock_labeled
+
+            result = await interceptor.intercept_stream_unary(continuation, call_details, MagicMock())
+
+            assert result == mock_response
+            mock_histogram.labels.assert_called_once_with(service="AudioService", method="PlaySound")
+            mock_labeled.observe.assert_called_once()
+
+
+class TestMetricsStreamStreamInterceptor:
+    """Tests for the stream-stream metrics interceptor."""
+
+    @pytest.mark.asyncio
+    async def test_records_duration_on_success(self):
+        """Test that duration is recorded for stream-stream calls."""
+        interceptor = MetricsStreamStreamInterceptor()
+
+        mock_response = MagicMock()
+        continuation = AsyncMock(return_value=mock_response)
+
+        call_details = MagicMock(spec=grpc.aio.ClientCallDetails)
+        call_details.method = "/pkg.ControllerManager/StreamGameplayData"
+
+        with patch("lib.grpc_metrics.grpc_client_request_duration_seconds") as mock_histogram:
+            mock_labeled = MagicMock()
+            mock_histogram.labels.return_value = mock_labeled
+
+            result = await interceptor.intercept_stream_stream(continuation, call_details, MagicMock())
+
+            assert result == mock_response
+            mock_histogram.labels.assert_called_once_with(service="ControllerManager", method="StreamGameplayData")
+            mock_labeled.observe.assert_called_once()
+
+
+class TestGetMetricsInterceptors:
+    """Tests for the get_metrics_interceptors factory."""
+
+    def test_returns_four_interceptors(self):
+        """Test that exactly 4 interceptors are returned."""
+        interceptors = get_metrics_interceptors()
+        assert len(interceptors) == 4
+
+    def test_interceptor_types(self):
+        """Test that interceptors cover all 4 RPC patterns."""
+        interceptors = get_metrics_interceptors()
+        types = {type(i) for i in interceptors}
+        assert types == {
+            MetricsUnaryUnaryInterceptor,
+            MetricsUnaryStreamInterceptor,
+            MetricsStreamUnaryInterceptor,
+            MetricsStreamStreamInterceptor,
+        }

--- a/services/grafana/dashboards/service-health-overview.json
+++ b/services/grafana/dashboards/service-health-overview.json
@@ -1051,6 +1051,193 @@
       ],
       "title": "gRPC Error Rate",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "P99 latency of outbound gRPC client calls by service and method",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "line+area"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "transparent",
+                "value": 0.1
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 20
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.2.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.99, sum by(service, method, le) (rate(grpc_client_request_duration_seconds_bucket[5m])))",
+          "legendFormat": "{{service}}/{{method}}",
+          "refId": "A"
+        }
+      ],
+      "title": "gRPC Client Latency P99",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Error rate of outbound gRPC client calls by service, method, and status code",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 20
+      },
+      "id": 14,
+      "options": {
+        "legend": {
+          "calcs": [
+            "sum"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.2.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by(service, method, code) (rate(grpc_client_errors_total[5m]))",
+          "legendFormat": "{{service}}/{{method}} ({{code}})",
+          "refId": "A"
+        }
+      ],
+      "title": "gRPC Client Error Rate",
+      "type": "timeseries"
     }
   ],
   "refresh": "5s",

--- a/services/prometheus/alerts.yml
+++ b/services/prometheus/alerts.yml
@@ -113,3 +113,12 @@ groups:
         annotations:
           summary: "Service files have been updated"
           description: "Run 'sudo ./scripts/setup/install_autostart.sh' to apply the new service configuration."
+
+      - alert: HighGRPCClientErrorRate
+        expr: rate(grpc_client_errors_total[2m]) > 0.5
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High gRPC client error rate on {{ $labels.service }}/{{ $labels.method }}"
+          description: "Service {{ $labels.service }} method {{ $labels.method }} has error rate {{ $value }}/s for 2+ minutes"


### PR DESCRIPTION
## Summary
- New `lib/grpc_metrics.py` with 4 interceptor classes (one per RPC pattern) that record latency histograms and error counters for all outbound gRPC calls
- Integrated into `lib/grpc_utils.py` `create_channel()` -- metrics enabled by default, outermost interceptors so they measure full call time including tracing overhead
- Added `HighGRPCClientErrorRate` Prometheus alert (rate > 0.5/s for 2min)
- Added P99 latency and error rate panels to service-health-overview Grafana dashboard

## Test plan
- [x] Unit tests for `_parse_method()` helper (7 cases: standard, bytes, no slash, no package, fallback, nested, bytes no slash)
- [x] Unit tests for interceptor recording behavior (success duration, error counter + re-raise)
- [x] Unit tests for `get_metrics_interceptors()` factory (returns 4 correct types)
- [x] `make lint` passes
- [x] `uv run python -m pytest tests/test_grpc_metrics.py -v` passes (14/14)

Fixes #336

🤖 Generated with [Claude Code](https://claude.com/claude-code)