### PR TITLE
refactor: Standardize game mode cleanup and shutdown hooks

### DIFF
--- a/services/game_coordinator/games/base.py
+++ b/services/game_coordinator/games/base.py
@@ -228,6 +228,9 @@ class BaseGameMode(ABC):
         self.gameplay_span: trace.Span | None = None  # Reference for span events
         self.gameplay_span_context = None  # Context for child spans in background tasks
 
+        # Tracked async tasks for automatic cleanup on game end
+        self._tasks: set[asyncio.Task] = set()
+
         logger.info(f"{self.get_game_name()} game initialized: {self.game_id}")
 
     # ========================================================================
@@ -898,6 +901,57 @@ class BaseGameMode(ABC):
         self.running = False
 
     # ========================================================================
+    # Task Tracking and Lifecycle Hooks
+    # ========================================================================
+
+    def _track_task(self, task: asyncio.Task) -> asyncio.Task:
+        """
+        Register an async task for automatic cleanup.
+
+        Tracked tasks are cancelled when cleanup() is called, preventing
+        dangling tasks after game end.
+
+        Args:
+            task: The asyncio.Task to track
+
+        Returns:
+            The same task (for chaining with asyncio.create_task)
+        """
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.discard)
+        return task
+
+    async def cleanup(self) -> None:
+        """
+        Clean up game resources. Called in finally block after game ends.
+
+        Cancels any tracked async tasks registered via _track_task().
+        Subclasses should override to add mode-specific cleanup
+        (e.g., cancel timers, close connections) and call super().cleanup().
+        """
+        if self._tasks:
+            # Snapshot tasks before cancelling (done callbacks remove from set)
+            tasks_to_cancel = list(self._tasks)
+            logger.info(f"Cleaning up {len(tasks_to_cancel)} tracked tasks")
+            for task in tasks_to_cancel:
+                if not task.done():
+                    task.cancel()
+            # Wait for all tasks to complete cancellation
+            await asyncio.gather(*tasks_to_cancel, return_exceptions=True)
+            self._tasks.clear()
+        logger.info(f"{self.get_game_name()} cleanup complete")
+
+    async def on_force_end(self) -> None:
+        """
+        Hook called when game is force-ended (not natural completion).
+
+        Called before cleanup(). Use for mode-specific force-end logic
+        like announcing forced end or saving partial results.
+        Subclasses can override to add custom behavior.
+        """
+        logger.info(f"{self.get_game_name()} force-ended")
+
+    # ========================================================================
     # Template Method - Orchestrates entire game lifecycle with spans
     # ========================================================================
 
@@ -1002,7 +1056,13 @@ class BaseGameMode(ABC):
             raise
 
         finally:
+            force_ended = not self.running
             self.running = False
+            # Call force-end hook if game was externally stopped
+            if force_ended:
+                await self.on_force_end()
+            # Always call cleanup to cancel tracked tasks
+            await self.cleanup()
             # Ensure analytics are always cleared, even on error
             metrics.clear_all_player_analytics()
             logger.info(f"{self.get_game_name()} game finished: {self.game_id}")

--- a/services/game_coordinator/games/fight_club.py
+++ b/services/game_coordinator/games/fight_club.py
@@ -279,7 +279,7 @@ class FightClubGame(BaseGameMode):
 
         # Start round timer task (unless face-off)
         if not self.face_off_mode:
-            self.round_task = asyncio.create_task(self._round_timer())
+            self.round_task = self._track_task(asyncio.create_task(self._round_timer()))
 
     async def _round_timer(self):
         """
@@ -541,6 +541,17 @@ class FightClubGame(BaseGameMode):
 
         logger.info("Fight Club game ended")
 
+    async def cleanup(self) -> None:
+        """Cancel round timer and any tracked tasks."""
+        if self.round_task and not self.round_task.done():
+            self.round_task.cancel()
+        await super().cleanup()
+
+    async def on_force_end(self) -> None:
+        """Handle force-end by marking game as over."""
+        self.game_over = True
+        await super().on_force_end()
+
     async def run(self):
         """
         Run the Fight Club game.
@@ -620,10 +631,12 @@ class FightClubGame(BaseGameMode):
                 game_span.set_status(Status(StatusCode.ERROR, str(e)))
                 raise
             finally:
+                force_ended = not self.running
                 self.running = False
                 await self._stop_game_music()
