### PR TITLE
fix: Filter player-insights dashboard by ready/alive state

### DIFF
--- a/services/grafana/dashboards/player-insights.json
+++ b/services/grafana/dashboards/player-insights.json
@@ -974,7 +974,7 @@
           "type": "prometheus",
           "uid": "prometheus"
         },
-        "definition": "label_values(controller_info, name)",
+        "definition": "label_values(controller_info * on(serial) group_left(name) ((menu_player_ready == 1) or (game_player_alive == 1)), name)",
         "hide": 0,
         "includeAll": true,
         "label": "Player",
@@ -982,7 +982,7 @@
         "name": "player",
         "options": [],
         "query": {
-          "query": "label_values(controller_info, name)",
+          "query": "label_values(controller_info * on(serial) group_left(name) ((menu_player_ready == 1) or (game_player_alive == 1)), name)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 2,
@@ -997,7 +997,7 @@
           "type": "prometheus",
           "uid": "prometheus"
         },
-        "definition": "label_values(controller_info{name=~\"$player\"}, serial)",
+        "definition": "label_values(controller_info{name=~\"$player\"} * on(serial) group_left(name) ((menu_player_ready == 1) or (game_player_alive == 1)), serial)",
         "hide": 2,
         "includeAll": true,
         "label": "Serial",
@@ -1005,7 +1005,7 @@
         "name": "serial",
         "options": [],
         "query": {
-          "query": "label_values(controller_info{name=~\"$player\"}, serial)",
+          "query": "label_values(controller_info{name=~\"$player\"} * on(serial) group_left(name) ((menu_player_ready == 1) or (game_player_alive == 1)), serial)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 2,


### PR DESCRIPTION
## Summary

- Update player-insights dashboard template variable queries to filter by active controller state
- Join `controller_info` with `menu_player_ready == 1` (lobby) and `game_player_alive == 1` (in-game) via `serial` label
- Dashboard now only shows controllers that are currently ready or alive, instead of all controllers that have ever published metrics

## How it works

The `player` and `serial` template variables now use a PromQL join:

```promql
label_values(
  controller_info * on(serial) group_left(name)
  ((menu_player_ready == 1) or (game_player_alive == 1)),
  name
)
```

- **Lobby**: only controllers with `menu_player_ready == 1` appear (trigger pressed)
- **In-game**: only alive players with `game_player_alive == 1` appear
- **Idle**: both metrics are cleared → dropdown is empty (correct)
- Variables refresh every 2 seconds, so transitions are near-instant

## Test plan

- [ ] Start JoustMania in mock mode (`make up-mock`)
- [ ] Connect 4 mock controllers
- [ ] Open dashboard at `/grafana/d/player-insights/player-insights`
- [ ] **Lobby**: press trigger on 2 controllers → only those 2 appear in dropdown
- [ ] **Start game**: all playing controllers appear, dropdown auto-updates
- [ ] **Kill a player**: they disappear from the dropdown
- [ ] **End game**: dropdown empties (no active players)
- [ ] **Return to lobby**: ready controllers reappear as triggers are pressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)