### PR TITLE
refactor: migrate MENU_AUTO_START to flagd user_preferences domain

### DIFF
--- a/services/flagd/user_preferences.json
+++ b/services/flagd/user_preferences.json
@@ -42,6 +42,14 @@
         "off": false
       },
       "defaultVariant": "on"
+    },
+    "menu_auto_start": {
+      "state": "ENABLED",
+      "variants": {
+        "on": true,
+        "off": false
+      },
+      "defaultVariant": "on"
     }
   }
 }

--- a/services/menu/README.md
+++ b/services/menu/README.md
@@ -116,7 +116,7 @@ When all connected controllers are ready (trigger pressed) and there are at leas
 stateDiagram-v2
     [*] --> STOPPED: Service starts
 
-    STOPPED --> RUNNING: StartMenu RPC\nor MENU_AUTO_START=true
+    STOPPED --> RUNNING: StartMenu RPC\nor menu_auto_start flag=true
     RUNNING --> STOPPED: StopMenu RPC
     RUNNING --> GAME_STARTING: All controllers ready\n(≥2 controllers)
     GAME_STARTING --> RUNNING: Game ends\n(game_ended event)

--- a/services/menu/server.py
+++ b/services/menu/server.py
@@ -18,7 +18,7 @@ import os
 
 # Configure logging early, before any logging calls
 # This must happen before any logging.warning/info/etc to ensure LOG_LEVEL is respected
-log_level = os.getenv("LOG_LEVEL", "INFO").upper()
+log_level = os.environ.get("LOG_LEVEL", "INFO").upper()
 logging.basicConfig(
     level=getattr(logging, log_level, logging.INFO),
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
@@ -89,11 +89,12 @@ async def serve(port=50054):
     await menu_servicer.start_game_event_monitor()
 
     # Auto-start menu (so controllers light up immediately)
-    auto_start = os.getenv("MENU_AUTO_START", "true").lower() == "true"
+    # Read from flagd user_preferences domain (initialized by MenuServicer.__init__)
+    auto_start = menu_servicer.user_prefs_client.get_boolean_value("menu_auto_start", True)
     if auto_start:
         menu_servicer.state = menu_pb2.MenuState.RUNNING
         menu_servicer.current_selection = Games.JoustFFA
-        logger.info("Menu auto-started (MENU_AUTO_START=true)")
+        logger.info("Menu auto-started (menu_auto_start flag=true)")
 
     try:
         await server.wait_for_termination()


### PR DESCRIPTION
## Summary
- Replace `MENU_AUTO_START` env var with `menu_auto_start` flag in the `user_preferences` flagd domain
- Flag defaults to `on` (true), preserving existing behavior
- Reads flag via `MenuServicer.user_prefs_client` which is already initialized in `servicer.py`
- Update README state diagram to reference the flag instead of the env var

Fixes #468

## Test plan
- [x] `make lint` passes
- [x] `uv run pytest -x -v` passes (175 tests)
- [ ] Integration test: verify menu auto-starts with default flag config
- [ ] Integration test: set `menu_auto_start` defaultVariant to `off`, verify menu stays STOPPED

🤖 Generated with [Claude Code](https://claude.com/claude-code)