### PR TITLE
refactor: reduce cognitive complexity in audio servicer

### DIFF
--- a/services/audio/servicer.py
+++ b/services/audio/servicer.py
@@ -71,64 +71,11 @@ class SoundChannel:
                 volume = max(0.0, min(1.0, volume))
 
                 def play_thread():
-                    import array
-                    import time
-
                     try:
                         if volume < 1.0:
-                            # Decode file to apply volume scaling
-                            decoded = miniaudio.decode_file(file_path)
-                            samples = array.array("h", decoded.samples)  # 16-bit signed
-
-                            # Apply volume scaling
-                            for i in range(len(samples)):
-                                samples[i] = int(samples[i] * volume)
-
-                            # Convert back to bytes for playback
-                            scaled_data = samples.tobytes()
-
-                            # Calculate bytes per frame for proper alignment
-                            # Frame = one sample per channel
-                            bytes_per_sample = decoded.sample_width
-                            bytes_per_frame = bytes_per_sample * decoded.nchannels
-
-                            # Create generator that responds to framecount requests
-                            # miniaudio calls send(framecount) to request specific frames
-                            def scaled_stream():
-                                idx = 0
-                                required_frames = yield b""  # Priming yield
-                                while idx < len(scaled_data) and self._playing.is_set():
-                                    # Calculate bytes needed for requested frames
-                                    bytes_needed = required_frames * bytes_per_frame
-                                    end = min(idx + bytes_needed, len(scaled_data))
-                                    required_frames = yield scaled_data[idx:end]
-                                    idx = end
-
-                            device = miniaudio.PlaybackDevice(
-                                output_format=decoded.sample_format,
-                                nchannels=decoded.nchannels,
-                                sample_rate=decoded.sample_rate,
-                            )
-                            stream = scaled_stream()
-                            next(stream)  # Prime the generator for send()
-                            with device:
-                                device.start(stream)
-                                duration = file_info.duration
-                                elapsed = 0.0
-                                while self._playing.is_set() and elapsed < duration + 0.5:
-                                    time.sleep(0.05)
-                                    elapsed += 0.05
+                            self._play_with_volume(file_path, volume, file_info.duration)
                         else:
-                            # Full volume - use streaming for efficiency
-                            stream = miniaudio.stream_file(file_path)
-                            device = miniaudio.PlaybackDevice()
-                            with device:
-                                device.start(stream)
-                                duration = file_info.duration
-                                elapsed = 0.0
-                                while self._playing.is_set() and elapsed < duration + 0.5:
-                                    time.sleep(0.05)
-                                    elapsed += 0.05
+                            self._play_full_volume(file_path, file_info.duration)
                     except Exception as e:
                         logger.warning(f"Playback error on channel {self.channel_id}: {e}")
                     finally:
@@ -141,6 +88,78 @@ class SoundChannel:
                 logger.error(f"Error playing sound on channel {self.channel_id}: {e}")
                 self._playing.clear()
                 return False
