### PR TITLE
refactor: replace CONTROLLER_BACKEND env var with OpenFeature flag

### DIFF
--- a/.claude/rules/debugging.md
+++ b/.claude/rules/debugging.md
@@ -64,7 +64,7 @@ make protos
 
 ### Controller Not Detected
 
-1. Check backend: `CONTROLLER_BACKEND=mock` for testing
+1. Check backend: set `controller_backend=mock` in flagd performance.json for testing
 2. Check Bluetooth: `bluetoothctl devices`
 3. Check permissions: user must be in `bluetooth` group
 
@@ -82,7 +82,8 @@ uv run python
 ### Mock Controller Testing
 
 ```bash
-CONTROLLER_BACKEND=mock docker compose up controller-manager
+make up-mock
+# Or set controller_backend=mock in services/flagd/performance.json
 # Use MockControllerService on port 50062 to simulate controllers
 ```
 

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -59,7 +59,7 @@ make test      # Run full integration tests
 ## Mocking
 
 - Use `unittest.mock` for service dependencies
-- Controller Manager has a mock backend (`CONTROLLER_BACKEND=mock`)
+- Controller Manager has a mock backend (`controller_backend=mock` flag in flagd)
 - Tests use `MockControllerManagerService`, etc.
 
 ## Disabling OTEL in Tests

--- a/.env.mock
+++ b/.env.mock
@@ -1,17 +1,11 @@
 # Mock Mode Environment Variables
 #
-# Copy this file to .env to enable mock mode persistently:
-#   cp .env.mock .env
+# NOTE: Controller backend is now configured via flagd, not environment variables.
+# To use mock mode, use the CI flagd config which defaults controller_backend to "mock":
+#   docker compose -f docker-compose.yml -f docker-compose.ci.yml up
+#   # Or: make up-mock
 #
-# Or use directly:
-#   docker-compose --env-file .env.mock up
-
-# Controller backend: bluetooth (default), mock, or windows
-CONTROLLER_BACKEND=mock
-
-# mock_controller_count is now a flagd flag in the performance domain
-# (default: 4, see services/flagd/performance.json)
-
-# Audio output is controlled by the play_audio flagd flag (user_preferences domain).
-# To disable audio, set play_audio defaultVariant to "off" in
-# services/flagd/user_preferences.json.
+# This file is kept for reference. Most configuration is now in flagd:
+# - controller_backend: services/flagd/performance.json (or performance.ci.json for mock)
+# - mock_controller_count: services/flagd/performance.json
+# - play_audio: services/flagd/user_preferences.json

--- a/Makefile
+++ b/Makefile
@@ -66,14 +66,15 @@ dev:
 	@echo "  Jaeger:     http://localhost/jaeger/"
 	@echo "  Grafana:    http://localhost/grafana/"
 
-# Mock mode sets environment variables - this is the main value-add over raw docker compose
+# Mock mode uses CI flagd config (controller_backend=mock)
 .PHONY: up-mock
 up-mock:
-	CONTROLLER_BACKEND=mock docker compose up -d $(if $(BUILD),--build)
+	docker compose -f docker-compose.yml -f docker-compose.ci.yml up -d $(if $(BUILD),--build)
 	@echo ""
 	@echo "=========================================="
 	@echo "JoustMania is running (MOCK MODE)"
 	@echo "=========================================="
+	@echo "  Using flagd performance.ci.json (controller_backend=mock)"
 	@echo "  Dashboard:  http://localhost/"
 	@echo "  Jaeger:     http://localhost/jaeger/"
 	@echo "  Prometheus: http://localhost/prometheus/"

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The setup script will guide you through installation and optionally enable autos
 ```bash
 git clone https://github.com/WatchMeJoustMyFlags/JoustMania.git
 cd JoustMania
-CONTROLLER_BACKEND=mock docker compose up -d
+make up-mock
 ```
 
 **Open the dashboard:** http://localhost:8080

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -24,22 +24,20 @@ services:
       FLAGD_HOST: flagd
       FLAGD_PORT: "8015"
 
-  # flagd - Use CI user_preferences override (play_audio=off)
+  # flagd - Use CI overrides (play_audio=off, controller_backend=mock)
   flagd:
     volumes:
-      - ./services/flagd/performance.json:/etc/flagd/performance.json
+      - ./services/flagd/performance.ci.json:/etc/flagd/performance.json
       - ./services/flagd/game_settings.json:/etc/flagd/game_settings.json
       - ./services/flagd/user_preferences.ci.json:/etc/flagd/user_preferences.json
 
