### PR TITLE
cleanup: Add from __future__ import annotations across services

### DIFF
--- a/lib/clock.py
+++ b/lib/clock.py
@@ -27,6 +27,8 @@ Usage in tests:
         # No patching needed!
 """
 
+from __future__ import annotations
+
 import asyncio
 import time
 from typing import Protocol

--- a/lib/colors.py
+++ b/lib/colors.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import colorsys
 import random
 from enum import Enum
@@ -34,7 +36,7 @@ def generate_colors(color_num: int) -> list[tuple[int, int, int]]:
 
 def generate_team_colors(
     num_teams: int, color_lock: bool = False, color_lock_choices: dict[int, list[str]] | None = None
-) -> list["Colors"]:
+) -> list[Colors]:
     if color_lock and color_lock_choices is not None and num_teams in [2, 3, 4]:
         temp_colors = color_lock_choices[num_teams]
         return [Colors[c] for c in temp_colors]

--- a/lib/controller_constants.py
+++ b/lib/controller_constants.py
@@ -5,6 +5,8 @@ Centralized string constants for controller state dict keys, button names,
 and other shared values to prevent typos and key mismatches across files.
 """
 
+from __future__ import annotations
+
 from enum import StrEnum
 
 

--- a/lib/feature_flags.py
+++ b/lib/feature_flags.py
@@ -3,6 +3,8 @@ Feature Flag Wrapper for JoustMania
 Integrates OpenFeature with flagd provider.
 """
 
+from __future__ import annotations
+
 import logging
 import os
 from typing import Any

--- a/lib/grpc_metrics.py
+++ b/lib/grpc_metrics.py
@@ -11,6 +11,8 @@ Usage:
     channel = grpc.aio.insecure_channel("service:50051", interceptors=interceptors)
 """
 
+from __future__ import annotations
+
 import time
 from collections.abc import Callable
 from typing import Any

--- a/lib/grpc_tracing.py
+++ b/lib/grpc_tracing.py
@@ -25,6 +25,8 @@ Usage (Server):
     server = grpc.aio.server(options=options, interceptors=interceptors)
 """
 
+from __future__ import annotations
+
 import inspect
 import logging
 import os

--- a/lib/grpc_utils.py
+++ b/lib/grpc_utils.py
@@ -11,6 +11,8 @@ Phase XX: Made compression conditional - disabled for local connections
 to reduce CPU overhead when bandwidth is not a concern.
 """
 
+from __future__ import annotations
+
 from typing import Any
 
 import grpc

--- a/lib/system_metrics.py
+++ b/lib/system_metrics.py
@@ -20,6 +20,8 @@ Usage:
         # ... rest of server setup
 """
 
+from __future__ import annotations
+
 import asyncio
 import logging
 

--- a/lib/telemetry.py
+++ b/lib/telemetry.py
@@ -20,6 +20,8 @@ Usage:
     tracer = init_telemetry(service_name="my-service")
 """
 
+from __future__ import annotations
+
 import logging
 import os
 import threading

--- a/lib/tests/test_clock.py
+++ b/lib/tests/test_clock.py
@@ -4,6 +4,8 @@ Tests for the Clock abstraction.
 Verifies that FakeClock works correctly for testing time-dependent code.
 """
 
+from __future__ import annotations
+
 import asyncio
 import time
 

--- a/lib/tests/test_colors.py
+++ b/lib/tests/test_colors.py
@@ -1,5 +1,7 @@
 """Tests for lib/colors.py"""
 
+from __future__ import annotations
+
 import sys
 from pathlib import Path
 

--- a/lib/tests/test_controller_constants.py
+++ b/lib/tests/test_controller_constants.py
@@ -1,5 +1,7 @@
 """Tests for lib/controller_constants.py"""
 
+from __future__ import annotations
+
 import sys
 from pathlib import Path
 

--- a/lib/tests/test_feature_flags.py
+++ b/lib/tests/test_feature_flags.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -26,6 +28,7 @@ def test_initialization(mock_api, mock_provider):
     # Check if provider was set with expected defaults for in-process
     mock_api.set_provider.assert_called_once()
     from openfeature.contrib.provider.flagd.config import ResolverType
+
     mock_provider.assert_called_once()
     args, kwargs = mock_provider.call_args
     assert kwargs["port"] == 8015

--- a/lib/tests/test_grpc_metrics.py
+++ b/lib/tests/test_grpc_metrics.py
@@ -1,5 +1,7 @@
 """Unit tests for the gRPC client metrics interceptors."""
 
+from __future__ import annotations
+
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import grpc

--- a/lib/tests/test_otel_metrics.py
+++ b/lib/tests/test_otel_metrics.py
@@ -1,5 +1,7 @@
 """Unit tests for the OTEL metrics wrapper library."""
 
+from __future__ import annotations
+
 import time
 from threading import Thread
 from unittest.mock import MagicMock, patch

--- a/lib/tests/test_types.py
+++ b/lib/tests/test_types.py
@@ -1,5 +1,7 @@
 """Tests for lib/types.py"""
 
+from __future__ import annotations
+
 import sys
 from pathlib import Path
 

--- a/lib/types.py
+++ b/lib/types.py
@@ -5,6 +5,8 @@ Pure data types and enums used across the application.
 No hardware dependencies.
 """
 
+from __future__ import annotations
+
 from enum import Enum, StrEnum
 
 
@@ -34,7 +36,7 @@ class Games(Enum):
     Ninja = (11, "Ninja Bomb", 2)
     Random = (12, "Random", 2)
 
-    def __new__(cls, value: int, pretty_name: str, min_players: int) -> "Games":
+    def __new__(cls, value: int, pretty_name: str, min_players: int) -> Games:
         """This odd constructor lets us keep Foo.value as an integer, but also
         add some extra properties to each option."""
         obj = object.__new__(cls)
@@ -44,7 +46,7 @@ class Games(Enum):
         return obj
 
     @classmethod