+
+    def _play_with_volume(self, file_path: str, volume: float, duration: float):
+        """Play a sound with volume scaling by decoding and resampling.
+
+        Args:
+            file_path: Path to the audio file
+            volume: Volume level (0.0 to 1.0, exclusive of 1.0)
+            duration: Duration in seconds from file info
+        """
+        import array
+
+        decoded = miniaudio.decode_file(file_path)
+        samples = array.array("h", decoded.samples)  # 16-bit signed
+
+        # Apply volume scaling
+        for i in range(len(samples)):
+            samples[i] = int(samples[i] * volume)
+
+        scaled_data = samples.tobytes()
+
+        # Calculate bytes per frame for proper alignment
+        # Frame = one sample per channel
+        bytes_per_sample = decoded.sample_width
+        bytes_per_frame = bytes_per_sample * decoded.nchannels
+
+        # Create generator that responds to framecount requests
+        # miniaudio calls send(framecount) to request specific frames
+        def scaled_stream():
+            idx = 0
+            required_frames = yield b""  # Priming yield
+            while idx < len(scaled_data) and self._playing.is_set():
+                bytes_needed = required_frames * bytes_per_frame
+                end = min(idx + bytes_needed, len(scaled_data))
+                required_frames = yield scaled_data[idx:end]
+                idx = end
+
+        device = miniaudio.PlaybackDevice(
+            output_format=decoded.sample_format,
+            nchannels=decoded.nchannels,
+            sample_rate=decoded.sample_rate,
+        )
+        stream = scaled_stream()
+        next(stream)  # Prime the generator for send()
+        with device:
+            device.start(stream)
+            self._wait_for_playback(duration)
+
+    def _play_full_volume(self, file_path: str, duration: float):
+        """Play a sound at full volume using streaming for efficiency.
+
+        Args:
+            file_path: Path to the audio file
+            duration: Duration in seconds from file info
+        """
+        stream = miniaudio.stream_file(file_path)
+        device = miniaudio.PlaybackDevice()
+        with device:
+            device.start(stream)
+            self._wait_for_playback(duration)
+
+    def _wait_for_playback(self, duration: float):
+        """Wait for playback to complete or be stopped.
+
+        Args:
+            duration: Expected duration in seconds
+        """
+        import time
+
+        elapsed = 0.0
+        while self._playing.is_set() and elapsed < duration + 0.5:
+            time.sleep(0.05)
+            elapsed += 0.05
 
     def stop(self):
         """Stop playback on this channel."""
@@ -450,33 +469,44 @@ class AudioServiceServicer(audio_pb2_grpc.AudioServiceServicer):
         """
         base_assets_dir = Path(__file__).parent / "assets"
 
-        # Scan all game asset directories
         for base_dir in ["Joust", "Menu", "Zombie", "Fight_Club", "Commander"]:
             assets_dir = base_assets_dir / base_dir
-
             # Scan vox directory (use aaron as reference - all voices should have same files)
-            vox_dir = assets_dir / "vox" / "aaron"
-            if vox_dir.exists():
-                for ogg_file in vox_dir.glob("*.ogg"):
-                    sound_name = ogg_file.stem  # filename without extension
-                    # Don't overwrite existing entries - first found wins
-                    if sound_name not in self.sound_registry:
-                        self.sound_registry[sound_name] = ("vox", base_dir)
-                    if sound_name.lower() not in self.sound_registry:
-                        self.sound_registry[sound_name.lower()] = ("vox", base_dir)
-
+            self._scan_directory_for_sounds(assets_dir / "vox" / "aaron", "vox", base_dir)
             # Scan sounds directory
-            sounds_dir = assets_dir / "sounds"
-            if sounds_dir.exists():
-                for ogg_file in sounds_dir.glob("*.ogg"):
-                    sound_name = ogg_file.stem
-                    # Don't overwrite existing entries
-                    if sound_name not in self.sound_registry:
-                        self.sound_registry[sound_name] = ("sound", base_dir)
-                    if sound_name.lower() not in self.sound_registry:
-                        self.sound_registry[sound_name.lower()] = ("sound", base_dir)
+            self._scan_directory_for_sounds(assets_dir / "sounds", "sound", base_dir)
 
         logger.info(f"Sound registry built: {len(self.sound_registry)} sounds indexed")
+
+    def _scan_directory_for_sounds(self, directory: Path, sound_type: str, base_dir: str):
+        """Scan a directory for .ogg files and register them.
+
+        Args:
+            directory: Directory to scan for .ogg files
+            sound_type: Type of sound ("vox" or "sound")
+            base_dir: Base directory name (e.g., "Joust", "Menu")
+        """
+        if not directory.exists():
+            return
+        for ogg_file in directory.glob("*.ogg"):
+            self._register_sound(ogg_file.stem, sound_type, base_dir)
+
+    def _register_sound(self, sound_name: str, sound_type: str, base_dir: str):
+        """Register a sound name in the registry if not already present.
+
+        First-found wins: existing entries are not overwritten.
+        Both original case and lowercase variants are registered.
+
+        Args:
+            sound_name: The sound name (filename without extension)
+            sound_type: Type of sound ("vox" or "sound")
+            base_dir: Base directory name (e.g., "Joust", "Menu")
+        """
+        entry = (sound_type, base_dir)
+        if sound_name not in self.sound_registry:
+            self.sound_registry[sound_name] = entry
+        if sound_name.lower() not in self.sound_registry:
+            self.sound_registry[sound_name.lower()] = entry
 
     def _resolve_sound_path(self, sound_input: str) -> str:
         """
