### PR TITLE
fix: Add git-lfs to setup scripts for audio assets

### DIFF
--- a/scripts/setup/joustmania-start.sh
+++ b/scripts/setup/joustmania-start.sh
@@ -37,6 +37,8 @@ echo "Checking for code updates..."
 GIT_PULL_STATUS="success"
 if git pull --ff-only 2>&1; then
     echo "Code updated successfully"
+    # Fetch LFS objects (audio assets) after pull
+    git lfs pull 2>&1 || echo "Could not fetch LFS objects"
 else
     echo "Could not update code (offline or conflict) - continuing with current version"
     GIT_PULL_STATUS="failed"

--- a/scripts/setup/setup_host.sh
+++ b/scripts/setup/setup_host.sh
@@ -36,7 +36,7 @@ sudo apt-get install -y  \
     libportmidi-dev portaudio19-dev \
     libsdl-image1.2-dev libsdl-ttf2.0-dev \
     libblas-dev liblapack-dev \
-    bluez bluez-tools iptables rfkill supervisor cmake ffmpeg \
+    bluez bluez-tools iptables rfkill supervisor cmake ffmpeg git-lfs \
     libudev-dev swig libbluetooth-dev \
     alsa-utils alsa-tools libasound2-dev libsdl2-mixer-2.0-0 \
     python-dbus-dev python3-dbus libdbus-glib-1-dev usbutils libopenblas-dev \

--- a/scripts/setup/setup_runtime.sh
+++ b/scripts/setup/setup_runtime.sh
@@ -80,9 +80,15 @@ sudo apt-get install -y \
     bluez \
     bluez-tools \
     alsa-utils \
+    git-lfs \
     jq \
     || exit 1
 echo -e "  → ${GREEN}Dependencies installed${NC}"
+
+# Initialize Git LFS (audio assets are stored in LFS)
+echo "  → Initializing Git LFS..."
+git lfs install --skip-repo 2>/dev/null || true
+(cd "$JOUSTMANIA_DIR" && git lfs pull) || echo "  → Could not fetch LFS objects (offline?)"
 
 # Step 3: Configure Bluetooth
 echo "[3/4] Configuring Bluetooth..."


### PR DESCRIPTION
## Summary

- Audio assets are tracked with Git LFS but setup scripts didn't install `git-lfs` or fetch LFS objects
- Without this, audio files are tiny LFS pointer files that ffmpeg/miniaudio can't decode, causing `could not open/decode file` errors
- **`setup_runtime.sh`**: install `git-lfs` package, run `git lfs install` and `git lfs pull`
- **`setup_host.sh`**: add `git-lfs` to apt dependencies
- **`joustmania-start.sh`**: run `git lfs pull` after `git pull` on boot so new audio assets are fetched during auto-update

## Test plan

- [ ] Fresh clone + `./scripts/setup/setup_runtime.sh` installs git-lfs
- [ ] `ls -la services/audio/assets/Menu/music/` shows real audio files (not 130-byte pointers)
- [ ] After reboot, `joustmania-start.sh` fetches LFS objects before starting containers

🤖 Generated with [Claude Code](https://claude.com/claude-code)