-    def from_name(cls, name: str) -> "Games | None":
+    def from_name(cls, name: str) -> Games | None:
         """
         Resolve any game name alias to a Games enum member.
 
@@ -101,7 +103,7 @@ class Games(Enum):
 
 # Alias mappings for Games.from_name() - maps lowercase aliases to Games members
 # Built after class definition to reference enum members
-_GAME_ALIASES: dict[str, "Games"] = {}
+_GAME_ALIASES: dict[str, Games] = {}
 
 
 def _init_game_aliases() -> None:

--- a/services/audio/metrics.py
+++ b/services/audio/metrics.py
@@ -4,6 +4,8 @@ Prometheus metrics for Audio Service (Phase 38).
 Tracks system resources and gRPC request performance.
 """
 
+from __future__ import annotations
+
 from prometheus_client import Counter, Gauge, Histogram
 
 # System metrics

--- a/services/audio/music_player.py
+++ b/services/audio/music_player.py
@@ -8,6 +8,8 @@ Uses resampy for real-time tempo changes without pitch shifting.
 Runs audio playback in a separate process to avoid blocking the gRPC server.
 """
 
+from __future__ import annotations
+
 import asyncio
 import contextlib
 import glob

--- a/services/audio/server.py
+++ b/services/audio/server.py
@@ -8,6 +8,8 @@ Handles audio playback with priority-based mixing and real-time tempo control.
 See services/audio/servicer.py for the AudioServiceServicer implementation.
 """
 
+from __future__ import annotations
+
 import asyncio
 import logging
 import os

--- a/services/audio/servicer.py
+++ b/services/audio/servicer.py
@@ -6,6 +6,8 @@ Handles audio playback with priority-based mixing and real-time tempo control.
 - Background music: MusicPlayer with resampy for real-time tempo control
 """
 
+from __future__ import annotations
+
 import asyncio
 import logging
 import os

--- a/services/audio/tests/conftest.py
+++ b/services/audio/tests/conftest.py
@@ -2,6 +2,8 @@
 Pytest fixtures for audio service tests.
 """
 
+from __future__ import annotations
+
 # Disable OpenTelemetry for tests - must be done before importing service modules
 from lib.otel_metrics import disable_metrics_for_tests
 from lib.telemetry import disable_telemetry_for_tests

--- a/services/audio/tests/test_audio_manager.py
+++ b/services/audio/tests/test_audio_manager.py
@@ -2,6 +2,8 @@
 Unit tests for AudioManager.
 """
 
+from __future__ import annotations
+
 import os
 from unittest.mock import patch
 

--- a/services/audio/tests/test_servicer.py
+++ b/services/audio/tests/test_servicer.py
@@ -2,6 +2,8 @@
 Unit tests for Audio gRPC Servicer.
 """
 
+from __future__ import annotations
+
 import os
 from unittest.mock import MagicMock, patch
 

--- a/services/audio/tests/test_sound_channel.py
+++ b/services/audio/tests/test_sound_channel.py
@@ -2,6 +2,8 @@
 Unit tests for SoundChannel.
 """
 
+from __future__ import annotations
+
 from services.audio.servicer import SoundChannel
 
 

--- a/services/audio/tests/test_sound_registry.py
+++ b/services/audio/tests/test_sound_registry.py
@@ -8,6 +8,8 @@ These tests verify that:
 4. All asset directories are scanned (Joust, Menu, Zombie, Fight_Club, Commander)
 """
 
+from __future__ import annotations
+
 from pathlib import Path
 
 import pytest

--- a/services/controller_manager/backend.py
+++ b/services/controller_manager/backend.py
@@ -6,6 +6,8 @@ Each backend implements this interface to provide platform-specific
 controller access while maintaining a consistent API.
 """
 
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 
 

--- a/services/controller_manager/backend_factory.py
+++ b/services/controller_manager/backend_factory.py
@@ -4,6 +4,8 @@ Backend Factory for Controller Manager
 Detects platform and creates appropriate backend instance.
 """
 
+from __future__ import annotations
+
 import logging
 import os
 import platform

--- a/services/controller_manager/bluetooth.py
+++ b/services/controller_manager/bluetooth.py
@@ -2,6 +2,8 @@
 This module handles interacting with Bluez over DBus for JoustMania
 """
 
+from __future__ import annotations
+
 import logging
 import os
 import subprocess

--- a/services/controller_manager/bluetooth_backend.py
+++ b/services/controller_manager/bluetooth_backend.py
@@ -4,6 +4,8 @@ Linux/BlueZ Backend for PS Move Controllers
 Uses psmove library + BlueZ/DBus for controller access on Raspberry Pi/Linux.
 """
 
+from __future__ import annotations
+
 import contextlib
 import logging
 import os
@@ -264,7 +266,7 @@ class BluetoothBackend(ControllerBackend):
             logger.error(f"Error disconnecting controller {serial}: {e}", exc_info=True)
             return False
 
-    def _get_move_by_serial(self, serial: str) -> "psmove.PSMove | None":
+    def _get_move_by_serial(self, serial: str) -> psmove.PSMove | None:
         """Get a fresh PSMove handle for a serial number."""
         count = psmove.count_connected()
         for i in range(count):

--- a/services/controller_manager/button_detector.py
+++ b/services/controller_manager/button_detector.py
@@ -7,6 +7,8 @@ to stream subscribers. Also handles connection/disconnection events.
 Phase 41: Button event streaming.
 """
 
+from __future__ import annotations
+
 import asyncio
 import logging
 import time

--- a/services/controller_manager/controller_state.py
+++ b/services/controller_manager/controller_state.py
@@ -16,6 +16,8 @@ Benefits:
     - Better observability
 """
 
+from __future__ import annotations
+
 import logging
 import time
 from multiprocessing import Value