@@ -503,27 +533,51 @@ class AudioServiceServicer(audio_pb2_grpc.AudioServiceServicer):
 
         # If it's a simple name (no path separators), look up in registry
         if "/" not in lookup_name and "\\" not in lookup_name:
-            registry_entry = self.sound_registry.get(lookup_name) or self.sound_registry.get(lookup_name.lower())
-            if registry_entry:
-                sound_type, base_dir = registry_entry
-                if sound_type == "vox":
-                    return f"{base_dir}/vox/{self.menu_voice}/{lookup_name}.ogg"
-                # sound_type == "sound"
-                return f"{base_dir}/sounds/{lookup_name}.ogg"
-            # Unknown sound - try Joust vox first with current voice
-            logger.warning(f"Sound '{lookup_name}' not in registry, trying Joust vox path")
-            return f"Joust/vox/{self.menu_voice}/{lookup_name}.ogg"
+            return self._resolve_simple_name(lookup_name)
 
-        # Handle paths - check if it needs voice insertion
-        if "/vox/" in sound_input:
-            parts = sound_input.split("/vox/")
-            if len(parts) == 2:
-                remainder = parts[1]
-                # Check if voice folder is already present
-                if not remainder.startswith("aaron/") and not remainder.startswith("ivy/"):
-                    return f"{parts[0]}/vox/{self.menu_voice}/{remainder}"
+        # Handle paths - check if voice insertion is needed
+        return self._resolve_vox_path(sound_input)
 
-        return sound_input
+    def _resolve_simple_name(self, lookup_name: str) -> str:
+        """Resolve a simple sound name (no path separators) via the registry.
+
+        Args:
+            lookup_name: Sound name without extension or path separators
+
+        Returns:
+            Resolved path to the sound file
+        """
+        registry_entry = self.sound_registry.get(lookup_name) or self.sound_registry.get(lookup_name.lower())
+        if registry_entry:
+            sound_type, base_dir = registry_entry
+            if sound_type == "vox":
+                return f"{base_dir}/vox/{self.menu_voice}/{lookup_name}.ogg"
+            return f"{base_dir}/sounds/{lookup_name}.ogg"
+        # Unknown sound - try Joust vox first with current voice
+        logger.warning(f"Sound '{lookup_name}' not in registry, trying Joust vox path")
+        return f"Joust/vox/{self.menu_voice}/{lookup_name}.ogg"
+
+    def _resolve_vox_path(self, sound_input: str) -> str:
+        """Resolve a path that may need voice directory insertion.
+
+        If the path contains '/vox/' but no voice folder, inserts the current
+        menu voice. Paths with voice already present are returned as-is.
+
+        Args:
+            sound_input: Sound path potentially containing '/vox/'
+
+        Returns:
+            Path with voice directory inserted if needed
+        """
+        if "/vox/" not in sound_input:
+            return sound_input
+        parts = sound_input.split("/vox/")
+        if len(parts) != 2:
+            return sound_input
+        remainder = parts[1]
+        if remainder.startswith("aaron/") or remainder.startswith("ivy/"):
+            return sound_input
+        return f"{parts[0]}/vox/{self.menu_voice}/{remainder}"
 
     async def _load_audio_setting(self):
         """Load audio settings from flagd (user_preferences domain)."""

