### PR TITLE
fix: Pin Docker Compose image tags to release-please version

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+IMAGE_TAG=0.5.0 # x-release-please-version
+ENV=dev

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -96,6 +96,13 @@ docker compose build --parallel
 docker compose up -d
 ```
 
+> **Note:** By default, `docker compose up` uses the pinned release version from `.env` (e.g., `0.2.0`).
+> For development with the latest builds, override with:
+> ```bash
+> IMAGE_TAG=latest docker compose up -d
+> ```
+> Or set `IMAGE_TAG=latest` in your local `.env` (don't commit this change).
+
 ### 4. Verify Services
 
 ```bash

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,13 @@
   "release-type": "python",
   "packages": {
     ".": {
-      "package-name": "joustmania"
+      "package-name": "joustmania",
+      "extra-files": [
+        {
+          "type": "generic",
+          "path": ".env"
+        }
+      ]
     }
   },
   "changelog-sections": [


### PR DESCRIPTION
## Summary

- Add `IMAGE_TAG=0.2.0` to `.env` with `x-release-please-version` annotation so `docker compose up` defaults to the pinned release version instead of `latest`
- Configure release-please `extra-files` in `release-please-config.json` to auto-bump the version in `.env` on each release
- Document the `IMAGE_TAG=latest` override for development in `docs/DEVELOPMENT.md`

Fixes #424

## Test plan

- [x] `docker compose config 2>&1 | grep 'image:'` — all JoustMania service images show `0.2.0`
- [x] `IMAGE_TAG=latest docker compose config 2>&1 | grep 'image:'` — override shows `latest`
- [x] `python -m json.tool release-please-config.json` — JSON valid
- [ ] Verify release-please picks up the `x-release-please-version` annotation on next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)