### PR TITLE
fix: Correct stale labels in pipeline comparison dashboard

### DIFF
--- a/services/grafana/dashboards/metrics-pipeline-comparison.json
+++ b/services/grafana/dashboards/metrics-pipeline-comparison.json
@@ -250,7 +250,7 @@
             "uid": "prometheus-direct"
           },
           "editorMode": "code",
-          "expr": "controller_accel_magnitude{job=\"infrastructure/controller-manager\", serial=~\"$serial\"}",
+          "expr": "controller_accel_magnitude{job=\"controller-manager-service\", serial=~\"$serial\"}",
           "instant": false,
           "legendFormat": "{{serial}}",
           "range": true,
@@ -344,7 +344,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "controller_accel_magnitude{service_name=\"controller-manager\", serial=~\"$serial\"}",
+          "expr": "controller_accel_magnitude{service_name=\"controller-manager-service\", serial=~\"$serial\"}",
           "instant": false,
           "legendFormat": "{{serial}}",
           "range": true,
@@ -528,7 +528,7 @@
             "uid": "prometheus-direct"
           },
           "editorMode": "code",
-          "expr": "controller_accel_magnitude{job=\"infrastructure/controller-manager\", serial=~\"$serial\"}",
+          "expr": "controller_accel_magnitude{job=\"controller-manager-service\", serial=~\"$serial\"}",
           "instant": false,
           "legendFormat": "{{serial}} (OTEL→Prom 500ms)",
           "range": true,
@@ -540,7 +540,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "controller_accel_magnitude{service_name=\"controller-manager\", serial=~\"$serial\"}",
+          "expr": "controller_accel_magnitude{service_name=\"controller-manager-service\", serial=~\"$serial\"}",
           "instant": false,
           "legendFormat": "{{serial}} (OTEL→VM 100ms)",
           "range": true,
@@ -683,7 +683,7 @@
             "uid": "prometheus-direct"
           },
           "editorMode": "code",
-          "expr": "count_over_time(controller_accel_magnitude{job=\"infrastructure/controller-manager\", serial=~\"$serial\"}[1m])",
+          "expr": "count_over_time(controller_accel_magnitude{job=\"controller-manager-service\", serial=~\"$serial\"}[1m])",
           "instant": true,
           "legendFormat": "OTEL→Prom 500ms",
           "refId": "B"
@@ -694,7 +694,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "count_over_time(controller_accel_magnitude{service_name=\"controller-manager\", serial=~\"$serial\"}[1m])",
+          "expr": "count_over_time(controller_accel_magnitude{service_name=\"controller-manager-service\", serial=~\"$serial\"}[1m])",
           "instant": true,
           "legendFormat": "OTEL→VM 100ms",
           "refId": "C"
@@ -823,7 +823,7 @@
             "uid": "prometheus-direct"
           },
           "editorMode": "code",
-          "expr": "time() - controller_accel_magnitude{job=\"infrastructure/controller-manager\", serial=~\"$serial\"}",
+          "expr": "time() - controller_accel_magnitude{job=\"controller-manager-service\", serial=~\"$serial\"}",
           "instant": true,
           "legendFormat": "OTEL→Prom 500ms",
           "refId": "B"
@@ -834,7 +834,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "time() - controller_accel_magnitude{service_name=\"controller-manager\", serial=~\"$serial\"}",
+          "expr": "time() - controller_accel_magnitude{service_name=\"controller-manager-service\", serial=~\"$serial\"}",
           "instant": true,
           "legendFormat": "OTEL→VM 100ms",
           "refId": "C"


### PR DESCRIPTION
## Summary
- Path 2 queries used `job="infrastructure/controller-manager"` — Prometheus relabel strips the namespace prefix, and the actual job is `controller-manager-service`
- Path 3 queries used `service_name="controller-manager"` — the OTEL service name is `controller-manager-service`
- Updated all 8 query expressions (4 per path) to use the correct label values

Fixes #439

## Test plan
- [ ] Open the Metrics Pipeline Comparison dashboard
- [ ] Verify Path 2 (OTEL → Prometheus) shows data
- [ ] Verify Path 3 (OTEL → VictoriaMetrics) shows data
- [ ] Verify overlay chart shows all 3 paths
- [ ] Verify "Samples per Minute" and "Data Staleness" stat panels work for all paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)