### PR TITLE
fix: Use Grafana subpath in Live publisher URL

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -562,7 +562,7 @@ services:
     expose:
       - "4318"  # OTLP HTTP receiver
     environment:
-      - GRAFANA_URL=http://grafana:3000
+      - GRAFANA_URL=http://grafana:3000/grafana
       - GRAFANA_PUSH_PATH=joustmania/accel
     depends_on:
       grafana:


### PR DESCRIPTION
## Summary
- Fix `GRAFANA_URL` for `grafana-live-publisher` to include `/grafana` subpath
- Grafana is configured with `serve_from_sub_path=true`, so all API endpoints are under `/grafana/`
- The publisher was hitting `http://grafana:3000/api/live/push/...` → 404
- Now correctly hits `http://grafana:3000/grafana/api/live/push/...`

This fixes the empty "Acceleration Magnitude (Real-Time Stream)" panel in the Real-Time Acceleration dashboard.

## Test plan
- [x] Confirmed 404 errors in `docker compose logs grafana-live-publisher`
- [ ] After deploy, verify no more 404s in publisher logs
- [ ] Verify real-time acceleration panel shows data when controllers are connected

🤖 Generated with [Claude Code](https://claude.com/claude-code)