### PR TITLE
fix: Preserve OTEL push service job labels in Prometheus

### DIFF
--- a/services/grafana/dashboards/service-health-overview.json
+++ b/services/grafana/dashboards/service-health-overview.json
@@ -96,7 +96,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "count(up{job=~\"controller-manager|game-coordinator|menu|audio\"} == 1)",
+          "expr": "count(count by(job) (process_cpu_percent{job=~\"controller-manager|game-coordinator|menu|audio\"}))",
           "legendFormat": "Services",
           "refId": "A"
         }
@@ -389,7 +389,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "up{job=~\"controller-manager|game-coordinator|menu|audio\"}",
+          "expr": "count by(job) (process_cpu_percent{job=~\"controller-manager|game-coordinator|menu|audio\"}) > 0",
           "format": "table",
           "instant": true,
           "refId": "A"

--- a/services/prometheus/prometheus.yml
+++ b/services/prometheus/prometheus.yml
@@ -11,18 +11,22 @@ rule_files:
 scrape_configs:
   # OTEL Collector - aggregates metrics from real-time services (Issue #106)
   # Services push metrics via OTLP; collector exposes them on :8889
+  # The OTEL Prometheus exporter sets job="joustmania/<service>" on metrics.
+  # honor_labels preserves these instead of overwriting with job="otel-collector".
   - job_name: 'otel-collector'
     scrape_interval: 500ms
+    honor_labels: true
     static_configs:
       - targets: ['otel-collector:8889']
         labels:
           collector: 'otel'
-    # Map service_name label to job label so dashboard queries work
-    # OTEL metrics have service_name="controller-manager" etc.
+          pipeline: 'otel-push'
+    # Strip "joustmania/" prefix from job label so dashboard queries match
+    # e.g. "joustmania/controller-manager" -> "controller-manager"
     metric_relabel_configs:
-      - source_labels: [service_name]
+      - source_labels: [job]
         target_label: job
-        regex: (.+)
+        regex: 'joustmania/(.*)'
         replacement: $1
 
   # Controller Manager direct pull (pipeline comparison)


### PR DESCRIPTION
## Summary
- Adds `honor_labels: true` to the otel-collector scrape config so Prometheus preserves the original `job` labels from pushed metrics
- Strips `joustmania/` prefix via `metric_relabel_configs` so labels match dashboard queries
- Updates service health dashboard to use `process_cpu_percent` as a heartbeat metric instead of `up{}` (which only exists for pull targets, not OTEL push)

## Problem
Services pushing metrics via OTEL (controller-manager, game-coordinator) were invisible in Grafana dashboards. The otel-collector Prometheus exporter sets `job="joustmania/controller-manager"` on metrics, but Prometheus overwrites this with `job="otel-collector"` on scrape — collapsing all pushed services into one label.

## After this fix
| Job Label | Source | Pipeline |
|-----------|--------|----------|
| `controller-manager` | otel-collector:8889 | OTEL push |
| `controller-manager-pull` | controller-manager:8000 | Prometheus pull |
| `game-coordinator` | otel-collector:8889 | OTEL push |
| `menu` | menu:8000 | Prometheus pull |
| `audio` | audio:8000 | Prometheus pull |

## Test plan
- [ ] Deploy on Pi, verify `curl localhost:9090/api/v1/query?query=up` shows correct job labels
- [ ] Grafana service health dashboard shows all 4 app services
- [ ] Pipeline comparison dashboard still works (push vs pull for controller-manager)

🤖 Generated with [Claude Code](https://claude.com/claude-code)