--- a/services/controller_manager/discovery.py
+++ b/services/controller_manager/discovery.py
@@ -9,6 +9,8 @@ to ensure controllers paired externally (via pairing daemon, bluetoothctl, etc.)
 are discovered promptly.
 """
 
+from __future__ import annotations
+
 import logging
 import time
 

--- a/services/controller_manager/discovery_loop.py
+++ b/services/controller_manager/discovery_loop.py
@@ -14,6 +14,8 @@ Note: RSSI monitoring is handled by the host pairing-daemon which has
 direct access to hcitool for reliable signal strength readings.
 """
 
+from __future__ import annotations
+
 import asyncio
 import contextlib
 import logging
@@ -60,18 +62,18 @@ class DiscoveryLoop:
 
     def __init__(
         self,
-        backend: "ControllerBackend",
+        backend: ControllerBackend,
         tracked_controllers: dict[str, dict],
         controller_states: dict[str, dict],
-        button_detector: "ButtonDetector",
-        state_cache_manager: "StateCache",
-        feedback_manager: "FeedbackManager",
-        monitoring: "ControllerMonitoring",
-        rescan_timer: "PeriodicRescanTimer",
+        button_detector: ButtonDetector,
+        state_cache_manager: StateCache,
+        feedback_manager: FeedbackManager,
+        monitoring: ControllerMonitoring,
+        rescan_timer: PeriodicRescanTimer,
         paired_serials: list[str],
         base_colors: dict[str, tuple[int, int, int]],
-        event_publisher: "EventPublisher",
-        name_manager: "NameManager | None" = None,
+        event_publisher: EventPublisher,
+        name_manager: NameManager | None = None,
     ):
         """
         Initialize the discovery loop.

--- a/services/controller_manager/effects_base.py
+++ b/services/controller_manager/effects_base.py
@@ -8,6 +8,8 @@ which must be implemented by subclasses.
 Phase 40: Refactoring to eliminate code duplication between real and mock servers.
 """
 
+from __future__ import annotations
+
 import asyncio
 import colorsys
 import logging

--- a/services/controller_manager/event_publisher.py
+++ b/services/controller_manager/event_publisher.py
@@ -8,6 +8,8 @@ as gRPC handlers (not in a separate thread), we use direct queue.put_nowait()
 instead of call_soon_threadsafe().
 """
 
+from __future__ import annotations
+
 import asyncio
 import logging
 from typing import Any

--- a/services/controller_manager/feedback_manager.py
+++ b/services/controller_manager/feedback_manager.py
@@ -8,6 +8,8 @@ Phase 46: Internal feedback methods.
 Phase 57: Backend abstraction for platform independence.
 """
 
+from __future__ import annotations
+
 import asyncio
 import contextlib
 import logging
@@ -48,7 +50,7 @@ class FeedbackManager(ControllerEffectsBase):
 
     def __init__(
         self,
-        backend: "ControllerBackend",
+        backend: ControllerBackend,
         tracked_controllers: dict[str, dict],
     ):
         """

--- a/services/controller_manager/message_pool.py
+++ b/services/controller_manager/message_pool.py
@@ -4,6 +4,8 @@ Message pool for reusable protobuf messages.
 Extracted from server.py to reduce file size (Phase 18 - Task 3).
 """
 
+from __future__ import annotations
+
 import threading
 from collections import deque
 

--- a/services/controller_manager/metrics.py
+++ b/services/controller_manager/metrics.py
@@ -5,6 +5,8 @@ Tracks controller health, input latency, stream performance, and cache efficienc
 Uses OTLP push at 100ms intervals for real-time dashboard updates.
 """
 
+from __future__ import annotations
+
 from prometheus_client import Gauge as PromGauge
 
 from lib.otel_metrics import Counter, Gauge, Histogram

--- a/services/controller_manager/mock_backend.py
+++ b/services/controller_manager/mock_backend.py
@@ -5,6 +5,8 @@ Simulates controllers for testing without hardware.
 Useful for CI/CD, development without controllers, and automated testing.
 """
 
+from __future__ import annotations
+
 import asyncio
 import contextlib
 import logging

--- a/services/controller_manager/mock_control_service.py
+++ b/services/controller_manager/mock_control_service.py
@@ -5,6 +5,8 @@ Provides control RPCs for simulating controller behavior during tests.
 Only active when using MockBackend (Phase 57).
 """
 
+from __future__ import annotations
+
 import asyncio
 import contextlib
 import logging
@@ -23,7 +25,7 @@ logger = logging.getLogger(__name__)
 class MockControllerService(controller_manager_mock_pb2_grpc.MockControllerServiceServicer):
     """Service for controlling mock controllers during integration tests."""
 
-    def __init__(self, backend: "MockBackend"):
+    def __init__(self, backend: MockBackend):
         """
         Initialize mock control service.
 

--- a/services/controller_manager/monitoring.py
+++ b/services/controller_manager/monitoring.py
@@ -6,6 +6,8 @@ Note: RSSI monitoring is handled by the host pairing-daemon which has
 direct access to hcitool for reliable signal strength readings.
 """
 
+from __future__ import annotations
+
 import logging
 
 from services.controller_manager import metrics

--- a/services/controller_manager/name_manager.py
+++ b/services/controller_manager/name_manager.py
@@ -6,6 +6,8 @@ Provides deterministic name generation from controller serial numbers
 and persistent storage of custom names.
 """
 
+from __future__ import annotations
+
 import hashlib
 import logging
 import os

--- a/services/controller_manager/process.py
+++ b/services/controller_manager/process.py
@@ -10,6 +10,8 @@ Manages Move controller lifecycle as a separate process:
 This is part of the microservices refactoring to separate concerns.
 """
 
+from __future__ import annotations
+
 import logging
 import queue
 import time

--- a/services/controller_manager/server.py
+++ b/services/controller_manager/server.py
@@ -5,6 +5,8 @@ This module provides the entry point for the ControllerManager service.
 The actual servicer implementation is in servicer.py.
 """
 
+from __future__ import annotations
+
 import asyncio
 import logging
 import os

