### PR TITLE
feat: Add flagd to observability stack

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,12 +71,19 @@ services:
       - "file:/etc/flagd/game_settings.json"
       - "--uri"
       - "file:/etc/flagd/user_preferences.json"
+      - "--metrics-exporter"
+      - "otel"
+      - "--otel-collector-uri"
+      - "otel-collector:4317"
+    environment:
+      - OTEL_SERVICE_NAME=flagd
     volumes:
       - ./services/flagd/performance.json:/etc/flagd/performance.json
       - ./services/flagd/game_settings.json:/etc/flagd/game_settings.json
       - ./services/flagd/user_preferences.json:/etc/flagd/user_preferences.json
     expose:
       - "8013"  # flagd evaluation port (gRPC)
+      - "8014"  # flagd management port (metrics)
       - "8015"  # flagd sync port (for in-process evaluation)
     networks:
       - joustmania

--- a/services/prometheus/prometheus.yml
+++ b/services/prometheus/prometheus.yml
@@ -72,3 +72,11 @@ scrape_configs:
       - targets: ['pairing-daemon:8002']
         labels:
           service: 'psmove-pairing'
+
+  # flagd feature flag service (management port exposes Prometheus metrics)
+  - job_name: 'flagd'
+    scrape_interval: 30s
+    static_configs:
+      - targets: ['flagd:8014']
+        labels:
+          service: 'flagd'


### PR DESCRIPTION
## Summary

- Configure flagd to export metrics and traces via OpenTelemetry to the OTEL Collector
- Add `--metrics-exporter otel` and `--otel-collector-uri otel-collector:4317` flags
- Set `OTEL_SERVICE_NAME=flagd` for proper service identification in Jaeger and Grafana
- Expose management port 8014 and add Prometheus scrape job as a fallback
- Metrics flow: flagd -> OTEL Collector -> VictoriaMetrics (for Grafana dashboards)
- Traces flow: flagd -> OTEL Collector -> Jaeger (for distributed tracing)

Fixes #411

## Test plan

- [ ] `make lint` passes
- [ ] `make test` -- integration tests pass
- [ ] Verify flagd metrics appear in VictoriaMetrics after deployment
- [ ] Verify flagd traces appear in Jaeger after deployment
- [ ] Verify flagd metrics are scraped by Prometheus on port 8014

🤖 Generated with [Claude Code](https://claude.com/claude-code)