### PR TITLE
feat: Add infrastructure CPU/memory panels to service health dashboard

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,7 +83,7 @@ services:
       - ./services/flagd/user_preferences.json:/etc/flagd/user_preferences.json
     expose:
       - "8013"  # flagd evaluation port (gRPC)
-      - "8014"  # flagd management port (metrics)
+      - "8014"  # flagd management port (Prometheus metrics)
       - "8015"  # flagd sync port (for in-process evaluation)
     networks:
       - joustmania

--- a/services/grafana/dashboards/service-health-overview.json
+++ b/services/grafana/dashboards/service-health-overview.json
@@ -420,6 +420,177 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
+      "description": "Number of healthy infrastructure components",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 2
+              },
+              {
+                "color": "green",
+                "value": 3
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 0,
+        "y": 4
+      },
+      "id": 15,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.2.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "count(up{job=~\"psmove-pairing|controller-manager-pull|node\"} == 1)",
+          "legendFormat": "Infrastructure",
+          "refId": "A"
+        }
+      ],
+      "title": "Infra Up",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Status of infrastructure components",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "color-background"
+            },
+            "inspect": false
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "red",
+                  "index": 0,
+                  "text": "DOWN"
+                },
+                "1": {
+                  "color": "green",
+                  "index": 1,
+                  "text": "UP"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 9,
+        "x": 3,
+        "y": 4
+      },
+      "id": 16,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "10.2.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "up{job=~\"psmove-pairing|controller-manager-pull|node\"}",
+          "format": "table",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Infrastructure",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true,
+              "collector": true,
+              "instance": true
+            },
+            "renameByName": {
+              "Value": "Status",
+              "job": "Component"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "description": "Number of healthy observability components",
       "fieldConfig": {
         "defaults": {
@@ -449,8 +620,8 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 4,
-        "x": 0,
+        "w": 3,
+        "x": 12,
         "y": 4
       },
       "id": 11,
@@ -475,7 +646,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "count(up{job=~\"observability/prometheus|observability/grafana|observability/loki|observability/victoria-metrics|observability/otel-collector|host/node\"} == 1)",
+          "expr": "count(up{job=~\"prometheus|grafana|loki|victoria-metrics|otel-collector\"} == 1)",
           "legendFormat": "Observability",
           "refId": "A"
         }
@@ -536,8 +707,8 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 20,
-        "x": 4,
+        "w": 9,
+        "x": 15,
         "y": 4
       },
       "id": 12,
@@ -560,7 +731,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "up{job=~\"observability/prometheus|observability/grafana|observability/loki|observability/victoria-metrics|observability/otel-collector|host/node\"}",
+          "expr": "up{job=~\"prometheus|grafana|loki|victoria-metrics|otel-collector\"}",
           "format": "table",
           "instant": true,
           "refId": "A"
@@ -676,12 +847,12 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "rate(process_cpu_seconds_total[5m]) * 100",
+          "expr": "process_cpu_percent{job=~\"controller-manager|game-coordinator|menu|audio\"}",
           "legendFormat": "{{job}}",
           "refId": "A"
         }
       ],
-      "title": "CPU Usage by Service",
+      "title": "App CPU Usage",
       "type": "timeseries"
     },
     {
@@ -735,7 +906,7 @@
               }
             ]
           },
-          "unit": "bytes"
+          "unit": "decmbytes"
         },
         "overrides": []
       },
@@ -768,12 +939,215 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "process_resident_memory_bytes",
+          "expr": "process_memory_mb{job=~\"controller-manager|game-coordinator|menu|audio\"}",
           "legendFormat": "{{job}}",
           "refId": "A"
         }
       ],
-      "title": "Memory Usage by Service",
+      "title": "App Memory Usage",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 14
+      },
+      "id": 19,
+      "panels": [],
+      "title": "Infrastructure Resources",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "CPU usage by infrastructure services (last 15 minutes)",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "line+area"
+            }
+          },
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "transparent",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 15
+      },
+      "id": 17,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.2.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "process_cpu_percent{job!~\"controller-manager|game-coordinator|menu|audio\"}",
+          "legendFormat": "{{job}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Infra CPU Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Memory usage by infrastructure services",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "decmbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 15
+      },
+      "id": 18,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.2.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "process_memory_mb{job!~\"controller-manager|game-coordinator|menu|audio\"}",
+          "legendFormat": "{{job}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Infra Memory Usage",
       "type": "timeseries"
     },
     {
@@ -835,7 +1209,7 @@
         "h": 6,
         "w": 8,
         "x": 0,
-        "y": 14
+        "y": 21
       },
       "id": 8,
       "options": {
@@ -928,7 +1302,7 @@
         "h": 6,
         "w": 8,
         "x": 8,
-        "y": 14
+        "y": 21
       },
       "id": 9,
       "options": {
@@ -1020,7 +1394,7 @@
         "h": 6,
         "w": 8,
         "x": 16,
-        "y": 14
+        "y": 21
       },
       "id": 10,
       "options": {
@@ -1115,7 +1489,7 @@
         "h": 6,
         "w": 12,
         "x": 0,
-        "y": 20
+        "y": 27
       },
       "id": 13,
       "options": {
@@ -1207,7 +1581,7 @@
         "h": 6,
         "w": 12,
         "x": 12,
-        "y": 20
+        "y": 27
       },
       "id": 14,
       "options": {


### PR DESCRIPTION
## Summary
- Add "Infra Up" stat and "Infrastructure" table to the status row (y=4), showing health of pairing-daemon, controller-manager-pull, and node-exporter
- Split existing CPU/memory charts into "App CPU Usage" and "App Memory Usage" (filtered to app services only using process_cpu_percent and process_memory_mb)
- Add new "Infrastructure Resources" row with "Infra CPU Usage" and "Infra Memory Usage" panels for all non-app services
- Update Observability Up/Stack panels to use simple job names and narrower layout to fit alongside new Infrastructure panels
- Document flagd management port 8014 (Prometheus metrics) in docker-compose expose

Fixes #429

## Test plan
- [ ] Deploy and verify "Infra Up" stat shows correct count (green at 3, yellow at 2, red below)
- [ ] Verify "Infrastructure" table shows UP/DOWN status for psmove-pairing, controller-manager-pull, node
- [ ] Verify "Observability Up" and "Observability Stack" panels still function correctly at new positions
- [ ] Verify "App CPU Usage" and "App Memory Usage" only show controller-manager, game-coordinator, menu, audio
- [ ] Verify "Infra CPU Usage" and "Infra Memory Usage" show all non-app services
- [ ] Verify gRPC panels still render correctly at shifted y positions
- [ ] Validate JSON with python3 -c "import json; json.load(open('services/grafana/dashboards/service-health-overview.json'))"

Generated with [Claude Code](https://claude.com/claude-code)