--- a/services/controller_manager/servicer.py
+++ b/services/controller_manager/servicer.py
@@ -5,6 +5,8 @@ Contains the ControllerManagerServicer class that handles all gRPC methods
 for managing PS Move controllers.
 """
 
+from __future__ import annotations
+
 import asyncio
 import logging
 import os

--- a/services/controller_manager/state_cache.py
+++ b/services/controller_manager/state_cache.py
@@ -7,6 +7,8 @@ controller state messages on every frame.
 Phase 18: Object pooling and state caching for performance.
 """
 
+from __future__ import annotations
+
 import logging
 from typing import TYPE_CHECKING
 
@@ -33,7 +35,7 @@ class StateCache:
     the underlying state hasn't changed.
     """
 
-    def __init__(self, monitoring: "ControllerMonitoring"):
+    def __init__(self, monitoring: ControllerMonitoring):
         """
         Initialize state cache.
 

--- a/services/controller_manager/tests/conftest.py
+++ b/services/controller_manager/tests/conftest.py
@@ -2,6 +2,8 @@
 Pytest fixtures for controller_manager tests.
 """
 
+from __future__ import annotations
+
 import pytest
 
 # Disable OpenTelemetry for tests - must be done before importing service modules

--- a/services/controller_manager/tests/test_bluetooth_backend.py
+++ b/services/controller_manager/tests/test_bluetooth_backend.py
@@ -12,6 +12,8 @@ Note: Requires mocking psmove library as hardware is not available in tests.
 Issue #209: Improve test coverage for critical game flow
 """
 
+from __future__ import annotations
+
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch

--- a/services/controller_manager/tests/test_button_detector.py
+++ b/services/controller_manager/tests/test_button_detector.py
@@ -4,6 +4,8 @@ Unit tests for ButtonDetector.
 Tests button state transition detection and event publishing.
 """
 
+from __future__ import annotations
+
 import asyncio
 from unittest.mock import MagicMock, patch
 

--- a/services/controller_manager/tests/test_controller_state.py
+++ b/services/controller_manager/tests/test_controller_state.py
@@ -14,6 +14,8 @@ Note: Requires mocking psmove library as hardware is not available in tests.
 Issue #209: Improve test coverage for critical game flow
 """
 
+from __future__ import annotations
+
 import sys
 import time
 from pathlib import Path

--- a/services/controller_manager/tests/test_discovery_loop.py
+++ b/services/controller_manager/tests/test_discovery_loop.py
@@ -4,6 +4,8 @@ Unit tests for DiscoveryLoop.
 Tests activity tracking and adaptive polling logic.
 """
 
+from __future__ import annotations
+
 import time
 from unittest.mock import MagicMock
 

--- a/services/controller_manager/tests/test_discovery_loop_extended.py
+++ b/services/controller_manager/tests/test_discovery_loop_extended.py
@@ -10,6 +10,8 @@ Tests controller discovery, disconnection detection, and state management:
 Issue #209: Improve test coverage for critical game flow
 """
 
+from __future__ import annotations
+
 import sys
 import time
 from pathlib import Path

--- a/services/controller_manager/tests/test_effects_base.py
+++ b/services/controller_manager/tests/test_effects_base.py
@@ -7,6 +7,8 @@ or integration test infrastructure.
 Uses FakeClock for time control - no patching required!
 """
 
+from __future__ import annotations
+
 import asyncio
 import contextlib
 

--- a/services/controller_manager/tests/test_event_publisher.py
+++ b/services/controller_manager/tests/test_event_publisher.py
@@ -4,6 +4,8 @@ Unit tests for EventPublisher.
 Tests thread-safe event publishing to asyncio queues.
 """
 
+from __future__ import annotations
+
 import asyncio
 import threading
 from unittest.mock import patch

--- a/services/controller_manager/tests/test_feedback_manager_effects.py
+++ b/services/controller_manager/tests/test_feedback_manager_effects.py
@@ -5,6 +5,8 @@ Tests the critical behavior where base_color is updated DURING an effect,
 and verifies that the effect restores to the NEW base_color, not the old one.
 """
 
+from __future__ import annotations
+
 import asyncio
 from unittest.mock import patch
 

--- a/services/controller_manager/tests/test_name_manager.py
+++ b/services/controller_manager/tests/test_name_manager.py
@@ -4,6 +4,8 @@ Unit tests for NameManager.
 Tests human-readable controller name generation and persistence.
 """
 
+from __future__ import annotations
+
 import os
 import tempfile
 

--- a/services/controller_manager/tests/test_servicer.py
+++ b/services/controller_manager/tests/test_servicer.py
@@ -13,6 +13,8 @@ integration tests.
 Issue #209: Improve test coverage for critical game flow
 """
 
+from __future__ import annotations
+
 import asyncio
 import sys
 from pathlib import Path

--- a/services/controller_manager/tests/test_state_cache.py
+++ b/services/controller_manager/tests/test_state_cache.py
@@ -10,6 +10,8 @@ Tests the controller state caching mechanism:
 Issue #209: Improve test coverage for critical game flow
 """
 
+from __future__ import annotations
+
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch

--- a/services/controller_manager/windows_backend.py
+++ b/services/controller_manager/windows_backend.py
@@ -5,6 +5,8 @@ Uses psmoveapi library for controller access on Windows.
 Designed for development/debugging on Windows with WSL.
 """
 
+from __future__ import annotations
+
 import logging
 
 from services.controller_manager.backend import ControllerBackend

--- a/services/game_coordinator/event_bus.py
+++ b/services/game_coordinator/event_bus.py
@@ -22,6 +22,8 @@ Usage:
     await event_bus.unsubscribe("subscriber_1")
 """
 
+from __future__ import annotations
+
 import asyncio
 import logging
 import time

--- a/services/game_coordinator/game_factory.py
+++ b/services/game_coordinator/game_factory.py
@@ -31,6 +31,8 @@ Usage:
     await game.run()
 """
 
+from __future__ import annotations
+
 import logging
 from collections.abc import Callable
 from typing import Any

--- a/services/game_coordinator/games/analytics.py
+++ b/services/game_coordinator/games/analytics.py
@@ -16,6 +16,8 @@ Memory footprint:
 - Replay mode: +48 bytes per sample x 60Hz x duration (~170KB/3min game)
 """
 
