### PR TITLE
docs: Add docker-compose.override.yml template for audio configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ conf/supervisor/conf.d/joust.conf
 # Environment files (local overrides)
 .env
 !.env.mock
+docker-compose.override.yml
 
 .python_history
 # Byte-compiled / optimized / DLL files

--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -1,0 +1,39 @@
+# Docker Compose Override Example
+#
+# Copy this file to docker-compose.override.yml and customize for your environment:
+#   cp docker-compose.override.yml.example docker-compose.override.yml
+#
+# This file is automatically loaded by Docker Compose when present.
+# See: https://docs.docker.com/compose/multiple-compose-files/extends/
+#
+# Note: docker-compose.override.yml is git-ignored to prevent committing
+# environment-specific configuration.
+
+services:
+  # Audio Service - ALSA Configuration
+  # Uncomment and customize the following settings if you need ALSA dmix support
+  # or other audio-specific configuration on your Raspberry Pi/Linux system.
+
+  audio:
+    # Required for ALSA dmix shared memory access
+    # Allows the container to use dmix plugin for software audio mixing
+    # ipc: host
+
+    # Mount your ALSA configuration file (if you have custom audio setup)
+    # This is typically needed when using dmix or other ALSA plugins
+    # volumes:
+    #   - /etc/asound.conf:/etc/asound.conf:ro
+
+    # Example: Custom ALSA device configuration
+    # environment:
+    #   - ALSA_CARD=PCM
+
+  # Example: Controller Manager - Custom Bluetooth Adapter
+  # controller-manager:
+  #   environment:
+  #     - BLUETOOTH_HCI=hci1  # Use hci1 instead of default hci0
+
+  # Example: Enable debug logging for specific service
+  # game-coordinator:
+  #   environment:
+  #     - LOG_LEVEL=DEBUG

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -258,8 +258,29 @@ docker compose up -d --scale game-coordinator=3
 
 ### Override Configuration
 
