### PR TITLE
feat: Add docker-compose.dev.yml for hot-reload development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ help:
 	@echo "=============================="
 	@echo ""
 	@echo "Docker (use docker compose directly for most operations):"
+	@echo "  make dev             - Start with hot-reload source mounting"
 	@echo "  make up-mock         - Start in mock mode (no hardware)"
 	@echo "  make builders        - Build base images (run once)"
 	@echo ""
@@ -47,6 +48,22 @@ help:
 # ============================================================================
 # Docker Convenience Targets
 # ============================================================================
+
+# Hot-reload mode: volume-mounts Python source for live code changes without rebuilds
+.PHONY: dev
+dev:
+	docker compose -f docker-compose.yml -f docker-compose.override.yml -f docker-compose.dev.yml up -d $(if $(BUILD),--build)
+	@echo ""
+	@echo "=========================================="
+	@echo "JoustMania is running (DEV MODE)"
+	@echo "=========================================="
+	@echo "  Source directories are volume-mounted."
+	@echo "  Restart a service after code changes:"
+	@echo "    docker compose restart settings"
+	@echo ""
+	@echo "  Dashboard:  http://localhost/"
+	@echo "  Jaeger:     http://localhost/jaeger/"
+	@echo "  Grafana:    http://localhost/grafana/"
 
 # Mock mode sets environment variables - this is the main value-add over raw docker compose
 .PHONY: up-mock

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,46 @@
+# Development Override - Hot-reload source mounting
+#
+# Volume-mounts Python service source directories so code changes are
+# reflected immediately without rebuilding images.
+#
+# Usage:
+#   make dev                          # Recommended shortcut
+#   docker compose -f docker-compose.yml -f docker-compose.override.yml -f docker-compose.dev.yml up -d
+#
+# Note: Only Python application services are mounted. Infrastructure
+# services (redis, prometheus, grafana, etc.) and non-Python services
+# (connect-proxy, dashboard, grafana-live-publisher) are unchanged.
+#
+# After changing code, restart the affected service to pick up changes:
+#   docker compose restart settings
+
+services:
+  settings:
+    volumes:
+      - ./services/settings:/app/services/settings
+      - ./lib:/app/lib
+      - ./proto:/app/proto
+
+  controller-manager:
+    volumes:
+      - ./services/controller_manager:/app/services/controller_manager
+      - ./lib:/app/lib
+      - ./proto:/app/proto
+
+  game-coordinator:
+    volumes:
+      - ./services/game_coordinator:/app/services/game_coordinator
+      - ./lib:/app/lib
+      - ./proto:/app/proto
+
+  menu:
+    volumes:
+      - ./services/menu:/app/services/menu
+      - ./lib:/app/lib
+      - ./proto:/app/proto
+
+  audio:
+    volumes:
+      - ./services/audio:/app/services/audio
+      - ./lib:/app/lib
+      - ./proto:/app/proto


### PR DESCRIPTION
## Summary
- New `docker-compose.dev.yml` that volume-mounts source directories for all Python services (settings, controller-manager, game-coordinator, menu, audio)
- Mounts `./services/<name>/`, `./lib/`, and `./proto/` into each container at `/app/`
- Source changes reflected without `docker compose up --build` -- just `docker compose restart <service>`
- New `make dev` target for convenience

Usage:
```bash
make dev  # starts with hot-reload source mounting
```

## Test plan
- [x] `docker compose -f docker-compose.yml -f docker-compose.override.yml -f docker-compose.dev.yml config` validates successfully
- [x] Volume mounts correctly merge with base compose volumes (verified settings keeps `joustsettings.yaml`, controller-manager keeps hardware mounts, audio keeps assets mount)
- [ ] Code changes reflected without rebuild after `docker compose restart <service>`

Fixes #372

Generated with [Claude Code](https://claude.com/claude-code)