### PR TITLE
fix: Use query_result() for player-insights active filter

### DIFF
--- a/services/game_coordinator/games/base.py
+++ b/services/game_coordinator/games/base.py
@@ -350,6 +350,7 @@ class BaseGameMode(ABC):
             # Set alive metric for all initialized players (Phase 75: filter dead from dashboard)
             for serial in self.players:
                 metrics.player_alive.labels(serial=serial).set(1)
+            metrics.players_alive.set(len(self.players))
 
             logger.info(f"Initialized {len(self.players)} players from StartGame RPC")
 
@@ -834,6 +835,8 @@ class BaseGameMode(ABC):
 
         # Mark player as dead in metrics (Phase 75: filter dead players from dashboard)
         metrics.player_alive.labels(serial=serial).set(0)
+        alive_count = len([p for p in self.players.values() if p.alive])
+        metrics.players_alive.set(alive_count)
 
         # Play death explosion sound (Phase 29)
         await self._play_sound(Sound.SFX_EXPLOSION, priority=2)

--- a/services/grafana/dashboards/player-insights.json
+++ b/services/grafana/dashboards/player-insights.json
@@ -974,7 +974,7 @@
           "type": "prometheus",
           "uid": "prometheus"
         },
-        "definition": "query_result(controller_info * on(serial) group_left(name) ((menu_player_ready == 1) or (game_player_alive == 1)))",
+        "definition": "query_result(controller_info * on(serial) group_left() ((menu_player_ready == 1) or (game_player_alive == 1)))",
         "hide": 0,
         "includeAll": true,
         "label": "Player",
@@ -982,7 +982,7 @@
         "name": "player",
         "options": [],
         "query": {
-          "query": "query_result(controller_info * on(serial) group_left(name) ((menu_player_ready == 1) or (game_player_alive == 1)))",
+          "query": "query_result(controller_info * on(serial) group_left() ((menu_player_ready == 1) or (game_player_alive == 1)))",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 2,
@@ -997,7 +997,7 @@
           "type": "prometheus",
           "uid": "prometheus"
         },
-        "definition": "query_result(controller_info{name=~\"$player\"} * on(serial) group_left(name) ((menu_player_ready == 1) or (game_player_alive == 1)))",
+        "definition": "query_result(controller_info{name=~\"$player\"} * on(serial) group_left() ((menu_player_ready == 1) or (game_player_alive == 1)))",
         "hide": 2,
         "includeAll": true,
         "label": "Serial",
@@ -1005,7 +1005,7 @@
         "name": "serial",
         "options": [],
         "query": {
-          "query": "query_result(controller_info{name=~\"$player\"} * on(serial) group_left(name) ((menu_player_ready == 1) or (game_player_alive == 1)))",
+          "query": "query_result(controller_info{name=~\"$player\"} * on(serial) group_left() ((menu_player_ready == 1) or (game_player_alive == 1)))",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 2,


### PR DESCRIPTION
## Summary

- Fix player-insights dashboard showing only one empty row during games
- Fix "Alive: 0" in dashboard header during active games

## Root causes

### 1. `group_left(name)` drops the `name` label

The `query_result()` PromQL join used `group_left(name)`, which tells PromQL to copy `name` from the **right** side (`game_player_alive`). But that metric doesn't have a `name` label — `name` is on the **left** side (`controller_info`).

This caused `name` to be dropped from results entirely, so the regex `/name="([^"]+)"/` never matched, and the `$player` template variable was always empty.

**Fix:** `group_left()` with no arguments — it already preserves all left-side labels including `name`.

Verified with raw PromQL:
```
# Before (group_left(name)) — name missing from result:
{"serial":"e0:ae:5e:e1:11:ab","job":"controller-manager",...}

# After (group_left()) — name preserved:
{"serial":"e0:ae:5e:e1:11:ab","name":"Calm Bear","job":"controller-manager",...}
```

### 2. `game_players_alive` gauge never set at game start

The aggregate `game_players_alive` gauge (used by the "Players: Alive/Total" stat panel) was only zeroed at game end (`servicer.py:252`). It was never set to the player count at game init, and never decremented on death.

**Fix:** Set `players_alive` to player count in `_initialize_players()` and update it in `_kill_player()`.

## Files modified

| File | Change |
|------|--------|
| `services/grafana/dashboards/player-insights.json` | `group_left(name)` → `group_left()` in 4 template variable queries |
| `services/game_coordinator/games/base.py` | Set `players_alive` at game init, decrement on death |

## Test plan

- [x] 333 unit tests pass
- [ ] Start game with mock controllers
- [ ] Verify dashboard header shows correct "Alive: N / Total: N"
- [ ] Verify player dropdown populates with controller names
- [ ] Verify per-player rows appear with acceleration data
- [ ] Kill a player — alive count decrements, row disappears
- [ ] End game — dashboard clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)