### PR TITLE
fix: Improve player-insights dashboard UX for empty state

### DIFF
--- a/services/grafana/dashboards/player-insights.json
+++ b/services/grafana/dashboards/player-insights.json
@@ -107,7 +107,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "game_players_alive",
+          "expr": "game_players_alive or vector(0)",
           "legendFormat": "Alive",
           "refId": "A"
         },
@@ -116,7 +116,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "game_active_players",
+          "expr": "game_active_players or vector(0)",
           "legendFormat": "Total",
           "refId": "B"
         }
@@ -963,7 +963,7 @@
       "type": "state-timeline"
     }
   ],
-  "refresh": "1s",
+  "refresh": "500ms",
   "schemaVersion": 39,
   "tags": ["joustmania", "game", "per-player", "sensitivity", "presentation"],
   "templating": {
@@ -974,7 +974,7 @@
           "type": "prometheus",
           "uid": "prometheus"
         },
-        "definition": "query_result(controller_info * on(serial) group_left() ((menu_player_ready == 1) or (game_player_alive == 1)))",
+        "definition": "query_result(controller_info * on(serial) group_left() ((menu_player_ready == 1) or (game_player_alive == 1)) or controller_info)",
         "hide": 0,
         "includeAll": true,
         "label": "Player",
@@ -982,7 +982,7 @@
         "name": "player",
         "options": [],
         "query": {
-          "query": "query_result(controller_info * on(serial) group_left() ((menu_player_ready == 1) or (game_player_alive == 1)))",
+          "query": "query_result(controller_info * on(serial) group_left() ((menu_player_ready == 1) or (game_player_alive == 1)) or controller_info)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 2,
@@ -997,7 +997,7 @@
           "type": "prometheus",
           "uid": "prometheus"
         },
-        "definition": "query_result(controller_info{name=~\"$player\"} * on(serial) group_left() ((menu_player_ready == 1) or (game_player_alive == 1)))",
+        "definition": "query_result(controller_info{name=~\"$player\"} * on(serial) group_left() ((menu_player_ready == 1) or (game_player_alive == 1)) or controller_info{name=~\"$player\"})",
         "hide": 2,
         "includeAll": true,
         "label": "Serial",
@@ -1005,7 +1005,7 @@
         "name": "serial",
         "options": [],
         "query": {
-          "query": "query_result(controller_info{name=~\"$player\"} * on(serial) group_left() ((menu_player_ready == 1) or (game_player_alive == 1)))",
+          "query": "query_result(controller_info{name=~\"$player\"} * on(serial) group_left() ((menu_player_ready == 1) or (game_player_alive == 1)) or controller_info{name=~\"$player\"})",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 2,


### PR DESCRIPTION
## Summary

- Add `or vector(0)` fallback to the Players stat panel (id=201) so it displays "0" instead of "No data" when no game is running
- Change dashboard auto-refresh from 1s to 500ms for snappier real-time updates during gameplay
- Add `or controller_info` fallback to `query_result()` in player/serial template variables so the dropdown shows all known controllers even when no players are currently active, enabling review of past game data

Fixes #441

## Test plan

- [ ] Open Player Insights dashboard with no game running -- Players panel should show "0 / 0" instead of "No data"
- [ ] Start a game -- verify refresh rate feels snappier at 500ms
- [ ] With no game running, verify player dropdown still lists all known controllers
- [ ] Select a past player and confirm historical acceleration/zone data still renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)