-                if self.round_task and not self.round_task.done():
-                    self.round_task.cancel()
+                if force_ended:
+                    await self.on_force_end()
+                await self.cleanup()
 
     async def _process_controller_state(self, state):
         """

--- a/services/game_coordinator/games/tournament.py
+++ b/services/game_coordinator/games/tournament.py
@@ -712,6 +712,13 @@ class TournamentGame(BaseGameMode):
 
         logger.info("Tournament game ended")
 
+    async def cleanup(self) -> None:
+        """Cancel match timer and any tracked tasks."""
+        if self.match_span:
+            self.match_span.end()
+            self.match_span = None
+        await super().cleanup()
+
     async def run(self):
         """
         Run the Tournament game.
@@ -783,5 +790,9 @@ class TournamentGame(BaseGameMode):
                 game_span.set_status(Status(StatusCode.ERROR, str(e)))
                 raise
             finally:
+                force_ended = not self.running
                 self.running = False
                 await self._stop_game_music()
+                if force_ended:
+                    await self.on_force_end()
+                await self.cleanup()

--- a/services/game_coordinator/games/werewolf.py
+++ b/services/game_coordinator/games/werewolf.py
@@ -467,6 +467,12 @@ class WerewolfGame(BaseGameMode):
 
         logger.info("Werewolf game ended")
 
+    async def cleanup(self) -> None:
+        """Cancel reveal task and any tracked tasks."""
+        if self.reveal_task and not self.reveal_task.done():
+            self.reveal_task.cancel()
+        await super().cleanup()
+
     async def run(self):
         """
         Run the werewolf game with reveal timer.
@@ -530,7 +536,7 @@ class WerewolfGame(BaseGameMode):
                 await self._start_game_music()
 
                 # Start reveal timer as background task
-                self.reveal_task = asyncio.create_task(self._reveal_werewolves())
+                self.reveal_task = self._track_task(asyncio.create_task(self._reveal_werewolves()))
 
                 # Game loop (gameplay stream already started before intro)
                 with tracer.start_as_current_span("gameplay_phase"):
@@ -548,7 +554,9 @@ class WerewolfGame(BaseGameMode):
                 game_span.set_status(Status(StatusCode.ERROR, str(e)))
                 raise
             finally:
+                force_ended = not self.running
                 self.running = False
                 await self._stop_game_music()
-                if self.reveal_task and not self.reveal_task.done():
-                    self.reveal_task.cancel()
+                if force_ended:
+                    await self.on_force_end()
+                await self.cleanup()

--- a/services/game_coordinator/games/zombie.py
+++ b/services/game_coordinator/games/zombie.py
@@ -124,8 +124,6 @@ class ZombieGame(BaseGameMode):
         self.time_remaining: float = 0.0
         self.timer_task: asyncio.Task | None = None
         self.game_span: trace.Span | None = None
-        # Track respawn tasks to prevent garbage collection
-        self._respawn_tasks: set[asyncio.Task] = set()
 
     def get_game_name(self) -> str:
         """Return game mode identifier."""
@@ -360,10 +358,8 @@ class ZombieGame(BaseGameMode):
 
             logger.info(f"Zombie {serial} killed, respawning in {respawn_delay:.1f}s")
 
-            # Start respawn task (track to prevent garbage collection)
-            task = asyncio.create_task(self._respawn_zombie(serial, respawn_delay))
-            self._respawn_tasks.add(task)
-            task.add_done_callback(self._respawn_tasks.discard)
+            # Start respawn task (tracked for automatic cleanup)
+            self._track_task(asyncio.create_task(self._respawn_zombie(serial, respawn_delay)))
 
             if player.span:
                 player.span.add_event(
@@ -533,6 +529,12 @@ class ZombieGame(BaseGameMode):
 
         logger.info("Zombie game ended")
 
+    async def cleanup(self) -> None:
+        """Cancel timer task, respawn tasks, and any tracked tasks."""
+        if self.timer_task and not self.timer_task.done():
+            self.timer_task.cancel()
+        await super().cleanup()
+
     async def run(self):
         """
         Run the zombie game with timer.
@@ -589,7 +591,7 @@ class ZombieGame(BaseGameMode):
                 await self._start_game_music()
 
                 # Start game timer as background task
