### PR TITLE
fix: Security hardening for Grafana and Envoy

### DIFF
--- a/services/envoy/envoy.yaml
+++ b/services/envoy/envoy.yaml
@@ -188,5 +188,5 @@ static_resources:
 admin:
   address:
     socket_address:
-      address: 0.0.0.0
+      address: 127.0.0.1
       port_value: 9901

--- a/services/grafana/grafana.ini
+++ b/services/grafana/grafana.ini
@@ -443,7 +443,7 @@ enabled = true
 org_name = Main Org.
 
 # specify role for unauthenticated users
-org_role = Admin
+org_role = Viewer
 
 # mask the Grafana version number for unauthenticated users
 ;hide_version = false


### PR DESCRIPTION
## Summary
- **Grafana**: Change anonymous auth from `Admin` to `Viewer` role -- dashboards still viewable without login, but datasources/API keys/provisioning protected
- **Envoy**: Bind admin interface to `127.0.0.1:9901` instead of `0.0.0.0:9901` -- prevents other containers from hitting `/quitquitquit`

## Test plan
- [x] `docker compose config` validates
- [ ] Grafana dashboards viewable without login
- [ ] Grafana admin features require login
- [ ] Envoy admin not reachable from other containers

Fixes #371

Generated with [Claude Code](https://claude.com/claude-code)