### PR TITLE
refactor: reduce cognitive complexity in teams_base.py

### DIFF
--- a/services/game_coordinator/games/teams_base.py
+++ b/services/game_coordinator/games/teams_base.py
@@ -411,108 +411,178 @@ class TeamsGameBase(BaseGameMode):
             team.span = None  # Mark as closed to prevent double-ending
             logger.info(f"Team {team.name} eliminated! Ended team lifecycle span")
 
-    async def _end_game_impl(self):
-        """Handle game ending for team-based games."""
+    def _get_winning_team_num(self, alive_teams: set[int]) -> int | None:
+        """
+        Determine the winning team number from alive teams.
+
+        Args:
+            alive_teams: Set of team numbers that still have alive players
+
+        Returns:
+            Winning team number if exactly one team remains, None otherwise
+        """
+        if len(alive_teams) == 1:
+            return list(alive_teams)[0]
+        return None
+
+    async def _send_winner_rainbow_effects(self, winning_team_num: int):
+        """
+        Send rainbow LED effects to all alive members of the winning team.
+
+        Args:
+            winning_team_num: The winning team number
+        """
+        from proto import controller_manager_pb2
+
+        if not self.gameplay_stream:
+            return
+
+        for serial, player in self.players.items():
+            if player.alive and player.team == winning_team_num:
+                effect_cmd = controller_manager_pb2.GameplayStreamControl(
+                    game_effect=controller_manager_pb2.GameEffectCommand(
+                        serial=serial,
+                        effect=controller_manager_pb2.GAME_EFFECT_WINNER_RAINBOW,
+                    )
+                )
+                await self.gameplay_stream.write(effect_cmd)
+
+    async def _play_team_victory_sound(self, winning_team_num: int):
+        """
+        Play the victory sound for the winning team.
+
+        Falls back to congratulations sound if team has no specific sound.
+
+        Args:
+            winning_team_num: The winning team number
+        """
+        winning_team = self.teams.get(winning_team_num)
+        if winning_team:
+            sound = TEAM_WIN_SOUNDS.get(winning_team.name, Sound.VOX_CONGRATULATIONS)
+            await self._play_sound(sound, priority=2)
+
+    def _build_survived_span_attrs(self, player, is_winner: bool) -> dict:
+        """
+        Build span attributes for a surviving player.
+
+        Includes game duration, winner status, team, and analytics summary if available.
+
+        Args:
+            player: Player object
+            is_winner: Whether this player is on the winning team
+
+        Returns:
+            Dict of span attributes
+        """
+        survived_attrs = {
+            "game_duration": time.time() - self.start_time if self.start_time else 0,
+            "winner": is_winner,
+            "team": player.team,
+        }
+
+        if player.analytics is not None:
+            analytics_summary = player.analytics.get_summary()
+            for key, value in analytics_summary.items():
+                survived_attrs[f"analytics.{key}"] = value
+
+        return survived_attrs
+
+    def _end_surviving_player_spans(self, winning_team_num: int | None):
+        """
+        End lifecycle spans for surviving players after the celebration.
+
+        This ensures winners' spans are longer than losers'.
+
+        Args:
+            winning_team_num: Winning team number, or None if no winner
+        """
+        for serial, player in self.players.items():
+            if not (player.span and player.alive):
+                continue
+
+            is_winner = winning_team_num is not None and player.team == winning_team_num
+            survived_attrs = self._build_survived_span_attrs(player, is_winner)
+
+            player.span.add_event("player_survived", attributes=survived_attrs)
+            player.span.set_status(Status(StatusCode.OK))
+            player.span.end()
+            logger.debug(f"Ended lifecycle span for surviving player {serial}")
+
+    async def _publish_player_analytics(self, winning_team_num: int | None):
+        """
+        Publish analytics summaries and update metrics for all players.
+
+        Args:
+            winning_team_num: Winning team number, or None if no winner
+        """
         from services.game_coordinator import metrics
 
