### PR TITLE
fix: Resolve CI paths-filter failure after branch rename

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,7 @@ jobs:
       - uses: dorny/paths-filter@v3
         id: changes
         with:
+          base: main
           filters: |
             service:
               - 'services/${{ matrix.service }}/**'
@@ -214,6 +215,7 @@ jobs:
       - uses: dorny/paths-filter@v3
         id: changes
         with:
+          base: main
           filters: |
             pairing:
               - 'scripts/pairing-daemon/**'
@@ -296,6 +298,7 @@ jobs:
       - uses: dorny/paths-filter@v3
         id: filter
         with:
+          base: main
           filters: |
             builder:
               - 'images/builder/**'


### PR DESCRIPTION
## Summary
- Fix `dorny/paths-filter@v3` failures caused by stale `dev-refactor` branch reference after rename to `main`
- Add explicit `base: main` to all three paths-filter instances in CI workflow
- Prevents paths-filter from auto-detecting the old branch name and failing with `fatal: couldn't find remote ref dev-refactor`

Error: `fatal: couldn't find remote ref dev-refactor`
See: https://github.com/WatchMeJoustMyFlags/JoustMania/actions/runs/21776873731

## Test plan
- [ ] CI passes on this PR (paths-filter steps succeed)
- [ ] Push to main triggers successful CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)