### PR TITLE
refactor: consolidate audio MOCK_MODE into play_audio flagd flag

### DIFF
--- a/.env.mock
+++ b/.env.mock
@@ -12,5 +12,6 @@ CONTROLLER_BACKEND=mock
 # Number of simulated controllers in mock mode
 MOCK_CONTROLLER_COUNT=4
 
-# Disable audio output (no sound hardware needed)
-AUDIO_MOCK_MODE=true
+# Audio output is controlled by the play_audio flagd flag (user_preferences domain).
+# To disable audio, set play_audio defaultVariant to "off" in
+# services/flagd/user_preferences.json.

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ dev:
 # Mock mode sets environment variables - this is the main value-add over raw docker compose
 .PHONY: up-mock
 up-mock:
-	CONTROLLER_BACKEND=mock AUDIO_MOCK_MODE=true docker compose up -d $(if $(BUILD),--build)
+	CONTROLLER_BACKEND=mock docker compose up -d $(if $(BUILD),--build)
 	@echo ""
 	@echo "=========================================="
 	@echo "JoustMania is running (MOCK MODE)"

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -10,15 +10,26 @@
 # (docker-compose merges arrays, doesn't replace them)
 
 services:
-  # Audio Service - Mock mode, no sound device required
+  # Audio Service - No sound device required (play_audio=off via CI flagd override)
   # Fully redefined to remove devices list
   audio:
     # Clear devices list from base compose (requires docker compose v2.24.0+)
     devices: !reset []
+    volumes:
+      - ./services/audio/assets:/app/services/audio/assets:ro
+      - ./services/flagd/user_preferences.ci.json:/app/services/flagd/user_preferences.ci.json:ro
     environment: !override
-      MOCK_MODE: "true"
       OTEL_SERVICE_NAME: audio-service
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317
+      FLAGD_HOST: flagd
+      FLAGD_PORT: "8015"
+
+  # flagd - Use CI user_preferences override (play_audio=off)
+  flagd:
+    volumes:
+      - ./services/flagd/performance.json:/etc/flagd/performance.json
+      - ./services/flagd/game_settings.json:/etc/flagd/game_settings.json
+      - ./services/flagd/user_preferences.ci.json:/etc/flagd/user_preferences.json
 
   # Controller Manager - Mock mode, no Bluetooth required
   controller-manager:

--- a/docker-compose.lite.yml
+++ b/docker-compose.lite.yml
@@ -188,7 +188,6 @@ services:
     expose:
       - "50056"
     environment:
-      - MOCK_MODE=${AUDIO_MOCK_MODE:-false}
       - OTEL_SDK_DISABLED=true
       - AUDIODEV=default
       - FLAGD_HOST=flagd

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,14 +10,13 @@
 #   make up              # Build and start all services
 #
 # Base config defaults to bluetooth mode (real hardware).
-# For mock mode (testing): CONTROLLER_BACKEND=mock AUDIO_MOCK_MODE=true make up
+# For mock mode (testing): CONTROLLER_BACKEND=mock make up
 #
 # Environment Variables (can be set in shell or .env file):
 # - IMAGE_TAG: Image tag to use [default: latest]
 # - CONTROLLER_BACKEND: Controller backend type (bluetooth, mock, windows) [default: bluetooth]
 # - MOCK_CONTROLLER_COUNT: Number of mock controllers when CONTROLLER_BACKEND=mock [default: 4]
 # - BLUETOOTH_HCI: Bluetooth adapter to use (hci0, hci1, etc.) [default: hci0]
-# - AUDIO_MOCK_MODE: Disable audio output for testing [default: false]
 # - LOG_LEVEL: Logging level for all services (DEBUG, INFO, WARNING, ERROR) [default: INFO]
 #
 # Notes:
@@ -368,7 +367,6 @@ services:
     expose:
       - "50056"  # gRPC service
     environment:
-      - MOCK_MODE=${AUDIO_MOCK_MODE:-false}
       - OTEL_SERVICE_NAME=audio-service
       - OTEL_SERVICE_NAMESPACE=joustmania
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -319,7 +319,7 @@ Settings are configured via admin mode (hold all 4 face buttons):
 |----------|-------------|---------|
 | `CONTROLLER_BACKEND` | Controller backend type | `bluetooth` |
 | `MOCK_CONTROLLER_COUNT` | Simulated controllers | `4` |
-| `AUDIO_MOCK_MODE` | Silent audio mode | `false` |
+| `play_audio` (flagd) | Audio output toggle | `on` (enabled) |
 | `LOG_LEVEL` | Logging verbosity | `INFO` |
 
 ### Docker Compose Variants