+        for serial, player in self.players.items():
+            if player.analytics is None:
+                continue
+
+            is_winner = winning_team_num is not None and player.team == winning_team_num
+            summary = player.analytics.get_summary()
+            summary["game_id"] = self.game_id
+            summary["winner"] = is_winner
+            summary["team"] = player.team
+            summary["survival_time_ms"] = player.analytics.total_time_ms
+
+            await self.event_publisher(GameEvent.PLAYER_ANALYTICS, summary)
+
+            metrics.game_analytics_samples_total.labels(game_mode=self.get_game_name()).inc(
+                player.analytics.sample_count
+            )
+            metrics.near_death_events_total.labels(serial=serial, game_mode=self.get_game_name()).inc(
+                player.analytics.near_death_count
+            )
+
+            logger.info(
+                f"Player {serial} analytics: peak={summary['peak_accel']:.2f}g, "
+                f"playstyle={summary['playstyle']}, near_deaths={summary['near_death_count']}"
+            )
+
+    def _end_surviving_team_spans(self, alive_teams: set[int], winning_team_num: int | None):
+        """
+        End lifecycle spans for surviving teams after the celebration.
+
+        Args:
+            alive_teams: Set of team numbers that still have alive players
+            winning_team_num: Winning team number, or None if no winner
+        """
+        for team_num, team in self.teams.items():
+            if not (team.span and team_num in alive_teams):
+                continue
+
+            is_winning_team = winning_team_num is not None and team_num == winning_team_num
+            team.span.add_event(
+                "team_victory" if is_winning_team else "team_survived",
+                attributes={
+                    "game_duration": time.time() - self.start_time if self.start_time else 0,
+                    "winner": is_winning_team,
+                },
+            )
+            team.span.set_status(Status(StatusCode.OK))
+            team.span.end()
+            logger.info(f"Ended lifecycle span for team {team.name} ({'WINNER' if is_winning_team else 'survived'})")
+
+    async def _end_game_impl(self):
+        """Handle game ending for team-based games."""
         logger.info("Ending game...")
         self.state = self.state.__class__.ENDING
 
-        # Determine winning team
         alive_teams = self._get_alive_teams()
-        winning_team_num = list(alive_teams)[0] if len(alive_teams) == 1 else None
+        winning_team_num = self._get_winning_team_num(alive_teams)
 
-        # Phase XX: Show rainbow effect on winning team's controllers via game effect
         if winning_team_num is not None:
-            from proto import controller_manager_pb2
+            await self._send_winner_rainbow_effects(winning_team_num)
+            await self._play_team_victory_sound(winning_team_num)
 
-            # Play rainbow effect on all winning team members
-            if self.gameplay_stream:
-                for serial, player in self.players.items():
-                    if player.alive and player.team == winning_team_num:
-                        effect_cmd = controller_manager_pb2.GameplayStreamControl(
-                            game_effect=controller_manager_pb2.GameEffectCommand(
-                                serial=serial,
-                                effect=controller_manager_pb2.GAME_EFFECT_WINNER_RAINBOW,
-                            )
-                        )
-                        await self.gameplay_stream.write(effect_cmd)
-
-            # Play team victory sound (Phase 29)
-            winning_team = self.teams.get(winning_team_num)
-            if winning_team:
-                sound = TEAM_WIN_SOUNDS.get(winning_team.name, Sound.VOX_CONGRATULATIONS)
-                await self._play_sound(sound, priority=2)
-
-        # Wait for rainbow effect to complete
         await self._wait_for_rainbow_effect()
 