-  # Controller Manager - Mock mode, no Bluetooth required
+  # Controller Manager - Mock mode via flagd (controller_backend=mock in performance.ci.json)
   controller-manager:
     # Clear devices and volumes from base compose (requires docker compose v2.24.0+)
     devices: !reset []
     volumes: !reset []
     privileged: false
     environment: !override
-      CONTROLLER_BACKEND: mock
-      # Winner rainbow and countdown timing now controlled via flagd game_settings (Issue #464)
       OTEL_SERVICE_NAME: controller-manager-service
       OTEL_SERVICE_NAMESPACE: infrastructure
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317

--- a/docker-compose.lite.yml
+++ b/docker-compose.lite.yml
@@ -68,7 +68,6 @@ services:
       - "50052"
     environment:
       - CONTROLLER_NAMES_FILE=/app/data/controller_names.txt
-      - CONTROLLER_BACKEND=${CONTROLLER_BACKEND:-bluetooth}
       - DBUS_SYSTEM_BUS_ADDRESS=unix:path=/var/run/dbus/system_bus_socket
       - OTEL_SDK_DISABLED=true
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,12 +10,13 @@
 #   make up              # Build and start all services
 #
 # Base config defaults to bluetooth mode (real hardware).
-# For mock mode (testing): CONTROLLER_BACKEND=mock make up
+# For mock mode (testing): make up-mock
 #
 # Environment Variables (can be set in shell or .env file):
 # - IMAGE_TAG: Image tag to use [default: latest]
-# - CONTROLLER_BACKEND: Controller backend type (bluetooth, mock, windows) [default: bluetooth]
 # - LOG_LEVEL: Logging level for all services (DEBUG, INFO, WARNING, ERROR) [default: INFO]
+#
+# Controller backend is configured via the "controller_backend" flag in flagd (performance domain).
 #
 # Notes:
 # - All images default to ghcr.io/watchmejoustmyflags/joustmania registry
@@ -207,7 +208,6 @@ services:
       - "8000"   # Prometheus metrics
     environment:
       - CONTROLLER_NAMES_FILE=/app/data/controller_names.txt
-      - CONTROLLER_BACKEND=${CONTROLLER_BACKEND:-bluetooth}
       - DBUS_SYSTEM_BUS_ADDRESS=unix:path=/var/run/dbus/system_bus_socket
       - OTEL_SERVICE_NAME=controller-manager-service
       - OTEL_SERVICE_NAMESPACE=infrastructure

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -313,14 +313,14 @@ Settings are configured via admin mode (hold all 4 face buttons):
 
 ## Configuration
 
-### Environment Variables
+### Configuration
 
-| Variable | Description | Default |
-|----------|-------------|---------|
-| `CONTROLLER_BACKEND` | Controller backend type | `bluetooth` |
-| `MOCK_CONTROLLER_COUNT` | Simulated controllers | `4` |
-| `play_audio` (flagd) | Audio output toggle | `on` (enabled) |
-| `LOG_LEVEL` | Logging verbosity | `INFO` |
+| Setting | Source | Default |
+|---------|--------|---------|
+| `controller_backend` | flagd (performance) | `bluetooth` |
+| `mock_controller_count` | flagd (performance) | `4` |
+| `play_audio` | flagd (user_preferences) | `on` |
+| `LOG_LEVEL` | env var | `INFO` |
 
 ### Docker Compose Variants
 

--- a/docs/architecture/controller-backends.md
+++ b/docs/architecture/controller-backends.md
@@ -1,18 +1,11 @@
-# Controller Backend Architecture (Phase 57)
+# Controller Backend Architecture
 
 ## Overview
 
-The controller manager now uses a unified backend system that supports multiple platforms and testing modes through a single interface.
+The controller manager uses a unified backend system that supports multiple platforms and testing modes through a single interface.
 
-**Before Phase 57:**
-- Separate `Dockerfile.mock` for testing
-- `MOCK_MODE=true` flag
-- Tightly coupled to psmove + dbus-python
-- Difficult to develop on Windows
-
-**After Phase 57:**
 - Single `Dockerfile` for all modes
-- `CONTROLLER_BACKEND` environment variable selects implementation
+- `controller_backend` flagd flag selects implementation at runtime
 - Clean abstraction via `ControllerBackend` interface
 - Easy development on Windows/Linux/Mock
 
