### PR TITLE
refactor: reduce cognitive complexity in controller_manager servicer

### DIFF
--- a/services/controller_manager/feedback_manager.py
+++ b/services/controller_manager/feedback_manager.py
@@ -627,6 +627,27 @@ class FeedbackManager(ControllerEffectsBase):
             return True
         return False
 
+    async def apply_base_color(self, serial: str, color: tuple[int, int, int], label: str = "") -> None:
+        """Cancel cancellable effects and apply base color for a controller.
+
+        Combines cancel_if_cancellable + store-and-apply-under-lock into one call.
+        Used by both StreamButtonEvents and StreamGameplayData to handle base_color commands.
+
+        Args:
+            serial: Controller serial number
+            color: RGB tuple (r, g, b)
+            label: Stream label for log messages (e.g. "ButtonStream", "GameplayStream")
+        """
+        await self.cancel_if_cancellable(serial)
+        async with self.effect_lock:
+            self.base_colors[serial] = color
+            if serial not in self.active_effects:
+                await self.set_controller_color(serial, color)
+                logger.info(f"[{label}] Applied base color for {serial}: {color}")
+            else:
+                active = self.active_effects[serial]
+                logger.warning(f"[{label}] Base color for {serial} blocked by effect: {active.effect_type}")
+
     def clear_controller(self, serial: str) -> None:
         """Clear feedback state for a disconnected controller."""
         # Note: Keep base_colors[serial] so we can restore on reconnect

