### PR TITLE
fix: Set flagd gRPC keepalive to 30s to prevent too_many_pings

### DIFF
--- a/lib/feature_flags.py
+++ b/lib/feature_flags.py
@@ -45,6 +45,7 @@ def init_flag_domain(domain: str) -> None:
             port=flagd_port,
             resolver_type=ResolverType.IN_PROCESS,
             selector=f"flagSetId={domain}",
+            keep_alive_time=30000,
         )
         api.set_provider(provider, domain=domain)
         _initialized_domains.add(domain)


### PR DESCRIPTION
## Summary
- Set `keep_alive_time=30000` (30s) on `FlagdProvider` to prevent gRPC `too_many_pings` GOAWAY errors
- FlagdProvider defaults `keep_alive_time` to 0ms, causing the gRPC client to ping constantly and triggering flagd's `ENHANCE_YOUR_CALM` rate limit
- 30s matches the inter-service gRPC keepalive settings in `lib/grpc_utils.py`

## Test plan
- [x] `ruff check` passes
- [x] `lib/tests/test_feature_flags.py` - all 3 tests pass
- [ ] Deploy and verify no `too_many_pings` GOAWAY errors in flagd logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)