+from __future__ import annotations
+
 import json
 import logging
 import math
@@ -125,7 +127,7 @@ class PlayerAnalytics:
         raw_accel_mag: float,
         smoothed_accel: float,
         death_threshold: float,
-        config: "AnalyticsConfig",
+        config: AnalyticsConfig,
         gyro_x: float = 0.0,
         gyro_y: float = 0.0,
         gyro_z: float = 0.0,
@@ -207,7 +209,7 @@ class PlayerAnalytics:
         """Record that a warning was triggered for this player."""
         self.warning_count += 1
 
-    def _classify_zone(self, accel_mag: float, config: "AnalyticsConfig") -> MovementZone:
+    def _classify_zone(self, accel_mag: float, config: AnalyticsConfig) -> MovementZone:
         """Classify acceleration magnitude into movement zone."""
         if accel_mag < config.zone_still_max:
             return MovementZone.STILL

--- a/services/game_coordinator/games/base.py
+++ b/services/game_coordinator/games/base.py
@@ -12,6 +12,8 @@ Uses Template Method pattern:
 Phase 70: Added dynamic music tempo system.
 """
 
+from __future__ import annotations
+
 import asyncio
 import contextlib
 import logging
@@ -124,7 +126,7 @@ class Player:
     # This is purely visual - player CAN still die during warning (matches original)
     warning_until: float = 0.0
     # Analytics tracker for this player (initialized when game starts)
-    analytics: "PlayerAnalytics | None" = None
+    analytics: PlayerAnalytics | None = None
     # Per-player sensitivity multiplier (Phase 3: Per-Player Sensitivity Infrastructure)
     # 1.0 = default, >1.0 = more sensitive (easier to die), <1.0 = less sensitive (harder to die)
     # Thresholds are divided by this factor: higher factor = lower threshold = easier to trigger

--- a/services/game_coordinator/games/ffa.py
+++ b/services/game_coordinator/games/ffa.py
@@ -7,6 +7,8 @@ async/await patterns, proper state machine, and event publishing.
 Phase 36b: Refactored to extend BaseGameMode, eliminating ~550 lines of duplicate code.
 """
 
+from __future__ import annotations
+
 import logging
 import time
 

--- a/services/game_coordinator/games/fight_club.py
+++ b/services/game_coordinator/games/fight_club.py
@@ -8,6 +8,8 @@ Highest score at end wins.
 Original JoustMania behavior preserved.
 """
 
+from __future__ import annotations
+
 import asyncio
 import logging
 import time

--- a/services/game_coordinator/games/nonstop_joust.py
+++ b/services/game_coordinator/games/nonstop_joust.py
@@ -11,6 +11,8 @@ Features:
 Phase 36b: Refactored to extend BaseGameMode, eliminating ~450 lines of duplicate code.
 """
 
+from __future__ import annotations
+
 import asyncio
 import logging
 import time

--- a/services/game_coordinator/games/random_teams.py
+++ b/services/game_coordinator/games/random_teams.py
@@ -8,6 +8,8 @@ Last team standing wins.
 Phase 36b: Refactored to extend TeamsGameBase, eliminating ~550 lines of duplicate code.
 """
 
+from __future__ import annotations
+
 import asyncio
 import logging
 import random

--- a/services/game_coordinator/games/swapper.py
+++ b/services/game_coordinator/games/swapper.py
@@ -7,6 +7,8 @@ but the last player to die is excluded from winners.
 Original JoustMania behavior preserved.
 """
 
+from __future__ import annotations
+
 import asyncio
 import logging
 import time

--- a/services/game_coordinator/games/teams.py
+++ b/services/game_coordinator/games/teams.py
@@ -7,6 +7,8 @@ Last team standing wins.
 Phase 36b: Refactored to extend TeamsGameBase, eliminating ~500 lines of duplicate code.
 """
 
+from __future__ import annotations
+
 import logging
 import random
 import time

--- a/services/game_coordinator/games/teams_base.py
+++ b/services/game_coordinator/games/teams_base.py
@@ -9,6 +9,8 @@ Subclasses:
 - RandomTeamsGame (Random Teams): Random team assignment with team_formation_phase
 """
 
+from __future__ import annotations
+
 import asyncio
 import logging
 import time

--- a/services/game_coordinator/games/tournament.py
+++ b/services/game_coordinator/games/tournament.py
@@ -8,6 +8,8 @@ with byes (automatically advance to next round).
 Original JoustMania behavior preserved.
 """
 
+from __future__ import annotations
+
 import asyncio
 import logging
 import math

--- a/services/game_coordinator/games/traitor.py
+++ b/services/game_coordinator/games/traitor.py
@@ -8,6 +8,8 @@ with their secret team.
 Original JoustMania behavior preserved.
 """
 
+from __future__ import annotations
+
 import asyncio
 import logging
 import random

--- a/services/game_coordinator/games/werewolf.py
+++ b/services/game_coordinator/games/werewolf.py
@@ -7,6 +7,8 @@ but after 35 seconds the werewolves are revealed. Last team standing wins.
 Original JoustMania behavior preserved.
 """
 
+from __future__ import annotations
+
 import asyncio
 import logging
 import random

--- a/services/game_coordinator/games/zombie.py
+++ b/services/game_coordinator/games/zombie.py
@@ -11,6 +11,8 @@ event support in gameplay stream - not yet implemented.
 Original JoustMania behavior preserved (minus weapon system).
 """
 
+from __future__ import annotations
+
 import asyncio
 import logging
 import random

