### PR TITLE
fix: Add audio group to container for ALSA device access

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -320,6 +320,8 @@ services:
     # Sound device access for real audio output
     devices:
       - /dev/snd:/dev/snd
+    group_add:
+      - "29"  # host 'audio' group GID — required for ALSA device access
     volumes:
       - ./services/audio/assets:/app/services/audio/assets:ro  # Audio files (read-only)
     # Ports exposed only within Docker network (no host binding)


### PR DESCRIPTION
## Summary

- The audio container maps `/dev/snd` from the host but the container process didn't have permission to open the ALSA devices
- Add `group_add: ["29"]` (host `audio` group GID) so the container process can access the sound card
- Without this, audio playback fails with `ALSA lib pcm_dmix.c:999:(snd_pcm_dmix_open) unable to open slave`

## Test plan

- [ ] `docker compose up audio` — no ALSA errors in logs
- [ ] Trigger a sound (e.g. controller ready beep) — audio plays through speakers

🤖 Generated with [Claude Code](https://claude.com/claude-code)