--- a/services/audio/tests/test_extracted_helpers.py
+++ b/services/audio/tests/test_extracted_helpers.py
@@ -1,0 +1,239 @@
+"""
+Unit tests for extracted helper methods from cognitive complexity refactoring.
+
+Tests cover:
+- SoundChannel._wait_for_playback
+- AudioServiceServicer._scan_directory_for_sounds
+- AudioServiceServicer._register_sound
+- AudioServiceServicer._resolve_simple_name
+- AudioServiceServicer._resolve_vox_path
+"""
+
+import threading
+from pathlib import Path
+
+import pytest
+
+from services.audio.servicer import SoundChannel
+
+
+class TestWaitForPlayback:
+    """Tests for SoundChannel._wait_for_playback."""
+
+    def test_stops_when_playing_cleared(self):
+        """Playback wait exits when _playing event is cleared."""
+        channel = SoundChannel(channel_id=0)
+        channel._playing.set()
+
+        # Clear after a short delay
+        def clear_later():
+            import time
+
+            time.sleep(0.1)
+            channel._playing.clear()
+
+        threading.Thread(target=clear_later, daemon=True).start()
+        # Should return quickly after clearing (not wait full duration)
+        channel._wait_for_playback(duration=10.0)
+        assert not channel.is_playing
+
+    def test_stops_when_duration_exceeded(self):
+        """Playback wait exits when duration + 0.5s is exceeded."""
+        channel = SoundChannel(channel_id=0)
+        channel._playing.set()
+        # Very short duration so it completes quickly
+        channel._wait_for_playback(duration=0.0)
+        # After duration+0.5s, should have exited (playing still set from our side)
+        # The wait loop checks elapsed < duration + 0.5, so with 0.0 duration
+        # it should exit after ~0.5s
+        assert channel.is_playing  # _wait_for_playback doesn't clear _playing
+
+    def test_zero_duration_exits_quickly(self):
+        """With zero duration, wait loop runs for at most ~0.5 seconds."""
+        import time
+
+        channel = SoundChannel(channel_id=0)
+        channel._playing.set()
+        start = time.monotonic()
+        channel._wait_for_playback(duration=0.0)
+        elapsed = time.monotonic() - start
+        # Should take about 0.5s (duration + 0.5 margin), give some tolerance
+        assert elapsed < 1.5
+
+
+class TestScanDirectoryForSounds:
+    """Tests for AudioServiceServicer._scan_directory_for_sounds."""
+
+    @pytest.fixture
+    def servicer(self, mock_audio_servicer):
+        return mock_audio_servicer
+
+    def test_nonexistent_directory_is_skipped(self, servicer):
+        """Non-existent directory adds nothing to registry."""
+        initial_count = len(servicer.sound_registry)
+        servicer._scan_directory_for_sounds(Path("/nonexistent/path"), "vox", "Test")
+        assert len(servicer.sound_registry) == initial_count
+
+    def test_scans_ogg_files(self, servicer, tmp_path):
+        """Scans .ogg files and registers them."""
+        # Create test .ogg files
+        (tmp_path / "test_sound_a.ogg").touch()
+        (tmp_path / "test_sound_b.ogg").touch()
+        (tmp_path / "not_audio.txt").touch()  # Should be ignored
+
+        servicer._scan_directory_for_sounds(tmp_path, "sound", "TestDir")
+
+        assert "test_sound_a" in servicer.sound_registry
+        assert "test_sound_b" in servicer.sound_registry
+        assert "not_audio" not in servicer.sound_registry
+
+    def test_registers_correct_type_and_base_dir(self, servicer, tmp_path):
+        """Registered entries have correct type and base_dir."""
+        (tmp_path / "mysound.ogg").touch()
+
+        servicer._scan_directory_for_sounds(tmp_path, "vox", "Zombie")
+
+        sound_type, base_dir = servicer.sound_registry["mysound"]
+        assert sound_type == "vox"
+        assert base_dir == "Zombie"
+
+
+class TestRegisterSound:
+    """Tests for AudioServiceServicer._register_sound."""
+
+    @pytest.fixture
+    def servicer(self, mock_audio_servicer):
+        # Clear registry for isolated tests
+        servicer = mock_audio_servicer
+        servicer.sound_registry = {}
+        return servicer
+
+    def test_registers_original_case(self, servicer):
+        servicer._register_sound("MySound", "sound", "Joust")
+        assert "MySound" in servicer.sound_registry
+        assert servicer.sound_registry["MySound"] == ("sound", "Joust")
+
+    def test_registers_lowercase_variant(self, servicer):
+        servicer._register_sound("MySound", "sound", "Joust")
+        assert "mysound" in servicer.sound_registry
+        assert servicer.sound_registry["mysound"] == ("sound", "Joust")
+
+    def test_first_found_wins_original_case(self, servicer):
+        """First registration wins - second call doesn't overwrite."""
+        servicer._register_sound("beep", "vox", "Menu")
+        servicer._register_sound("beep", "sound", "Joust")
+
+        assert servicer.sound_registry["beep"] == ("vox", "Menu")
+
+    def test_first_found_wins_lowercase(self, servicer):
+        """Lowercase variant also uses first-found-wins."""
+        servicer._register_sound("Beep", "vox", "Menu")
+        servicer._register_sound("beep", "sound", "Joust")
+
+        # "beep" lowercase was registered from "Beep" first
+        assert servicer.sound_registry["beep"] == ("vox", "Menu")
+
+    def test_already_lowercase_name(self, servicer):
+        """Name that is already lowercase registers both entries as same."""
+        servicer._register_sound("explosion", "sound", "Joust")
+        assert "explosion" in servicer.sound_registry
+        assert servicer.sound_registry["explosion"] == ("sound", "Joust")
+
+    def test_mixed_case_registers_both(self, servicer):
+        """Mixed case name registers both original and lowercase."""
+        servicer._register_sound("Explosion34", "sound", "Joust")
+        assert "Explosion34" in servicer.sound_registry
+        assert "explosion34" in servicer.sound_registry
+
+
+class TestResolveSimpleName:
+    """Tests for AudioServiceServicer._resolve_simple_name."""
+
+    @pytest.fixture
+    def servicer(self, mock_audio_servicer):
+        servicer = mock_audio_servicer
+        servicer.sound_registry = {
+            "congratulations": ("vox", "Joust"),
+            "Explosion34": ("sound", "Joust"),
+            "explosion34": ("sound", "Joust"),
+            "zombie_victory": ("vox", "Zombie"),
+        }
+        servicer.menu_voice = "ivy"
+        return servicer
+
+    def test_vox_sound_returns_voice_path(self, servicer):
+        result = servicer._resolve_simple_name("congratulations")
+        assert result == "Joust/vox/ivy/congratulations.ogg"
+
+    def test_sound_effect_returns_sounds_path(self, servicer):
+        result = servicer._resolve_simple_name("Explosion34")
+        assert result == "Joust/sounds/Explosion34.ogg"
+
+    def test_vox_with_different_voice(self, servicer):
+        servicer.menu_voice = "aaron"
+        result = servicer._resolve_simple_name("congratulations")
+        assert result == "Joust/vox/aaron/congratulations.ogg"
+
+    def test_case_insensitive_lookup(self, servicer):
+        result = servicer._resolve_simple_name("explosion34")
+        assert result == "Joust/sounds/explosion34.ogg"
+
+    def test_different_base_dir(self, servicer):
+        result = servicer._resolve_simple_name("zombie_victory")
+        assert result == "Zombie/vox/ivy/zombie_victory.ogg"
+
+    def test_unknown_sound_falls_back_to_joust_vox(self, servicer):
+        result = servicer._resolve_simple_name("nonexistent_xyz")
+        assert result == "Joust/vox/ivy/nonexistent_xyz.ogg"
+
+    def test_unknown_sound_uses_current_voice(self, servicer):
+        servicer.menu_voice = "aaron"
+        result = servicer._resolve_simple_name("nonexistent_xyz")
+        assert result == "Joust/vox/aaron/nonexistent_xyz.ogg"
+
+
+class TestResolveVoxPath:
+    """Tests for AudioServiceServicer._resolve_vox_path."""
+
+    @pytest.fixture
+    def servicer(self, mock_audio_servicer):
+        servicer = mock_audio_servicer
+        servicer.menu_voice = "ivy"
+        return servicer
+
+    def test_no_vox_in_path_returns_as_is(self, servicer):
+        result = servicer._resolve_vox_path("Joust/sounds/beep.ogg")
+        assert result == "Joust/sounds/beep.ogg"
+
+    def test_inserts_voice_when_missing(self, servicer):
+        result = servicer._resolve_vox_path("Joust/vox/congratulations.ogg")
+        assert result == "Joust/vox/ivy/congratulations.ogg"
+
+    def test_preserves_aaron_voice(self, servicer):
+        result = servicer._resolve_vox_path("Joust/vox/aaron/congratulations.ogg")
+        assert result == "Joust/vox/aaron/congratulations.ogg"
+
+    def test_preserves_ivy_voice(self, servicer):
+        result = servicer._resolve_vox_path("Joust/vox/ivy/congratulations.ogg")
+        assert result == "Joust/vox/ivy/congratulations.ogg"
+
+    def test_uses_current_menu_voice(self, servicer):
+        servicer.menu_voice = "aaron"
+        result = servicer._resolve_vox_path("Zombie/vox/zombie_death.ogg")
+        assert result == "Zombie/vox/aaron/zombie_death.ogg"
+
+    def test_path_without_vox_segment(self, servicer):
+        result = servicer._resolve_vox_path("Joust/music/track.ogg")
+        assert result == "Joust/music/track.ogg"
+
+    def test_multiple_vox_segments_returns_as_is(self, servicer):
+        """Path with multiple /vox/ segments (unusual) is returned as-is."""
+        weird_path = "a/vox/b/vox/c.ogg"
+        result = servicer._resolve_vox_path(weird_path)
+        # split("/vox/") produces 3 parts, len != 2, so returns as-is
+        assert result == weird_path
+
+    def test_plain_filename_without_path(self, servicer):
+        """A plain filename without path separators is returned as-is (no /vox/)."""
+        result = servicer._resolve_vox_path("congratulations.ogg")
+        assert result == "congratulations.ogg"


