### PR TITLE
refactor: Configure OTEL identity via env vars only

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -258,6 +258,7 @@ services:
       - "8000"   # Prometheus metrics (Phase 38)
     environment:
       - OTEL_SERVICE_NAME=${OTEL_SERVICE_NAME_GAME_COORDINATOR:-game-coordinator-service}
+      - OTEL_SERVICE_NAMESPACE=joustmania
       - OTEL_EXPORTER_OTLP_ENDPOINT=${OTEL_EXPORTER_OTLP_ENDPOINT:-http://otel-collector:4317}
     depends_on:
       redis:
@@ -290,6 +291,7 @@ services:
       - "50054"  # gRPC service
     environment:
       - OTEL_SERVICE_NAME=menu-service
+      - OTEL_SERVICE_NAMESPACE=joustmania
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
       # Phase 60: Audio service connection
       - AUDIO_HOST=audio
@@ -338,6 +340,7 @@ services:
     environment:
       - MOCK_MODE=${AUDIO_MOCK_MODE:-false}
       - OTEL_SERVICE_NAME=audio-service
+      - OTEL_SERVICE_NAMESPACE=joustmania
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
       - FLAGD_HOST=flagd
       - FLAGD_PORT=8015

--- a/lib/otel_metrics.py
+++ b/lib/otel_metrics.py
@@ -11,8 +11,8 @@ Usage:
     gauge = Gauge("metric_name", "description", ["serial"])
     counter = Counter("events_total", "description", ["type"])
 
-    # Initialize in server startup (100ms for real-time services)
-    init_metrics(service_name="game-coordinator", export_interval_ms=100)
+    # Initialize in server startup (service identity from env vars)
+    init_metrics(export_interval_ms=100)
 
     # Use same API as prometheus_client
     gauge.labels(serial="ABC").set(1.5)
@@ -73,31 +73,25 @@ def is_test_mode() -> bool:
 
 
 def init_metrics(
-    service_name: str | None = None,
-    version: str = "1.0.0",
     export_interval_ms: int = 100,
-    namespace: str | None = None,
 ) -> metrics.Meter:
     """
     Initialize OpenTelemetry metrics with OTLP push exporter.
 
     This must be called during service startup, after metric objects are defined
-    but before they are used.
+    but before they are used. Service identity is configured via environment
+    variables set in docker-compose.yml.
 
     Args:
-        service_name: Service name for metrics. Defaults to OTEL_SERVICE_NAME env var.
-        version: Service version for resource attributes.
         export_interval_ms: How often to push metrics (default 100ms for real-time).
-        namespace: Service namespace (e.g. "joustmania", "infrastructure").
-                   Defaults to OTEL_SERVICE_NAMESPACE env var, or "joustmania".
 
     Returns:
         Configured meter instance.
 
     Environment Variables:
+        OTEL_SERVICE_NAME: Service name (required in docker-compose.yml)
+        OTEL_SERVICE_NAMESPACE: Service namespace (default: "joustmania")
         OTEL_EXPORTER_OTLP_ENDPOINT: OTLP collector endpoint (default: http://otel-collector:4317)
-        OTEL_SERVICE_NAME: Default service name if not provided as argument
-        OTEL_SERVICE_NAMESPACE: Default namespace if not provided as argument
     """
     global _meter, _initialized
 
@@ -107,14 +101,14 @@ def init_metrics(
             return _meter
 
         otlp_endpoint = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://otel-collector:4317")
-        resolved_service_name = service_name or os.getenv("OTEL_SERVICE_NAME", "unknown-service")
-        resolved_namespace = namespace or os.getenv("OTEL_SERVICE_NAMESPACE", "joustmania")
+        service_name = os.getenv("OTEL_SERVICE_NAME", "unknown-service")
+        namespace = os.getenv("OTEL_SERVICE_NAMESPACE", "joustmania")
 
         resource = Resource(
             attributes={
-                SERVICE_NAME: resolved_service_name,
-                SERVICE_VERSION: version,
-                "service.namespace": resolved_namespace,
+                SERVICE_NAME: service_name,
+                SERVICE_VERSION: "1.0.0",
+                "service.namespace": namespace,
             }
         )
 
@@ -130,7 +124,7 @@ def init_metrics(
         provider = MeterProvider(resource=resource, metric_readers=[reader])
         metrics.set_meter_provider(provider)
 
-        _meter = metrics.get_meter(resolved_service_name, version)
+        _meter = metrics.get_meter(service_name, "1.0.0")
         _initialized = True
 
         # Initialize any metrics that were created before init_metrics() was called
@@ -139,8 +133,7 @@ def init_metrics(
         _pending_metrics.clear()
 
         logger.info(
-            f"OTEL metrics initialized: {resolved_service_name} -> {otlp_endpoint} "
-            f"(export interval: {export_interval_ms}ms)"
+            f"OTEL metrics initialized: {service_name} -> {otlp_endpoint} (export interval: {export_interval_ms}ms)"
         )
         return _meter
 

--- a/lib/telemetry.py
+++ b/lib/telemetry.py
@@ -17,7 +17,7 @@ Usage:
     span.set_attribute(SpanAttr.CONTROLLER_SERIAL, serial)
 
     # Legacy usage (still works, but prefer get_tracer for lazy init)
-    tracer = init_telemetry(service_name="my-service")
+    tracer = init_telemetry()
 """
 
 import logging
@@ -84,14 +84,16 @@ class SpanAttr:
     VALIDATION_REASON = "validation.reason"
 
 
-def _do_init(service_name: str, version: str, namespace: str = "joustmania") -> None:
-    """Perform actual OpenTelemetry initialization (internal)."""
+def _do_init() -> None:
+    """Perform actual OpenTelemetry initialization from env vars (internal)."""
     otlp_endpoint = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")
+    service_name = os.getenv("OTEL_SERVICE_NAME", "unknown-service")
+    namespace = os.getenv("OTEL_SERVICE_NAMESPACE", "joustmania")
 
     resource = Resource(
         attributes={
             SERVICE_NAME: service_name,
-            SERVICE_VERSION: version,
+            SERVICE_VERSION: "1.0.0",
             "service.namespace": namespace,
         }
     )
@@ -115,9 +117,7 @@ def _ensure_initialized() -> None:
         if _initialized:
             return
 
-        service_name = os.getenv("OTEL_SERVICE_NAME", "unknown-service")
-        namespace = os.getenv("OTEL_SERVICE_NAMESPACE", "joustmania")
-        _do_init(service_name, "1.0.0", namespace)
+        _do_init()
         _initialized = True
 
 
@@ -143,43 +143,24 @@ def get_tracer(name: str | None = None) -> trace.Tracer:
     return trace.get_tracer(name or os.getenv("OTEL_SERVICE_NAME", "unknown-service"))
 
 
-def init_telemetry(
-    service_name: str | None = None,
-    version: str = "1.0.0",
-    namespace: str | None = None,
-) -> trace.Tracer:
+def init_telemetry() -> trace.Tracer:
     """
     Initialize OpenTelemetry with OTLP exporter (legacy API).
 
     Note: Prefer get_tracer() for lazy initialization. This function is
-    kept for backward compatibility but now performs lazy initialization.
-
-    Args:
-        service_name: Service name for traces. Defaults to OTEL_SERVICE_NAME env var,
-                      or "unknown-service" if not set.
-        version: Service version for resource attributes.
-        namespace: Service namespace (e.g. "joustmania", "infrastructure").
-                   Defaults to OTEL_SERVICE_NAMESPACE env var, or "joustmania".
+    kept for backward compatibility. Service identity is configured via
+    environment variables set in docker-compose.yml.
 
     Returns:
         Configured tracer instance for creating spans.
 
     Environment Variables:
+        OTEL_SERVICE_NAME: Service name (required in docker-compose.yml)
+        OTEL_SERVICE_NAMESPACE: Service namespace (default: "joustmania")
         OTEL_EXPORTER_OTLP_ENDPOINT: OTLP collector endpoint (default: http://localhost:4317)
-        OTEL_SERVICE_NAME: Default service name if not provided as argument
-        OTEL_SERVICE_NAMESPACE: Default namespace if not provided as argument
     """
-    global _initialized
-
-    resolved_service_name = service_name or os.getenv("OTEL_SERVICE_NAME", "unknown-service")
-    resolved_namespace = namespace or os.getenv("OTEL_SERVICE_NAMESPACE", "joustmania")
-
-    with _init_lock:
-        if not _initialized:
-            _do_init(resolved_service_name, version, resolved_namespace)
-            _initialized = True
-
-    return trace.get_tracer(resolved_service_name)
+    _ensure_initialized()
+    return trace.get_tracer(os.getenv("OTEL_SERVICE_NAME", "unknown-service"))
 
 
 def inject_trace_context(span: trace.Span | None = None) -> tuple[str, str]:

--- a/lib/tests/test_otel_metrics.py
+++ b/lib/tests/test_otel_metrics.py
@@ -257,7 +257,7 @@ class TestInitMetricsWithMock:
         mock_meter = MagicMock()
         mock_metrics.get_meter.return_value = mock_meter
 
-        result = otel_metrics.init_metrics(service_name="test-service")
+        result = otel_metrics.init_metrics()
 
         assert result == mock_meter
         mock_exporter.assert_called_once()
@@ -288,7 +288,7 @@ class TestInitMetricsWithMock:
         mock_meter = MagicMock()
         mock_metrics.get_meter.return_value = mock_meter
 
-        otel_metrics.init_metrics(service_name="test", export_interval_ms=500)
+        otel_metrics.init_metrics(export_interval_ms=500)
 
         mock_reader.assert_called_once()
         call_kwargs = mock_reader.call_args[1]
@@ -305,8 +305,8 @@ class TestInitMetricsWithMock:
         mock_meter = MagicMock()
         mock_metrics.get_meter.return_value = mock_meter
 
-        result1 = otel_metrics.init_metrics(service_name="test")
-        result2 = otel_metrics.init_metrics(service_name="test")
+        result1 = otel_metrics.init_metrics()
+        result2 = otel_metrics.init_metrics()
 
         assert result1 == result2
         # Provider should only be created once
@@ -326,7 +326,7 @@ class TestInitMetricsWithMock:
         counter = otel_metrics.Counter("pending_counter", "Test")
         assert len(otel_metrics._pending_metrics) == 2
 
-        otel_metrics.init_metrics(service_name="test")
+        otel_metrics.init_metrics()
 
         # Pending metrics should be cleared
         assert len(otel_metrics._pending_metrics) == 0

--- a/services/audio/server.py
+++ b/services/audio/server.py
@@ -36,7 +36,7 @@ async def serve():
     logger.info("Starting JoustMania Audio service...")
 
     # Initialize OTEL push metrics
-    init_metrics(service_name="audio")
+    init_metrics()
     logger.info("OTEL push metrics initialized for audio service")
 
     # Start system metrics collection

--- a/services/controller_manager/server.py
+++ b/services/controller_manager/server.py
@@ -35,7 +35,7 @@ async def serve(port=50052):
     # Default 100ms for real-time acceleration visualization
     # Use METRICS_EXPORT_INTERVAL_MS env var to configure (10ms for 100Hz)
     export_interval_ms = int(os.getenv("METRICS_EXPORT_INTERVAL_MS", "100"))
-    init_metrics(service_name="controller-manager", export_interval_ms=export_interval_ms, namespace="infrastructure")
+    init_metrics(export_interval_ms=export_interval_ms)
     logger.info(f"OTEL push metrics initialized ({export_interval_ms}ms export interval)")
 
     # Start prometheus_client HTTP server for direct pull scraping (pipeline comparison)

--- a/services/game_coordinator/server.py
+++ b/services/game_coordinator/server.py
@@ -65,7 +65,7 @@ async def serve(port=50053):
 
     # Initialize OTEL push metrics (Issue #103)
     # 100ms export interval for real-time gameplay visualization
-    init_metrics(service_name="game-coordinator", export_interval_ms=100)
+    init_metrics(export_interval_ms=100)
     logger.info("OTEL push metrics initialized (100ms export interval)")
 
     # Start system metrics collection

--- a/services/menu/server.py
+++ b/services/menu/server.py
@@ -40,7 +40,7 @@ logger = logging.getLogger(__name__)
 async def serve(port=50054):
     """Start the Menu gRPC server."""
     # Initialize OTEL push metrics
-    init_metrics(service_name="menu")
+    init_metrics()
     logger.info("OTEL push metrics initialized for menu service")
 
     # Start system metrics collection

--- a/services/pairing_daemon/psmove_pairing/telemetry.py
+++ b/services/pairing_daemon/psmove_pairing/telemetry.py
@@ -1,34 +1,14 @@
-"""OpenTelemetry initialization for PS Move pairing daemon."""
+"""OpenTelemetry initialization for PS Move pairing daemon.
 
-import logging
+Delegates to the shared lib.telemetry module. Service identity
+(name, namespace) is configured via environment variables.
+"""
 
 from opentelemetry import trace
-from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
-from opentelemetry.sdk.resources import SERVICE_NAME, SERVICE_VERSION, Resource
-from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
-from .config import OTEL_ENDPOINT
-
-logger = logging.getLogger("psmove-pairing")
+from lib.telemetry import init_telemetry as _init_telemetry
 
 
 def init_telemetry() -> trace.Tracer:
     """Initialize OpenTelemetry with OTLP exporter."""
-    service_name = "pairing-daemon"
-
-    resource = Resource(
-        attributes={
-            SERVICE_NAME: service_name,
-            SERVICE_VERSION: "1.0.0",
-            "service.namespace": "infrastructure",
-        }
-    )
-
-    provider = TracerProvider(resource=resource)
-    otlp_exporter = OTLPSpanExporter(endpoint=OTEL_ENDPOINT, insecure=True)
-    provider.add_span_processor(BatchSpanProcessor(otlp_exporter))
-    trace.set_tracer_provider(provider)
-
-    logger.info(f"OpenTelemetry initialized: {service_name} -> {OTEL_ENDPOINT}")
-    return trace.get_tracer(service_name)
+    return _init_telemetry()

--- a/services/pairing_daemon/server.py
+++ b/services/pairing_daemon/server.py
@@ -96,7 +96,7 @@ def main() -> None:
     global _daemon
 
     # Initialize OTEL push metrics
-    init_metrics(service_name="pairing-daemon", namespace="infrastructure")
+    init_metrics()
     logger.info("OTEL push metrics initialized for pairing daemon")
 
     # Start process-level system metrics collection (CPU, memory, threads)


### PR DESCRIPTION
## Summary
- Remove `service_name`, `version`, and `namespace` parameters from `init_metrics()` and `init_telemetry()` — all OTEL identity now comes from env vars in docker-compose.yml
- Add missing `OTEL_SERVICE_NAMESPACE` to game-coordinator, menu, and audio services
- Pairing daemon telemetry now delegates to `lib.telemetry` instead of duplicating TracerProvider setup

## Motivation
After #434 added namespace support, there were two ways to configure service identity: code parameters and env vars. This caused confusion about which took precedence. Consolidating to env-var-only is simpler and follows the OTEL convention where `OTEL_SERVICE_NAME` is a standard SDK env var.

Closes #436

## Test plan
- [x] `make lint` passes
- [x] lib unit tests pass (39/39)
- [x] game-coordinator unit tests pass (333/333)
- [x] controller-manager unit tests pass (209/209)
- [x] menu unit tests pass (209/209)
- [ ] Integration test with `make test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)