--- a/docs/AUDIO.md
+++ b/docs/AUDIO.md
@@ -118,7 +118,7 @@ Example: Add custom Joust music to `services/audio/assets/Joust/music/`
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `AUDIO_ASSETS_DIR` | `services/audio/assets` | Path to audio files |
-| `MOCK_MODE` | `false` | Silent mode for testing |
+| `play_audio` (flagd) | `on` | Audio output toggle (user_preferences domain) |
 | `LOG_LEVEL` | `INFO` | Logging verbosity |
 
 ### Configuration (flagd)

--- a/services/audio/README.md
+++ b/services/audio/README.md
@@ -80,7 +80,7 @@ grpcurl -plaintext -d '{"volume": 0.8}' \
 |----------|---------|-------------|
 | `AUDIO_PORT` | 50056 | gRPC service port |
 | `AUDIO_ASSETS_DIR` | `/audio` | Path to audio files |
-| `MOCK_MODE` | `false` | Silent mode for testing |
+| `play_audio` (flagd) | `on` | Audio output toggle (user_preferences domain) |
 
 ## Development
 

--- a/services/audio/servicer.py
+++ b/services/audio/servicer.py
@@ -157,23 +157,28 @@ class AudioManager:
 
     MAX_CHANNELS = 8  # Maximum concurrent sound effects
 
-    def __init__(self):
-        """Initialize audio systems."""
-        self.mock_mode = os.getenv("MOCK_MODE", "false").lower() == "true"
+    def __init__(self, *, silent: bool = False):
+        """Initialize audio systems.
+
+        Args:
+            silent: If True, skip hardware initialization (no channels, dummy music player).
+                    Controlled by the play_audio flagd flag at the servicer level.
+        """
+        self.silent = silent
 
         # Assets directory - clients send relative paths, we resolve to full path
         self.assets_dir = os.getenv("AUDIO_ASSETS_DIR", "services/audio/assets")
 
         # Initialize sound channels for concurrent playback
         self.channels: list[SoundChannel] = []
-        if not self.mock_mode:
+        if not self.silent:
             self.channels = [SoundChannel(i) for i in range(self.MAX_CHANNELS)]
             logger.info(f"Miniaudio initialized with {self.MAX_CHANNELS} channels")
         else:
-            logger.info("AudioManager running in MOCK_MODE - no actual audio playback")
+            logger.info("AudioManager running in silent mode - no actual audio playback")
 
         # Initialize music player with tempo control
-        if self.mock_mode:
+        if self.silent:
             self.music_player = DummyMusicPlayer("background")
         else:
             self.music_player = MusicPlayer("background")
@@ -183,7 +188,7 @@ class AudioManager:
         self.music_lock = threading.Lock()
         self.event_loop: asyncio.AbstractEventLoop | None = None  # Set from async context
 
-        logger.info(f"AudioManager initialized (assets_dir={self.assets_dir})")
+        logger.info(f"AudioManager initialized (assets_dir={self.assets_dir}, silent={self.silent})")
 
         # Track currently playing sounds for status
         self.active_sounds: dict[str, dict] = {}
@@ -239,8 +244,8 @@ class AudioManager:
         # Resolve relative path to full path
         full_path = self._resolve_path(file_path)
 
-        if self.mock_mode:
-            logger.debug(f"MOCK: Would play sound: {file_path}")
+        if self.silent:
+            logger.debug(f"Silent mode: skipping sound: {file_path}")
             return True
 
         try:
@@ -406,13 +411,33 @@ class AudioServiceServicer(audio_pb2_grpc.AudioServiceServicer):
 
     def __init__(self):
         """Initialize audio servicer."""
-        self.audio_manager = AudioManager()
-        self.audio_enabled = True  # Controlled by play_audio setting (default: enabled)
+        # Load play_audio flag eagerly to decide whether to initialize audio hardware.
+        # If flagd is unavailable, default to audio enabled (hardware initialized).
+        self.audio_enabled = self._load_play_audio_flag()
+        self.audio_manager = AudioManager(silent=not self.audio_enabled)
         self.menu_voice = "ivy"  # Controlled by menu_voice setting
-        self._settings_loaded = False  # Lazy load settings on first audio request
+        self._settings_loaded = False  # Lazy load full settings on first audio request
         self.sound_registry: dict[str, tuple[str, str]] = {}  # sound_name -> (type, base_dir)
         self._build_sound_registry()
