### PR TITLE
fix: Add basic auth to Grafana Live publisher and enable login form

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -593,6 +593,8 @@ services:
     environment:
       - GRAFANA_URL=http://grafana:3000/grafana
       - GRAFANA_PUSH_PATH=joustmania-accel
+      - GRAFANA_USER=admin
+      - GRAFANA_PASSWORD=admin
     depends_on:
       grafana:
         condition: service_healthy

--- a/services/grafana-live-publisher/main.go
+++ b/services/grafana-live-publisher/main.go
@@ -11,6 +11,8 @@
 //   - PORT: HTTP server port (default: 4318)
 //   - GRAFANA_URL: Grafana base URL (default: http://grafana:3000)
 //   - GRAFANA_PUSH_PATH: Grafana Live stream ID (default: joustmania-accel)
+//   - GRAFANA_USER: Grafana username for basic auth (default: admin)
+//   - GRAFANA_PASSWORD: Grafana password for basic auth (default: admin)
 package main
 
 import (
@@ -52,6 +54,8 @@ type Config struct {
 	Port            string
 	GrafanaURL      string
 	GrafanaPushPath string
+	GrafanaUser     string
+	GrafanaPassword string
 }
 
 // AccelMessage represents acceleration data for Grafana Live
@@ -114,6 +118,8 @@ func main() {
 		Port:            getEnv("PORT", "4318"),
 		GrafanaURL:      getEnv("GRAFANA_URL", "http://grafana:3000"),
 		GrafanaPushPath: getEnv("GRAFANA_PUSH_PATH", "joustmania-accel"),
+		GrafanaUser:     getEnv("GRAFANA_USER", "admin"),
+		GrafanaPassword: getEnv("GRAFANA_PASSWORD", "admin"),
 	}
 
 	httpClient = &http.Client{
@@ -130,6 +136,7 @@ func main() {
 	log.Printf("Grafana Live Publisher starting on %s", addr)
 	log.Printf("  Grafana URL: %s", config.GrafanaURL)
 	log.Printf("  Push path: %s", config.GrafanaPushPath)
+	log.Printf("  Grafana user: %s", config.GrafanaUser)
 
 	if err := http.ListenAndServe(addr, nil); err != nil {
 		log.Fatalf("Server failed: %v", err)
@@ -380,6 +387,7 @@ func pushToGrafanaLive(msg AccelMessage) {
 	}
 
 	req.Header.Set("Content-Type", "text/plain")
+	req.SetBasicAuth(config.GrafanaUser, config.GrafanaPassword)
 
 	resp, err := httpClient.Do(req)
 	if err != nil {

--- a/services/grafana/grafana.ini
+++ b/services/grafana/grafana.ini
@@ -407,7 +407,7 @@ home_page = /grafana/dashboards/f/demo/?orgId=1
 ;token_rotation_interval_minutes = 10
 
 # Set to true to disable (hide) the login form, useful if you use OAuth, defaults to false
-disable_login_form = true
+disable_login_form = false
 
 # Set to true to disable the sign out link in the side menu. Useful if you use auth.proxy or auth.jwt, defaults to false
 ;disable_signout_menu = false


### PR DESCRIPTION
## Summary

- **No authentication on push requests**: The Grafana Live publisher was sending HTTP POST requests to the Grafana Live push endpoint without any credentials, causing 401/403 errors. Added `GRAFANA_USER` and `GRAFANA_PASSWORD` environment variables (default: `admin`/`admin`) and `req.SetBasicAuth()` on every push request.
- **Grafana login form disabled**: `disable_login_form = true` in `grafana.ini` prevented admin authentication, which is required for the Live push endpoint (Editor-level access). Changed to `disable_login_form = false`.
- **Docker Compose env vars**: Added the new `GRAFANA_USER` and `GRAFANA_PASSWORD` environment variables to the `grafana-live-publisher` service in `docker-compose.yml`.

### Verified

- Dashboard channel reference in `realtime-accel.json` already uses the correct `stream/joustmania-accel` path.
- Content format already uses InfluxDB line protocol with `Content-Type: text/plain` (fixed in a prior PR).

## Test plan

- [ ] Rebuild containers: `docker compose build grafana-live-publisher`
- [ ] Start services: `docker compose up -d`
- [ ] Check grafana-live-publisher logs for no more 401/403 errors: `docker compose logs grafana-live-publisher`
- [ ] Open Grafana and verify the Real-time Acceleration dashboard shows live data
- [ ] Verify Grafana login form is accessible at `/grafana/login`

🤖 Generated with [Claude Code](https://claude.com/claude-code)