--- a/services/controller_manager/servicer.py
+++ b/services/controller_manager/servicer.py
@@ -157,6 +157,65 @@ class ControllerManagerServicer(controller_manager_pb2_grpc.ControllerManagerSer
         """
         await self.feedback_manager._set_led_color(serial, color)
 
+    async def _send_initial_connection_events(self, subscriber_id: str, event_queue: asyncio.Queue) -> None:
+        """Send initial connection events for all currently tracked controllers.
+
+        This allows new subscribers to immediately know about existing controllers.
+        """
+        # Snapshot to avoid RuntimeError if dict changes at await points
+        for serial, info in dict(self.tracked_controllers).items():
+            battery = info.get(ControllerInfoKey.BATTERY, 0)
+            name = info.get(ControllerInfoKey.NAME, "")
+            connect_event = controller_manager_pb2.ButtonEvent(
+                serial=serial,
+                timestamp=int(time.time() * 1000),
+                battery=battery,
+                event_type=controller_manager_pb2.EVENT_CONNECT,
+                name=name,
+            )
+            try:
+                event_queue.put_nowait(connect_event)
+                logger.debug(f"[{subscriber_id}] Sent initial connection event for {serial} ({name})")
+            except asyncio.QueueFull:
+                logger.warning(f"[{subscriber_id}] Queue full, skipping initial event for {serial}")
+
+        logger.info(f"[{subscriber_id}] Sent initial connection events for {len(self.tracked_controllers)} controllers")
+
+    async def _process_base_color_command(self, cmd, subscriber_id: str, stream_label: str) -> None:
+        """Process a base_color command from either stream type.
+
+        Delegates to feedback_manager.apply_base_color() for the cancel+apply logic.
+        """
+        serial = cmd.serial
+        color = (cmd.color.r, cmd.color.g, cmd.color.b)
+
+        if serial and serial in self.tracked_controllers:
+            await self.feedback_manager.apply_base_color(serial, color, label=stream_label)
+            logger.debug(f"[{subscriber_id}] Base color set: serial={serial}, rgb={color}")
+
+        metrics.stream_commands_total.labels(command_type="base_color").inc()
+
+    async def _process_game_effect_command(self, cmd, subscriber_id: str) -> None:
+        """Process a game_effect command from either stream type."""
+        effect_color = None
+        if cmd.HasField("color"):
+            effect_color = (cmd.color.r, cmd.color.g, cmd.color.b)
+        await self.feedback_manager.handle_game_effect(
+            cmd.serial,
+            cmd.effect,
+            subscriber_id,
+            color=effect_color,
+            duration_ms=cmd.duration_ms,
+            speed=cmd.speed,
+            trace_parent=cmd.trace_parent,
+            trace_state=cmd.trace_state,
+        )
+
+        effect_name = controller_manager_pb2.GameEffect.Name(cmd.effect)
+        logger.debug(f"[{subscriber_id}] Game effect: serial={cmd.serial or 'all'}, effect={effect_name}")
+
+        metrics.stream_commands_total.labels(command_type="game_effect").inc()
+
     async def StreamButtonEvents(self, request_iterator, context):
         """
         Stream button press/release events as they occur (Phase 41).
@@ -193,99 +252,18 @@ class ControllerManagerServicer(controller_manager_pb2_grpc.ControllerManagerSer
         # to restore to current base color. Menu will overwrite colors when it sends
         # new base_color commands for each controller.
 
-        # Send initial connection events for all currently tracked controllers
-        # This allows new subscribers to immediately know about existing controllers
-        # Snapshot to avoid RuntimeError if dict changes at await points
-        for serial, info in dict(self.tracked_controllers).items():
-            battery = info.get(ControllerInfoKey.BATTERY, 0)
-            name = info.get(ControllerInfoKey.NAME, "")
-            connect_event = controller_manager_pb2.ButtonEvent(
-                serial=serial,
-                timestamp=int(time.time() * 1000),
-                battery=battery,
-                event_type=controller_manager_pb2.EVENT_CONNECT,
-                name=name,
-            )
-            try:
-                event_queue.put_nowait(connect_event)
-                logger.debug(f"[{subscriber_id}] Sent initial connection event for {serial} ({name})")
-            except asyncio.QueueFull:
-                logger.warning(f"[{subscriber_id}] Queue full, skipping initial event for {serial}")
+        await self._send_initial_connection_events(subscriber_id, event_queue)
 
-        logger.info(f"[{subscriber_id}] Sent initial connection events for {len(self.tracked_controllers)} controllers")
-
-        # Phase XX: Background task to read client control messages
+        # Background task to read client control messages
         async def read_client_controls():
             try:
                 async for control_msg in request_iterator:
                     if control_msg.HasField("config"):
-                        # Initial configuration (currently empty, for future use)
                         logger.info(f"[{subscriber_id}] Button stream configured")
-
                     elif control_msg.HasField("base_color"):
-                        # Phase XX: Set base color for a controller
-                        cmd = control_msg.base_color
-                        serial = cmd.serial
-                        color = (cmd.color.r, cmd.color.g, cmd.color.b)
-
-                        if serial and serial in self.tracked_controllers:
-                            # Only cancel effect if it's marked as cancellable
-                            async with self.feedback_manager.effect_lock:
-                                if serial in self.feedback_manager.active_effects:
-                                    active = self.feedback_manager.active_effects[serial]
-                                    if active.effect_type in self.feedback_manager.cancellable_effects:
-                                        active.task.cancel()
-                                        with contextlib.suppress(asyncio.CancelledError):
-                                            await active.task
-                                        del self.feedback_manager.active_effects[serial]
-                                        # Clear effect active flag
-                                        self.backend.set_effect_active(serial, False)
-                                        logger.debug(f"Cancelled cancellable effect for {serial}")
-
-                            # Store base color and check/apply under lock to avoid TOCTOU
-                            async with self.feedback_manager.effect_lock:
-                                self.feedback_manager.base_colors[serial] = color
-
-                                # Only set LED immediately if no effect is running
-                                if serial not in self.feedback_manager.active_effects:
-                                    await self.feedback_manager.set_controller_color(serial, color)
-                                    logger.info(f"[ButtonStream] Applied base color for {serial}: {color}")
-                                else:
-                                    active = self.feedback_manager.active_effects[serial]
-                                    logger.warning(
-                                        f"[ButtonStream] Base color for {serial} blocked by effect: "
-                                        f"{active.effect_type}"
-                                    )
-
-                            logger.debug(f"[{subscriber_id}] Base color set: serial={serial}, rgb={color}")
-
-                        metrics.stream_commands_total.labels(command_type="base_color").inc()
-
+                        await self._process_base_color_command(control_msg.base_color, subscriber_id, "ButtonStream")
                     elif control_msg.HasField("game_effect"):
-                        # Phase XX: Trigger semantic game effect
-                        cmd = control_msg.game_effect
-                        # Extract optional color if provided
-                        effect_color = None
-                        if cmd.HasField("color"):
-                            effect_color = (cmd.color.r, cmd.color.g, cmd.color.b)
-                        await self.feedback_manager.handle_game_effect(
-                            cmd.serial,
-                            cmd.effect,
-                            subscriber_id,
-                            color=effect_color,
-                            duration_ms=cmd.duration_ms,
-                            speed=cmd.speed,
-                            trace_parent=cmd.trace_parent,
-                            trace_state=cmd.trace_state,
-                        )
-
-                        effect_name = controller_manager_pb2.GameEffect.Name(cmd.effect)
-                        logger.debug(
-                            f"[{subscriber_id}] Game effect: serial={cmd.serial or 'all'}, effect={effect_name}"
-                        )
-
-                        metrics.stream_commands_total.labels(command_type="game_effect").inc()
-
+                        await self._process_game_effect_command(control_msg.game_effect, subscriber_id)
             except Exception as e:
                 logger.error(f"[{subscriber_id}] Error reading client controls: {e}", exc_info=True)
 
@@ -331,6 +309,90 @@ class ControllerManagerServicer(controller_manager_pb2_grpc.ControllerManagerSer
 
             logger.info(f"Button event subscriber disconnected: {subscriber_id}")
 
+    async def _process_gameplay_config(self, config, subscriber_id: str, span) -> tuple[int, set | None]:
+        """Process initial gameplay stream configuration.
+
+        Returns:
+            Tuple of (update_frequency_hz, controller_filter).
+            Filter is None for all controllers, or a set of serials.
+        """
+        current_hz = config.update_frequency_hz or 30
+        current_filter = None
+
+        if config.colors:
+            current_filter = set()
+            for color_config in config.colors:
+                serial = color_config.serial
+                if serial:
+                    current_filter.add(serial)
+                    color = (color_config.color.r, color_config.color.g, color_config.color.b)
+                    self.feedback_manager.base_colors[serial] = color
+                    if serial in self.tracked_controllers:
+                        await self.feedback_manager.set_controller_color(serial, color)
+            logger.info(f"[{subscriber_id}] Set base colors for {len(current_filter)} controllers")
+
+        logger.info(
+            f"[{subscriber_id}] Stream configured: {current_hz}Hz, "
+            f"filter={len(current_filter) if current_filter else 'all'} controllers"
+        )
+        span.set_attribute("update_frequency_hz", current_hz)
+        span.set_attribute("initial_filter_count", len(current_filter) if current_filter else 0)
+
+        return current_hz, current_filter
+
+    def _process_filter_update(self, filter_update, subscriber_id: str, span, current_filter: set | None) -> set | None:
+        """Process a mid-stream filter update.
+
+        Returns:
+            The new filter (None for all controllers, or set of serials).
+        """
+        new_filter = set(filter_update.serials) if filter_update.serials else None
+
+        if new_filter != current_filter:
+            old_count = len(current_filter) if current_filter else 0
+            new_count = len(new_filter) if new_filter else 0
+
+            logger.info(f"[{subscriber_id}] Filter updated: {old_count} → {new_count} controllers")
+
+            span.add_event(
+                "filter_updated",
+                {"previous_count": old_count, "new_count": new_count},
+            )
+            return new_filter
+
+        return current_filter
+
+    def _build_gameplay_update(self, current_filter: set | None) -> controller_manager_pb2.GameplayDataUpdate:
+        """Build a GameplayDataUpdate message from current controller state.
+
+        Args:
+            current_filter: Set of serial numbers to include, or None for all.
+
+        Returns:
+            GameplayDataUpdate protobuf message.
+        """
+        gameplay_data = []
+        # Snapshot to avoid RuntimeError if dict changes at await points
+        for serial, info in dict(self.tracked_controllers).items():
+            if current_filter is not None and serial not in current_filter:
+                continue
+
+            full_state = self.state_cache_manager.build_or_get_cached_state(serial, info)
+            gd = controller_manager_pb2.GameplayData(
+                serial=full_state.serial,
+                move_num=full_state.move_num,
+                battery=full_state.battery,
+                team=full_state.team,
+                color=full_state.color,
+                accel=full_state.accel,
+                gyro=full_state.gyro,
+                rssi=full_state.rssi,
+                name=full_state.name,
+            )
+            gameplay_data.append(gd)
+
+        return controller_manager_pb2.GameplayDataUpdate(controllers=gameplay_data, timestamp=int(time.time() * 1000))
+
     async def StreamGameplayData(self, request_iterator, context):
         """
         Stream gameplay data with dynamic filtering via bidirectional communication (Phase 45).
@@ -370,120 +432,17 @@ class ControllerManagerServicer(controller_manager_pb2_grpc.ControllerManagerSer
             try:
                 async for control_msg in request_iterator:
                     if control_msg.HasField("config"):
-                        # Initial configuration
-                        current_hz = control_msg.config.update_frequency_hz or 30
-
-                        # Extract filter from colors if provided
-                        if control_msg.config.colors:
-                            # Use serials from colors as filter
-                            current_filter = set()
-                            for color_config in control_msg.config.colors:
-                                serial = color_config.serial
-                                if serial:
-                                    current_filter.add(serial)
-                                    # Store base color and set LED
-                                    color = (color_config.color.r, color_config.color.g, color_config.color.b)
-                                    self.feedback_manager.base_colors[serial] = color
-                                    if serial in self.tracked_controllers:
-                                        await self.feedback_manager.set_controller_color(serial, color)
-                            logger.info(f"[{subscriber_id}] Set base colors for {len(current_filter)} controllers")
-                        else:
-                            current_filter = None  # All controllers
-
-                        logger.info(
-                            f"[{subscriber_id}] Stream configured: {current_hz}Hz, "
-                            f"filter={len(current_filter) if current_filter else 'all'} controllers"
+                        current_hz, current_filter = await self._process_gameplay_config(
+                            control_msg.config, subscriber_id, span
                         )
-                        span.set_attribute("update_frequency_hz", current_hz)
-                        span.set_attribute("initial_filter_count", len(current_filter) if current_filter else 0)
-
                     elif control_msg.HasField("filter_update"):
-                        # Mid-stream filter update
-                        new_filter = (
-                            set(control_msg.filter_update.serials) if control_msg.filter_update.serials else None
+                        current_filter = self._process_filter_update(
+                            control_msg.filter_update, subscriber_id, span, current_filter
                         )
-
-                        if new_filter != current_filter:
-                            old_count = len(current_filter) if current_filter else 0
-                            new_count = len(new_filter) if new_filter else 0
-
-                            logger.info(f"[{subscriber_id}] Filter updated: {old_count} → {new_count} controllers")
-
-                            current_filter = new_filter
-
-                            # Add span event for filter update
-                            span.add_event(
-                                "filter_updated",
-                                {
-                                    "previous_count": old_count,
-                                    "new_count": new_count,
-                                },
-                            )
-
                     elif control_msg.HasField("base_color"):
-                        # Phase XX: Set base color for a controller (LED state ownership)
-                        cmd = control_msg.base_color
-                        serial = cmd.serial
-                        color = (cmd.color.r, cmd.color.g, cmd.color.b)
-
-                        if serial and serial in self.tracked_controllers:
-                            # Only cancel effect if it's marked as cancellable
-                            async with self.feedback_manager.effect_lock:
-                                if serial in self.feedback_manager.active_effects:
-                                    active = self.feedback_manager.active_effects[serial]
-                                    if active.effect_type in self.feedback_manager.cancellable_effects:
-                                        active.task.cancel()
-                                        with contextlib.suppress(asyncio.CancelledError):
-                                            await active.task
-                                        del self.feedback_manager.active_effects[serial]
-                                        # Clear effect active flag
-                                        self.backend.set_effect_active(serial, False)
-                                        logger.debug(f"Cancelled cancellable effect for {serial}")
-
-                            # Store base color and check/apply under lock to avoid TOCTOU
-                            async with self.feedback_manager.effect_lock:
-                                self.feedback_manager.base_colors[serial] = color
-
-                                # Only set LED immediately if no effect is running
-                                if serial not in self.feedback_manager.active_effects:
-                                    await self.feedback_manager.set_controller_color(serial, color)
-                                    logger.info(f"[GameplayStream] Applied base color for {serial}: {color}")
-                                else:
-                                    active = self.feedback_manager.active_effects[serial]
-                                    logger.warning(
-                                        f"[GameplayStream] Base color for {serial} blocked by effect: "
-                                        f"{active.effect_type}"
-                                    )
-
-                            logger.debug(f"[{subscriber_id}] Base color set: serial={serial}, rgb={color}")
-
-                        metrics.stream_commands_total.labels(command_type="base_color").inc()
-
+                        await self._process_base_color_command(control_msg.base_color, subscriber_id, "GameplayStream")
                     elif control_msg.HasField("game_effect"):
-                        # Phase XX: Trigger semantic game effect (LED state ownership)
-                        cmd = control_msg.game_effect
-                        # Extract optional color if provided
-                        effect_color = None
-                        if cmd.HasField("color"):
-                            effect_color = (cmd.color.r, cmd.color.g, cmd.color.b)
-                        await self.feedback_manager.handle_game_effect(
-                            cmd.serial,
-                            cmd.effect,
-                            subscriber_id,
-                            color=effect_color,
-                            duration_ms=cmd.duration_ms,
-                            speed=cmd.speed,
-                            trace_parent=cmd.trace_parent,
-                            trace_state=cmd.trace_state,
-                        )
-
-                        effect_name = controller_manager_pb2.GameEffect.Name(cmd.effect)
-                        logger.debug(
-                            f"[{subscriber_id}] Game effect: serial={cmd.serial or 'all'}, effect={effect_name}"
-                        )
-
-                        metrics.stream_commands_total.labels(command_type="game_effect").inc()
-
+                        await self._process_game_effect_command(control_msg.game_effect, subscriber_id)
             except Exception as e:
                 logger.error(f"[{subscriber_id}] Error reading client updates: {e}", exc_info=True)
 
@@ -507,42 +466,13 @@ class ControllerManagerServicer(controller_manager_pb2_grpc.ControllerManagerSer
                     # Calculate interval from current Hz
                     interval = 1.0 / current_hz
 
-                    # Build data for each controller (respecting filter)
-                    gameplay_data = []
-                    # Snapshot to avoid RuntimeError if dict changes at await points
-                    for serial, info in dict(self.tracked_controllers).items():
-                        # Apply filter if present
-                        if current_filter is not None and serial not in current_filter:
-                            continue  # Skip filtered controller
-
-                        # Get full controller state
-                        full_state = self.state_cache_manager.build_or_get_cached_state(serial, info)
-
-                        # Convert to GameplayData (no buttons)
-                        gd = controller_manager_pb2.GameplayData(
-                            serial=full_state.serial,
-                            move_num=full_state.move_num,
-                            battery=full_state.battery,
-                            team=full_state.team,
-                            color=full_state.color,
-                            accel=full_state.accel,
-                            gyro=full_state.gyro,
-                            rssi=full_state.rssi,  # Signal strength for gameplay adaptation
-                            name=full_state.name,  # Human-readable name (Issue #7)
-                        )
-                        gameplay_data.append(gd)
-
-                    # Send update
-                    update = controller_manager_pb2.GameplayDataUpdate(
-                        controllers=gameplay_data, timestamp=int(time.time() * 1000)
-                    )
+                    update = self._build_gameplay_update(current_filter)
                     yield update
 
                     # Track stream update
-                    if gameplay_data:
+                    if update.controllers:
                         metrics.stream_updates_total.labels(stream_type="gameplay_data").inc()
-                        # Track number of controllers streamed per frame (Phase 45)
-                        metrics.streamed_controllers.observe(len(gameplay_data))
+                        metrics.streamed_controllers.observe(len(update.controllers))
 
                     # Fixed frame timing: sleep until next scheduled frame time
                     # This accounts for processing time to maintain consistent frame rate

--- a/services/controller_manager/tests/test_feedback_manager.py
+++ b/services/controller_manager/tests/test_feedback_manager.py
@@ -1,0 +1,152 @@
+"""
+Unit tests for FeedbackManager.
+
+Tests the apply_base_color() method that consolidates the cancel-if-cancellable
++ store-and-apply logic used by both stream RPCs.
+"""
+
+import asyncio
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+# Setup paths for imports
+test_dir = Path(__file__).parent
+service_dir = test_dir.parent
+project_root = service_dir.parent.parent
+sys.path.insert(0, str(project_root))
+
+from proto import controller_manager_pb2
+from services.controller_manager.effects_base import ActiveEffect
+from services.controller_manager.feedback_manager import FeedbackManager
+
+
+class TestApplyBaseColor:
+    """Tests for FeedbackManager.apply_base_color()."""
+
+    @pytest.fixture
+    def feedback_manager(self):
+        """Create FeedbackManager with mock backend."""
+        backend = MagicMock()
+        backend.set_led_color = AsyncMock(return_value=True)
+        backend.set_effect_active = MagicMock()
+        tracked = {"AA:BB": {"battery": 80}}
+        return FeedbackManager(backend=backend, tracked_controllers=tracked)
+
+    @pytest.mark.asyncio
+    async def test_apply_base_color_no_active_effect(self, feedback_manager):
+        """apply_base_color should set color immediately when no effect is active."""
+        fm = feedback_manager
+        fm.set_controller_color = AsyncMock(return_value=True)
+
+        await fm.apply_base_color("AA:BB", (255, 0, 0), label="Test")
+
+        assert fm.base_colors["AA:BB"] == (255, 0, 0)
+        fm.set_controller_color.assert_called_once_with("AA:BB", (255, 0, 0))
+
+    @pytest.mark.asyncio
+    async def test_apply_base_color_blocked_by_non_cancellable_effect(self, feedback_manager):
+        """apply_base_color should store color but not set LED when effect is active."""
+        fm = feedback_manager
+        fm.set_controller_color = AsyncMock(return_value=True)
+
+        # Add a non-cancellable effect (PLAYER_DEATH is not in cancellable_effects)
+        done_future = asyncio.get_running_loop().create_future()
+        done_future.set_result(None)
+        fm.active_effects["AA:BB"] = ActiveEffect(
+            task=done_future,
+            effect_type=controller_manager_pb2.GAME_EFFECT_PLAYER_DEATH,
+        )
+
+        await fm.apply_base_color("AA:BB", (0, 255, 0), label="Test")
+
+        # Color should be stored but not applied
+        assert fm.base_colors["AA:BB"] == (0, 255, 0)
+        fm.set_controller_color.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_apply_base_color_cancels_cancellable_effect(self, feedback_manager):
+        """apply_base_color should cancel cancellable effects then apply color."""
+        fm = feedback_manager
+        fm.set_controller_color = AsyncMock(return_value=True)
+
+        # Add a cancellable effect (FORCE_START_CHARGE)
+        task = asyncio.create_task(asyncio.sleep(100))
+        fm.active_effects["AA:BB"] = ActiveEffect(
+            task=task,
+            effect_type=controller_manager_pb2.GAME_EFFECT_FORCE_START_CHARGE,
+        )
+
+        await fm.apply_base_color("AA:BB", (0, 0, 255), label="Test")
+
+        # Cancellable effect should have been cancelled and removed
+        assert "AA:BB" not in fm.active_effects
+        assert fm.base_colors["AA:BB"] == (0, 0, 255)
+        fm.set_controller_color.assert_called_once_with("AA:BB", (0, 0, 255))
+
+    @pytest.mark.asyncio
+    async def test_apply_base_color_overwrites_previous_base_color(self, feedback_manager):
+        """apply_base_color should overwrite previously stored base color."""
+        fm = feedback_manager
+        fm.set_controller_color = AsyncMock(return_value=True)
+
+        await fm.apply_base_color("AA:BB", (255, 0, 0), label="Test")
+        await fm.apply_base_color("AA:BB", (0, 255, 0), label="Test")
+
+        assert fm.base_colors["AA:BB"] == (0, 255, 0)
+        assert fm.set_controller_color.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_apply_base_color_stores_even_when_blocked(self, feedback_manager):
+        """apply_base_color should always store the color, even if LED can't be set."""
+        fm = feedback_manager
+        fm.set_controller_color = AsyncMock(return_value=True)
+
+        # Add a non-cancellable effect
+        done_future = asyncio.get_running_loop().create_future()
+        done_future.set_result(None)
+        fm.active_effects["AA:BB"] = ActiveEffect(
+            task=done_future,
+            effect_type=controller_manager_pb2.GAME_EFFECT_WINNER_RAINBOW,
+        )
+
+        await fm.apply_base_color("AA:BB", (128, 128, 0), label="Test")
+
+        # Color stored for later restore, but LED not set now
+        assert fm.base_colors["AA:BB"] == (128, 128, 0)
+        fm.set_controller_color.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_apply_base_color_no_effect_on_other_controllers(self, feedback_manager):
+        """apply_base_color should not affect other controllers' effects."""
+        fm = feedback_manager
+        fm.tracked_controllers["CC:DD"] = {"battery": 90}
+        fm.set_controller_color = AsyncMock(return_value=True)
+
+        # Add effect on a different controller
+        done_future = asyncio.get_running_loop().create_future()
+        done_future.set_result(None)
+        fm.active_effects["CC:DD"] = ActiveEffect(
+            task=done_future,
+            effect_type=controller_manager_pb2.GAME_EFFECT_PLAYER_DEATH,
+        )
+
+        await fm.apply_base_color("AA:BB", (255, 0, 0), label="Test")
+
+        # AA:BB should get color, CC:DD effect should be untouched
+        assert fm.base_colors["AA:BB"] == (255, 0, 0)
+        fm.set_controller_color.assert_called_once_with("AA:BB", (255, 0, 0))
+        assert "CC:DD" in fm.active_effects
+
+    @pytest.mark.asyncio
+    async def test_apply_base_color_default_label(self, feedback_manager):
+        """apply_base_color should work with default empty label."""
+        fm = feedback_manager
+        fm.set_controller_color = AsyncMock(return_value=True)
+
+        # Should not raise with default label
+        await fm.apply_base_color("AA:BB", (100, 200, 50))
+
+        assert fm.base_colors["AA:BB"] == (100, 200, 50)

--- a/services/controller_manager/tests/test_servicer.py
+++ b/services/controller_manager/tests/test_servicer.py
@@ -354,3 +354,338 @@ class TestServicerShutdown:
         await servicer.shutdown()
 
         mock_proc.terminate.assert_not_called()
+
+
+class TestExtractedHelpers:
+    """Tests for extracted helper methods used by stream RPCs."""
+
+    @pytest.fixture
+    def servicer_components(self):
+        """Create servicer with mocked dependencies."""
+        with (
+            patch("services.controller_manager.servicer.create_backend") as mock_create_backend,
+            patch("services.controller_manager.servicer.DiscoveryLoop") as mock_discovery_loop,
+        ):
+            mock_backend = MockBackend()
+            mock_create_backend.return_value = mock_backend
+
+            mock_loop = MagicMock()
+            mock_loop.start = MagicMock()
+            mock_loop.stop = MagicMock()
+            mock_loop.wait_stopped = AsyncMock()
+            mock_discovery_loop.return_value = mock_loop
+
+            from services.controller_manager.servicer import ControllerManagerServicer
+
+            servicer = ControllerManagerServicer()
+            yield servicer, mock_backend
+
+    @pytest.mark.asyncio
+    async def test_send_initial_connection_events(self, servicer_components):
+        """_send_initial_connection_events should enqueue connect events for tracked controllers."""
+        from lib.controller_constants import ControllerInfoKey
+
+        servicer, _ = servicer_components
+        queue = asyncio.Queue(maxsize=100)
+
+        servicer.tracked_controllers["AA:BB"] = {
+            ControllerInfoKey.BATTERY: 80,
+            ControllerInfoKey.NAME: "P1",
+        }
+        servicer.tracked_controllers["CC:DD"] = {
+            ControllerInfoKey.BATTERY: 60,
+            ControllerInfoKey.NAME: "P2",
+        }
+
+        await servicer._send_initial_connection_events("sub_1", queue)
+
+        assert queue.qsize() == 2
+        event1 = queue.get_nowait()
+        assert event1.event_type == controller_manager_pb2.EVENT_CONNECT
+        assert event1.serial in ("AA:BB", "CC:DD")
+
+    @pytest.mark.asyncio
+    async def test_send_initial_connection_events_queue_full(self, servicer_components):
+        """_send_initial_connection_events should skip events when queue is full."""
+        servicer, _ = servicer_components
+        queue = asyncio.Queue(maxsize=1)
+
+        servicer.tracked_controllers["AA:BB"] = {}
+        servicer.tracked_controllers["CC:DD"] = {}
+
+        # Should not raise, just log warning and skip
+        await servicer._send_initial_connection_events("sub_1", queue)
+
+        assert queue.qsize() == 1
+
+    @pytest.mark.asyncio
+    async def test_process_base_color_command_tracked(self, servicer_components):
+        """_process_base_color_command should delegate to feedback_manager.apply_base_color."""
+        servicer, _ = servicer_components
+        servicer.tracked_controllers["AA:BB"] = {}
+        servicer.feedback_manager.apply_base_color = AsyncMock()
+
+        cmd = MagicMock()
+        cmd.serial = "AA:BB"
+        cmd.color.r = 255
+        cmd.color.g = 0
+        cmd.color.b = 0
+
+        await servicer._process_base_color_command(cmd, "sub_1", "TestStream")
+
+        servicer.feedback_manager.apply_base_color.assert_called_once_with("AA:BB", (255, 0, 0), label="TestStream")
+
+    @pytest.mark.asyncio
+    async def test_process_base_color_command_untracked(self, servicer_components):
+        """_process_base_color_command should skip untracked controllers."""
+        servicer, _ = servicer_components
+        servicer.feedback_manager.apply_base_color = AsyncMock()
+
+        cmd = MagicMock()
+        cmd.serial = "UNKNOWN"
+        cmd.color.r = 255
+        cmd.color.g = 0
+        cmd.color.b = 0
+
+        await servicer._process_base_color_command(cmd, "sub_1", "TestStream")
+
+        servicer.feedback_manager.apply_base_color.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_process_game_effect_command(self, servicer_components):
+        """_process_game_effect_command should delegate to feedback_manager.handle_game_effect."""
+        servicer, _ = servicer_components
+        servicer.feedback_manager.handle_game_effect = AsyncMock()
+
+        cmd = MagicMock()
+        cmd.serial = "AA:BB"
+        cmd.effect = controller_manager_pb2.GAME_EFFECT_PLAYER_DEATH
+        cmd.HasField.return_value = False  # no color
+        cmd.duration_ms = 0
+        cmd.speed = 0
+        cmd.trace_parent = ""
+        cmd.trace_state = ""
+
+        await servicer._process_game_effect_command(cmd, "sub_1")
+
+        servicer.feedback_manager.handle_game_effect.assert_called_once_with(
+            "AA:BB",
+            controller_manager_pb2.GAME_EFFECT_PLAYER_DEATH,
+            "sub_1",
+            color=None,
+            duration_ms=0,
+            speed=0,
+            trace_parent="",
+            trace_state="",
+        )
+
+    @pytest.mark.asyncio
+    async def test_process_game_effect_command_with_color(self, servicer_components):
+        """_process_game_effect_command should pass color when provided."""
+        servicer, _ = servicer_components
+        servicer.feedback_manager.handle_game_effect = AsyncMock()
+
+        cmd = MagicMock()
+        cmd.serial = "AA:BB"
+        cmd.effect = controller_manager_pb2.GAME_EFFECT_FLASH
+        cmd.HasField.side_effect = lambda field: field == "color"
+        cmd.color.r = 0
+        cmd.color.g = 255
+        cmd.color.b = 0
+        cmd.duration_ms = 500
+        cmd.speed = 3
+        cmd.trace_parent = ""
+        cmd.trace_state = ""
+
+        await servicer._process_game_effect_command(cmd, "sub_1")
+
+        servicer.feedback_manager.handle_game_effect.assert_called_once_with(
+            "AA:BB",
+            controller_manager_pb2.GAME_EFFECT_FLASH,
+            "sub_1",
+            color=(0, 255, 0),
+            duration_ms=500,
+            speed=3,
+            trace_parent="",
+            trace_state="",
+        )
+
+    def _make_mock_state(self, serial="AA:BB", name="P1"):
+        """Create a mock controller state with real protobuf sub-messages."""
+        mock_state = MagicMock()
+        mock_state.serial = serial
+        mock_state.move_num = 0
+        mock_state.battery = 80
+        mock_state.team = 0
+        mock_state.color = controller_manager_pb2.RGB(r=255, g=0, b=0)
+        mock_state.accel = controller_manager_pb2.Vector3(x=0.0, y=0.0, z=1.0)
+        mock_state.gyro = controller_manager_pb2.Vector3(x=0.0, y=0.0, z=0.0)
+        mock_state.rssi = 0
+        mock_state.name = name
+        return mock_state
+
+    def test_build_gameplay_update_no_filter(self, servicer_components):
+        """_build_gameplay_update should include all controllers when filter is None."""
+        servicer, _ = servicer_components
+
+        servicer.state_cache_manager.build_or_get_cached_state = MagicMock(return_value=self._make_mock_state())
+
+        servicer.tracked_controllers["AA:BB"] = {}
+        servicer.tracked_controllers["CC:DD"] = {}
+
+        update = servicer._build_gameplay_update(None)
+
+        assert len(update.controllers) == 2
+
+    def test_build_gameplay_update_with_filter(self, servicer_components):
+        """_build_gameplay_update should only include filtered controllers."""
+        servicer, _ = servicer_components
+
+        servicer.state_cache_manager.build_or_get_cached_state = MagicMock(return_value=self._make_mock_state())
+
+        servicer.tracked_controllers["AA:BB"] = {}
+        servicer.tracked_controllers["CC:DD"] = {}
+
+        update = servicer._build_gameplay_update({"AA:BB"})
+
+        assert len(update.controllers) == 1
+
+    def test_process_filter_update_changes_filter(self, servicer_components):
+        """_process_filter_update should return new filter when it changes."""
+        servicer, _ = servicer_components
+        span = MagicMock()
+
+        filter_update = MagicMock()
+        filter_update.serials = ["AA:BB", "CC:DD"]
+
+        result = servicer._process_filter_update(filter_update, "sub_1", span, None)
+
+        assert result == {"AA:BB", "CC:DD"}
+        span.add_event.assert_called_once()
+
+    def test_process_filter_update_no_change(self, servicer_components):
+        """_process_filter_update should return same filter when unchanged."""
+        servicer, _ = servicer_components
+        span = MagicMock()
+
+        existing = {"AA:BB"}
+        filter_update = MagicMock()
+        filter_update.serials = ["AA:BB"]
+
+        result = servicer._process_filter_update(filter_update, "sub_1", span, existing)
+
+        assert result == existing
+        span.add_event.assert_not_called()
+
+    def test_process_filter_update_empty_to_none(self, servicer_components):
+        """_process_filter_update with empty serials should return None (all controllers)."""
+        servicer, _ = servicer_components
+        span = MagicMock()
+
+        filter_update = MagicMock()
+        filter_update.serials = []
+
+        result = servicer._process_filter_update(filter_update, "sub_1", span, {"AA:BB"})
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_process_base_color_command_empty_serial(self, servicer_components):
+        """_process_base_color_command should skip when serial is empty string."""
+        servicer, _ = servicer_components
+        servicer.feedback_manager.apply_base_color = AsyncMock()
+
+        cmd = MagicMock()
+        cmd.serial = ""
+        cmd.color.r = 255
+        cmd.color.g = 0
+        cmd.color.b = 0
+
+        await servicer._process_base_color_command(cmd, "sub_1", "TestStream")
+
+        servicer.feedback_manager.apply_base_color.assert_not_called()
+
+    def test_build_gameplay_update_empty_controllers(self, servicer_components):
+        """_build_gameplay_update should return empty update when no controllers tracked."""
+        servicer, _ = servicer_components
+
+        update = servicer._build_gameplay_update(None)
+
+        assert len(update.controllers) == 0
+        assert update.timestamp > 0
+
+    def test_build_gameplay_update_filter_excludes_all(self, servicer_components):
+        """_build_gameplay_update should return empty when filter matches nothing."""
+        servicer, _ = servicer_components
+
+        servicer.state_cache_manager.build_or_get_cached_state = MagicMock(return_value=self._make_mock_state())
+        servicer.tracked_controllers["AA:BB"] = {}
+
+        update = servicer._build_gameplay_update({"XX:YY"})
+
+        assert len(update.controllers) == 0
+
+    @pytest.mark.asyncio
+    async def test_process_gameplay_config_with_colors(self, servicer_components):
+        """_process_gameplay_config should set base colors and build filter from color configs."""
+        servicer, _ = servicer_components
+        servicer.tracked_controllers["AA:BB"] = {}
+        servicer.feedback_manager.set_controller_color = AsyncMock(return_value=True)
+        span = MagicMock()
+
+        config = MagicMock()
+        config.update_frequency_hz = 60
+
+        # Create color config entries
+        color1 = MagicMock()
+        color1.serial = "AA:BB"
+        color1.color.r = 255
+        color1.color.g = 0
+        color1.color.b = 0
+        config.colors = [color1]
+
+        hz, filt = await servicer._process_gameplay_config(config, "sub_1", span)
+
+        assert hz == 60
+        assert filt == {"AA:BB"}
+        assert servicer.feedback_manager.base_colors["AA:BB"] == (255, 0, 0)
+        servicer.feedback_manager.set_controller_color.assert_called_once_with("AA:BB", (255, 0, 0))
+
+    @pytest.mark.asyncio
+    async def test_process_gameplay_config_without_colors(self, servicer_components):
+        """_process_gameplay_config without colors should return None filter (all controllers)."""
+        servicer, _ = servicer_components
+        span = MagicMock()
+
+        config = MagicMock()
+        config.update_frequency_hz = 30
+        config.colors = []
+
+        hz, filt = await servicer._process_gameplay_config(config, "sub_1", span)
+
+        assert hz == 30
+        assert filt is None
+
+    @pytest.mark.asyncio
+    async def test_process_gameplay_config_default_hz(self, servicer_components):
+        """_process_gameplay_config should default to 30Hz when frequency is 0."""
+        servicer, _ = servicer_components
+        span = MagicMock()
+
+        config = MagicMock()
+        config.update_frequency_hz = 0
+        config.colors = []
+
+        hz, filt = await servicer._process_gameplay_config(config, "sub_1", span)
+
+        assert hz == 30
+
+    @pytest.mark.asyncio
+    async def test_send_initial_connection_events_empty_controllers(self, servicer_components):
+        """_send_initial_connection_events should be safe with no controllers."""
+        servicer, _ = servicer_components
+        queue = asyncio.Queue(maxsize=100)
+
+        await servicer._send_initial_connection_events("sub_1", queue)
+
+        assert queue.qsize() == 0


### PR DESCRIPTION
## Summary

- Extract inline logic from `StreamButtonEvents` (complexity 46→~18) and `StreamGameplayData` (complexity 103→~28) into focused helper methods
- Add `FeedbackManager.apply_base_color()` to deduplicate the cancel-if-cancellable + store-and-apply pattern copied verbatim between both streams
- Extract 6 private servicer helpers: `_send_initial_connection_events()`, `_process_base_color_command()`, `_process_game_effect_command()`, `_process_gameplay_config()`, `_process_filter_update()`, `_build_gameplay_update()`
- Pure refactor — no behavioral changes, 24 new unit tests added (286 total pass)

## Test plan

- [x] `make lint` passes
- [x] `cd services/controller_manager && uv run pytest -v` — 286 passed
- [ ] Integration tests (`make test`) pass in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)