+Docker Compose automatically loads `docker-compose.override.yml` if present, allowing you to customize settings without modifying the main `docker-compose.yml` file.
+
 ```bash
-# Use custom compose file
+# Create override file from template
+cp docker-compose.override.yml.example docker-compose.override.yml
+
+# Edit with your environment-specific settings
+nano docker-compose.override.yml
+
+# Docker Compose automatically merges the override file
+docker compose up -d
+```
+
+**Common use cases for overrides:**
+- ALSA audio configuration (dmix, custom sound devices)
+- Custom Bluetooth adapter selection
+- Debug logging for specific services
+- Development-specific volume mounts
+
+See `docker-compose.override.yml.example` for examples and [Troubleshooting - Audio issues](#audio-issues-alsa-errors-no-sound-device-busy) for audio setup.
+
+```bash
+# Use additional custom compose file
 docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d
 ```
 
@@ -811,6 +832,115 @@ docker compose exec game-coordinator env | grep OTEL
 # Test trace export
 grpcurl -plaintext localhost:4317 list
 ```
+
+#### Audio issues (ALSA errors, no sound, device busy)
+
+If you encounter ALSA errors like:
+
+```
+ALSA lib ... Unknown PCM default
+Device or resource busy
+Cannot open audio device
+```
+
+This typically happens when:
+1. Multiple processes try to access the same audio device
+2. Your audio device doesn't support hardware mixing
+3. ALSA dmix (software mixing) is not configured
+
+**Solution:** Configure ALSA dmix and use docker-compose.override.yml
+
+1. **Create ALSA configuration** on your host system:
+
+```bash
+sudo nano /etc/asound.conf
+```
+
+Add the following configuration (adjust `card` and `device` for your hardware):
+
+```conf
+# Use dmix (software mixing) to allow multiple processes to share audio
+pcm.!default {
+    type plug
+    slave.pcm "dmixer"
+}
+
+pcm.dmixer {
+    type dmix
+    ipc_key 1024
+    ipc_perm 0666
+    slave {
+        pcm "hw:0,0"    # Adjust for your hardware (card 0, device 0)
+        period_time 0
+        period_size 1024
+        buffer_size 8192
+        rate 44100
+    }
+    bindings {
+        0 0
+        1 1
+    }
+}
+
+ctl.dmixer {
+    type hw
+    card 0              # Adjust for your hardware
+}
+```
+
+2. **Find your audio hardware:**
+
+```bash
+# List audio devices
+aplay -l
+
+# Example output:
+# card 0: Headphones [bcm2835 Headphones], device 0: bcm2835 Headphones [bcm2835 Headphones]
+# Use hw:0,0 in the config above
+```
+
+3. **Test ALSA configuration:**
+
+```bash
+# Test playback
+speaker-test -t wav -c 2
+
+# If this works, proceed to Docker configuration
+```
+
+4. **Create docker-compose override:**
+
+```bash
+cp docker-compose.override.yml.example docker-compose.override.yml
+```
+
+Edit `docker-compose.override.yml` and uncomment the audio configuration:
+
+```yaml
+services:
+  audio:
+    # Required for ALSA dmix shared memory access
+    ipc: host
+    volumes:
+      - /etc/asound.conf:/etc/asound.conf:ro
+```
+
+5. **Restart the audio service:**
+
+```bash
+docker compose up -d audio
+docker compose logs -f audio
+```
+
+**Why this is needed:**
+
+- `ipc: host` - Allows the container to access the host's IPC namespace for dmix shared memory
+- `/etc/asound.conf` mount - Provides the container with your custom ALSA configuration
+- dmix - Enables software mixing so multiple processes (or containers) can use audio simultaneously
+
+**Alternative:** If you don't need multiple audio streams, you can use direct hardware access without dmix, but this may cause "device busy" errors when multiple services try to play audio.
+
+**Docker memory limits:** If you see errors about cgroup memory limits, see the [Docker cgroup memory troubleshooting guide](https://github.com/docker/for-linux/issues/1112).
 
 ---
 


### PR DESCRIPTION
## Summary

Add `docker-compose.override.yml.example` template and comprehensive documentation for audio configuration, specifically for ALSA dmix support on Raspberry Pi.

This addresses environment-specific audio configuration needs without requiring changes to the main `docker-compose.yml` file.

## Changes

- **New file:** `docker-compose.override.yml.example` - Template with:
  - ALSA dmix configuration for audio service
  - Example environment overrides for other services
  - Clear comments explaining when/why to use each setting

- **Updated:** `docs/DEVELOPMENT.md` - Added:
  - Enhanced "Override Configuration" section with usage instructions
  - New troubleshooting section: "Audio issues (ALSA errors, no sound, device busy)"
  - Step-by-step guide for ALSA dmix configuration
  - Hardware device detection instructions
  - Explanation of `ipc: host` and volume mount requirements

- **Updated:** `.gitignore` - Added `docker-compose.override.yml` to prevent committing environment-specific configurations

## Why These Changes?

The audio service ALSA configuration is **environment-specific** and shouldn't be in the main docker-compose.yml because:
- Not all systems have `/etc/asound.conf` in the same location or at all
- The ALSA configuration contents are specific to each user's hardware
- Some users may not need dmix (direct hardware access)
- Mounting a non-existent file would cause the service to fail

## Test Plan

- [x] Verified override file syntax is valid YAML
- [x] Confirmed .gitignore excludes docker-compose.override.yml
- [x] Documentation links and formatting are correct
- [ ] Users can follow the guide to set up audio on their Pi

## Usage

Users with audio issues can now:
```bash
# Create their own override file
cp docker-compose.override.yml.example docker-compose.override.yml

# Customize for their hardware
nano docker-compose.override.yml

# Docker Compose automatically merges it
docker compose up -d audio
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)