### PR TITLE
fix: Disable Pyroscope profiling by default to reduce load

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -155,9 +155,12 @@ services:
           cpus: '0.5'
     logging: *default-logging
   # Pyroscope for continuous profiling (CPU flame graphs)
+  # Only starts with: docker compose --profile profiling up
   pyroscope:
     image: grafana/pyroscope:latest
     container_name: joustmania-pyroscope
+    profiles:
+      - profiling
     expose:
       - "4040"
     networks:
@@ -211,6 +214,7 @@ services:
       - OTEL_SERVICE_NAME=controller-manager-service
       - OTEL_SERVICE_NAMESPACE=infrastructure
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
+      - PROFILING_ENABLED=false
       - PYROSCOPE_SERVER_ADDRESS=http://pyroscope:4040
       # Issue #62: 100Hz acceleration metrics for real-time visualization
       # Default 100ms; set to 10ms for 100Hz demo
@@ -282,6 +286,7 @@ services:
       - OTEL_SERVICE_NAME=${OTEL_SERVICE_NAME_GAME_COORDINATOR:-game-coordinator-service}
       - OTEL_SERVICE_NAMESPACE=joustmania
       - OTEL_EXPORTER_OTLP_ENDPOINT=${OTEL_EXPORTER_OTLP_ENDPOINT:-http://otel-collector:4317}
+      - PROFILING_ENABLED=false
       - PYROSCOPE_SERVER_ADDRESS=http://pyroscope:4040
     depends_on:
       redis:
@@ -316,6 +321,7 @@ services:
       - OTEL_SERVICE_NAME=menu-service
       - OTEL_SERVICE_NAMESPACE=joustmania
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
+      - PROFILING_ENABLED=false
       - PYROSCOPE_SERVER_ADDRESS=http://pyroscope:4040
       # Phase 60: Audio service connection
       - AUDIO_HOST=audio
@@ -366,6 +372,7 @@ services:
       - OTEL_SERVICE_NAME=audio-service
       - OTEL_SERVICE_NAMESPACE=joustmania
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
+      - PROFILING_ENABLED=false
       - PYROSCOPE_SERVER_ADDRESS=http://pyroscope:4040
       - FLAGD_HOST=flagd
       - FLAGD_PORT=8015

--- a/lib/profiling.py
+++ b/lib/profiling.py
@@ -58,6 +58,11 @@ def init_profiling(application_name: str | None = None) -> None:
         if _initialized:
             return
 
+        if os.getenv("PROFILING_ENABLED", "false").lower() not in ("true", "1", "yes"):
+            logger.info("Profiling disabled (set PROFILING_ENABLED=true to enable)")
+            _initialized = True
+            return
+
         try:
             import pyroscope
         except ImportError:

--- a/lib/telemetry.py
+++ b/lib/telemetry.py
@@ -103,13 +103,14 @@ def _do_init() -> None:
     provider.add_span_processor(BatchSpanProcessor(otlp_exporter))
 
     # Trace-profile correlation: link Pyroscope CPU profiles to trace spans
-    try:
-        from pyroscope.otel import PyroscopeSpanProcessor
+    if os.getenv("PROFILING_ENABLED", "false").lower() in ("true", "1", "yes"):
+        try:
+            from pyroscope.otel import PyroscopeSpanProcessor
 
-        provider.add_span_processor(PyroscopeSpanProcessor())
-        logger.info("Pyroscope span processor enabled for trace-profile correlation")
-    except ImportError:
-        pass  # pyroscope-io not installed
+            provider.add_span_processor(PyroscopeSpanProcessor())
+            logger.info("Pyroscope span processor enabled for trace-profile correlation")
+        except ImportError:
+            pass  # pyroscope-io not installed
 
     trace.set_tracer_provider(provider)
 


### PR DESCRIPTION
## Summary
- Gate profiling behind `PROFILING_ENABLED` env var (default: `false`) in `lib/profiling.py` and `lib/telemetry.py`
- Add Docker Compose `profiles: [profiling]` to Pyroscope container so it only starts with `--profile profiling`
- Set `PROFILING_ENABLED=false` in all 4 service env blocks in `docker-compose.yml`

To enable profiling: set `PROFILING_ENABLED=true` on services and run `docker compose --profile profiling up`.

## Test plan
- [ ] All unit tests pass (793/793 across 4 services)
- [ ] `docker compose up` no longer starts Pyroscope container
- [ ] `docker compose --profile profiling up` starts Pyroscope
- [ ] Services log "Profiling disabled" on startup when `PROFILING_ENABLED=false`
- [ ] Setting `PROFILING_ENABLED=true` re-enables profiling

🤖 Generated with [Claude Code](https://claude.com/claude-code)