### PR TITLE
fix: clean up stale SonarCloud exclusion paths

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -10,7 +10,7 @@ sonar.projectVersion=2.0.0
 
 # Source code locations (relative to repo root)
 sonar.sources=.
-sonar.tests=services/controller_manager/tests,services/game_coordinator/tests,services/menu/tests,services/audio/tests,lib/tests,tests/integration
+sonar.tests=services/controller_manager/tests,services/game_coordinator/tests,services/menu/tests,services/audio/tests,services/pairing_daemon/tests,lib/tests,tests/integration
 
 # Python configuration
 sonar.python.version=3.12
@@ -23,9 +23,6 @@ sonar.exclusions=\
   **/proto/*_pb2*.py,\
   **/node_modules/**,\
   **/.venv/**,\
-  **/.venv-test/**,\
-  **/legacy/**,\
-  **/Archive/**,\
   **/__pycache__/**,\
   **/tests/**,\
   services/grafana/**,\
@@ -33,7 +30,12 @@ sonar.exclusions=\
   services/jaeger/**,\
   services/loki/**,\
   services/otel-collector/**,\
-  services/envoy/**
+  services/envoy/**,\
+  services/victoria-metrics/**,\
+  services/flagd/**,\
+  services/connect-proxy/**,\
+  services/dashboard/**,\
+  services/grafana-live-publisher/**
 
 # Exclude from coverage calculation (entry points, boilerplate, tools)
 sonar.coverage.exclusions=\


### PR DESCRIPTION
## Summary
- Remove stale exclusion paths (`.venv-test`, `legacy`, `Archive`) that no longer exist in the repository
- Add missing exclusions for infra-only services (`victoria-metrics`, `flagd`) and non-Python services (`connect-proxy`, `dashboard`, `grafana-live-publisher`)
- Add `services/pairing_daemon/tests` to `sonar.tests` (was missing despite the directory existing)

Fixes #486

## Test plan
- [ ] Verify SonarCloud analysis runs successfully on this PR
- [ ] Confirm no new false-positive issues appear from previously-unexcluded infra/non-Python services
- [ ] Confirm `pairing_daemon` test coverage is now reported

🤖 Generated with [Claude Code](https://claude.com/claude-code)