### PR TITLE
feat: Add continuous profiling with Grafana Pyroscope

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -154,6 +154,24 @@ services:
           memory: 256m
           cpus: '0.5'
     logging: *default-logging
+  # Pyroscope for continuous profiling (CPU flame graphs)
+  pyroscope:
+    image: grafana/pyroscope:latest
+    container_name: joustmania-pyroscope
+    expose:
+      - "4040"
+    networks:
+      - joustmania
+    volumes:
+      - pyroscope-data:/data
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 256m
+          cpus: '0.5'
+    logging: *default-logging
+
   # Controller Manager Service
   controller-manager:
     image: ghcr.io/watchmejoustmyflags/joustmania/controller-manager-service:${IMAGE_TAG:-latest}
@@ -193,6 +211,7 @@ services:
       - OTEL_SERVICE_NAME=controller-manager-service
       - OTEL_SERVICE_NAMESPACE=infrastructure
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
+      - PYROSCOPE_SERVER_ADDRESS=http://pyroscope:4040
       # Issue #62: 100Hz acceleration metrics for real-time visualization
       # Default 100ms; set to 10ms for 100Hz demo
       - METRICS_EXPORT_INTERVAL_MS=${METRICS_EXPORT_INTERVAL_MS:-100}
@@ -263,6 +282,7 @@ services:
       - OTEL_SERVICE_NAME=${OTEL_SERVICE_NAME_GAME_COORDINATOR:-game-coordinator-service}
       - OTEL_SERVICE_NAMESPACE=joustmania
       - OTEL_EXPORTER_OTLP_ENDPOINT=${OTEL_EXPORTER_OTLP_ENDPOINT:-http://otel-collector:4317}
+      - PYROSCOPE_SERVER_ADDRESS=http://pyroscope:4040
     depends_on:
       redis:
         condition: service_healthy
@@ -296,6 +316,7 @@ services:
       - OTEL_SERVICE_NAME=menu-service
       - OTEL_SERVICE_NAMESPACE=joustmania
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
+      - PYROSCOPE_SERVER_ADDRESS=http://pyroscope:4040
       # Phase 60: Audio service connection
       - AUDIO_HOST=audio
       - AUDIO_PORT=50056
@@ -345,6 +366,7 @@ services:
       - OTEL_SERVICE_NAME=audio-service
       - OTEL_SERVICE_NAMESPACE=joustmania
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
+      - PYROSCOPE_SERVER_ADDRESS=http://pyroscope:4040
       - FLAGD_HOST=flagd
       - FLAGD_PORT=8015
     depends_on:
@@ -664,3 +686,4 @@ volumes:
   loki-data:
   controller-names:
   psmoveapi-data:
+  pyroscope-data:

--- a/lib/profiling.py
+++ b/lib/profiling.py
@@ -1,0 +1,82 @@
+"""
+Continuous profiling with Grafana Pyroscope for JoustMania services.
+
+Provides CPU flame graphs for identifying hotspots in the 100Hz controller
+polling loop, game loop processing, and gRPC handlers. Especially valuable
+on resource-constrained Raspberry Pi hardware.
+
+Usage:
+    from lib.profiling import init_profiling
+
+    # In service startup, after init_metrics():
+    init_profiling()
+
+    # In tests (conftest.py):
+    from lib.profiling import disable_profiling_for_tests
+    disable_profiling_for_tests()
+"""
+
+import logging
+import os
+import threading
+
+logger = logging.getLogger(__name__)
+
+_initialized = False
+_init_lock = threading.Lock()
+_test_mode = False
+
+
+def disable_profiling_for_tests() -> None:
+    """
+    Disable Pyroscope profiling for unit tests.
+
+    Call this once in conftest.py to prevent Pyroscope connection attempts
+    during tests. Follows the same pattern as disable_telemetry_for_tests().
+    """
+    global _initialized, _test_mode
+    _test_mode = True
+    _initialized = True
+
+
+def init_profiling(application_name: str | None = None) -> None:
+    """
+    Initialize Pyroscope continuous profiling.
+
+    Configures CPU profiling at 100Hz with GIL-only sampling. The application
+    name defaults to OTEL_SERVICE_NAME for consistency with tracing/metrics.
+
+    Args:
+        application_name: Override for the Pyroscope application name.
+            Defaults to OTEL_SERVICE_NAME env var.
+    """
+    global _initialized
+    if _initialized:
+        return
+
+    with _init_lock:
+        if _initialized:
+            return
+
+        try:
+            import pyroscope
+        except ImportError:
+            logger.warning("pyroscope-io not installed, skipping profiling initialization")
+            _initialized = True
+            return
+
+        server_address = os.getenv("PYROSCOPE_SERVER_ADDRESS", "http://pyroscope:4040")
+        app_name = application_name or os.getenv("OTEL_SERVICE_NAME", "unknown")
+
+        pyroscope.configure(
+            application_name=app_name,
+            server_address=server_address,
+            sample_rate=100,
+            detect_subprocesses=False,
+            oncpu=True,
+            gil_only=True,
+            tags={"service": app_name},
+        )
+
+        _initialized = True
+        logger.info(f"Pyroscope profiling initialized: {app_name} -> {server_address}")

--- a/lib/pyproject.toml
+++ b/lib/pyproject.toml
@@ -19,6 +19,9 @@ dependencies = [
     # System metrics
     "psutil>=5.9.0",
 
+    # Continuous profiling
+    "pyroscope-io>=0.8.16",
+
     # Feature Flags
     "openfeature-sdk>=0.6.0",
     "openfeature-provider-flagd>=0.1.0",

--- a/lib/telemetry.py
+++ b/lib/telemetry.py
@@ -101,6 +101,16 @@ def _do_init() -> None:
     provider = TracerProvider(resource=resource)
     otlp_exporter = OTLPSpanExporter(endpoint=otlp_endpoint, insecure=True)
     provider.add_span_processor(BatchSpanProcessor(otlp_exporter))
+
+    # Trace-profile correlation: link Pyroscope CPU profiles to trace spans
+    try:
+        from pyroscope.otel import PyroscopeSpanProcessor
+
+        provider.add_span_processor(PyroscopeSpanProcessor())
+        logger.info("Pyroscope span processor enabled for trace-profile correlation")
+    except ImportError:
+        pass  # pyroscope-io not installed
+
     trace.set_tracer_provider(provider)
 
     logger.info(f"OpenTelemetry initialized: {service_name} -> {otlp_endpoint}")

--- a/services/audio/server.py
+++ b/services/audio/server.py
@@ -16,6 +16,7 @@ import grpc.aio
 from grpc_health.v1 import health, health_pb2, health_pb2_grpc
 
 from lib.otel_metrics import init_metrics
+from lib.profiling import init_profiling
 from lib.system_metrics import start_system_metrics_collector
 from proto import audio_pb2_grpc
 from services.audio import metrics
@@ -37,6 +38,7 @@ async def serve():
 
     # Initialize OTEL push metrics
     init_metrics()
+    init_profiling()
     logger.info("OTEL push metrics initialized for audio service")
 
     # Start system metrics collection

--- a/services/audio/tests/conftest.py
+++ b/services/audio/tests/conftest.py
@@ -2,12 +2,14 @@
 Pytest fixtures for audio service tests.
 """
 
-# Disable OpenTelemetry for tests - must be done before importing service modules
+# Disable OpenTelemetry and profiling for tests - must be done before importing service modules
 from lib.otel_metrics import disable_metrics_for_tests
+from lib.profiling import disable_profiling_for_tests
 from lib.telemetry import disable_telemetry_for_tests
 
 disable_telemetry_for_tests()
 disable_metrics_for_tests()
+disable_profiling_for_tests()
 
 import os
 from unittest.mock import patch

--- a/services/controller_manager/server.py
+++ b/services/controller_manager/server.py
@@ -14,6 +14,7 @@ import grpc.aio
 from grpc_health.v1 import health, health_pb2, health_pb2_grpc
 
 from lib.otel_metrics import init_metrics
+from lib.profiling import init_profiling
 from lib.system_metrics import start_system_metrics_collector
 from proto import controller_manager_pb2_grpc
 from services.controller_manager import metrics
@@ -36,6 +37,7 @@ async def serve(port=50052):
     # Use METRICS_EXPORT_INTERVAL_MS env var to configure (10ms for 100Hz)
     export_interval_ms = int(os.getenv("METRICS_EXPORT_INTERVAL_MS", "100"))
     init_metrics(export_interval_ms=export_interval_ms)
+    init_profiling()
     logger.info(f"OTEL push metrics initialized ({export_interval_ms}ms export interval)")
 
     # Start prometheus_client HTTP server for direct pull scraping (pipeline comparison)

--- a/services/controller_manager/tests/conftest.py
+++ b/services/controller_manager/tests/conftest.py
@@ -4,12 +4,14 @@ Pytest fixtures for controller_manager tests.
 
 import pytest
 
-# Disable OpenTelemetry for tests - must be done before importing service modules
+# Disable OpenTelemetry and profiling for tests - must be done before importing service modules
 from lib.otel_metrics import disable_metrics_for_tests
+from lib.profiling import disable_profiling_for_tests
 from lib.telemetry import disable_telemetry_for_tests
 
 disable_telemetry_for_tests()
 disable_metrics_for_tests()
+disable_profiling_for_tests()
 
 
 class FakeMove:

--- a/services/game_coordinator/server.py
+++ b/services/game_coordinator/server.py
@@ -46,6 +46,7 @@ from grpc_health.v1 import health, health_pb2, health_pb2_grpc
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 
 from lib.otel_metrics import init_metrics
+from lib.profiling import init_profiling
 from lib.system_metrics import start_system_metrics_collector
 from proto import game_coordinator_pb2_grpc
 from services.game_coordinator import metrics
@@ -66,6 +67,7 @@ async def serve(port=50053):
     # Initialize OTEL push metrics (Issue #103)
     # 100ms export interval for real-time gameplay visualization
     init_metrics(export_interval_ms=100)
+    init_profiling()
     logger.info("OTEL push metrics initialized (100ms export interval)")
 
     # Start system metrics collection

--- a/services/game_coordinator/tests/conftest.py
+++ b/services/game_coordinator/tests/conftest.py
@@ -20,12 +20,14 @@ project_root = service_dir.parent.parent
 # Add paths for imports
 sys.path.insert(0, str(project_root))
 
-# Disable OpenTelemetry for tests - must be done before importing service modules
+# Disable OpenTelemetry and profiling for tests - must be done before importing service modules
 from lib.otel_metrics import disable_metrics_for_tests
+from lib.profiling import disable_profiling_for_tests
 from lib.telemetry import disable_telemetry_for_tests
 
 disable_telemetry_for_tests()
 disable_metrics_for_tests()
+disable_profiling_for_tests()
 
 # Import protobufs from proto package (must be after path setup)
 from proto import controller_manager_pb2

--- a/services/grafana/provisioning/datasources/pyroscope.yml
+++ b/services/grafana/provisioning/datasources/pyroscope.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+datasources:
+  - name: Pyroscope
+    uid: pyroscope
+    type: grafana-pyroscope-datasource
+    access: proxy
+    url: http://pyroscope:4040
+    isDefault: false
+    editable: false

--- a/services/menu/server.py
+++ b/services/menu/server.py
@@ -28,6 +28,7 @@ import grpc.aio
 from grpc_health.v1 import health, health_pb2, health_pb2_grpc
 
 from lib.otel_metrics import init_metrics
+from lib.profiling import init_profiling
 from lib.system_metrics import start_system_metrics_collector
 from lib.types import Games
 from proto import menu_pb2, menu_pb2_grpc
@@ -41,6 +42,7 @@ async def serve(port=50054):
     """Start the Menu gRPC server."""
     # Initialize OTEL push metrics
     init_metrics()
+    init_profiling()
     logger.info("OTEL push metrics initialized for menu service")
 
     # Start system metrics collection

--- a/services/menu/tests/conftest.py
+++ b/services/menu/tests/conftest.py
@@ -2,9 +2,11 @@
 Pytest fixtures for menu service tests.
 """
 
-# Disable OpenTelemetry for tests - must be done before importing service modules
+# Disable OpenTelemetry and profiling for tests - must be done before importing service modules
 from lib.otel_metrics import disable_metrics_for_tests
+from lib.profiling import disable_profiling_for_tests
 from lib.telemetry import disable_telemetry_for_tests
 
 disable_telemetry_for_tests()
 disable_metrics_for_tests()
+disable_profiling_for_tests()

--- a/uv.lock
+++ b/uv.lock
@@ -552,6 +552,7 @@ dependencies = [
     { name = "opentelemetry-sdk" },
     { name = "prometheus-client" },
     { name = "psutil" },
+    { name = "pyroscope-io" },
 ]
 
 [package.optional-dependencies]
@@ -573,6 +574,7 @@ requires-dist = [
     { name = "opentelemetry-sdk", specifier = ">=1.28.0" },
     { name = "prometheus-client", specifier = ">=0.19.0" },
     { name = "psutil", specifier = ">=5.9.0" },
+    { name = "pyroscope-io", specifier = ">=0.8.16" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.23.0" },
     { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=4.1.0" },
@@ -1107,6 +1109,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pyroscope-io"
+version = "0.8.16"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/50/607b38b120ba8adad954119ba512c53590c793f0cf7f009ba6549e4e1d77/pyroscope_io-0.8.16-py2.py3-none-macosx_11_0_arm64.whl", hash = "sha256:e07edcfd59f5bdce42948b92c9b118c824edbd551730305f095a6b9af401a9e8", size = 3138869, upload-time = "2026-01-22T06:23:24.664Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/c1/90fc335f2224da86d49016ebe15fb4f709c7b8853d4b5beced5a052d9ea3/pyroscope_io-0.8.16-py2.py3-none-macosx_11_0_x86_64.whl", hash = "sha256:dc98355e27c0b7b61f27066500fe1045b70e9459bb8b9a3082bc4755cb6392b6", size = 3375865, upload-time = "2026-01-22T06:23:27.736Z" },
+    { url = "https://files.pythonhosted.org/packages/39/7a/261f53ede16b7db19984ec80480572b8e9aa3be0ffc82f62650c4b9ca7d6/pyroscope_io-0.8.16-py2.py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:86f0f047554ff62bd92c3e5a26bc2809ccd467d11fbacb9fef898ba299dbda59", size = 3236172, upload-time = "2026-01-22T06:23:29.107Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/8f/88d792e9cacd6ff3bd9a50100586ddc665e02a917662c17d30931f778542/pyroscope_io-0.8.16-py2.py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6b91ce5b240f8de756c16a17022ca8e25ef8a4eed461c7d074b8a0841cf7b445", size = 3485288, upload-time = "2026-01-22T06:23:32Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add Grafana Pyroscope for continuous CPU profiling across all Python services
- Enable trace-profile correlation so clicking a trace span in Grafana shows the corresponding flame graph
- Follow existing observability patterns (lazy init, test disabling, Grafana datasource provisioning)

Closes #445

## Changes

| Action | File |
|--------|------|
| **New** | `lib/profiling.py` — Pyroscope init module (lazy, thread-safe, test-disablable) |
| **New** | `services/grafana/provisioning/datasources/pyroscope.yml` — Grafana datasource |
| **Edit** | `lib/pyproject.toml` — Add `pyroscope-io>=0.8.16` dependency |
| **Edit** | `lib/telemetry.py` — Add `PyroscopeSpanProcessor` for trace↔profile linking |
| **Edit** | `docker-compose.yml` — Add pyroscope container + env vars to all services |
| **Edit** | 4× `server.py` — Add `init_profiling()` call after `init_metrics()` |
| **Edit** | 4× `tests/conftest.py` — Add `disable_profiling_for_tests()` |

## Test plan

- [x] `make lint` passes
- [x] `cd services/controller_manager && uv run pytest` — 209 passed
- [x] `cd services/game_coordinator && uv run pytest` — 315 passed
- [x] `cd services/menu && uv run pytest` — 175 passed
- [x] `cd services/audio && uv run pytest` — 67 passed
- [ ] `docker compose up pyroscope` — Pyroscope server starts on port 4040
- [ ] `docker compose up` — all services start, no pyroscope connection errors in logs
- [ ] Open Grafana → Explore → Pyroscope datasource → see flame graphs per service
- [ ] Open a trace → "Profiles for this span" → see linked CPU profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)