### PR TITLE
refactor: replace if/elif chains with match/case

### DIFF
--- a/services/controller_manager/backend_factory.py
+++ b/services/controller_manager/backend_factory.py
@@ -58,28 +58,26 @@ def _resolve_backend_name() -> str | None:
 
 def _create_backend_by_name(name: str) -> ControllerBackend:
     """Create a backend instance by name."""
-    if name == "mock":
-        from services.controller_manager.mock_backend import MockBackend
+    match name:
+        case "mock":
+            from services.controller_manager.mock_backend import MockBackend
 
-        num_controllers = _get_mock_controller_count()
-        return MockBackend(num_controllers)
+            num_controllers = _get_mock_controller_count()
+            return MockBackend(num_controllers)
+        case "bluetooth":
+            from services.controller_manager.bluetooth_backend import BluetoothBackend
 
-    if name == "bluetooth":
-        from services.controller_manager.bluetooth_backend import BluetoothBackend
+            return BluetoothBackend()
+        case "hidapi":
+            from services.controller_manager.hidapi_backend import HidapiBackend
 
-        return BluetoothBackend()
+            return HidapiBackend()
+        case "windows":
+            from services.controller_manager.windows_backend import WindowsBackend
 
-    if name == "hidapi":
-        from services.controller_manager.hidapi_backend import HidapiBackend
-
-        return HidapiBackend()
-
-    if name == "windows":
-        from services.controller_manager.windows_backend import WindowsBackend
-
-        return WindowsBackend()
-
-    raise RuntimeError(f"Unknown backend: {name}")
+            return WindowsBackend()
+        case _:
+            raise RuntimeError(f"Unknown backend: {name}")
 
 
 def create_backend() -> ControllerBackend:

--- a/services/controller_manager/feedback_manager.py
+++ b/services/controller_manager/feedback_manager.py
@@ -284,16 +284,17 @@ class FeedbackManager(ControllerEffectsBase):
         # Create wrapper that restores color after effect
         async def effect_with_restore():
             try:
-                if effect_type == "flash":
-                    await self._effect_flash(serial, color, duration_ms, speed)
-                elif effect_type == "pulse":
-                    await self._effect_pulse(serial, color, duration_ms, speed)
-                elif effect_type == "rainbow":
-                    await self._effect_rainbow(serial, duration_ms, speed)
-                elif effect_type == "fade_out":
-                    await self._effect_fade_out(serial, color, duration_ms)
-                elif effect_type == "fade_in":
-                    await self._effect_fade_in(serial, color, duration_ms)
+                match effect_type:
+                    case "flash":
+                        await self._effect_flash(serial, color, duration_ms, speed)
+                    case "pulse":
+                        await self._effect_pulse(serial, color, duration_ms, speed)
+                    case "rainbow":
+                        await self._effect_rainbow(serial, duration_ms, speed)
+                    case "fade_out":
+                        await self._effect_fade_out(serial, color, duration_ms)
+                    case "fade_in":
+                        await self._effect_fade_in(serial, color, duration_ms)
             except asyncio.CancelledError:
                 raise
             finally:

--- a/services/controller_manager/mock_control_service.py
+++ b/services/controller_manager/mock_control_service.py
@@ -273,34 +273,34 @@ class MockControllerService(controller_manager_mock_pb2_grpc.MockControllerServi
             serial=event.get("serial", ""),
         )
 
-        event_type = event.get("type")
-        if event_type == "led_change":
-            proto_event.led_change.CopyFrom(
-                controller_manager_mock_pb2.LedChangeEvent(
-                    r=event.get("r", 0),
-                    g=event.get("g", 0),
-                    b=event.get("b", 0),
-                    source=event.get("source", ""),
+        match event.get("type"):
+            case "led_change":
+                proto_event.led_change.CopyFrom(
+                    controller_manager_mock_pb2.LedChangeEvent(
+                        r=event.get("r", 0),
+                        g=event.get("g", 0),
+                        b=event.get("b", 0),
+                        source=event.get("source", ""),
+                    )
                 )
-            )
-        elif event_type == "rumble_change":
-            proto_event.rumble_change.CopyFrom(
-                controller_manager_mock_pb2.RumbleChangeEvent(
-                    intensity=event.get("intensity", 0),
+            case "rumble_change":
+                proto_event.rumble_change.CopyFrom(
+                    controller_manager_mock_pb2.RumbleChangeEvent(
+                        intensity=event.get("intensity", 0),
+                    )
                 )
-            )
-        elif event_type == "button_change":
-            proto_event.button_change.CopyFrom(
-                controller_manager_mock_pb2.ButtonChangeEvent(
-                    button=event.get("button", ""),
-                    pressed=event.get("pressed", False),
+            case "button_change":
+                proto_event.button_change.CopyFrom(
+                    controller_manager_mock_pb2.ButtonChangeEvent(
+                        button=event.get("button", ""),
+                        pressed=event.get("pressed", False),
+                    )
                 )
-            )
-        elif event_type == "connection":
-            proto_event.connection.CopyFrom(
-                controller_manager_mock_pb2.ConnectionEvent(
-                    connected=event.get("connected", False),
+            case "connection":
+                proto_event.connection.CopyFrom(
+                    controller_manager_mock_pb2.ConnectionEvent(
+                        connected=event.get("connected", False),
+                    )
                 )
-            )
 
         return proto_event

--- a/services/game_coordinator/games/analytics.py
+++ b/services/game_coordinator/games/analytics.py
@@ -171,14 +171,15 @@ class PlayerAnalytics:
         zone = self._classify_zone(raw_accel_mag, config)
         frame_ms = int(frame_duration_ms)
 
-        if zone == MovementZone.STILL:
-            self.time_still_ms += frame_ms
-        elif zone == MovementZone.ACTIVE:
-            self.time_active_ms += frame_ms
-        elif zone == MovementZone.WARNING:
-            self.time_warning_ms += frame_ms
-        else:  # DANGER
-            self.time_danger_ms += frame_ms
+        match zone:
+            case MovementZone.STILL:
+                self.time_still_ms += frame_ms
+            case MovementZone.ACTIVE:
+                self.time_active_ms += frame_ms
+            case MovementZone.WARNING:
+                self.time_warning_ms += frame_ms
+            case MovementZone.DANGER:
+                self.time_danger_ms += frame_ms
 
         self._last_zone = zone
 


### PR DESCRIPTION
## Summary
- Convert 4 dispatch-style `if/elif/else` chains to Python `match/case` structural pattern matching
- `backend_factory.py`: backend name → backend class dispatch (4 cases + default)
- `mock_control_service.py`: event type → protobuf message dispatch (4 cases)
- `feedback_manager.py`: effect type → effect handler dispatch (5 cases)
- `analytics.py`: `MovementZone` enum → time accumulator dispatch (4 cases)

Pure readability refactor — no logic changes.

## Test plan
- [x] `make lint` passes
- [x] `services/controller_manager` — 286 tests pass
- [x] `services/game_coordinator` — 334 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)