@@ -65,11 +58,11 @@ The controller manager now uses a unified backend system that supports multiple 
 - `pair` - Controller pairing
 
 **Usage**:
-```yaml
-# docker-compose.yml (production)
-controller-manager:
-  environment:
-    - CONTROLLER_BACKEND=bluetooth  # Auto-detected on Linux
+```json
+// services/flagd/performance.json (default)
+"controller_backend": {
+  "defaultVariant": "bluetooth"
+}
 ```
 
 **Features**:
@@ -78,9 +71,9 @@ controller-manager:
 - Battery level tracking
 - Motion sensors (accel/gyro)
 - LED + rumble control
-- Controller hot-plug (Phase 73)
+- Controller hot-plug
 
-**Hot-Plug Support** (Phase 73):
+**Hot-Plug Support**:
 
 Controllers can connect/disconnect dynamically after container startup. The backend polls `psmove.count_connected()` and rescans when count changes:
 
@@ -111,17 +104,11 @@ controller-manager:
 - `psmoveapi` only (no dbus required)
 
 **Usage**:
-```powershell
-# Windows - Run natively (not in Docker)
-$env:CONTROLLER_BACKEND = "windows"
-python -m services.controller_manager.server --host 0.0.0.0 --port 50051
-```
-
-```yaml
-# docker-compose.override.yml (WSL services)
-game-coordinator:
-  environment:
-    - CONTROLLER_MANAGER_HOST=host.docker.internal:50051
+```json
+// services/flagd/performance.json
+"controller_backend": {
+  "defaultVariant": "windows"
+}
 ```
 
 **Features**:
@@ -142,13 +129,14 @@ game-coordinator:
 **Dependencies**: None
 
 **Usage**:
-```yaml
-# docker-compose.mock.yml
-controller-manager:
-  environment:
-    - CONTROLLER_BACKEND=mock
-    - MOCK_CONTROLLER_COUNT=4
+```json
+// services/flagd/performance.ci.json (CI default)
+"controller_backend": {
+  "defaultVariant": "mock"
+}
 ```
+
+Or use `make up-mock` which applies the CI flagd config.
 
 **Features**:
 - Simulates 1-N controllers
@@ -166,9 +154,14 @@ controller-manager:
 
 ## Backend Selection
 
+### Priority
+
+1. **OpenFeature flag** (`controller_backend` in performance domain) - runtime-switchable via flagd
+2. **Platform auto-detection** - Linux -> bluetooth, Windows -> windows
+
 ### Auto-Detection
 
-The system auto-detects platform if `CONTROLLER_BACKEND` not set:
+If the flagd flag is empty or flagd is unavailable, the system auto-detects:
 
 ```python
 # services/controller_manager/backend_factory.py
@@ -185,12 +178,12 @@ def create_backend():
 
 ### Manual Override
 
-Force a specific backend with `CONTROLLER_BACKEND`:
+Set the backend via flagd flag in `services/flagd/performance.json`:
 
-```bash
-export CONTROLLER_BACKEND=mock      # Use mock (any platform)
-export CONTROLLER_BACKEND=bluetooth  # Force BlueZ (Linux only)
-export CONTROLLER_BACKEND=windows    # Force Windows (Windows only)
+```json
+"controller_backend": {
+  "defaultVariant": "mock"
+}
 ```
 
 ## Docker Compose Integration
@@ -203,83 +196,29 @@ controller-manager:
   privileged: true  # Bluetooth access
   devices:
     - /dev/bus/usb  # USB pairing
-  environment:
-    # CONTROLLER_BACKEND auto-detected (Linux → Bluetooth)
+  # controller_backend defaults to "bluetooth" in flagd performance.json
 ```
 
-### Testing (docker-compose.mock.yml)
+### Testing (docker-compose.ci.yml)
 
 ```yaml
-mock-controller-manager:
-  dockerfile: services/controller_manager/Dockerfile  # Same Dockerfile!
-  environment:
-    - CONTROLLER_BACKEND=mock  # No privileged mode, no devices needed
-    - MOCK_CONTROLLER_COUNT=4
-  # No 'privileged', no 'devices' - runs anywhere
+# Uses performance.ci.json with controller_backend=mock
+flagd:
+  volumes:
+    - ./services/flagd/performance.ci.json:/etc/flagd/performance.json
 ```
 
-### Development (docker-compose.override.yml)
+### Mock Mode
 