-        # End spans for surviving players AFTER the celebration
-        # This ensures winners' spans are longer than losers'
-        for serial, player in self.players.items():
-            if player.span and player.alive:
-                is_winner = winning_team_num is not None and player.team == winning_team_num
-
-                # Build attributes including analytics summary if available
-                survived_attrs = {
-                    "game_duration": time.time() - self.start_time if self.start_time else 0,
-                    "winner": is_winner,
-                    "team": player.team,
-                }
-
-                # Add analytics summary to span
-                if player.analytics is not None:
-                    analytics_summary = player.analytics.get_summary()
-                    for key, value in analytics_summary.items():
-                        survived_attrs[f"analytics.{key}"] = value
-
-                player.span.add_event("player_survived", attributes=survived_attrs)
-                player.span.set_status(Status(StatusCode.OK))
-                player.span.end()
-                logger.debug(f"Ended lifecycle span for surviving player {serial}")
-
-        # Publish analytics summaries for all players
-        for serial, player in self.players.items():
-            if player.analytics is not None:
-                is_winner = winning_team_num is not None and player.team == winning_team_num
-                summary = player.analytics.get_summary()
-                summary["game_id"] = self.game_id
-                summary["winner"] = is_winner
-                summary["team"] = player.team
-                summary["survival_time_ms"] = player.analytics.total_time_ms
-
-                # Publish player analytics event
-                await self.event_publisher(GameEvent.PLAYER_ANALYTICS, summary)
-
-                # Update Prometheus metrics
-                metrics.game_analytics_samples_total.labels(game_mode=self.get_game_name()).inc(
-                    player.analytics.sample_count
-                )
-                metrics.near_death_events_total.labels(serial=serial, game_mode=self.get_game_name()).inc(
-                    player.analytics.near_death_count
-                )
-
-                logger.info(
-                    f"Player {serial} analytics: peak={summary['peak_accel']:.2f}g, "
-                    f"playstyle={summary['playstyle']}, near_deaths={summary['near_death_count']}"
-                )
-
-        # End spans for surviving teams AFTER the celebration
-        for team_num, team in self.teams.items():
-            if team.span and team_num in alive_teams:
-                is_winning_team = winning_team_num is not None and team_num == winning_team_num
-                team.span.add_event(
-                    "team_victory" if is_winning_team else "team_survived",
-                    attributes={
-                        "game_duration": time.time() - self.start_time if self.start_time else 0,
-                        "winner": is_winning_team,
-                    },
-                )
-                team.span.set_status(Status(StatusCode.OK))
-                team.span.end()
-                logger.info(
-                    f"Ended lifecycle span for team {team.name} ({'WINNER' if is_winning_team else 'survived'})"
-                )
+        self._end_surviving_player_spans(winning_team_num)
+        await self._publish_player_analytics(winning_team_num)
+        self._end_surviving_team_spans(alive_teams, winning_team_num)
 
         self.state = self.state.__class__.ENDED
         await self.event_publisher(

--- a/services/game_coordinator/tests/test_teams_base_helpers.py
+++ b/services/game_coordinator/tests/test_teams_base_helpers.py
@@ -1,0 +1,492 @@
+"""
+Unit tests for extracted helper methods in TeamsGameBase._end_game_impl.
+
+Tests each helper independently to verify the refactoring preserved behavior:
+- _get_winning_team_num: determine winner from alive teams
+- _send_winner_rainbow_effects: send LED effects to winning team
+- _play_team_victory_sound: play correct victory sound
+- _build_survived_span_attrs: build span attributes for surviving players
+- _end_surviving_player_spans: close spans for surviving players
+- _publish_player_analytics: publish analytics and update metrics
+- _end_surviving_team_spans: close spans for surviving teams
+"""
+
+import sys
+import time
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+# Setup paths for imports
+test_dir = Path(__file__).parent
+service_dir = test_dir.parent
+project_root = service_dir.parent.parent
+sys.path.insert(0, str(project_root))
+sys.path.insert(0, str(test_dir))
+
+from services.game_coordinator.games.base import Player
+from services.game_coordinator.games.teams_base import (
+    TEAM_WIN_SOUNDS,
+    TeamsGameBase,
+)
+
+
+class MockTeamsGame(TeamsGameBase):
+    """Minimal concrete subclass of TeamsGameBase for testing helpers."""
+
+    def get_game_name(self):
+        return "Mock Teams"
+
+    async def _initialize_players_impl(self, controllers):
+        for idx, controller in enumerate(controllers):
+            team_num = idx % self.num_teams
+            self.players[controller.serial] = Player(
+                serial=controller.serial,
+                team=team_num,
+                alive=True,
+                color=self.team_colors[team_num]["rgb"],
+            )
+
+    def _get_additional_phases(self):
+        return []
+
+    async def _kill_player_impl(self, serial, accel_mag):
+        self.players[serial].alive = False
+
+    def _create_player_spans(self, game_context):
+        pass
+
+
+@pytest.fixture
+def mock_event_publisher():
+    """Create mock async event publisher."""
+    return AsyncMock()
+
+
+@pytest.fixture
+def game(mock_event_publisher):
+    """Create a MockTeamsGame with 2 teams for testing."""
+    return MockTeamsGame(
+        controller_manager_client=AsyncMock(),
+        event_publisher=mock_event_publisher,
+        num_teams=2,
+        game_id="test_helpers_001",
+    )
+
+
+def _add_players(game, specs):
+    """
+    Add players to the game from a list of (serial, team, alive) tuples.
+
+    Args:
+        game: MockTeamsGame instance
+        specs: List of (serial, team, alive) tuples
+    """
+    for serial, team, alive in specs:
+        game.players[serial] = Player(
+            serial=serial,
+            team=team,
+            alive=alive,
+            color=game.team_colors[team]["rgb"],
+        )
+
+
+class TestGetWinningTeamNum:
+    """Test _get_winning_team_num helper."""
+
+    def test_one_team_alive_returns_that_team(self, game):
+        """Returns the single surviving team number."""
+        assert game._get_winning_team_num({0}) == 0
+        assert game._get_winning_team_num({1}) == 1
+
+    def test_no_teams_alive_returns_none(self, game):
+        """Returns None when no teams remain (tie)."""
+        assert game._get_winning_team_num(set()) is None
+
+    def test_multiple_teams_alive_returns_none(self, game):
+        """Returns None when multiple teams remain."""
+        assert game._get_winning_team_num({0, 1}) is None
+        assert game._get_winning_team_num({0, 1, 2}) is None
+
+    def test_single_higher_team_number(self, game):
+        """Returns the correct team even for higher team numbers."""
+        assert game._get_winning_team_num({5}) == 5
+
+
+class TestSendWinnerRainbowEffects:
+    """Test _send_winner_rainbow_effects helper."""
+
+    @pytest.mark.asyncio
+    async def test_sends_effects_to_alive_winning_players(self, game):
+        """Should send rainbow effect to alive players on the winning team."""
+        mock_stream = AsyncMock()
+        game.gameplay_stream = mock_stream
+
+        _add_players(
+            game,
+            [
+                ("p1", 0, True),
+                ("p2", 0, True),
+                ("p3", 1, False),
+            ],
+        )
+
+        await game._send_winner_rainbow_effects(0)
+
+        assert mock_stream.write.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_skips_dead_players_on_winning_team(self, game):
+        """Should not send effects to dead players even if on winning team."""
+        mock_stream = AsyncMock()
+        game.gameplay_stream = mock_stream
+
+        _add_players(
+            game,
+            [
+                ("p1", 0, True),
+                ("p2", 0, False),
+            ],
+        )
+
+        await game._send_winner_rainbow_effects(0)
+
+        assert mock_stream.write.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_skips_players_on_other_teams(self, game):
+        """Should not send effects to players on non-winning teams."""
+        mock_stream = AsyncMock()
+        game.gameplay_stream = mock_stream
+
+        _add_players(
+            game,
+            [
+                ("p1", 0, True),
+                ("p2", 1, True),
+            ],
+        )
+
+        await game._send_winner_rainbow_effects(0)
+
+        assert mock_stream.write.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_no_stream_does_nothing(self, game):
+        """Should return without error when no gameplay stream exists."""
+        game.gameplay_stream = None
+
+        _add_players(game, [("p1", 0, True)])
+
+        # Should not raise
+        await game._send_winner_rainbow_effects(0)
+
+
+class TestPlayTeamVictorySound:
+    """Test _play_team_victory_sound helper."""
+
+    @pytest.mark.asyncio
+    async def test_plays_specific_team_sound(self, game):
+        """Should play the team-specific victory sound when one exists."""
+        game._play_sound = AsyncMock()
+
+        # Blue has a specific sound
+        game.teams[0].name = "Blue"
+
+        await game._play_team_victory_sound(0)
+
+        game._play_sound.assert_awaited_once_with(TEAM_WIN_SOUNDS["Blue"], priority=2)
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_congratulations(self, game):
+        """Should fall back to congratulations for teams without specific sounds."""
+        from lib.types import Sound
+
+        game._play_sound = AsyncMock()
+
+        # Pink has no specific sound in TEAM_WIN_SOUNDS
+        game.teams[0].name = "Pink"
+
+        await game._play_team_victory_sound(0)
+
+        game._play_sound.assert_awaited_once_with(Sound.VOX_CONGRATULATIONS, priority=2)
+
+    @pytest.mark.asyncio
+    async def test_invalid_team_num_does_nothing(self, game):
+        """Should handle missing team number gracefully."""
+        game._play_sound = AsyncMock()
+
+        await game._play_team_victory_sound(99)
+
+        game._play_sound.assert_not_awaited()
+
+
+class TestBuildSurvivedSpanAttrs:
+    """Test _build_survived_span_attrs helper."""
+
+    def test_basic_attributes(self, game):
+        """Should include game_duration, winner, and team."""
+        game.start_time = time.time() - 10.0
+        player = Player(serial="p1", team=0, alive=True)
+
+        attrs = game._build_survived_span_attrs(player, is_winner=True)
+
+        assert "game_duration" in attrs
+        assert attrs["game_duration"] > 0
+        assert attrs["winner"] is True
+        assert attrs["team"] == 0
+
+    def test_winner_false(self, game):
+        """Should correctly mark non-winner."""
+        game.start_time = time.time()
+        player = Player(serial="p1", team=1, alive=True)
+
+        attrs = game._build_survived_span_attrs(player, is_winner=False)
+
+        assert attrs["winner"] is False
+        assert attrs["team"] == 1
+
+    def test_no_start_time(self, game):
+        """Should handle None start_time with duration 0."""
+        game.start_time = None
+        player = Player(serial="p1", team=0, alive=True)
+
+        attrs = game._build_survived_span_attrs(player, is_winner=True)
+
+        assert attrs["game_duration"] == 0
+
+    def test_includes_analytics_summary(self, game):
+        """Should include analytics data when player has analytics."""
+        game.start_time = time.time()
+        player = Player(serial="p1", team=0, alive=True)
+
+        # Mock analytics
+        mock_analytics = MagicMock()
+        mock_analytics.get_summary.return_value = {
+            "peak_accel": 3.5,
+            "playstyle": "aggressive",
+        }
+        player.analytics = mock_analytics
+
+        attrs = game._build_survived_span_attrs(player, is_winner=True)
+
+        assert attrs["analytics.peak_accel"] == 3.5
+        assert attrs["analytics.playstyle"] == "aggressive"
+
+    def test_no_analytics(self, game):
+        """Should not include analytics keys when analytics is None."""
+        game.start_time = time.time()
+        player = Player(serial="p1", team=0, alive=True)
+        player.analytics = None
+
+        attrs = game._build_survived_span_attrs(player, is_winner=True)
+
+        # Should only have the base keys
+        assert set(attrs.keys()) == {"game_duration", "winner", "team"}
+
+
+class TestEndSurvivingPlayerSpans:
+    """Test _end_surviving_player_spans helper."""
+
+    def test_ends_spans_for_alive_players_with_spans(self, game):
+        """Should end spans for alive players that have open spans."""
+        mock_span = MagicMock()
+
+        game.start_time = time.time()
+        _add_players(game, [("p1", 0, True)])
+        game.players["p1"].span = mock_span
+
+        game._end_surviving_player_spans(winning_team_num=0)
+
+        mock_span.add_event.assert_called_once()
+        mock_span.set_status.assert_called_once()
+        mock_span.end.assert_called_once()
+
+    def test_skips_dead_players(self, game):
+        """Should not touch spans of dead players."""
+        mock_span = MagicMock()
+
+        game.start_time = time.time()
+        _add_players(game, [("p1", 0, False)])
+        game.players["p1"].span = mock_span
+
+        game._end_surviving_player_spans(winning_team_num=0)
+
+        mock_span.end.assert_not_called()
+
+    def test_skips_players_without_spans(self, game):
+        """Should not error for alive players with no span."""
+        game.start_time = time.time()
+        _add_players(game, [("p1", 0, True)])
+        game.players["p1"].span = None
+
+        # Should not raise
+        game._end_surviving_player_spans(winning_team_num=0)
+
+    def test_marks_winners_correctly(self, game):
+        """Should pass is_winner=True for players on the winning team."""
+        mock_span = MagicMock()
+
+        game.start_time = time.time()
+        _add_players(game, [("p1", 0, True)])
+        game.players["p1"].span = mock_span
+
+        game._end_surviving_player_spans(winning_team_num=0)
+
+        event_args = mock_span.add_event.call_args
+        assert event_args[1]["attributes"]["winner"] is True
+
+    def test_marks_non_winners_correctly(self, game):
+        """Should pass is_winner=False for players not on winning team."""
+        mock_span = MagicMock()
+
+        game.start_time = time.time()
+        _add_players(game, [("p1", 1, True)])
+        game.players["p1"].span = mock_span
+
+        game._end_surviving_player_spans(winning_team_num=0)
+
+        event_args = mock_span.add_event.call_args
+        assert event_args[1]["attributes"]["winner"] is False
+
+    def test_no_winner_all_marked_false(self, game):
+        """Should pass is_winner=False for all players when no winner."""
+        mock_span = MagicMock()
+
+        game.start_time = time.time()
+        _add_players(game, [("p1", 0, True)])
+        game.players["p1"].span = mock_span
+
+        game._end_surviving_player_spans(winning_team_num=None)
+
+        event_args = mock_span.add_event.call_args
+        assert event_args[1]["attributes"]["winner"] is False
+
+
+class TestPublishPlayerAnalytics:
+    """Test _publish_player_analytics helper."""
+
+    @pytest.mark.asyncio
+    async def test_publishes_analytics_for_players_with_data(self, game, mock_event_publisher):
+        """Should publish analytics event for players that have analytics."""
+        mock_analytics = MagicMock()
+        mock_analytics.get_summary.return_value = {
+            "peak_accel": 2.5,
+            "playstyle": "cautious",
+            "near_death_count": 3,
+        }
+        mock_analytics.total_time_ms = 15000
+        mock_analytics.sample_count = 900
+        mock_analytics.near_death_count = 3
+
+        _add_players(game, [("p1", 0, True)])
+        game.players["p1"].analytics = mock_analytics
+
+        await game._publish_player_analytics(winning_team_num=0)
+
+        # Verify event published
+        from lib.types import GameEvent
+
+        mock_event_publisher.assert_awaited_once()
+        call_args = mock_event_publisher.call_args
+        assert call_args[0][0] == GameEvent.PLAYER_ANALYTICS
+        summary = call_args[0][1]
+        assert summary["game_id"] == "test_helpers_001"
+        assert summary["winner"] is True
+        assert summary["team"] == 0
+        assert summary["survival_time_ms"] == 15000
+
+    @pytest.mark.asyncio
+    async def test_skips_players_without_analytics(self, game, mock_event_publisher):
+        """Should skip players that have no analytics data."""
+        _add_players(game, [("p1", 0, True)])
+        game.players["p1"].analytics = None
+
+        await game._publish_player_analytics(winning_team_num=0)
+
+        mock_event_publisher.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_winner_flag_reflects_team(self, game, mock_event_publisher):
+        """Should correctly set winner=False for losing team players."""
+        mock_analytics = MagicMock()
+        mock_analytics.get_summary.return_value = {
+            "peak_accel": 1.0,
+            "playstyle": "cautious",
+            "near_death_count": 0,
+        }
+        mock_analytics.total_time_ms = 5000
+        mock_analytics.sample_count = 300
+        mock_analytics.near_death_count = 0
+
+        _add_players(game, [("p1", 1, True)])
+        game.players["p1"].analytics = mock_analytics
+
+        await game._publish_player_analytics(winning_team_num=0)
+
+        summary = mock_event_publisher.call_args[0][1]
+        assert summary["winner"] is False
+
+
+class TestEndSurvivingTeamSpans:
+    """Test _end_surviving_team_spans helper."""
+
+    def test_ends_span_for_winning_team(self, game):
+        """Should end span for the winning team with team_victory event."""
+        mock_span = MagicMock()
+        game.start_time = time.time()
+        game.teams[0].span = mock_span
+
+        game._end_surviving_team_spans(alive_teams={0}, winning_team_num=0)
+
+        mock_span.add_event.assert_called_once()
+        event_name = mock_span.add_event.call_args[0][0]
+        assert event_name == "team_victory"
+        mock_span.end.assert_called_once()
+
+    def test_ends_span_for_surviving_non_winner(self, game):
+        """Should end span with team_survived event for non-winning alive teams."""
+        mock_span = MagicMock()
+        game.start_time = time.time()
+        game.teams[1].span = mock_span
+
+        game._end_surviving_team_spans(alive_teams={0, 1}, winning_team_num=0)
+
+        event_name = mock_span.add_event.call_args[0][0]
+        assert event_name == "team_survived"
+        attrs = mock_span.add_event.call_args[1]["attributes"]
+        assert attrs["winner"] is False
+        mock_span.end.assert_called_once()
+
+    def test_skips_eliminated_teams(self, game):
+        """Should not touch spans for teams not in alive_teams."""
+        mock_span = MagicMock()
+        game.teams[1].span = mock_span
+
+        game._end_surviving_team_spans(alive_teams={0}, winning_team_num=0)
+
+        mock_span.end.assert_not_called()
+
+    def test_skips_teams_without_spans(self, game):
+        """Should not error for alive teams with no span."""
+        game.teams[0].span = None
+
+        # Should not raise
+        game._end_surviving_team_spans(alive_teams={0}, winning_team_num=0)
+
+    def test_no_winner_all_survived(self, game):
+        """Should mark all teams as survived when no winner (tie/draw)."""
+        mock_span_0 = MagicMock()
+        mock_span_1 = MagicMock()
+        game.start_time = time.time()
+        game.teams[0].span = mock_span_0
+        game.teams[1].span = mock_span_1
+
+        game._end_surviving_team_spans(alive_teams={0, 1}, winning_team_num=None)
+
+        # Both should get "team_survived"
+        event_0 = mock_span_0.add_event.call_args[0][0]
+        event_1 = mock_span_1.add_event.call_args[0][0]
+        assert event_0 == "team_survived"
+        assert event_1 == "team_survived"


### PR DESCRIPTION
## Summary
- Extract 7 focused helper methods from `TeamsGameBase._end_game_impl()` to reduce cognitive complexity from **48** to under **15**
- Add 30 unit tests covering all extracted helpers
- Pure refactor: no behavioral changes, public API unchanged

### Extracted helpers
| Method | Responsibility |
|--------|---------------|
| `_get_winning_team_num` | Determine winner from alive teams set |
| `_send_winner_rainbow_effects` | Send LED rainbow effects to winning team |
| `_play_team_victory_sound` | Play team-specific or fallback victory sound |
| `_build_survived_span_attrs` | Build span attributes for surviving players |
| `_end_surviving_player_spans` | Close lifecycle spans for surviving players |
| `_publish_player_analytics` | Publish analytics summaries and update metrics |
| `_end_surviving_team_spans` | Close lifecycle spans for surviving teams |

## Test plan
- [x] All 30 new helper tests pass (`test_teams_base_helpers.py`)
- [x] All 364 existing game coordinator tests pass
- [x] `make lint` passes with no errors
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)