### PR TITLE
fix: Use InfluxDB line protocol for Grafana Live push

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -563,7 +563,7 @@ services:
       - "4318"  # OTLP HTTP receiver
     environment:
       - GRAFANA_URL=http://grafana:3000/grafana
-      - GRAFANA_PUSH_PATH=joustmania/accel
+      - GRAFANA_PUSH_PATH=joustmania-accel
     depends_on:
       grafana:
         condition: service_healthy

--- a/services/grafana-live-publisher/main.go
+++ b/services/grafana-live-publisher/main.go
@@ -10,11 +10,10 @@
 // Environment variables:
 //   - PORT: HTTP server port (default: 4318)
 //   - GRAFANA_URL: Grafana base URL (default: http://grafana:3000)
-//   - GRAFANA_PUSH_PATH: Grafana Live push path (default: joustmania/accel)
+//   - GRAFANA_PUSH_PATH: Grafana Live stream ID (default: joustmania-accel)
 package main
 
 import (
-	"bytes"
 	"compress/gzip"
 	"encoding/json"
 	"fmt"
@@ -114,7 +113,7 @@ func main() {
 	config = Config{
 		Port:            getEnv("PORT", "4318"),
 		GrafanaURL:      getEnv("GRAFANA_URL", "http://grafana:3000"),
-		GrafanaPushPath: getEnv("GRAFANA_PUSH_PATH", "joustmania/accel"),
+		GrafanaPushPath: getEnv("GRAFANA_PUSH_PATH", "joustmania-accel"),
 	}
 
 	httpClient = &http.Client{
@@ -365,22 +364,22 @@ func aggregateBySerial(messages []AccelMessage) []AccelMessage {
 }
 
 func pushToGrafanaLive(msg AccelMessage) {
-	// Grafana Live push endpoint
+	// Grafana Live push endpoint expects InfluxDB line protocol
 	url := fmt.Sprintf("%s/api/live/push/%s", config.GrafanaURL, config.GrafanaPushPath)
 
-	data, err := json.Marshal(msg)
-	if err != nil {
-		log.Printf("Failed to marshal message: %v", err)
-		return
-	}
+	// Format as InfluxDB line protocol: measurement,tag=val field=val timestamp_ns
+	// Timestamp must be in nanoseconds
+	timestampNs := msg.Time * 1e6 // Convert millis to nanos
+	line := fmt.Sprintf("accel,serial=%s magnitude=%f,x=%f,y=%f,z=%f %d",
+		msg.Serial, msg.Magnitude, msg.X, msg.Y, msg.Z, timestampNs)
 
-	req, err := http.NewRequest("POST", url, bytes.NewReader(data))
+	req, err := http.NewRequest("POST", url, strings.NewReader(line))
 	if err != nil {
 		log.Printf("Failed to create request: %v", err)
 		return
 	}
 
-	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Type", "text/plain")
 
 	resp, err := httpClient.Do(req)
 	if err != nil {

--- a/services/grafana/dashboards/realtime-accel.json
+++ b/services/grafana/dashboards/realtime-accel.json
@@ -123,13 +123,13 @@
       "pluginVersion": "10.2.3",
       "targets": [
         {
-          "channel": "stream/joustmania/accel",
+          "channel": "stream/joustmania-accel",
           "datasource": {
             "type": "grafana",
             "uid": "-- Grafana --"
           },
           "filter": {
-            "fields": ["time", "serial", "magnitude"]
+            "fields": ["time", "magnitude"]
           },
           "queryType": "streaming",
           "refId": "A"


### PR DESCRIPTION
## Summary
- Stream ID `joustmania/accel` had a slash that broke Grafana's `/api/live/push/:streamId` URL routing → 404. Changed to `joustmania-accel`
- Publisher sent JSON but Grafana Live push expects **InfluxDB line protocol** with nanosecond timestamps. Switched to `text/plain` line protocol format
- Updated dashboard channel from `stream/joustmania/accel` to `stream/joustmania-accel`
- Removed `serial` from the dashboard field filter (it's a tag/label in line protocol, not a data field)

## Test plan
- [ ] `docker compose logs grafana-live-publisher` shows no more 404 errors
- [ ] Open Real-Time Acceleration dashboard
- [ ] Verify "Acceleration Magnitude (Real-Time Stream)" panel shows live data
- [ ] Verify data updates in real-time as controllers move

🤖 Generated with [Claude Code](https://claude.com/claude-code)