### PR TITLE
fix: use card_indexes() for actual ALSA card detection

### DIFF
--- a/services/audio/alsa_config.py
+++ b/services/audio/alsa_config.py
@@ -66,17 +66,22 @@ def _auto_detect_card() -> int:
     try:
         import alsaaudio
 
-        cards = alsaaudio.cards()
+        indexes = alsaaudio.card_indexes()
     except Exception:
         logger.warning("Failed to enumerate ALSA cards, falling back to card 0", exc_info=True)
         return 0
 
-    if not cards:
+    if not indexes:
         logger.warning("No ALSA cards found, falling back to card 0")
         return 0
 
-    logger.info("Detected ALSA cards: %s — using card 0 (%s)", cards, cards[0])
-    return 0
+    card_index = indexes[0]
+    try:
+        name = alsaaudio.card_name(card_index)[0]
+    except Exception:
+        name = "unknown"
+    logger.info("Detected ALSA card indexes: %s — using card %d (%s)", indexes, card_index, name)
+    return card_index
 
 
 def _write_asound_conf(card_number: int) -> None:

--- a/services/audio/tests/test_alsa_config.py
+++ b/services/audio/tests/test_alsa_config.py
@@ -30,16 +30,22 @@ class TestResolveCardNumber:
 
 
 class TestAutoDetectCard:
-    @patch("alsaaudio.cards", return_value=["Headphones", "USB"])
-    def test_returns_first_card_index(self, mock_cards):
+    @patch("alsaaudio.card_name", return_value=("Headphones", "Headphones Audio"))
+    @patch("alsaaudio.card_indexes", return_value=[0, 1])
+    def test_returns_first_card_index(self, mock_indexes, mock_name):
         assert _auto_detect_card() == 0
 
-    @patch("alsaaudio.cards", return_value=[])
-    def test_empty_cards_returns_zero(self, mock_cards):
+    @patch("alsaaudio.card_name", return_value=("USB Audio", "USB Audio Device"))
+    @patch("alsaaudio.card_indexes", return_value=[2, 5])
+    def test_returns_nonzero_first_index(self, mock_indexes, mock_name):
+        assert _auto_detect_card() == 2
+
+    @patch("alsaaudio.card_indexes", return_value=[])
+    def test_empty_cards_returns_zero(self, mock_indexes):
         assert _auto_detect_card() == 0
 
-    @patch("alsaaudio.cards", side_effect=Exception("no ALSA"))
-    def test_exception_returns_zero(self, mock_cards):
+    @patch("alsaaudio.card_indexes", side_effect=Exception("no ALSA"))
+    def test_exception_returns_zero(self, mock_indexes):
         assert _auto_detect_card() == 0
 
 


### PR DESCRIPTION
## Summary

- Fix `_auto_detect_card()` to use `alsaaudio.card_indexes()` instead of `alsaaudio.cards()`
- The previous implementation always returned `0` regardless of code path (SonarCloud blocker S3516)
- Now returns the actual first hardware card index, which may be non-zero

## Test plan

- [x] `make lint` passes
- [x] `cd services/audio && uv run pytest -v tests/test_alsa_config.py` — 12 passed
- [x] Added test for non-zero card index (`test_returns_nonzero_first_index`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)