### PR TITLE
fix: Parent death effect and audio spans to player_lifecycle

### DIFF
--- a/services/game_coordinator/games/base.py
+++ b/services/game_coordinator/games/base.py
@@ -839,8 +839,23 @@ class BaseGameMode(ABC):
         alive_count = len([p for p in self.players.values() if p.alive])
         metrics.players_alive.set(alive_count)
 
+        # Extract trace context BEFORE _kill_player_impl() which may close the span.
+        # This ensures the death effect and sound are parented to the player_lifecycle
+        # span even after the subclass impl ends it. (#456)
+        trace_parent, trace_state = inject_trace_context(player.span)
+
         # Play death explosion sound (Phase 29)
-        await self._play_sound(Sound.SFX_EXPLOSION, priority=2)
+        # Temporarily set player's span as active so gRPC interceptor propagates
+        # the player's trace context to the audio service. (#456)
+        if player.span:
+            ctx = trace.set_span_in_context(player.span)
+            token = otel_context.attach(ctx)
+            try:
+                await self._play_sound(Sound.SFX_EXPLOSION, priority=2)
+            finally:
+                otel_context.detach(token)
+        else:
+            await self._play_sound(Sound.SFX_EXPLOSION, priority=2)
 
         # Add death event to player's lifecycle span (Phase 3: Per-Player Sensitivity)
         if player.span:
@@ -859,11 +874,11 @@ class BaseGameMode(ABC):
         await self._kill_player_impl(serial, accel_mag)
 
         # Send death effect via stream (red + vibrate, no restore)
-        # Use player's span as parent so effect appears under player_lifecycle in traces
+        # Use pre-extracted trace context so effect appears under player_lifecycle
+        # in traces, even though _kill_player_impl may have closed the span. (#456)
         from proto import controller_manager_pb2
 
         if self.gameplay_stream:
-            trace_parent, trace_state = inject_trace_context(player.span)
             effect_cmd = controller_manager_pb2.GameplayStreamControl(
                 game_effect=controller_manager_pb2.GameEffectCommand(
                     serial=serial,


### PR DESCRIPTION
## Summary
- Extract trace context from the player's lifecycle span **before** `_kill_player_impl()` closes it, fixing the death effect (`GameEffectCommand`) losing its parent span
- Temporarily set the player's span as the active OTEL context when calling `_play_sound()`, so the gRPC client interceptor automatically propagates trace context to the audio service

Fixes #456

## Test plan
- [x] `make lint` passes
- [x] `cd services/game_coordinator && uv run pytest` - all 333 tests pass
- [ ] Deploy and verify in Jaeger that death effect and audio spans appear under `player_lifecycle`

🤖 Generated with [Claude Code](https://claude.com/claude-code)