### PR TITLE
feat: Add stream health metrics for drop/disconnect tracking

### DIFF
--- a/services/game_coordinator/event_bus.py
+++ b/services/game_coordinator/event_bus.py
@@ -31,6 +31,7 @@ from opentelemetry import trace
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 
 from proto import game_coordinator_pb2
+from services.game_coordinator import metrics
 
 logger = logging.getLogger(__name__)
 
@@ -78,6 +79,7 @@ class EventBus:
         event_queue: asyncio.Queue = asyncio.Queue(maxsize=max_queue_size)
         async with self._event_lock:
             self._subscribers[subscriber_id] = event_queue
+            metrics.event_bus_active_subscribers.set(len(self._subscribers))
         logger.info(f"New event subscriber: {subscriber_id}")
         return event_queue
 
@@ -94,6 +96,7 @@ class EventBus:
         async with self._event_lock:
             if subscriber_id in self._subscribers:
                 del self._subscribers[subscriber_id]
+                metrics.event_bus_active_subscribers.set(len(self._subscribers))
                 logger.info(f"Event subscriber removed: {subscriber_id}")
                 return True
         return False
@@ -150,8 +153,10 @@ class EventBus:
                 event_queue.put_nowait(event)
                 logger.debug(f"Published {event_type} to subscriber {sub_id}")
             except asyncio.QueueFull:
+                metrics.event_bus_publish_drops_total.labels(event_type=event_type).inc()
                 logger.warning(f"Subscriber {sub_id} queue full, skipping event")
             except Exception as e:
+                metrics.event_bus_publish_errors_total.labels(event_type=event_type).inc()
                 logger.error(f"Error publishing to subscriber {sub_id}: {e}")
 
     async def get_subscriber_ids(self) -> list[str]:

--- a/services/game_coordinator/metrics.py
+++ b/services/game_coordinator/metrics.py
@@ -275,3 +275,22 @@ def clear_all_player_analytics() -> None:
     game_sensitivity.set(0)
     effective_warning_threshold.set(0)
     effective_death_threshold.set(0)
+
+
+# EventBus stream health metrics (Issue #337)
+event_bus_publish_drops_total = Counter(
+    "event_bus_publish_drops_total",
+    "Total events dropped due to full subscriber queues",
+    ["event_type"],
+)
+
+event_bus_active_subscribers = Gauge(
+    "event_bus_active_subscribers",
+    "Number of active EventBus subscribers",
+)
+
+event_bus_publish_errors_total = Counter(
+    "event_bus_publish_errors_total",
+    "Total errors during event publishing",
+    ["event_type"],
+)

--- a/services/menu/event_publisher.py
+++ b/services/menu/event_publisher.py
@@ -100,6 +100,7 @@ class EventPublisher:
                         event_queue.put_nowait(event)
                         logger.debug(f"Published {event_type} to subscriber {sub_id}")
                     except asyncio.QueueFull:
+                        self._metrics.stream_publish_drops_total.labels(event_type=event_type).inc()
                         logger.warning(f"Subscriber {sub_id} queue full, skipping event")
                     except Exception as e:
                         logger.error(f"Error publishing to subscriber {sub_id}: {e}")

--- a/services/menu/metrics.py
+++ b/services/menu/metrics.py
@@ -64,3 +64,15 @@ player_ready = Gauge(
     "Player ready status in lobby (1=ready, 0=not ready)",
     ["serial"],
 )
+
+# Stream health metrics (Issue #337)
+stream_publish_drops_total = Counter(
+    "menu_stream_publish_drops_total",
+    "Total menu events dropped due to full subscriber queues",
+    ["event_type"],
+)
+
+stream_disconnections_total = Counter(
+    "menu_stream_disconnections_total",
+    "Total menu event stream disconnections",
+)

--- a/services/menu/servicer.py
+++ b/services/menu/servicer.py
@@ -310,6 +310,7 @@ class MenuServicer(menu_pb2_grpc.MenuServiceServicer):
             finally:
                 await self.event_publisher.unsubscribe(subscriber_id)
                 metrics.stream_connections_active.dec()
+                metrics.stream_disconnections_total.inc()
 
     # Input handlers
 

--- a/services/settings/metrics.py
+++ b/services/settings/metrics.py
@@ -22,3 +22,20 @@ grpc_request_duration_seconds = Histogram(
     ["method"],
     buckets=[0.001, 0.005, 0.010, 0.025, 0.050, 0.100, 0.250, 0.500, 1.0],
 )
+
+# Stream health metrics (Issue #337)
+stream_publish_drops_total = Counter(
+    "settings_stream_publish_drops_total",
+    "Total setting change notifications dropped due to full subscriber queues",
+    ["key"],
+)
+
+stream_active_subscribers = Gauge(
+    "settings_stream_active_subscribers",
+    "Number of active settings change subscribers",
+)
+
+stream_disconnections_total = Counter(
+    "settings_stream_disconnections_total",
+    "Total settings stream disconnections",
+)

--- a/services/settings/servicer.py
+++ b/services/settings/servicer.py
@@ -21,6 +21,7 @@ from opentelemetry import trace
 from lib.telemetry import SpanAttr, get_tracer
 from lib.types import Games, Sensitivity
 from proto import settings_pb2, settings_pb2_grpc
+from services.settings import metrics
 
 logger = logging.getLogger(__name__)
 
@@ -292,6 +293,7 @@ class SettingsServicer(settings_pb2_grpc.SettingsServiceServicer):
                         event_queue.put_nowait(event)
                         logger.debug(f"Published change to subscriber {sub_id}")
                     except asyncio.QueueFull:
+                        metrics.stream_publish_drops_total.labels(key=key).inc()
                         logger.warning(f"Subscriber {sub_id} queue full, skipping")
                     except Exception as e:
                         logger.error(f"Error publishing to subscriber {sub_id}: {e}")
@@ -424,6 +426,7 @@ class SettingsServicer(settings_pb2_grpc.SettingsServiceServicer):
         # Register subscriber
         async with self.subscriber_lock:
             self.subscribers[subscriber_id] = event_queue
+        metrics.stream_active_subscribers.inc()
 
         try:
             # Stream events to client
@@ -442,3 +445,5 @@ class SettingsServicer(settings_pb2_grpc.SettingsServiceServicer):
                 if subscriber_id in self.subscribers:
                     del self.subscribers[subscriber_id]
                     logger.info(f"Subscriber disconnected: {subscriber_id}")
+            metrics.stream_active_subscribers.dec()
+            metrics.stream_disconnections_total.inc()


### PR DESCRIPTION
## Summary
- **Game Coordinator EventBus**: Track publish drops (`event_bus_publish_drops_total`), publish errors (`event_bus_publish_errors_total`), and active subscriber count (`event_bus_active_subscribers`)
- **Settings Service**: Track publish drops (`stream_publish_drops_total`), active subscribers (`stream_active_subscribers`), and disconnections (`stream_disconnections_total`)
- **Menu Service**: Track publish drops (`stream_publish_drops_total`) and disconnections (`stream_disconnections_total`)

## Test plan
- [x] `make lint` passes
- [x] `cd services/game_coordinator && uv run pytest -v` passes (305 tests)
- [x] `cd services/settings && uv run pytest -v` passes (48 tests)
- [x] `cd services/menu && uv run pytest -v` passes (152 tests)

Fixes #337

🤖 Generated with [Claude Code](https://claude.com/claude-code)