### PR TITLE
fix: use OTEL_SERVICE_NAME for OpenFeature API-level context

### DIFF
--- a/lib/feature_flags.py
+++ b/lib/feature_flags.py
@@ -53,7 +53,7 @@ def _init_global_context() -> None:
     logger.info("Registered ContextVarsTransactionContextPropagator")
 
     # Set API-level context with service identity (always available to all evaluations)
-    service_name = os.environ.get("SERVICE_NAME", "unknown")
+    service_name = os.environ.get("OTEL_SERVICE_NAME", "unknown")
     environment = os.environ.get("ENVIRONMENT", "production")
     hostname = platform.node()
 

--- a/lib/tests/test_feature_flags.py
+++ b/lib/tests/test_feature_flags.py
@@ -156,7 +156,7 @@ def test_api_level_context_uses_env_vars(mock_api, _mock_provider):
     with patch.dict(
         os.environ,
         {
-            "SERVICE_NAME": "test-service",
+            "OTEL_SERVICE_NAME": "test-service",
             "ENVIRONMENT": "staging",
         },
     ):


### PR DESCRIPTION
## Summary

- Fix `lib/feature_flags.py` to read `OTEL_SERVICE_NAME` instead of `SERVICE_NAME` for the API-level OpenFeature evaluation context
- No service sets `SERVICE_NAME` in docker-compose.yml — all use `OTEL_SERVICE_NAME` — so the `service_name` attribute was always `"unknown"`
- Update the corresponding test to use the corrected env var name

## Context

Found during the post-migration audit of environment variables vs flagd flags. This was the only actionable issue: all other env var reads are either already migrated, pending merge (#478, #480), or correctly kept as env vars (OTEL SDK vars, service discovery, file paths, etc.).

## Test plan

- [x] `lib/tests/test_feature_flags.py` — all 9 tests pass
- [x] `make lint` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)