-```yaml
-# Run controller_manager on Windows (native)
-# WSL services connect via host.docker.internal
-
-game-coordinator:
-  environment:
-    - CONTROLLER_MANAGER_HOST=host.docker.internal:50051
-
-menu:
-  environment:
-    - CONTROLLER_MANAGER_HOST=host.docker.internal:50051
-```
-
-## Migration Guide
-
-### Before Phase 57 (Old Approach)
-
-```python
-# server.py - Tightly coupled to psmove
-import psmove
-move = psmove.PSMove(0)
-trigger = move.get_trigger()
-move.set_leds(255, 0, 0)
-```
-
-```yaml
-# Separate mock Dockerfile
-services:
-  mock-controller-manager:
-    dockerfile: Dockerfile.mock  # Special mock image
-    environment:
-      - MOCK_MODE=true
-```
-
-### After Phase 57 (New Approach)
-
-```python
-# server.py - Uses backend abstraction
-from backend_factory import create_backend
-
-backend = create_backend()  # Auto-detects platform
-await backend.initialize()
-state = await backend.get_controller_state(serial)
-await backend.set_led_color(serial, 255, 0, 0)
-```
-
-```yaml
-# Single Dockerfile, backend selected via env var
-services:
-  mock-controller-manager:
-    dockerfile: Dockerfile  # Same for all modes!
-    environment:
-      - CONTROLLER_BACKEND=mock
+```bash
+make up-mock  # Uses CI flagd config (controller_backend=mock)
 ```
 
 ## Benefits
 
 ### 1. **Single Dockerfile**
 - No more `Dockerfile.mock`
-- Backend selected at runtime via environment variable
+- Backend selected at runtime via flagd
 - Reduces maintenance burden
 
 ### 2. **Windows Development**
@@ -298,16 +237,16 @@ services:
 - Easy to add new backends (macOS, virtual controllers, etc.)
 
 ### 5. **No Code Changes for Mock**
-- Set `CONTROLLER_BACKEND=mock` → instant mock mode
+- Set `controller_backend=mock` in flagd -> instant mock mode
 - No conditional code in service logic
 - Clean separation of concerns
 
-## Environment Variables
+## Configuration (flagd)
 
-| Variable | Values | Default | Description |
-|----------|---------|---------|-------------|
-| `CONTROLLER_BACKEND` | `bluetooth`, `windows`, `mock` | Auto-detect | Force specific backend |
-| `MOCK_CONTROLLER_COUNT` | 1-10 | 4 | Number of mock controllers |
+| Flag | Domain | Values | Default | Description |
+|------|--------|--------|---------|-------------|
+| `controller_backend` | performance | `bluetooth`, `windows`, `mock`, `hidapi` | `bluetooth` | Select backend |
+| `mock_controller_count` | performance | 2, 4, 6, 8 | 4 | Mock controllers count |
 
 ## See Also
 

--- a/services/controller_manager/Dockerfile
+++ b/services/controller_manager/Dockerfile
@@ -62,7 +62,7 @@ RUN uv pip install --system -e proto/ -e lib/ -e services/controller_manager/
 FROM python:3.11-slim
 
 # Install runtime dependencies (bluetooth for PS Move controllers)
-# libhidapi-hidraw0: Required for CONTROLLER_BACKEND=hidapi (pure Python HID backend)
+# libhidapi-hidraw0: Required for controller_backend=hidapi flag (pure Python HID backend)
 RUN apt-get update && apt-get install -y --no-install-recommends \
     bluez \
     libbluetooth3 \

--- a/services/controller_manager/README.md
+++ b/services/controller_manager/README.md
@@ -38,25 +38,24 @@ The Controller Manager service is the central component for managing PS Move con
 
 ## Configuration
 
-### Environment Variables
+### Configuration
 
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `CONTROLLER_BACKEND` | auto | Force backend: `bluetooth`, `windows`, `mock` |
-| `MOCK_CONTROLLERS` | `false` | Enable mock backend for testing |
-| `MOCK_CONTROLLER_COUNT` | `4` | Number of mock controllers |
-| `GRPC_PORT` | `50052` | gRPC server port |
-| `PROMETHEUS_PORT` | `8001` | Prometheus metrics port |
-| `OTEL_EXPORTER_OTLP_ENDPOINT` | `http://localhost:4317` | OpenTelemetry endpoint |
+Backend selection uses the `controller_backend` OpenFeature flag (performance domain):
+
+| Setting | Source | Default | Description |
+|---------|--------|---------|-------------|
+| `controller_backend` | flagd (performance) | auto-detect | Backend: `bluetooth`, `windows`, `mock`, `hidapi` |
+| `mock_controller_count` | flagd (performance) | `4` | Number of mock controllers |
+| `GRPC_PORT` | env var | `50052` | gRPC server port |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | env var | `http://localhost:4317` | OpenTelemetry endpoint |
 
 ### Backend Selection
 