### PR DESCRIPTION
## Summary
- Extract 7 focused helper methods from 3 over-complex methods in `services/audio/servicer.py` to bring cognitive complexity under the limit of 15
- `SoundChannel.play()` (22 -> ~10): Extract `_play_with_volume()`, `_play_full_volume()`, `_wait_for_playback()`
- `_build_sound_registry()` (27 -> ~3): Extract `_scan_directory_for_sounds()`, `_register_sound()`
- `_resolve_sound_path()` (16 -> ~5): Extract `_resolve_simple_name()`, `_resolve_vox_path()`
- Pure refactor with no behavioral changes; public API is identical
- Add 27 new unit tests for all extracted helpers (106 total, up from 79)

## Test plan
- [x] All 79 existing tests pass unchanged after refactoring
- [x] 27 new tests added in `test_extracted_helpers.py` covering:
  - [x] `_wait_for_playback` - stop on clear, stop on duration, timing
  - [x] `_scan_directory_for_sounds` - nonexistent dir, ogg scanning, type registration
  - [x] `_register_sound` - case variants, first-found-wins dedup
  - [x] `_resolve_simple_name` - vox/sound lookup, voice selection, fallback
  - [x] `_resolve_vox_path` - voice insertion, preservation, edge cases
- [x] `make lint` passes clean
- [x] Pre-commit hooks (ruff check + ruff format) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)