### PR TITLE
perf: Speed up CI integration tests with volume mounts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -457,6 +457,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            deps:
+              - 'services/*/Dockerfile'
+              - 'services/*/pyproject.toml'
+              - 'lib/pyproject.toml'
+              - 'proto/pyproject.toml'
+              - 'images/**'
+              - 'docker-compose.yml'
+              - 'docker-compose.ci.yml'
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -467,10 +480,16 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v5
 
-      - name: Run integration tests
+      # Fast path: pull latest images, overlay current source
+      - name: Run integration tests (fast - source only)
+        if: steps.changes.outputs.deps != 'true'
+        run: USE_PREBUILT_IMAGES=true USE_DEV_MOUNTS=true make test-integration
+
+      # Slow path: full build (Dockerfiles or deps changed)
+      - name: Run integration tests (full build)
+        if: steps.changes.outputs.deps == 'true'
         env:
           BUILDER_IMAGE: ${{ env.IMAGE_PREFIX }}/builder:${{ github.sha }}
           PSMOVE_BUILDER_IMAGE: ${{ env.IMAGE_PREFIX }}/psmove-builder:${{ github.sha }}

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ help:
 	@echo "Testing:"
 	@echo "  make test            - Run all tests (unit + integration)"
 	@echo "  make test-integration - Run integration tests only (CI)"
+	@echo "  make test-dev        - Run integration tests with pre-built images (fast)"
 	@echo "  make test TEST=name  - Run specific test by name"
 	@echo ""
 	@echo "Protos:"
@@ -193,6 +194,13 @@ test-integration: clean-test-venv
 test-pulled: clean-test-venv
 	USE_PREBUILT_IMAGES=true IMAGE_TAG=$(or $(IMAGE_TAG),latest) \
 		$(TEST_ENV) uv run --package joustmania-integration-tests \
+		pytest tests/integration/ -v $(if $(TEST),-k "$(TEST)")
+
+# Integration tests with pre-built images + volume-mounted source (no rebuild)
+# Requires images: run `docker compose pull` or `make dev` first
+.PHONY: test-dev
+test-dev: clean-test-venv
+	USE_PREBUILT_IMAGES=true USE_DEV_MOUNTS=true $(TEST_ENV) uv run --package joustmania-integration-tests \
 		pytest tests/integration/ -v $(if $(TEST),-k "$(TEST)")
 
 # Pause before teardown for Jaeger inspection

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -40,3 +40,8 @@ services:
       - ./services/audio:/app/services/audio
       - ./lib:/app/lib
       - ./proto:/app/proto
+
+  pairing-daemon:
+    volumes:
+      - ./services/pairing_daemon:/app/services/pairing_daemon
+      - ./lib:/app/lib

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -12,6 +12,7 @@ Usage:
 
 Environment Variables:
     USE_PREBUILT_IMAGES: Set to "true" to pull images from GHCR instead of building
+    USE_DEV_MOUNTS: Set to "true" to overlay source via docker-compose.dev.yml
     IMAGE_TAG: Specify image tag to pull (default: latest)
 """
 
@@ -42,19 +43,24 @@ def docker_compose():
 
     By default, builds images locally. Set USE_PREBUILT_IMAGES=true to pull from GHCR.
     """
-    # Check if we should use prebuilt images
+    # Check if we should use prebuilt images or dev volume mounts
     use_prebuilt = os.getenv("USE_PREBUILT_IMAGES", "false").lower() == "true"
+    use_dev_mounts = os.getenv("USE_DEV_MOUNTS", "false").lower() == "true"
     image_tag = os.getenv("IMAGE_TAG", "latest")
+
+    compose_files = [
+        "docker-compose.yml",
+        "docker-compose.override.yml",
+        "docker-compose.ci.yml",
+    ]
+    if use_dev_mounts:
+        compose_files.append("docker-compose.dev.yml")
 
     compose = DockerCompose(
         context=".",
-        compose_file_name=[
-            "docker-compose.yml",
-            "docker-compose.override.yml",
-            "docker-compose.ci.yml",
-        ],
+        compose_file_name=compose_files,
         pull=use_prebuilt,
-        build=not use_prebuilt,
+        build=not use_prebuilt and not use_dev_mounts,
         env_file=None,  # Avoid conflicts with .env (e.g., IMAGE_TAG from development)
     )
 
@@ -63,6 +69,8 @@ def docker_compose():
     if use_prebuilt:
         os.environ["IMAGE_TAG"] = image_tag
         print(f"\n🐳 Using prebuilt images from GHCR (tag: {image_tag})")
+    elif use_dev_mounts:
+        print("\n📂 Using dev volume mounts (no build)")
     else:
         print("\n🔨 Building images locally")
 


### PR DESCRIPTION
## Summary

- Add fast path for CI integration tests: pull pre-built `:latest` images from GHCR and overlay current source via `docker-compose.dev.yml` volume mounts, skipping full Docker builds
- Use `dorny/paths-filter` to detect dependency changes (Dockerfiles, pyproject.toml, builder images, compose configs) — falls back to full build when deps change
- Add `make test-dev` for local fast testing with the same pull+mount approach
- Add pairing-daemon to `docker-compose.dev.yml` for volume mount completeness

**Most PRs only touch Python/proto/lib files**, so this avoids rebuilding all Docker images (~2-5 min) in favor of pulling cached images (~30s).

## How it works

| PR type | Path | What happens |
|---------|------|--------------|
| Source-only (most PRs) | Fast | Pull `:latest` images, overlay source via volumes |
| Deps/Dockerfiles changed | Slow | Full build as today (unchanged) |

Compose file merge order: base → ports → CI mocking (`!reset` clears hardware volumes) → dev mounts (adds source volumes).

## Test plan

- [ ] CI: PR with only Python changes → fast path (pull + mount), step name shows "fast - source only"
- [ ] CI: PR with Dockerfile/pyproject.toml changes → slow path (full build)
- [ ] `make test-integration` still works unchanged (no env vars set = full build)
- [ ] `make test-dev` works locally after `docker compose pull`

🤖 Generated with [Claude Code](https://claude.com/claude-code)