--- a/services/game_coordinator/grpc_clients.py
+++ b/services/game_coordinator/grpc_clients.py
@@ -24,6 +24,8 @@ Usage:
     await clients.close()
 """
 
+from __future__ import annotations
+
 import logging
 import os
 

--- a/services/game_coordinator/metrics.py
+++ b/services/game_coordinator/metrics.py
@@ -5,6 +5,8 @@ Tracks game state, player performance, audio playback, and game quality metrics.
 Uses OTLP push at 100ms intervals for real-time dashboard updates.
 """
 
+from __future__ import annotations
+
 from contextlib import suppress
 
 from lib.otel_metrics import Counter, Gauge, Histogram

--- a/services/game_coordinator/runtime_config.py
+++ b/services/game_coordinator/runtime_config.py
@@ -8,6 +8,8 @@ Phase 44: OpenFeature integration with event-driven flag updates.
 Uses PROVIDER_CONFIGURATION_CHANGED events to reactively update config.
 """
 
+from __future__ import annotations
+
 import logging
 import os
 import threading

--- a/services/game_coordinator/server.py
+++ b/services/game_coordinator/server.py
@@ -10,6 +10,8 @@ Manages game lifecycle as a gRPC service:
 See services/game_coordinator/servicer.py for the GameCoordinatorServicer implementation.
 """
 
+from __future__ import annotations
+
 import asyncio
 import logging
 import os

--- a/services/game_coordinator/servicer.py
+++ b/services/game_coordinator/servicer.py
@@ -8,6 +8,8 @@ Manages game lifecycle:
 - Stream game events (deaths, scoring, game end)
 """
 
+from __future__ import annotations
+
 import asyncio
 import logging
 import threading

--- a/services/game_coordinator/tests/conftest.py
+++ b/services/game_coordinator/tests/conftest.py
@@ -5,6 +5,8 @@ Provides MockControllerManagerService, MockSettingsService, and EventCollector
 for testing game modes without real hardware or gRPC services.
 """
 
+from __future__ import annotations
+
 import asyncio
 import sys
 import time

--- a/services/game_coordinator/tests/test_base_game.py
+++ b/services/game_coordinator/tests/test_base_game.py
@@ -12,6 +12,8 @@ Tests the core game physics and death detection logic:
 Issue #209: Improve test coverage for critical game flow
 """
 
+from __future__ import annotations
+
 import sys
 import time
 from pathlib import Path

--- a/services/game_coordinator/tests/test_event_bus.py
+++ b/services/game_coordinator/tests/test_event_bus.py
@@ -11,6 +11,8 @@ Tests event publishing and subscription:
 Issue #209: Improve test coverage for critical game flow
 """
 
+from __future__ import annotations
+
 import asyncio
 import sys
 from pathlib import Path

--- a/services/game_coordinator/tests/test_ffa.py
+++ b/services/game_coordinator/tests/test_ffa.py
@@ -7,6 +7,8 @@ Tests the core FFA mechanics:
 - Win condition detection (last player standing)
 """
 
+from __future__ import annotations
+
 import sys
 from pathlib import Path
 

--- a/services/game_coordinator/tests/test_fight_club.py
+++ b/services/game_coordinator/tests/test_fight_club.py
@@ -9,6 +9,8 @@ Tests the core Fight Club mechanics:
 - Win condition (highest score after minimum rounds)
 """
 
+from __future__ import annotations
+
 import sys
 import time
 from pathlib import Path

--- a/services/game_coordinator/tests/test_game_factory.py
+++ b/services/game_coordinator/tests/test_game_factory.py
@@ -10,6 +10,8 @@ Tests game instance creation:
 Issue #209: Improve test coverage for critical game flow
 """
 
+from __future__ import annotations
+
 import sys
 from pathlib import Path
 

--- a/services/game_coordinator/tests/test_nonstop.py
+++ b/services/game_coordinator/tests/test_nonstop.py
@@ -8,6 +8,8 @@ Tests the core Nonstop mechanics:
 - Time-based win condition
 """
 
+from __future__ import annotations
+
 import sys
 import time
 from pathlib import Path

--- a/services/game_coordinator/tests/test_random_teams.py
+++ b/services/game_coordinator/tests/test_random_teams.py
@@ -8,6 +8,8 @@ Tests the core Random Teams mechanics:
 - Team elimination detection
 """
 
+from __future__ import annotations
+
 import sys
 from pathlib import Path
 

--- a/services/game_coordinator/tests/test_runtime_config.py
+++ b/services/game_coordinator/tests/test_runtime_config.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from unittest.mock import ANY, MagicMock, patch
 
@@ -228,9 +230,11 @@ def test_refresh_from_flags_with_metrics(mock_get_client, _mock_add_handler):
     mock_client.get_integer_value.side_effect = [60, 45]
     mock_client.get_string_value.side_effect = ["MEDIUM", "HIGH"]
 
-    with patch("services.game_coordinator.metrics.config_changes_total") as mock_changes, patch(
-        "services.game_coordinator.metrics.flag_evaluations_total"
-    ) as mock_evaluations, patch("services.game_coordinator.metrics.current_update_frequency_hz") as mock_gauge:
+    with (
+        patch("services.game_coordinator.metrics.config_changes_total") as mock_changes,
+        patch("services.game_coordinator.metrics.flag_evaluations_total") as mock_evaluations,
+        patch("services.game_coordinator.metrics.current_update_frequency_hz") as mock_gauge,
+    ):
         manager = RuntimeConfigManager()
 
         # Verify initial setup called metrics

--- a/services/game_coordinator/tests/test_servicer.py
+++ b/services/game_coordinator/tests/test_servicer.py
@@ -11,6 +11,8 @@ Tests the game lifecycle management:
 Issue #209: Improve test coverage for critical game flow
 """
 
+from __future__ import annotations
+
 import sys
 import time
 from pathlib import Path

--- a/services/game_coordinator/tests/test_swapper.py
+++ b/services/game_coordinator/tests/test_swapper.py
@@ -7,6 +7,8 @@ Tests the core swapper mechanics:
 - Win condition detection (all players on same team)
 """
 
+from __future__ import annotations
+
 import sys
 import time
 from pathlib import Path

--- a/services/game_coordinator/tests/test_team_colors.py
+++ b/services/game_coordinator/tests/test_team_colors.py
@@ -4,6 +4,8 @@ Unit tests for team color assignment (Phase 39 - Task 3).
 Tests team color functionality in TeamsGameBase and subclasses.
 """
 