-        logger.info("AudioServiceServicer initialized")
+        logger.info("AudioServiceServicer initialized (audio_enabled=%s)", self.audio_enabled)
+
+    @staticmethod
+    def _load_play_audio_flag() -> bool:
+        """Load play_audio flag from flagd at startup.
+
+        Returns True (audio enabled) if flagd is unavailable or flag is not set.
+        """
+        try:
+            from lib.feature_flags import get_flag_client, init_flag_domain
+
+            init_flag_domain("user_preferences")
+            client = get_flag_client("user_preferences")
+            value = client.get_boolean_value("play_audio", True)
+            logger.info("play_audio flag loaded at startup: %s", value)
+            return value
+        except Exception as e:
+            logger.debug("Could not load play_audio flag from flagd: %s, defaulting to enabled", e)
+            return True
 
     def _build_sound_registry(self):
         """

--- a/services/audio/tests/conftest.py
+++ b/services/audio/tests/conftest.py
@@ -11,7 +11,6 @@ disable_telemetry_for_tests()
 disable_metrics_for_tests()
 disable_profiling_for_tests()
 
-import os
 from unittest.mock import patch
 
 import pytest
@@ -37,19 +36,26 @@ def mock_grpc_context():
 
 @pytest.fixture
 def mock_audio_servicer():
-    """Create AudioServiceServicer in mock mode."""
-    with patch.dict(os.environ, {"MOCK_MODE": "true"}):
-        from services.audio.servicer import AudioServiceServicer
+    """Create AudioServiceServicer with silent AudioManager (no hardware).
 