-The backend is selected automatically based on platform:
+The backend is selected via the `controller_backend` flag in flagd (`services/flagd/performance.json`).
+If the flag is not set or flagd is unavailable, platform auto-detection is used:
 - **Linux**: BluetoothBackend (BlueZ/psmove)
 - **Windows**: WindowsBackend (psmoveapi)
 - **Testing**: MockBackend (simulated controllers)
-
-Override with `CONTROLLER_BACKEND` environment variable or `MOCK_CONTROLLERS=true`.
 
 ## gRPC API
 

--- a/services/controller_manager/backend_factory.py
+++ b/services/controller_manager/backend_factory.py
@@ -4,16 +4,14 @@ Backend Factory for Controller Manager
 Detects platform and creates appropriate backend instance.
 
 Backend selection priority:
-  1. CONTROLLER_BACKEND env var (hard override, e.g. for testing)
-  2. OpenFeature "controller_backend" flag (runtime-switchable via flagd)
-  3. Platform auto-detection (Linux -> bluetooth, Windows -> windows)
+  1. OpenFeature "controller_backend" flag (runtime-switchable via flagd)
+  2. Platform auto-detection (Linux -> bluetooth, Windows -> windows)
 
-Flag value (mock_controller_count) is read once at startup.
-Runtime changes to this flag require a service restart to take effect.
+Flag values (controller_backend, mock_controller_count) are read once at startup.
+Runtime changes to these flags require a service restart to take effect.
 """
 
 import logging
-import os
 import platform
 
 from services.controller_manager.backend import ControllerBackend
@@ -22,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 
 def _get_mock_controller_count() -> int:
-    """Read mock_controller_count from flagd performance domain with env var fallback."""
+    """Read mock_controller_count from flagd performance domain."""
     try:
         from openfeature.evaluation_context import EvaluationContext
 
@@ -33,22 +31,15 @@ def _get_mock_controller_count() -> int:
         logger.info(f"mock_controller_count from flagd: {count}")
         return count
     except Exception as e:
-        logger.warning(f"Failed to read mock_controller_count from flagd, using env/default: {e}")
-        return int(os.getenv("MOCK_CONTROLLER_COUNT", "4"))
+        logger.warning(f"Failed to read mock_controller_count from flagd, using default: {e}")
+        return 4
 
 
 def _resolve_backend_name() -> str | None:
-    """Resolve backend name from env var or OpenFeature flag.
+    """Resolve backend name from OpenFeature flag.
 
     Returns the backend name string, or None to fall through to platform detection.
     """
-    # Priority 1: Env var hard override
-    forced = os.getenv("CONTROLLER_BACKEND", "").lower()
-    if forced:
-        logger.info(f"Using forced backend from CONTROLLER_BACKEND env: {forced}")
-        return forced
-
-    # Priority 2: OpenFeature flag
     try:
         from lib.feature_flags import get_flag_client
 