+from __future__ import annotations
+
 from unittest.mock import AsyncMock
 
 import pytest

--- a/services/game_coordinator/tests/test_teams.py
+++ b/services/game_coordinator/tests/test_teams.py
@@ -8,6 +8,8 @@ Tests the core Teams mechanics:
 - Win condition (last team standing)
 """
 
+from __future__ import annotations
+
 import sys
 from pathlib import Path
 

--- a/services/game_coordinator/tests/test_tournament.py
+++ b/services/game_coordinator/tests/test_tournament.py
@@ -8,6 +8,8 @@ Tests the core Tournament mechanics:
 - Win condition (last player standing)
 """
 
+from __future__ import annotations
+
 import sys
 from pathlib import Path
 

--- a/services/game_coordinator/tests/test_traitor.py
+++ b/services/game_coordinator/tests/test_traitor.py
@@ -8,6 +8,8 @@ Tests the core Traitor mechanics:
 - Player death handling
 """
 
+from __future__ import annotations
+
 import sys
 from pathlib import Path
 

--- a/services/game_coordinator/tests/test_werewolf.py
+++ b/services/game_coordinator/tests/test_werewolf.py
@@ -8,6 +8,8 @@ Tests the core Werewolf mechanics:
 - Win conditions (team elimination)
 """
 
+from __future__ import annotations
+
 import sys
 from pathlib import Path
 

--- a/services/game_coordinator/tests/test_zombie.py
+++ b/services/game_coordinator/tests/test_zombie.py
@@ -8,6 +8,8 @@ Tests the core Zombie mechanics:
 - Win conditions (all converted vs time expired)
 """
 
+from __future__ import annotations
+
 import sys
 from pathlib import Path
 

--- a/services/menu/__init__.py
+++ b/services/menu/__init__.py
@@ -4,6 +4,8 @@ Menu Service
 Manages menu UI and game selection.
 """
 
+from __future__ import annotations
+
 from .process import MenuProcess, send_command
 
 __all__ = ["MenuProcess", "send_command"]

--- a/services/menu/event_publisher.py
+++ b/services/menu/event_publisher.py
@@ -1,5 +1,7 @@
 """Event publishing and streaming for the Menu service."""
 
+from __future__ import annotations
+
 import asyncio
 import logging
 import time

--- a/services/menu/handlers/__init__.py
+++ b/services/menu/handlers/__init__.py
@@ -1,5 +1,7 @@
 """Menu service controller state handlers."""
 
+from __future__ import annotations
+
 from services.menu.handlers.admin import AdminModeHandler
 from services.menu.handlers.base import ControllerHandler, ControllerState
 from services.menu.handlers.connected import ConnectedHandler

--- a/services/menu/handlers/base.py
+++ b/services/menu/handlers/base.py
@@ -1,5 +1,7 @@
 """Base handler protocol for controller state handlers."""
 
+from __future__ import annotations
+
 import time
 from enum import Enum
 from typing import TYPE_CHECKING, Protocol
@@ -113,7 +115,7 @@ class ControllerHandler(Protocol):
         """
         ...
 
-    def set_state_manager(self, manager: "StateManager") -> None:
+    def set_state_manager(self, manager: StateManager) -> None:
         """
         Set the state manager reference for state transitions.
 

--- a/services/menu/metrics.py
+++ b/services/menu/metrics.py
@@ -4,6 +4,8 @@ Prometheus metrics for Menu Service (Phase 38).
 Tracks system resources and gRPC request performance.
 """
 
+from __future__ import annotations
+
 from prometheus_client import Counter, Gauge, Histogram
 
 # System metrics

--- a/services/menu/process.py
+++ b/services/menu/process.py
@@ -11,6 +11,8 @@ Manages menu UI and game selection as a separate process:
 This is part of the microservices refactoring (Phase 5).
 """
 
+from __future__ import annotations
+
 import logging
 import queue
 import time

--- a/services/menu/server.py
+++ b/services/menu/server.py
@@ -11,6 +11,8 @@ Manages the game selection menu and lobby experience:
 See services/menu/README.md for full documentation.
 """
 
+from __future__ import annotations
+
 import asyncio
 import contextlib
 import logging

--- a/services/menu/servicer.py
+++ b/services/menu/servicer.py
@@ -1,5 +1,7 @@
 """Menu gRPC Servicer for JoustMania."""
 
+from __future__ import annotations
+
 import asyncio
 import contextlib
 import logging

--- a/services/menu/state_manager.py
+++ b/services/menu/state_manager.py
@@ -1,5 +1,7 @@
 """Controller state manager for the Menu service."""
 
+from __future__ import annotations
+
 import logging
 from collections.abc import Callable, Coroutine
 

--- a/services/menu/tests/conftest.py
+++ b/services/menu/tests/conftest.py
@@ -2,6 +2,8 @@
 Pytest fixtures for menu service tests.
 """
 
+from __future__ import annotations
+
 # Disable OpenTelemetry for tests - must be done before importing service modules
 from lib.otel_metrics import disable_metrics_for_tests
 from lib.telemetry import disable_telemetry_for_tests

--- a/services/menu/tests/test_admin_handler.py
+++ b/services/menu/tests/test_admin_handler.py
@@ -1,5 +1,7 @@
 """Unit tests for AdminModeHandler game settings."""
 
+from __future__ import annotations
+
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest

--- a/services/menu/tests/test_controller_events.py
+++ b/services/menu/tests/test_controller_events.py
@@ -1,5 +1,7 @@
 """Unit tests for ControllerEventLoop."""
 
+from __future__ import annotations
+
 import asyncio
 from unittest.mock import AsyncMock, MagicMock
 