+    The AudioManager is initialized in silent mode to avoid needing audio hardware,
+    but audio_enabled is set to True so RPC methods execute their full logic.
+    Tests that need audio_enabled=False set it explicitly.
+    """
+    from services.audio.servicer import AudioServiceServicer
+
+    # Bypass flagd lookup at init: return False so AudioManager uses silent=True (no hardware).
+    with patch.object(AudioServiceServicer, "_load_play_audio_flag", return_value=False):
         servicer = AudioServiceServicer()
-        servicer._settings_loaded = True
-        return servicer
+    # Enable audio at the servicer level so RPCs execute their full logic.
+    servicer.audio_enabled = True
+    servicer._settings_loaded = True
+    return servicer
 
 
 @pytest.fixture
 def mock_audio_manager():
-    """Create AudioManager in mock mode."""
-    with patch.dict(os.environ, {"MOCK_MODE": "true"}):
-        from services.audio.servicer import AudioManager
+    """Create AudioManager in silent mode (no hardware)."""
+    from services.audio.servicer import AudioManager
 
-        return AudioManager()
+    return AudioManager(silent=True)

--- a/services/audio/tests/test_audio_manager.py
+++ b/services/audio/tests/test_audio_manager.py
@@ -11,10 +11,10 @@ from services.audio.music_player import DummyMusicPlayer
 class TestAudioManagerInit:
     """Tests for AudioManager initialization."""
 
-    def test_mock_mode_no_channels(self, mock_audio_manager):
+    def test_silent_mode_no_channels(self, mock_audio_manager):
         assert len(mock_audio_manager.channels) == 0
 
-    def test_mock_mode_dummy_player(self, mock_audio_manager):
+    def test_silent_mode_dummy_player(self, mock_audio_manager):
         assert isinstance(mock_audio_manager.music_player, DummyMusicPlayer)
 
     def test_default_volume(self, mock_audio_manager):
@@ -24,46 +24,44 @@ class TestAudioManagerInit:
         assert mock_audio_manager.assets_dir == "services/audio/assets"
 
     def test_assets_dir_from_env(self):
-        with patch.dict(os.environ, {"MOCK_MODE": "true", "AUDIO_ASSETS_DIR": "/custom/path"}):
+        with patch.dict(os.environ, {"AUDIO_ASSETS_DIR": "/custom/path"}):
             from services.audio.servicer import AudioManager
 
-            manager = AudioManager()
+            manager = AudioManager(silent=True)
             assert manager.assets_dir == "/custom/path"
 
 
 class TestAudioManagerPlaySound:
     """Tests for AudioManager.play_sound."""
 
-    def test_play_sound_mock_mode(self, mock_audio_manager):
+    def test_play_sound_silent_mode(self, mock_audio_manager):
         result = mock_audio_manager.play_sound("test/sound.ogg", volume=1.0, priority=2)
         assert result is True
 
     def test_play_sound_no_channels_available(self):
-        """Non-mock mode with all channels busy returns False."""
-        with patch.dict(os.environ, {"MOCK_MODE": "false"}):
-            from services.audio.servicer import AudioManager
+        """Non-silent mode with all channels busy returns False."""
+        from services.audio.servicer import AudioManager
 
-            manager = AudioManager()
-            # Make all channels busy
-            for channel in manager.channels:
-                channel._playing.set()
-                channel.priority = 3  # High priority so they can't be stolen
-            # Try to play a sound with a real file
-            result = manager.play_sound("nonexistent.ogg", volume=1.0, priority=2)
-            # File doesn't exist so it fails before channel check
-            assert result is False
+        manager = AudioManager(silent=False)
+        # Make all channels busy
+        for channel in manager.channels:
+            channel._playing.set()
+            channel.priority = 3  # High priority so they can't be stolen
+        # Try to play a sound with a real file
+        result = manager.play_sound("nonexistent.ogg", volume=1.0, priority=2)
+        # File doesn't exist so it fails before channel check
+        assert result is False
 
     def test_play_sound_missing_file(self):
-        """Non-mock mode with missing file returns False."""
-        with patch.dict(os.environ, {"MOCK_MODE": "false"}):
-            from services.audio.servicer import AudioManager
+        """Non-silent mode with missing file returns False."""
+        from services.audio.servicer import AudioManager
 
-            manager = AudioManager()
-            result = manager.play_sound("definitely_not_a_real_file.ogg", volume=1.0, priority=2)
-            assert result is False
+        manager = AudioManager(silent=False)
+        result = manager.play_sound("definitely_not_a_real_file.ogg", volume=1.0, priority=2)
+        assert result is False
 
     def test_play_sound_volume_scaling(self, mock_audio_manager):
-        """In mock mode, play_sound succeeds regardless of volume."""
+        """In silent mode, play_sound succeeds regardless of volume."""
         mock_audio_manager.master_volume = 0.5
         result = mock_audio_manager.play_sound("test.ogg", volume=0.8, priority=2)
         assert result is True
@@ -73,46 +71,42 @@ class TestAudioManagerFindChannel:
     """Tests for AudioManager._find_channel."""
 
     def test_find_free_channel(self):
-        with patch.dict(os.environ, {"MOCK_MODE": "false"}):
-            from services.audio.servicer import AudioManager
+        from services.audio.servicer import AudioManager
 
-            manager = AudioManager()
-            channel = manager._find_channel()
-            assert channel is not None
-            assert channel.is_playing is False
+        manager = AudioManager(silent=False)
+        channel = manager._find_channel()
+        assert channel is not None
+        assert channel.is_playing is False
 
     def test_find_channel_all_busy(self):
-        with patch.dict(os.environ, {"MOCK_MODE": "false"}):
-            from services.audio.servicer import AudioManager
+        from services.audio.servicer import AudioManager
 
-            manager = AudioManager()
-            for ch in manager.channels:
-                ch._playing.set()
-                ch.priority = 5
-            channel = manager._find_channel(force_priority=False)
-            assert channel is None
+        manager = AudioManager(silent=False)
+        for ch in manager.channels:
+            ch._playing.set()
+            ch.priority = 5
+        channel = manager._find_channel(force_priority=False)
+        assert channel is None
 
     def test_find_channel_force_priority_steal(self):
-        with patch.dict(os.environ, {"MOCK_MODE": "false"}):
-            from services.audio.servicer import AudioManager
+        from services.audio.servicer import AudioManager
 
-            manager = AudioManager()
-            for ch in manager.channels:
-                ch._playing.set()
-                ch.priority = 1  # Low priority
-            channel = manager._find_channel(force_priority=True, priority=3)
-            assert channel is not None
+        manager = AudioManager(silent=False)
+        for ch in manager.channels:
+            ch._playing.set()
+            ch.priority = 1  # Low priority
+        channel = manager._find_channel(force_priority=True, priority=3)
+        assert channel is not None
 
     def test_find_channel_force_priority_no_steal_same_priority(self):
-        with patch.dict(os.environ, {"MOCK_MODE": "false"}):
-            from services.audio.servicer import AudioManager
+        from services.audio.servicer import AudioManager
 
-            manager = AudioManager()
-            for ch in manager.channels:
-                ch._playing.set()
-                ch.priority = 3  # Same priority
-            channel = manager._find_channel(force_priority=True, priority=3)
-            assert channel is None
+        manager = AudioManager(silent=False)
+        for ch in manager.channels:
+            ch._playing.set()
+            ch.priority = 3  # Same priority
+        channel = manager._find_channel(force_priority=True, priority=3)
+        assert channel is None
 
 
 class TestAudioManagerMusic:

--- a/services/audio/tests/test_servicer.py
+++ b/services/audio/tests/test_servicer.py
@@ -2,7 +2,6 @@
 Unit tests for Audio gRPC Servicer.
 """
 