@@ -93,15 +84,14 @@ def _create_backend_by_name(name: str) -> ControllerBackend:
 
 def create_backend() -> ControllerBackend:
     """
-    Create appropriate backend based on environment, flags, or platform.
+    Create appropriate backend based on flags or platform.
 
     Selection priority:
-        1. CONTROLLER_BACKEND env var (hard override)
-        2. OpenFeature "controller_backend" flag from performance domain
-        3. Platform auto-detection (Linux -> bluetooth, Windows -> windows)
+        1. OpenFeature "controller_backend" flag from performance domain
+        2. Platform auto-detection (Linux -> bluetooth, Windows -> windows)
 
     Configuration:
-        mock_controller_count: flagd flag (performance domain), fallback to MOCK_CONTROLLER_COUNT env var
+        mock_controller_count: flagd flag (performance domain)
 
     Returns:
         ControllerBackend instance
@@ -127,7 +117,7 @@ def create_backend() -> ControllerBackend:
         except ImportError as e:
             logger.error(f"Windows backend not available: {e}")
             logger.info("Install psmoveapi: pip install psmoveapi")
-            logger.info("Or use mock mode: set CONTROLLER_BACKEND=mock")
+            logger.info("Or use mock mode: set controller_backend=mock in flagd performance.json")
             raise RuntimeError("Windows backend not available") from e
 
     elif system == "Linux":
@@ -140,8 +130,11 @@ def create_backend() -> ControllerBackend:
         except ImportError as e:
             logger.error(f"Bluetooth backend not available: {e}")
             logger.info("Install dependencies: apt-get install python3-dbus, pip install psmove")
-            logger.info("Or use mock mode: set CONTROLLER_BACKEND=mock")
+            logger.info("Or use mock mode: set controller_backend=mock in flagd performance.json")
             raise RuntimeError("Bluetooth backend not available") from e
 
     else:
-        raise RuntimeError(f"Unsupported platform: {system}. Set CONTROLLER_BACKEND=mock to use mock controllers.")
+        raise RuntimeError(
+            f"Unsupported platform: {system}. "
+            "Set controller_backend=mock in flagd performance.json to use mock controllers."
+        )

--- a/services/controller_manager/hidapi_backend.py
+++ b/services/controller_manager/hidapi_backend.py
@@ -9,7 +9,7 @@ Requires:
 - hidapi Python package (pip install hidapi)
 - libhidapi-hidraw0 system library (apt install libhidapi-hidraw0)
 
-Activated via CONTROLLER_BACKEND=hidapi environment variable.
+Activated via controller_backend=hidapi flag in flagd (performance domain).
 """
 
 import asyncio

--- a/services/controller_manager/pyproject.toml
+++ b/services/controller_manager/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "dbus-python>=1.2.0; sys_platform == 'linux'",
     # NOTE: psmove/psmoveapi must be built from source (not on PyPI)
     # See: https://github.com/thp/psmoveapi for build instructions
-    # hidapi: Pure Python HID backend (alternative to psmoveapi, CONTROLLER_BACKEND=hidapi)
+    # hidapi: Pure Python HID backend (alternative to psmoveapi, controller_backend=hidapi flag)
     "hidapi>=0.14.0",
 
     # gRPC

--- a/services/controller_manager/tests/test_backend_factory.py
+++ b/services/controller_manager/tests/test_backend_factory.py
@@ -1,12 +1,11 @@
 """
 Unit tests for backend_factory.py -- backend selection logic and flagd integration.
 
-Tests the three-level priority: env var > OpenFeature flag > platform detection.
+Tests the two-level priority: OpenFeature flag > platform detection.
 Tests that mock_controller_count is read from flagd
 with proper env var fallback when flagd is unavailable.
 """
 
