### PR TITLE
fix: Add missing await to _check_win_condition() in game loop

### DIFF
--- a/services/game_coordinator/games/base.py
+++ b/services/game_coordinator/games/base.py
@@ -549,7 +549,7 @@ class BaseGameMode(ABC):
                             await self._process_controller_state(gameplay_data)
 
                             # Check after each controller - stop processing if we have a winner
-                            if self._check_win_condition():
+                            if await self._check_win_condition():
                                 game_over = True
                                 break
 


### PR DESCRIPTION
## Summary
- Add missing `await` to `_check_win_condition()` call in the main game loop (`base.py` line 552)
- Without `await`, the async method returned a coroutine object (always truthy), causing every game to end immediately after starting
- All other call sites (nonstop_joust.py, all test files) already correctly use `await`

## Root Cause
`_check_win_condition()` is an `async def` method. Calling it without `await` returns a coroutine object, which is always truthy in Python. This meant the `if self._check_win_condition():` check on line 552 always evaluated to `True`, setting `game_over = True` and ending the game on the very first frame.

## Test plan
- [x] Verified all other `_check_win_condition()` call sites already have `await`
- [x] Lint passes (`ruff check` + `ruff format`)
- [x] Pre-commit hooks pass
- [ ] Integration test: start a game with 2+ controllers and verify it does not immediately end

🤖 Generated with [Claude Code](https://claude.com/claude-code)