-import os
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -58,17 +57,17 @@ class TestPlaySound:
 
     @pytest.mark.asyncio
     async def test_play_sound_lazy_settings_load(self, mock_grpc_context):
-        with patch.dict(os.environ, {"MOCK_MODE": "true"}):
-            from services.audio.servicer import AudioServiceServicer
+        from services.audio.servicer import AudioServiceServicer
 
+        with patch.object(AudioServiceServicer, "_load_play_audio_flag", return_value=False):
             servicer = AudioServiceServicer()
-            servicer._settings_loaded = False
-            servicer.audio_manager.play_sound = MagicMock(return_value=True)
+        servicer._settings_loaded = False
+        servicer.audio_manager.play_sound = MagicMock(return_value=True)
 
-            with patch.object(servicer, "_load_audio_setting") as mock_load:
-                request = audio_pb2.PlaySoundRequest(file_path="beep_loud", volume=1.0, priority=2)
-                await servicer.PlaySound(request, mock_grpc_context)
-                mock_load.assert_called_once()
+        with patch.object(servicer, "_load_audio_setting") as mock_load:
+            request = audio_pb2.PlaySoundRequest(file_path="beep_loud", volume=1.0, priority=2)
+            await servicer.PlaySound(request, mock_grpc_context)
+            mock_load.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_play_sound_default_volume(self, servicer, mock_grpc_context):

--- a/services/controller_manager/MOCK_ENVIRONMENT.md
+++ b/services/controller_manager/MOCK_ENVIRONMENT.md
@@ -503,7 +503,7 @@ jobs:
 
 ### Mock Audio Service
 
-Currently, the audio service runs in mock mode (MOCK_MODE=true) but still requires the audio assets directory. Future enhancement: provide silent audio playback or optional audio synthesis.
+Audio playback is controlled by the `play_audio` flagd flag in the `user_preferences` domain. When set to `off`, the audio service runs in silent mode (no hardware initialization). The audio assets directory is still required for sound registry building.
 
 ## Related Documentation
 

--- a/services/flagd/user_preferences.ci.json
+++ b/services/flagd/user_preferences.ci.json
@@ -1,0 +1,47 @@
+{
+  "metadata": {
+    "flagSetId": "user_preferences"
+  },
+  "flags": {
+    "menu_voice": {
+      "state": "ENABLED",
+      "variants": {
+        "aaron": "aaron",
+        "ivy": "ivy"
+      },
+      "defaultVariant": "ivy"
+    },
+    "play_audio": {
+      "state": "ENABLED",
+      "variants": {
+        "on": true,
+        "off": false
+      },
+      "defaultVariant": "off"
+    },
+    "current_game": {
+      "state": "ENABLED",
+      "variants": {
+        "JoustFFA": "JoustFFA",
+        "JoustTeams": "JoustTeams",
+        "JoustRandomTeams": "JoustRandomTeams",
+        "Traitor": "Traitor",
+        "Werewolf": "Werewolf",
+        "Zombies": "Zombies",
+        "Tournament": "Tournament",
+        "FightClub": "FightClub",
+        "Swapper": "Swapper",
+        "NonStop": "NonStop"
+      },
+      "defaultVariant": "JoustFFA"
+    },
+    "game_instructions": {
+      "state": "ENABLED",
+      "variants": {
+        "on": true,
+        "off": false
+      },
+      "defaultVariant": "on"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Remove `MOCK_MODE` env var from `AudioManager` and `AUDIO_MOCK_MODE` from all docker-compose files, Makefile, and `.env.mock`
- `AudioManager` now accepts a `silent` keyword argument (replaces env var check); `AudioServiceServicer` loads the `play_audio` flagd flag eagerly at startup to decide hardware initialization
- CI uses a new `services/flagd/user_preferences.ci.json` override with `play_audio` defaultVariant set to `off`, mounted into flagd via `docker-compose.ci.yml`

Fixes #465

## Test plan

- [x] All 67 audio unit tests pass (`cd services/audio && uv run pytest -x -v`)
- [x] `make lint` passes (ruff check + ruff format)
- [ ] Integration tests pass in CI (docker compose with ci.yml overlay)
- [ ] Manual verification: `make up-mock` starts without errors, audio service logs show `audio_enabled=True`

🤖 Generated with [Claude Code](https://claude.com/claude-code)