-import os
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -30,33 +29,27 @@ from services.controller_manager.backend_factory import (
 class TestResolveBackendName:
     """Test _resolve_backend_name priority logic."""
 
-    def test_env_var_takes_priority(self):
-        """CONTROLLER_BACKEND env var should override everything."""
-        with patch.dict(os.environ, {"CONTROLLER_BACKEND": "mock"}):
-            assert _resolve_backend_name() == "mock"
-
-    def test_env_var_case_insensitive(self):
-        with patch.dict(os.environ, {"CONTROLLER_BACKEND": "HiDaPi"}):
-            assert _resolve_backend_name() == "hidapi"
-
-    def test_openfeature_flag_used_when_no_env(self):
-        """OpenFeature flag should be used when no env var set."""
+    def test_openfeature_flag_used(self):
+        """OpenFeature flag should be used as primary selection."""
         mock_client = MagicMock()
         mock_client.get_string_value.return_value = "hidapi"
 
-        with (
-            patch.dict(os.environ, {"CONTROLLER_BACKEND": ""}),
-            patch("lib.feature_flags.get_flag_client", return_value=mock_client),
-        ):
+        with patch("lib.feature_flags.get_flag_client", return_value=mock_client):
             result = _resolve_backend_name()
             assert result == "hidapi"
 
-    def test_returns_none_when_no_env_and_flag_fails(self):
-        """Should return None for platform detection when both sources fail."""
-        with (
-            patch.dict(os.environ, {"CONTROLLER_BACKEND": ""}),
-            patch("lib.feature_flags.get_flag_client", side_effect=Exception("flagd unavailable")),
-        ):
+    def test_openfeature_flag_case_insensitive(self):
+        """Flag value should be lowercased."""
+        mock_client = MagicMock()
+        mock_client.get_string_value.return_value = "Mock"
+
+        with patch("lib.feature_flags.get_flag_client", return_value=mock_client):
+            result = _resolve_backend_name()
+            assert result == "mock"
+
+    def test_returns_none_when_flag_fails(self):
+        """Should return None for platform detection when flag evaluation fails."""
+        with patch("lib.feature_flags.get_flag_client", side_effect=Exception("flagd unavailable")):
             result = _resolve_backend_name()
             assert result is None
 
@@ -65,10 +58,7 @@ class TestResolveBackendName:
         mock_client = MagicMock()
         mock_client.get_string_value.return_value = ""
 
-        with (
-            patch.dict(os.environ, {"CONTROLLER_BACKEND": ""}),
-            patch("lib.feature_flags.get_flag_client", return_value=mock_client),
-        ):
+        with patch("lib.feature_flags.get_flag_client", return_value=mock_client):
             result = _resolve_backend_name()
             assert result is None
 
@@ -97,25 +87,15 @@ class TestGetMockControllerCount:
 
         result = _get_mock_controller_count()
 
-        assert result == 4  # default from env fallback
-
-    @patch.dict("os.environ", {"MOCK_CONTROLLER_COUNT": "8"})
-    @patch("lib.feature_flags.get_flag_client")
-    def test_falls_back_to_env_var(self, mock_get_client):
-        mock_get_client.side_effect = RuntimeError("flagd unavailable")
-
-        result = _get_mock_controller_count()
-
-        assert result == 8
+        assert result == 4  # hardcoded default
 
 
 class TestCreateBackendByName:
     """Test _create_backend_by_name factory method."""
 
     def test_mock_backend(self):
-        with patch.dict(os.environ, {"MOCK_CONTROLLER_COUNT": "2"}):
-            backend = _create_backend_by_name("mock")
-            assert backend.__class__.__name__ == "MockBackend"
+        backend = _create_backend_by_name("mock")
+        assert backend.__class__.__name__ == "MockBackend"
 
     def test_unknown_backend_raises(self):
         with pytest.raises(RuntimeError, match="Unknown backend"):
@@ -125,34 +105,18 @@ class TestCreateBackendByName:
 class TestCreateBackendIntegration:
     """Test create_backend end-to-end."""
 
-    def test_env_var_mock(self):
-        """CONTROLLER_BACKEND=mock should create MockBackend."""
-        with patch.dict(os.environ, {"CONTROLLER_BACKEND": "mock", "MOCK_CONTROLLER_COUNT": "2"}):
-            backend = create_backend()
-            assert backend.__class__.__name__ == "MockBackend"
-
     def test_openfeature_selects_mock(self):
         """OpenFeature flag should create the correct backend."""
         mock_client = MagicMock()
         mock_client.get_string_value.return_value = "mock"
 
-        with (
-            patch.dict(os.environ, {"CONTROLLER_BACKEND": "", "MOCK_CONTROLLER_COUNT": "2"}),
-            patch("lib.feature_flags.get_flag_client", return_value=mock_client),
-        ):
+        with patch("lib.feature_flags.get_flag_client", return_value=mock_client):
             backend = create_backend()
             assert backend.__class__.__name__ == "MockBackend"
 
-    def test_env_var_overrides_flag(self):
-        """Env var should take priority over OpenFeature flag."""
-        mock_client = MagicMock()
-        mock_client.get_string_value.return_value = "hidapi"
-
-        with (
-            patch.dict(os.environ, {"CONTROLLER_BACKEND": "mock", "MOCK_CONTROLLER_COUNT": "2"}),
-            patch("lib.feature_flags.get_flag_client", return_value=mock_client),
-        ):
-            backend = create_backend()
-            assert backend.__class__.__name__ == "MockBackend"
-            # Flag should not have been consulted since env var was set
-            mock_client.get_string_value.assert_not_called()
+    def test_platform_fallback_when_flag_fails(self):
+        """Should fall through to platform detection when flag fails."""
+        with patch("lib.feature_flags.get_flag_client", side_effect=Exception("flagd unavailable")):
+            # Just verify _resolve_backend_name returns None (platform detection)
+            result = _resolve_backend_name()
+            assert result is None

--- a/services/flagd/performance.ci.json
+++ b/services/flagd/performance.ci.json
@@ -1,0 +1,125 @@
+{
+  "metadata": {
+    "flagSetId": "performance"
+  },
+  "flags": {
+    "update_frequency_hz": {
+      "state": "ENABLED",
+      "variants": {
+        "low": 15,
+        "medium": 30,
+        "high": 60
+      },
+      "defaultVariant": "high"
+    },
+    "sensitivity_mode": {
+      "state": "ENABLED",
+      "variants": {
+        "low": "low",
+        "medium": "medium",
+        "high": "high"
+      },
+      "defaultVariant": "medium"
+    },
+    "streaming_mode": {
+      "state": "ENABLED",
+      "variants": {
+        "standard": "standard",
+        "filtered": "filtered",
+        "aggressive": "aggressive"
+      },
+      "defaultVariant": "filtered"
+    },
+    "enable_adaptive_rewards": {
+      "state": "ENABLED",
+      "variants": {
+        "on": true,
+        "off": false
+      },
+      "defaultVariant": "off"
+    },
+    "idle_mode_enabled": {
+      "state": "ENABLED",
+      "variants": {
+        "on": true,
+        "off": false
+      },
+      "defaultVariant": "on"
+    },
+    "idle_timeout_minutes": {
+      "state": "ENABLED",
+      "variants": {
+        "5min": 5,
+        "10min": 10,
+        "15min": 15,
+        "30min": 30
+      },
+      "defaultVariant": "15min"
+    },
+    "sentinel_count": {
+      "state": "ENABLED",
+      "variants": {
+        "none": 0,
+        "one": 1,
+        "two": 2
+      },
+      "defaultVariant": "two"
+    },
+    "sentinel_rotation_minutes": {
+      "state": "ENABLED",
+      "variants": {
+        "off": 0,
+        "3min": 3,
+        "5min": 5,
+        "10min": 10
+      },
+      "defaultVariant": "5min"
+    },
+    "pairing_poll_interval": {
+      "state": "ENABLED",
+      "variants": {
+        "fast": 5,
+        "normal": 10,
+        "slow": 30
+      },
+      "defaultVariant": "normal"
+    },
+    "bt_monitor_interval": {
+      "state": "ENABLED",
+      "variants": {
+        "fast": 2,
+        "normal": 5,
+        "slow": 15
+      },
+      "defaultVariant": "normal"
+    },
+    "controller_backend": {
+      "state": "ENABLED",
+      "variants": {
+        "bluetooth": "bluetooth",
+        "hidapi": "hidapi",
+        "mock": "mock"
+      },
+      "defaultVariant": "mock"
+    },
+    "mock_controller_count": {
+      "state": "ENABLED",
+      "variants": {
+        "two": 2,
+        "four": 4,
+        "six": 6,
+        "eight": 8
+      },
+      "defaultVariant": "four"
+    },
+    "metrics_export_interval_ms": {
+      "state": "ENABLED",
+      "variants": {
+        "fast": 100,
+        "normal": 500,
+        "slow": 1000
+      },
+      "defaultVariant": "fast"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Remove `CONTROLLER_BACKEND` env var support from `backend_factory.py`, making the OpenFeature `controller_backend` flag the primary selection mechanism
- Remove `MOCK_CONTROLLER_COUNT` env var fallback (now fully a flagd flag since #470)
- Create `performance.ci.json` with `controller_backend` defaulting to `mock` for CI/testing
- Update all docker-compose files, Makefile, `.env.mock`, and documentation

## Changes

**Code:**
- `backend_factory.py`: Remove env var priority, remove `os` import, simplify to flagd-only selection
- `test_backend_factory.py`: Remove env var priority tests, update to two-level priority tests

**CI/Docker:**
- New `services/flagd/performance.ci.json` with `controller_backend=mock` default
- `docker-compose.ci.yml`: Use `performance.ci.json` instead of `CONTROLLER_BACKEND: mock` env var
- `docker-compose.yml`, `docker-compose.lite.yml`: Remove `CONTROLLER_BACKEND` passthrough
- `Makefile`: `make up-mock` now uses CI flagd config overlay
- `.env.mock`: Remove `CONTROLLER_BACKEND=mock`, add flagd instructions

**Docs (17 files total):**
- `docs/architecture/controller-backends.md`: Full rewrite for flagd-based selection
- `docs/ARCHITECTURE.md`, `README.md`, controller manager docs, `.claude/rules/*`

## Test plan
- [x] All 262 controller_manager unit tests pass
- [x] `make lint` passes
- [ ] Integration tests (`make test`) verify flagd-based backend selection end-to-end

Fixes #462

🤖 Generated with [Claude Code](https://claude.com/claude-code)