### PR TITLE
fix: Simplify Player Insights dashboard to only show gameplay data

### DIFF
--- a/services/game_coordinator/games/base.py
+++ b/services/game_coordinator/games/base.py
@@ -831,10 +831,9 @@ class BaseGameMode(ABC):
         # Phase 70: Track deaths for music tempo timing
         self.dead_count += 1
 
-        # Clear analytics metrics so dead players don't appear on dashboard
-        metrics.clear_player_analytics(serial, self.game_id)
-
-        # Mark player as dead in metrics (Phase 75: filter dead players from dashboard)
+        # Mark player as dead in metrics - dashboard template variables filter
+        # on game_player_alive==1 so dead players naturally disappear from panels.
+        # Metric removal happens at game end via clear_all_player_analytics().
         metrics.player_alive.labels(serial=serial).set(0)
         alive_count = len([p for p in self.players.values() if p.alive])
         metrics.players_alive.set(alive_count)

--- a/services/game_coordinator/metrics.py
+++ b/services/game_coordinator/metrics.py
@@ -230,10 +230,12 @@ game_analytics_replay_bytes = Histogram(
 
 def clear_player_analytics(serial: str, game_id: str = "") -> None:
     """
-    Clear analytics metrics for a player (e.g., when they die or game ends).
+    Clear analytics metrics for a specific player.
 
-    This removes the gauge labels so they no longer appear in dashboards,
-    rather than showing stale data.
+    Only used for targeted cleanup (e.g., controller disconnect during game).
+    Normal player death sets player_alive=0 instead, letting dashboard queries
+    filter dead players via game_player_alive==1 in template variables.
+    Bulk cleanup at game end uses clear_all_player_analytics().
     """
     with suppress(KeyError, ValueError):
         player_accel_magnitude.remove(serial)
@@ -255,10 +257,12 @@ def clear_player_analytics(serial: str, game_id: str = "") -> None:
 
 def clear_all_player_analytics() -> None:
     """
-    Clear all player analytics metrics (e.g., when game ends).
+    Clear all player analytics metrics at game end.
 
-    This removes all label combinations so dashboards show no data
-    when no game is running.
+    This is the single cleanup point for the game lifecycle, removing all
+    label combinations so the Player Insights dashboard shows no data
+    between games. Per-death metric removal was eliminated (Issue #458)
+    to prevent dashboard flicker during game transitions.
     """
     player_accel_magnitude._metrics.clear()
     player_accel_magnitude._values.clear()

--- a/services/grafana/dashboards/player-insights.json
+++ b/services/grafana/dashboards/player-insights.json
@@ -15,7 +15,7 @@
       }
     ]
   },
-  "description": "Per-player detailed view with 100Hz acceleration visualization, dynamic thresholds, and real-time status (Issue #62)",
+  "description": "Per-player gameplay view with 100Hz acceleration visualization, dynamic thresholds, and real-time status. Only shows alive players during active games (Issue #62, #458).",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
@@ -974,7 +974,7 @@
           "type": "prometheus",
           "uid": "prometheus"
         },
-        "definition": "query_result(controller_info * on(serial) group_left() ((menu_player_ready == 1) or (game_player_alive == 1)) or controller_info)",
+        "definition": "query_result(controller_info * on(serial) group_left() (game_player_alive == 1))",
         "hide": 0,
         "includeAll": true,
         "label": "Player",
@@ -982,7 +982,7 @@
         "name": "player",
         "options": [],
         "query": {
-          "query": "query_result(controller_info * on(serial) group_left() ((menu_player_ready == 1) or (game_player_alive == 1)) or controller_info)",
+          "query": "query_result(controller_info * on(serial) group_left() (game_player_alive == 1))",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 2,
@@ -997,7 +997,7 @@
           "type": "prometheus",
           "uid": "prometheus"
         },
-        "definition": "query_result(controller_info{name=~\"$player\"} * on(serial) group_left() ((menu_player_ready == 1) or (game_player_alive == 1)) or controller_info{name=~\"$player\"})",
+        "definition": "query_result(controller_info{name=~\"$player\"} * on(serial) group_left() (game_player_alive == 1))",
         "hide": 2,
         "includeAll": true,
         "label": "Serial",
@@ -1005,7 +1005,7 @@
         "name": "serial",
         "options": [],
         "query": {
-          "query": "query_result(controller_info{name=~\"$player\"} * on(serial) group_left() ((menu_player_ready == 1) or (game_player_alive == 1)) or controller_info{name=~\"$player\"})",
+          "query": "query_result(controller_info{name=~\"$player\"} * on(serial) group_left() (game_player_alive == 1))",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "refresh": 2,


### PR DESCRIPTION
## Summary
- Remove `menu_player_ready` dependency from Player Insights dashboard template variables, eliminating flicker during lobby-to-game transitions caused by 3-4 `.remove()`/`.clear()` events per game cycle
- Remove per-death `clear_player_analytics()` call from `base.py`, instead relying on `player_alive=0` gauge + Grafana `game_player_alive==1` query filtering to hide dead players
- Keep `clear_all_player_analytics()` at game end as the single metric cleanup point

Fixes #458

## Test plan
- [x] `make lint` passes
- [x] Unit tests pass (332/333 -- 1 pre-existing flaky perf test unrelated to changes)
- [ ] Verify dashboard shows no players between games (template variables return empty when no `game_player_alive` metrics exist)
- [ ] Verify dashboard shows only alive players during game (dead players disappear from repeated rows)
- [ ] Verify no visible flicker during game start/end transitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)