-                self.timer_task = asyncio.create_task(self._game_timer())
+                self.timer_task = self._track_task(asyncio.create_task(self._game_timer()))
 
                 # Game loop (gameplay stream already started before intro)
                 with tracer.start_as_current_span("gameplay_phase"):
@@ -607,7 +609,9 @@ class ZombieGame(BaseGameMode):
                 game_span.set_status(Status(StatusCode.ERROR, str(e)))
                 raise
             finally:
+                force_ended = not self.running
                 self.running = False
                 await self._stop_game_music()
-                if self.timer_task and not self.timer_task.done():
-                    self.timer_task.cancel()
+                if force_ended:
+                    await self.on_force_end()
+                await self.cleanup()

--- a/services/game_coordinator/tests/test_base_game.py
+++ b/services/game_coordinator/tests/test_base_game.py
@@ -1089,3 +1089,200 @@ class TestMusicTempoThresholds:
         """LERP with t<0 should extrapolate."""
         result = game._lerp(1.0, 2.0, -0.5)
         assert result == 0.5
+
+
+class TestTaskTracking:
+    """Tests for _track_task() and automatic task cleanup."""
+
+    @pytest.fixture
+    def game(self):
+        """Create a minimal FFA game for testing task tracking."""
+        mock_cm = MockControllerManagerService(num_controllers=2)
+        mock_settings = MockSettingsService()
+        return FFAGame(
+            controller_manager_client=mock_cm,
+            settings_client=mock_settings,
+            event_publisher=async_noop,
+            audio_client=None,
+            game_id="test_tasks",
+        )
+
+    def test_tasks_set_initialized_empty(self, game):
+        """_tasks set should be empty on init."""
+        assert isinstance(game._tasks, set)
+        assert len(game._tasks) == 0
+
+    @pytest.mark.asyncio
+    async def test_track_task_registers_task(self, game):
+        """_track_task should add task to the _tasks set."""
+        import asyncio
+        import contextlib
+
+        async def dummy():
+            await asyncio.sleep(100)
+
+        task = asyncio.create_task(dummy())
+        result = game._track_task(task)
+
+        assert result is task
+        assert task in game._tasks
+
+        # Cleanup
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+    @pytest.mark.asyncio
+    async def test_track_task_auto_removes_on_completion(self, game):
+        """Completed tasks should be automatically removed from _tasks."""
+        import asyncio
+
+        async def quick():
+            return "done"
+
+        task = asyncio.create_task(quick())
+        game._track_task(task)
+        assert task in game._tasks
+
+        # Wait for task to complete
+        await task
+        # Allow done callback to fire
+        await asyncio.sleep(0)
+
+        assert task not in game._tasks
+
+    @pytest.mark.asyncio
+    async def test_track_task_auto_removes_on_cancel(self, game):
+        """Cancelled tasks should be automatically removed from _tasks."""
+        import asyncio
+        import contextlib
+
+        async def slow():
+            await asyncio.sleep(100)
+
+        task = asyncio.create_task(slow())
+        game._track_task(task)
+        assert task in game._tasks
+
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+        # Allow done callback to fire
+        await asyncio.sleep(0)
+
+        assert task not in game._tasks
+
+    @pytest.mark.asyncio
+    async def test_cleanup_cancels_tracked_tasks(self, game):
+        """cleanup() should cancel all tracked tasks."""
+        import asyncio
+
+        started = []
+
+        async def wait_forever():
+            started.append(True)
+            await asyncio.sleep(100)
+
+        task1 = game._track_task(asyncio.create_task(wait_forever()))
+        task2 = game._track_task(asyncio.create_task(wait_forever()))
+
+        # Let tasks start running
+        await asyncio.sleep(0)
+        assert len(started) == 2
+        assert len(game._tasks) == 2
+
+        await game.cleanup()
+
+        assert task1.cancelled()
+        assert task2.cancelled()
+        assert len(game._tasks) == 0
+
+    @pytest.mark.asyncio
+    async def test_cleanup_handles_already_done_tasks(self, game):
+        """cleanup() should handle tasks that completed before cleanup."""
+        import asyncio
+
+        async def quick():
+            return "done"
+
+        task = asyncio.create_task(quick())
+        game._track_task(task)
+        await task  # Complete before cleanup
+        await asyncio.sleep(0)  # Let callback fire
+
+        # Should not raise even though task is already done
+        await game.cleanup()
+
+    @pytest.mark.asyncio
+    async def test_cleanup_idempotent(self, game):
+        """cleanup() should be safe to call multiple times."""
+        await game.cleanup()
+        await game.cleanup()  # Should not raise
+
+
+class TestOnForceEnd:
+    """Tests for on_force_end() lifecycle hook."""
+
+    @pytest.fixture
+    def game(self):
+        """Create a minimal FFA game for testing force-end."""
+        mock_cm = MockControllerManagerService(num_controllers=2)
+        mock_settings = MockSettingsService()
+        return FFAGame(
+            controller_manager_client=mock_cm,
+            settings_client=mock_settings,
+            event_publisher=async_noop,
+            audio_client=None,
+            game_id="test_force_end",
+        )
+
+    @pytest.mark.asyncio
+    async def test_on_force_end_default_does_not_raise(self, game):
+        """Default on_force_end() should complete without error."""
+        await game.on_force_end()
+
+    @pytest.mark.asyncio
+    async def test_force_end_sets_running_false(self, game):
+        """force_end() should set running to False."""
+        game.running = True
+        game.force_end()
+        assert game.running is False
+
+
+class TestGameLifecycleCleanup:
+    """Tests for cleanup integration in run() finally block."""
+
+    @pytest.fixture
+    def game(self):
+        """Create a minimal FFA game for lifecycle testing."""
+        mock_cm = MockControllerManagerService(num_controllers=3)
+        mock_settings = MockSettingsService()
+        events = EventCollector()
+        return FFAGame(
+            controller_manager_client=mock_cm,
+            settings_client=mock_settings,
+            event_publisher=events.publish,
+            audio_client=None,
+            game_id="test_lifecycle",
+            initial_players=[type("P", (), {"serial": f"mock_controller_{i}"})() for i in range(3)],
+        )
+
+    @pytest.mark.asyncio
+    async def test_cleanup_called_after_run(self, game):
+        """cleanup() should be called even when run() completes normally."""
+        import contextlib
+
+        cleanup_called = []
+        original_cleanup = game.cleanup
+
+        async def track_cleanup():
+            cleanup_called.append(True)
+            await original_cleanup()
+
+        game.cleanup = track_cleanup
+
+        # Run game (will complete because mock stream ends)
+        with contextlib.suppress(Exception):
+            await game.run()
+
+        assert len(cleanup_called) >= 1