--- a/services/menu/tests/test_event_publisher.py
+++ b/services/menu/tests/test_event_publisher.py
@@ -1,5 +1,7 @@
 """Unit tests for EventPublisher."""
 
+from __future__ import annotations
+
 import asyncio
 from unittest.mock import MagicMock
 

--- a/services/menu/tests/test_handlers.py
+++ b/services/menu/tests/test_handlers.py
@@ -1,5 +1,7 @@
 """Unit tests for controller state handlers."""
 
+from __future__ import annotations
+
 import time
 from unittest.mock import AsyncMock, MagicMock
 

--- a/services/menu/tests/test_lobby_feedback.py
+++ b/services/menu/tests/test_lobby_feedback.py
@@ -4,6 +4,8 @@ Unit tests for Menu service.
 Tests the MenuServicer public API and basic functionality.
 """
 
+from __future__ import annotations
+
 from unittest.mock import MagicMock, patch
 
 import pytest

--- a/services/menu/tests/test_servicer.py
+++ b/services/menu/tests/test_servicer.py
@@ -14,6 +14,8 @@ These tests mock at method level rather than trying to mock the entire __init__.
 Issue #209: Improve test coverage for critical game flow
 """
 
+from __future__ import annotations
+
 import asyncio
 import contextlib
 import sys

--- a/services/menu/tests/test_state_manager.py
+++ b/services/menu/tests/test_state_manager.py
@@ -1,5 +1,7 @@
 """Unit tests for StateManager."""
 
+from __future__ import annotations
+
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest

--- a/services/menu/tests/test_utils.py
+++ b/services/menu/tests/test_utils.py
@@ -1,5 +1,7 @@
 """Unit tests for menu utility classes."""
 
+from __future__ import annotations
+
 import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 

--- a/services/menu/utils/__init__.py
+++ b/services/menu/utils/__init__.py
@@ -1,5 +1,7 @@
 """Menu service utility classes."""
 
+from __future__ import annotations
+
 from services.menu.utils.audio import AudioHelper
 from services.menu.utils.led import LedController
 from services.menu.utils.settings import SettingsHelper

--- a/services/menu/utils/audio.py
+++ b/services/menu/utils/audio.py
@@ -1,5 +1,7 @@
 """Audio utilities for the Menu service."""
 
+from __future__ import annotations
+
 import logging
 
 import grpc.aio

--- a/services/menu/utils/led.py
+++ b/services/menu/utils/led.py
@@ -1,5 +1,7 @@
 """LED control utilities for the Menu service."""
 
+from __future__ import annotations
+
 import asyncio
 import logging
 

--- a/services/menu/utils/settings.py
+++ b/services/menu/utils/settings.py
@@ -1,5 +1,7 @@
 """Settings utilities for the Menu service."""
 
+from __future__ import annotations
+
 import logging
 
 import grpc.aio

--- a/services/settings/__init__.py
+++ b/services/settings/__init__.py
@@ -8,6 +8,8 @@ Supports both:
 - gRPC (server.py, settings_pb2, settings_pb2_grpc)
 """
 
+from __future__ import annotations
+
 # gRPC exports (always available)
 try:
     from . import settings_pb2, settings_pb2_grpc

--- a/services/settings/metrics.py
+++ b/services/settings/metrics.py
@@ -4,6 +4,8 @@ Prometheus metrics for Settings Service (Phase 38).
 Tracks system resources and gRPC request performance.
 """
 
+from __future__ import annotations
+
 from prometheus_client import Counter, Gauge, Histogram
 
 # System metrics

--- a/services/settings/process.py
+++ b/services/settings/process.py
@@ -10,6 +10,8 @@ Manages settings as a separate process:
 This is part of the microservices refactoring (Phase 3).
 """
 
+from __future__ import annotations
+
 import contextlib
 import fnmatch
 import logging

--- a/services/settings/server.py
+++ b/services/settings/server.py
@@ -10,6 +10,8 @@ Manages settings as a gRPC service:
 See services/settings/servicer.py for the SettingsServicer implementation.
 """
 
+from __future__ import annotations
+
 import asyncio
 import logging
 import os

--- a/services/settings/servicer.py
+++ b/services/settings/servicer.py
@@ -8,6 +8,8 @@ Manages settings as a gRPC service:
 - Publish change events via streaming
 """
 
+from __future__ import annotations
+
 import asyncio
 import logging
 import os

--- a/services/settings/tests/conftest.py
+++ b/services/settings/tests/conftest.py
@@ -2,6 +2,8 @@
 Pytest fixtures for settings service tests.
 """
 
+from __future__ import annotations
+
 # Disable OpenTelemetry for tests - must be done before importing service modules
 from lib.otel_metrics import disable_metrics_for_tests
 from lib.telemetry import disable_telemetry_for_tests

--- a/services/settings/tests/test_settings_servicer.py
+++ b/services/settings/tests/test_settings_servicer.py
@@ -4,6 +4,8 @@ Unit tests for Settings gRPC Servicer.
 Tests the core SettingsServicer functionality without full gRPC server.
 """
 
+from __future__ import annotations
+
 import asyncio
 import os
 import tempfile


### PR DESCRIPTION
## Summary
- Add `from __future__ import annotations` to all 126 Python source files in `services/` and `lib/` for consistent PEP 604 forward compatibility on Python 3.9+
- Remove 20 now-unnecessary quoted type annotations (UP037) that ruff flagged after the future import was added
- Fix import ordering in `name_manager.py` where a comment/docstring caused E402 placement issues

## Test plan
- [x] `make lint` passes (all checks passed)
- [x] All service unit tests pass (917 tests total):
  - game_coordinator: 305 passed
  - controller_manager: 209 passed
  - menu: 152 passed
  - lib: 136 passed
  - audio: 67 passed
  - settings: 48 passed
- [x] No runtime annotation inspection breakage
- [x] Pre-commit hooks (ruff check + ruff format) pass

Fixes #341

🤖 Generated with [Claude Code](https://claude.com/claude-code)