### PR TITLE
fix: Use job label for VictoriaMetrics in pipeline dashboard

### DIFF
--- a/services/grafana/dashboards/metrics-pipeline-comparison.json
+++ b/services/grafana/dashboards/metrics-pipeline-comparison.json
@@ -344,7 +344,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "controller_accel_magnitude{service_name=\"controller-manager-service\", serial=~\"$serial\"}",
+          "expr": "controller_accel_magnitude{job=\"infrastructure/controller-manager-service\", serial=~\"$serial\"}",
           "instant": false,
           "legendFormat": "{{serial}}",
           "range": true,
@@ -540,7 +540,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "controller_accel_magnitude{service_name=\"controller-manager-service\", serial=~\"$serial\"}",
+          "expr": "controller_accel_magnitude{job=\"infrastructure/controller-manager-service\", serial=~\"$serial\"}",
           "instant": false,
           "legendFormat": "{{serial}} (OTEL→VM 100ms)",
           "range": true,
@@ -694,7 +694,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "count_over_time(controller_accel_magnitude{service_name=\"controller-manager-service\", serial=~\"$serial\"}[1m])",
+          "expr": "count_over_time(controller_accel_magnitude{job=\"infrastructure/controller-manager-service\", serial=~\"$serial\"}[1m])",
           "instant": true,
           "legendFormat": "OTEL→VM 100ms",
           "refId": "C"
@@ -834,7 +834,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "time() - controller_accel_magnitude{service_name=\"controller-manager-service\", serial=~\"$serial\"}",
+          "expr": "time() - controller_accel_magnitude{job=\"infrastructure/controller-manager-service\", serial=~\"$serial\"}",
           "instant": true,
           "legendFormat": "OTEL→VM 100ms",
           "refId": "C"


### PR DESCRIPTION
## Summary
- Path 3 (OTEL → VictoriaMetrics) queries used `service_name="controller-manager-service"` but this label doesn't exist in VictoriaMetrics
- The `prometheusremotewrite` exporter maps `service.name` to the `job` label, not `service_name`
- VictoriaMetrics has no relabeling, so the full namespace-prefixed value is preserved: `job="infrastructure/controller-manager-service"`
- Updated all 4 Path 3 query expressions

Follow-up to #442, which fixed Path 2 but used the wrong label for Path 3.

Fixes #439

## Test plan
- [ ] Open the Metrics Pipeline Comparison dashboard
- [ ] Verify Path 3 (OTEL → VictoriaMetrics) now shows data
- [ ] Verify overlay chart shows all 3 paths
- [ ] Verify "Samples per Minute" and "Data Staleness" stat panels show Path 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)