### PR DESCRIPTION
## Summary
- Add `_track_task()`, `cleanup()`, and `on_force_end()` lifecycle methods to `BaseGameMode` in `base.py`
- Update `fight_club`, `werewolf`, `zombie`, and `tournament` to use the new standardized cleanup pattern
- Replace zombie's manual `_respawn_tasks` tracking with the base `_tasks` set and `_track_task()` helper
- Add 10 new unit tests covering task tracking, cleanup, force-end hooks, and lifecycle integration

## Details

### BaseGameMode changes (`base.py`)
- `self._tasks: set[asyncio.Task]` — tracked task registry, initialized in `__init__`
- `_track_task(task)` — registers a task with auto-removal via `done_callback`
- `cleanup()` — snapshots and cancels all tracked tasks, awaits completion
- `on_force_end()` — hook for force-end logic (before cleanup)
- `run()` finally block — detects force-end, calls `on_force_end()` then `cleanup()`

### Game mode updates
- **fight_club.py**: Uses `_track_task()` for round timer; overrides `cleanup()` and `on_force_end()`
- **werewolf.py**: Uses `_track_task()` for reveal timer; overrides `cleanup()`
- **zombie.py**: Removes manual `_respawn_tasks` set; uses `_track_task()` for respawn + game timer; overrides `cleanup()`
- **tournament.py**: Overrides `cleanup()` to end match span

### Tests (`test_base_game.py`)
- `TestTaskTracking` (7 tests): task registration, auto-removal on completion/cancel, cleanup cancellation, idempotency
- `TestOnForceEnd` (2 tests): default hook behavior, force_end state
- `TestGameLifecycleCleanup` (1 test): cleanup called after `run()` completes

## Test plan
- [x] All 315 game_coordinator tests pass (`uv run pytest -v`)
- [x] Lint passes (`make lint`)
- [x] 10 new tests for lifecycle methods
- [x] No changes to servicer.py needed (cleanup happens in `run()` finally block)

Fixes #338

🤖 Generated with [Claude Code](https://claude.com/claude-code)