### PR TITLE
fix: zombie/werewolf dead code thresholds + game mode test coverage

### DIFF
--- a/services/game_coordinator/games/werewolf.py
+++ b/services/game_coordinator/games/werewolf.py
@@ -302,11 +302,12 @@ class WerewolfGame(BaseGameMode):
 
         logger.info(f"Revealed {len(self.werewolf_serials)} werewolves")
 
-    def _get_effective_thresholds(self, player: Player) -> tuple[float, float]:
+    def _compute_effective_thresholds(self, player: Player) -> tuple[float, float]:
         """
-        Get death thresholds for a player.
+        Compute effective thresholds for a player.
 
         Werewolves have higher thresholds (harder to kill).
+        Humans use standard base class thresholds.
 
         Args:
             player: The player to get thresholds for
@@ -317,8 +318,7 @@ class WerewolfGame(BaseGameMode):
         wolf_player = player
         if wolf_player.is_werewolf:
             return WEREWOLF_THRESHOLDS.get(self.sensitivity, (2.1, 2.6))
-        # Use standard thresholds from sensitivity
-        return self.sensitivity.value
+        return super()._compute_effective_thresholds(player)
 
     async def _check_win_condition(self) -> bool:
         """

--- a/services/game_coordinator/games/zombie.py
+++ b/services/game_coordinator/games/zombie.py
@@ -255,16 +255,17 @@ class ZombieGame(BaseGameMode):
         await self.event_publisher("zombie_intro_end", {})
         logger.info("Zombie intro phase complete")
 
-    def _get_effective_thresholds(self, player: Player) -> tuple[float, float]:
+    def _compute_effective_thresholds(self, player: Player) -> tuple[float, float]:
         """
-        Get death thresholds for a player.
+        Compute effective thresholds for a player.
 
-        Zombies have higher thresholds.
+        Zombies have higher thresholds (harder to kill).
+        Humans use standard base class thresholds.
         """
         zombie_player = player
         if zombie_player.is_zombie:
             return ZOMBIE_THRESHOLDS.get(self.sensitivity, (2.1, 2.6))
-        return self.sensitivity.value
+        return super()._compute_effective_thresholds(player)
 
     async def _game_timer(self):
         """

--- a/services/game_coordinator/tests/test_ffa.py
+++ b/services/game_coordinator/tests/test_ffa.py
@@ -8,6 +8,7 @@ Tests the core FFA mechanics:
 """
 
 import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -21,6 +22,8 @@ sys.path.insert(0, str(test_dir))
 
 from conftest import EventCollector, MockControllerManagerService
 
+from lib.types import GameEvent
+from services.game_coordinator.games.base import GameState
 from services.game_coordinator.games.ffa import FFAGame
 
 
@@ -153,3 +156,80 @@ class TestFFAGameMode:
 
         assert "mock_controller_0" not in alive_serials
         assert len(alive_serials) == 3
+
+    @pytest.mark.asyncio
+    async def test_unique_color_assignment(self, ffa_game):
+        """Test that _assign_ffa_colors gives each player a distinct color."""
+        game, mock_controller_manager, _ = ffa_game
+
+        # Initialize players
+        await game._initialize_players_impl(mock_controller_manager.controllers)
+
+        # Assign colors
+        await game._assign_ffa_colors()
+
+        # Collect all player colors into a set
+        colors = {player.color for player in game.players.values()}
+
+        # Each player should have a unique color
+        assert len(colors) == len(game.players)
+
+    @pytest.mark.asyncio
+    async def test_end_game_impl_winner_state(self, ffa_game):
+        """Test that winner is correctly identified in _end_game_impl."""
+        game, mock_controller_manager, event_collector = ffa_game
+
+        # Initialize players
+        await game._initialize_players_impl(mock_controller_manager.controllers)
+
+        # Kill 3 players, leaving mock_controller_3 as the survivor
+        for serial in ["mock_controller_0", "mock_controller_1", "mock_controller_2"]:
+            game.players[serial].alive = False
+
+        # Set up game state for _end_game_impl
+        game.state = GameState.RUNNING
+        game.start_time = time.time()
+        game.gameplay_stream = MockGameplayStream()
+
+        # Trigger win condition check (publishes game_winner event)
+        assert await game._check_win_condition()
+
+        # End the game
+        await game._end_game_impl()
+
+        # Check that a "game_winner" event was published with the surviving player's serial
+        winner_events = event_collector.get_events_of_type(GameEvent.GAME_WINNER)
+        assert len(winner_events) == 1
+        assert winner_events[0]["serial"] == "mock_controller_3"
+
+        # _end_game_impl publishes GAME_ENDED event
+        ended_events = event_collector.get_events_of_type(GameEvent.GAME_ENDED)
+        assert len(ended_events) == 1
+        assert ended_events[0]["game_id"] == "test_ffa_001"
+
+    @pytest.mark.asyncio
+    async def test_two_player_last_standing(self):
+        """Minimal game with 2 players: one dies, the other wins."""
+        mock_controller_manager = MockControllerManagerService(
+            num_controllers=2,
+            death_schedule={},
+            max_duration=10.0,
+        )
+        event_collector = EventCollector()
+
+        game = FFAGame(
+            controller_manager_client=mock_controller_manager,
+            event_publisher=event_collector.publish,
+            audio_client=None,
+            game_id="test_ffa_2p",
+        )
+
+        # Initialize players
+        await game._initialize_players_impl(mock_controller_manager.controllers)
+        assert len(game.players) == 2
+
+        # Kill one player
+        game.players["mock_controller_0"].alive = False
+
+        # Check win condition - should be True since only 1 player alive
+        assert await game._check_win_condition()

--- a/services/game_coordinator/tests/test_fight_club.py
+++ b/services/game_coordinator/tests/test_fight_club.py
@@ -312,3 +312,72 @@ class TestFightClubGameMode:
 
         # Verify the player's smoothed_accel was updated
         assert game.players[defender_serial].smoothed_accel > 0
+
+    @pytest.mark.asyncio
+    async def test_start_round_assigns_roles(self, fight_club_game):
+        """Test that after _start_round, defender and fighter have correct state."""
+        game, mock_controller_manager, _ = fight_club_game
+        game.gameplay_stream = None
+
+        await game._initialize_players_impl(mock_controller_manager.controllers)
+        await game._start_round()
+
+        # Defender and fighter should be assigned
+        assert game.current_defender is not None
+        assert game.current_fighter is not None
+
+        # Verify their states
+        defender = game.players[game.current_defender]
+        fighter = game.players[game.current_fighter]
+
+        assert defender.state == FightState.DEFENDER
+        assert fighter.state == FightState.FIGHTER
+
+    @pytest.mark.asyncio
+    async def test_handle_timeout_both_to_queue(self, fight_club_game):
+        """Test that when round times out, both players go to back of queue."""
+        game, mock_controller_manager, _ = fight_club_game
+        game.gameplay_stream = None
+
+        await game._initialize_players_impl(mock_controller_manager.controllers)
+        await game._start_round()
+
+        # Record who is fighting
+        defender_serial = game.current_defender
+        fighter_serial = game.current_fighter
+
+        # Handle timeout
+        await game._handle_timeout()
+
+        # Both original combatants should be back in the queue
+        assert defender_serial in game.queue
+        assert fighter_serial in game.queue
+
+        # Both should be IN_LINE state
+        assert game.players[defender_serial].state == FightState.IN_LINE
+        assert game.players[fighter_serial].state == FightState.IN_LINE
+
+    @pytest.mark.asyncio
+    async def test_invincibility_blocks_death(self, fight_club_game):
+        """Test that a player with invincibility survives lethal motion."""
+        game, mock_controller_manager, _ = fight_club_game
+        game.gameplay_stream = MockGameplayStream()
+
+        await game._initialize_players_impl(mock_controller_manager.controllers)
+        await game._start_round()
+
+        defender_serial = game.current_defender
+
+        # Verify invincibility is active
+        assert game.players[defender_serial].invincible_until > time.time()
+
+        # Feed 10 lethal motion frames during invincibility
+        for _ in range(10):
+            state = controller_manager_pb2.ControllerState(
+                serial=defender_serial,
+                accel=controller_manager_pb2.Vector3(x=10.0, y=10.0, z=10.0),
+            )
+            await game._process_controller_state(state)
+
+        # Defender should still be alive
+        assert game.players[defender_serial].alive is True

--- a/services/game_coordinator/tests/test_motion_processing.py
+++ b/services/game_coordinator/tests/test_motion_processing.py
@@ -425,6 +425,41 @@ class TestZombieMotionProcessing:
 
         assert game.players[serial].alive is False
 
+    @pytest.mark.asyncio
+    async def test_zombie_survives_human_lethal_accel(self, game):
+        """Zombie should survive acceleration that kills a human (threshold differentiation)."""
+        game, mock_cm = game
+        game.gameplay_stream = MockGameplayStream()
+        await game._initialize_players_impl(mock_cm.controllers)
+
+        zombie_serial = next(s for s, p in game.players.items() if p.is_zombie)
+        human_serial = next(s for s, p in game.players.items() if not p.is_zombie)
+
+        # Get thresholds to find mid-range acceleration
+        zombie_thresh = game._compute_effective_thresholds(game.players[zombie_serial])
+        human_thresh = game._compute_effective_thresholds(game.players[human_serial])
+        mid_accel = (human_thresh[1] + zombie_thresh[1]) / 2
+
+        game.players[zombie_serial].grace_until = 0.0
+        game.players[human_serial].grace_until = 0.0
+
+        mid_state_human = controller_manager_pb2.GameplayData(
+            serial=human_serial,
+            accel=controller_manager_pb2.Vector3(x=mid_accel, y=0.0, z=0.0),
+        )
+        mid_state_zombie = controller_manager_pb2.GameplayData(
+            serial=zombie_serial,
+            accel=controller_manager_pb2.Vector3(x=mid_accel, y=0.0, z=0.0),
+        )
+
+        for _ in range(20):
+            if game.players[human_serial].alive and not game.players[human_serial].is_zombie:
+                await game._process_controller_state(mid_state_human)
+            await game._process_controller_state(mid_state_zombie)
+
+        assert game.players[human_serial].is_zombie, "Human should be converted at mid-range accel"
+        assert game.players[zombie_serial].alive, "Zombie should survive mid-range accel"
+
 
 # ─── Werewolf ──────────────────────────────────────────────────────────────
 
@@ -473,6 +508,42 @@ class TestWerewolfMotionProcessing:
                 await game._process_controller_state(_lethal_state(serial))
 
         assert game.players[serial].alive is False
+
+    @pytest.mark.asyncio
+    async def test_werewolf_survives_human_lethal_accel(self, game):
+        """Werewolf should survive acceleration that kills a human (threshold differentiation)."""
+        game, mock_cm = game
+        game.gameplay_stream = MockGameplayStream()
+        await game._initialize_players_impl(mock_cm.controllers)
+
+        werewolf_serial = next(s for s, p in game.players.items() if p.is_werewolf)
+        human_serial = next(s for s, p in game.players.items() if not p.is_werewolf)
+
+        # Get thresholds to find mid-range acceleration
+        werewolf_thresh = game._compute_effective_thresholds(game.players[werewolf_serial])
+        human_thresh = game._compute_effective_thresholds(game.players[human_serial])
+        mid_accel = (human_thresh[1] + werewolf_thresh[1]) / 2
+
+        game.players[werewolf_serial].grace_until = 0.0
+        game.players[human_serial].grace_until = 0.0
+
+        mid_state_human = controller_manager_pb2.GameplayData(
+            serial=human_serial,
+            accel=controller_manager_pb2.Vector3(x=mid_accel, y=0.0, z=0.0),
+        )
+        mid_state_werewolf = controller_manager_pb2.GameplayData(
+            serial=werewolf_serial,
+            accel=controller_manager_pb2.Vector3(x=mid_accel, y=0.0, z=0.0),
+        )
+
+        for _ in range(20):
+            if game.players[human_serial].alive:
+                await game._process_controller_state(mid_state_human)
+            if game.players[werewolf_serial].alive:
+                await game._process_controller_state(mid_state_werewolf)
+
+        assert game.players[human_serial].alive is False, "Human should die at mid-range accel"
+        assert game.players[werewolf_serial].alive is True, "Werewolf should survive mid-range accel"
 
 
 # ─── Tournament ────────────────────────────────────────────────────────────

--- a/services/game_coordinator/tests/test_nonstop.py
+++ b/services/game_coordinator/tests/test_nonstop.py
@@ -456,6 +456,56 @@ class TestNonstopScoring:
         expected_score = max(0, 100 - (player.deaths * 10))
         assert expected_score == 0
 
+    @pytest.mark.asyncio
+    async def test_end_game_scoring(self, nonstop_game):
+        """Test that _end_game_impl calculates final scores correctly."""
+        from services.game_coordinator.games.base import GameState
+
+        game, mock_controller_manager, _ = nonstop_game
+
+        await game._initialize_players_impl(mock_controller_manager.controllers)
+
+        # Give player 0 some deaths
+        serial = list(game.players.keys())[0]
+        player = game.players[serial]
+        player.deaths = 3
+
+        # Setup required state for _end_game_impl
+        game.gameplay_stream = MockGameplayStream()
+        game.start_time = time.time()
+        game.state = GameState.RUNNING
+
+        await game._end_game_impl()
+
+        # Score = max(0, 100 - (3 * 10)) = 70
+        assert player.score == 70
+
+    @pytest.mark.asyncio
+    async def test_respawn_timer_decrement(self, nonstop_game):
+        """Test that _update_respawn_timers decrements respawn timer."""
+        game, mock_controller_manager, _ = nonstop_game
+
+        await game._initialize_players_impl(mock_controller_manager.controllers)
+
+        # Setup gameplay stream for respawn countdown colors
+        game.gameplay_stream = MockGameplayStream()
+
+        # Kill player 0
+        serial = list(game.players.keys())[0]
+        await game._kill_player_impl(serial, accel_mag=5.0)
+
+        player = game.players[serial]
+        initial_timer = player.respawn_timer
+
+        # Set update frequency
+        game._current_update_frequency = 30
+
+        # Update respawn timers
+        await game._update_respawn_timers()
+
+        # Timer should have decreased
+        assert player.respawn_timer < initial_timer
+
 
 class TestNonstopSettings:
     """Tests for settings loading."""

--- a/services/game_coordinator/tests/test_swapper.py
+++ b/services/game_coordinator/tests/test_swapper.py
@@ -236,6 +236,46 @@ class TestSwapperTeamSwapping:
         await game._kill_player_impl("mock_controller_0", accel_mag=5.0)
         assert player.swap_count == 2
 
+    @pytest.mark.asyncio
+    async def test_swap_changes_color(self, swapper_game):
+        """After swap, player color should match their new team's color."""
+        game, mock_controller_manager, _ = swapper_game
+
+        # Initialize players
+        await game._initialize_players_impl(mock_controller_manager.controllers)
+
+        # Setup gameplay stream and assign team colors
+        game.gameplay_stream = MockGameplayStream()
+        await game._assign_team_colors()
+
+        # Record initial color for player 0
+        player = game.players["mock_controller_0"]
+        initial_color = player.color
+
+        # Swap player 0 via kill
+        await game._kill_player_impl("mock_controller_0", accel_mag=5.0)
+
+        # Color should have changed to new team's color
+        assert player.color != initial_color
+        new_team = player.team
+        expected_color = game.team_colors[new_team]["rgb"]
+        assert player.color == expected_color
+
+    @pytest.mark.asyncio
+    async def test_end_game_all_same_team(self, swapper_game):
+        """When all players are on the same team, game ends."""
+        game, mock_controller_manager, _ = swapper_game
+
+        # Initialize players
+        await game._initialize_players_impl(mock_controller_manager.controllers)
+
+        # Move all players to team 0
+        for serial in game.players:
+            game.players[serial].team = 0
+
+        # Win condition should trigger
+        assert await game._check_win_condition()
+
 
 class MockGameplayStream:
     """Minimal mock for gameplay stream writes."""

--- a/services/game_coordinator/tests/test_tournament.py
+++ b/services/game_coordinator/tests/test_tournament.py
@@ -205,6 +205,48 @@ class TestTournamentGameMode:
         game, _, _ = tournament_game
         assert game.get_game_name() == "Tournament"
 
+    @pytest.mark.asyncio
+    async def test_get_next_match(self, tournament_game):
+        """Test _get_next_match returns a ready, incomplete match."""
+        game, mock_controller_manager, _ = tournament_game
+
+        await game._initialize_players_impl(mock_controller_manager.controllers)
+
+        bracket = game._generate_bracket(4)
+        game.bracket = bracket
+
+        next_match = game._get_next_match()
+
+        assert next_match is not None
+        assert next_match.player1_serial is not None
+        assert next_match.player2_serial is not None
+        assert next_match.is_complete is False
+
+    @pytest.mark.asyncio
+    async def test_advance_winner(self, tournament_game):
+        """Test _advance_winner moves winner to next round."""
+        game, mock_controller_manager, _ = tournament_game
+
+        await game._initialize_players_impl(mock_controller_manager.controllers)
+
+        bracket = game._generate_bracket(4)
+        game.bracket = bracket
+
+        # Get first match from bracket
+        first_match = bracket[0]
+
+        # Complete the first match
+        first_match.is_complete = True
+        first_match.winner_serial = first_match.player1_serial
+
+        # Advance the winner
+        game._advance_winner(first_match.player1_serial, first_match)
+
+        # Winner should be in WAITING state with round 2
+        winner = game.players[first_match.player1_serial]
+        assert winner.tournament_state == TournamentState.WAITING
+        assert winner.round_number == 2
+
 
 class TestTournamentBracket:
     """Tests for tournament bracket generation."""

--- a/services/game_coordinator/tests/test_werewolf.py
+++ b/services/game_coordinator/tests/test_werewolf.py
@@ -271,7 +271,7 @@ class TestWerewolfThresholds:
         # Get threshold for a werewolf
         werewolf_serial = game.werewolf_serials[0]
         werewolf_player = game.players[werewolf_serial]
-        werewolf_thresholds = game._get_effective_thresholds(werewolf_player)
+        werewolf_thresholds = game._compute_effective_thresholds(werewolf_player)
 
         # Should return a tuple from WEREWOLF_THRESHOLDS
         assert isinstance(werewolf_thresholds, tuple), "Werewolf thresholds should be tuple"
@@ -283,18 +283,118 @@ class TestWerewolfThresholds:
         assert werewolf_thresholds == expected
 
     @pytest.mark.asyncio
-    async def test_human_returns_sensitivity_value(self, werewolf_game):
-        """Humans should return sensitivity.value for threshold lookup."""
+    async def test_human_returns_base_thresholds(self, werewolf_game):
+        """Humans should return base class thresholds (tuple of warn, death)."""
         game, mock_controller_manager = werewolf_game
         await game._initialize_players_impl(mock_controller_manager.controllers)
 
         # Get threshold for a human
         human_serial = game.human_serials[0]
         human_player = game.players[human_serial]
-        human_thresholds = game._get_effective_thresholds(human_player)
+        human_thresholds = game._compute_effective_thresholds(human_player)
 
-        # Humans return sensitivity.value (int index) for base class threshold lookup
-        assert isinstance(human_thresholds, int), "Human thresholds should be int index"
+        # Humans delegate to base class, which returns (warn, death) tuple
+        assert isinstance(human_thresholds, tuple), "Human thresholds should be tuple"
+        assert len(human_thresholds) == 2, "Human thresholds should have (warning, death)"
+        assert human_thresholds[0] < human_thresholds[1], "Warning should be less than death threshold"
+
+    @pytest.mark.asyncio
+    async def test_werewolf_threshold_higher_than_human(self, werewolf_game):
+        """Werewolf death threshold should be higher than human death threshold."""
+        game, mock_controller_manager = werewolf_game
+        await game._initialize_players_impl(mock_controller_manager.controllers)
+
+        werewolf_serial = game.werewolf_serials[0]
+        human_serial = game.human_serials[0]
+
+        werewolf_thresh = game._compute_effective_thresholds(game.players[werewolf_serial])
+        human_thresh = game._compute_effective_thresholds(game.players[human_serial])
+
+        # Werewolf death threshold should be higher (harder to kill)
+        assert werewolf_thresh[1] > human_thresh[1], (
+            f"Werewolf death threshold {werewolf_thresh[1]} should be > human {human_thresh[1]}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_werewolf_survives_accel_that_kills_human(self, werewolf_game):
+        """Integration test: acceleration between human and werewolf death thresholds kills human but not werewolf."""
+        from proto import controller_manager_pb2
+
+        game, mock_controller_manager = werewolf_game
+        game.gameplay_stream = MockGameplayStream()
+        await game._initialize_players_impl(mock_controller_manager.controllers)
+
+        werewolf_serial = game.werewolf_serials[0]
+        human_serial = game.human_serials[0]
+
+        werewolf_thresh = game._compute_effective_thresholds(game.players[werewolf_serial])
+        human_thresh = game._compute_effective_thresholds(game.players[human_serial])
+
+        # Pick acceleration between human death and werewolf death thresholds
+        mid_accel = (human_thresh[1] + werewolf_thresh[1]) / 2
+
+        game.players[werewolf_serial].grace_until = 0.0
+        game.players[human_serial].grace_until = 0.0
+
+        state_human = controller_manager_pb2.GameplayData(
+            serial=human_serial,
+            accel=controller_manager_pb2.Vector3(x=mid_accel, y=0.0, z=0.0),
+        )
+        state_werewolf = controller_manager_pb2.GameplayData(
+            serial=werewolf_serial,
+            accel=controller_manager_pb2.Vector3(x=mid_accel, y=0.0, z=0.0),
+        )
+
+        # Feed enough frames for EMA to build up
+        for _ in range(20):
+            if game.players[human_serial].alive:
+                await game._process_controller_state(state_human)
+            if game.players[werewolf_serial].alive:
+                await game._process_controller_state(state_werewolf)
+
+        # Human should be dead, werewolf should survive
+        assert game.players[human_serial].alive is False, "Human should die at mid-range acceleration"
+        assert game.players[werewolf_serial].alive is True, "Werewolf should survive mid-range acceleration"
+
+    @pytest.mark.asyncio
+    async def test_werewolf_thresholds_all_sensitivities(self, werewolf_game):
+        """All 5 sensitivity levels should return valid tuples from WEREWOLF_THRESHOLDS."""
+        from services.game_coordinator.games.base import Sensitivity
+        from services.game_coordinator.games.werewolf import WEREWOLF_THRESHOLDS
+
+        game, mock_controller_manager = werewolf_game
+        await game._initialize_players_impl(mock_controller_manager.controllers)
+
+        werewolf_serial = game.werewolf_serials[0]
+        werewolf_player = game.players[werewolf_serial]
+
+        for sensitivity in Sensitivity:
+            game.sensitivity = sensitivity
+            thresh = game._compute_effective_thresholds(werewolf_player)
+            expected = WEREWOLF_THRESHOLDS[sensitivity]
+            assert thresh == expected, f"Sensitivity {sensitivity}: got {thresh}, expected {expected}"
+
+    @pytest.mark.asyncio
+    async def test_werewolf_thresholds_static_across_music_speed(self, werewolf_game):
+        """Werewolf thresholds should not change with music tempo (intentionally static)."""
+        game, mock_controller_manager = werewolf_game
+        await game._initialize_players_impl(mock_controller_manager.controllers)
+
+        werewolf_serial = game.werewolf_serials[0]
+        werewolf_player = game.players[werewolf_serial]
+
+        # Get thresholds at slow music speed
+        game.music_speed = 1.0
+        thresh_slow = game._compute_effective_thresholds(werewolf_player)
+
+        # Get thresholds at fast music speed
+        game.music_speed = 1.3
+        thresh_fast = game._compute_effective_thresholds(werewolf_player)
+
+        # Werewolf thresholds come from static dict, not affected by music
+        assert thresh_slow == thresh_fast, (
+            f"Werewolf thresholds should be static: slow={thresh_slow}, fast={thresh_fast}"
+        )
 
 
 class TestWerewolfReveal:

--- a/services/game_coordinator/tests/test_zombie.py
+++ b/services/game_coordinator/tests/test_zombie.py
@@ -354,6 +354,7 @@ class TestZombieThresholds:
     @pytest.mark.asyncio
     async def test_zombie_returns_zombie_thresholds(self, zombie_game):
         """Zombies should get thresholds from ZOMBIE_THRESHOLDS dict."""
+        from services.game_coordinator.games.zombie import ZOMBIE_THRESHOLDS
 
         game, mock_controller_manager = zombie_game
         await game._initialize_players_impl(mock_controller_manager.controllers)
@@ -361,27 +362,127 @@ class TestZombieThresholds:
         # Get threshold for a zombie
         zombie_serial = game.zombie_serials[0]
         zombie_player = game.players[zombie_serial]
-        zombie_thresholds = game._get_effective_thresholds(zombie_player)
+        zombie_thresholds = game._compute_effective_thresholds(zombie_player)
 
         # Should return a tuple from ZOMBIE_THRESHOLDS
         assert isinstance(zombie_thresholds, tuple), "Zombie thresholds should be tuple"
         assert len(zombie_thresholds) == 2, "Zombie thresholds should have (warning, death)"
         assert zombie_thresholds[0] < zombie_thresholds[1], "Warning should be less than death threshold"
 
+        # Verify it matches ZOMBIE_THRESHOLDS for game's sensitivity
+        expected = ZOMBIE_THRESHOLDS.get(game.sensitivity, (2.1, 2.6))
+        assert zombie_thresholds == expected
+
     @pytest.mark.asyncio
-    async def test_human_returns_sensitivity_value(self, zombie_game):
-        """Humans should return sensitivity.value for threshold lookup."""
+    async def test_human_returns_base_thresholds(self, zombie_game):
+        """Humans should return base class thresholds (tuple of warn, death)."""
         game, mock_controller_manager = zombie_game
         await game._initialize_players_impl(mock_controller_manager.controllers)
 
         # Get threshold for a human
         human_serial = game.human_serials[0]
         human_player = game.players[human_serial]
-        human_thresholds = game._get_effective_thresholds(human_player)
+        human_thresholds = game._compute_effective_thresholds(human_player)
 
-        # Humans return sensitivity.value (int index) for base class threshold lookup
-        # This is intentional - base class uses this to index into SLOW_MAX/FAST_MAX arrays
-        assert isinstance(human_thresholds, int), "Human thresholds should be int index"
+        # Humans delegate to base class, which returns (warn, death) tuple
+        assert isinstance(human_thresholds, tuple), "Human thresholds should be tuple"
+        assert len(human_thresholds) == 2, "Human thresholds should have (warning, death)"
+        assert human_thresholds[0] < human_thresholds[1], "Warning should be less than death threshold"
+
+    @pytest.mark.asyncio
+    async def test_zombie_threshold_higher_than_human(self, zombie_game):
+        """Zombie death threshold should be higher than human death threshold."""
+        game, mock_controller_manager = zombie_game
+        await game._initialize_players_impl(mock_controller_manager.controllers)
+
+        zombie_serial = game.zombie_serials[0]
+        human_serial = game.human_serials[0]
+
+        zombie_thresh = game._compute_effective_thresholds(game.players[zombie_serial])
+        human_thresh = game._compute_effective_thresholds(game.players[human_serial])
+
+        # Zombie death threshold should be higher (harder to kill)
+        assert zombie_thresh[1] > human_thresh[1], (
+            f"Zombie death threshold {zombie_thresh[1]} should be > human {human_thresh[1]}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_zombie_survives_accel_that_kills_human(self, zombie_game):
+        """Integration test: acceleration between human and zombie death thresholds kills human but not zombie."""
+        from proto import controller_manager_pb2
+
+        game, mock_controller_manager = zombie_game
+        game.gameplay_stream = MockGameplayStream()
+        await game._initialize_players_impl(mock_controller_manager.controllers)
+
+        zombie_serial = game.zombie_serials[0]
+        human_serial = game.human_serials[0]
+
+        zombie_thresh = game._compute_effective_thresholds(game.players[zombie_serial])
+        human_thresh = game._compute_effective_thresholds(game.players[human_serial])
+
+        # Pick acceleration between human death and zombie death thresholds
+        mid_accel = (human_thresh[1] + zombie_thresh[1]) / 2
+
+        game.players[zombie_serial].grace_until = 0.0
+        game.players[human_serial].grace_until = 0.0
+
+        state_human = controller_manager_pb2.GameplayData(
+            serial=human_serial,
+            accel=controller_manager_pb2.Vector3(x=mid_accel, y=0.0, z=0.0),
+        )
+        state_zombie = controller_manager_pb2.GameplayData(
+            serial=zombie_serial,
+            accel=controller_manager_pb2.Vector3(x=mid_accel, y=0.0, z=0.0),
+        )
+
+        # Feed enough frames for EMA to build up
+        for _ in range(20):
+            if game.players[human_serial].alive and not game.players[human_serial].is_zombie:
+                await game._process_controller_state(state_human)
+            await game._process_controller_state(state_zombie)
+
+        # Human should be dead (converted to zombie), zombie should survive
+        assert game.players[human_serial].is_zombie, "Human should have been converted to zombie"
+        assert game.players[zombie_serial].alive, "Zombie should survive mid-range acceleration"
+
+    @pytest.mark.asyncio
+    async def test_zombie_thresholds_all_sensitivities(self, zombie_game):
+        """All 5 sensitivity levels should return valid tuples from ZOMBIE_THRESHOLDS."""
+        from services.game_coordinator.games.base import Sensitivity
+        from services.game_coordinator.games.zombie import ZOMBIE_THRESHOLDS
+
+        game, mock_controller_manager = zombie_game
+        await game._initialize_players_impl(mock_controller_manager.controllers)
+
+        zombie_serial = game.zombie_serials[0]
+        zombie_player = game.players[zombie_serial]
+
+        for sensitivity in Sensitivity:
+            game.sensitivity = sensitivity
+            thresh = game._compute_effective_thresholds(zombie_player)
+            expected = ZOMBIE_THRESHOLDS[sensitivity]
+            assert thresh == expected, f"Sensitivity {sensitivity}: got {thresh}, expected {expected}"
+
+    @pytest.mark.asyncio
+    async def test_zombie_thresholds_static_across_music_speed(self, zombie_game):
+        """Zombie thresholds should not change with music tempo (intentionally static)."""
+        game, mock_controller_manager = zombie_game
+        await game._initialize_players_impl(mock_controller_manager.controllers)
+
+        zombie_serial = game.zombie_serials[0]
+        zombie_player = game.players[zombie_serial]
+
+        # Get thresholds at slow music speed
+        game.music_speed = 1.0
+        thresh_slow = game._compute_effective_thresholds(zombie_player)
+
+        # Get thresholds at fast music speed
+        game.music_speed = 1.3
+        thresh_fast = game._compute_effective_thresholds(zombie_player)
+
+        # Zombie thresholds come from static dict, not affected by music
+        assert thresh_slow == thresh_fast, f"Zombie thresholds should be static: slow={thresh_slow}, fast={thresh_fast}"
 
 
 class TestZombieEdgeCases:


### PR DESCRIPTION
## Summary
- **Bug fix**: Renamed `_get_effective_thresholds` → `_compute_effective_thresholds` in `zombie.py` and `werewolf.py` so the base class actually calls the override (was dead code — zombies/werewolves used same thresholds as regular players)
- **Fallback fix**: Changed human fallback from `return self.sensitivity.value` (returns `int`, would crash) to `return super()._compute_effective_thresholds(player)` (returns proper `tuple[float, float]`)
- **Test coverage**: Added 22+ new tests across all game modes — threshold integration, motion processing differentiation, and expanded coverage for FFA, swapper, fight club, tournament, and nonstop joust

Fixes #514

## Test plan
- [x] `uv run pytest -v` — 449 tests pass (up from ~427)
- [x] `make lint` — clean
- [x] Key proof: `test_zombie_survives_accel_that_kills_human` would FAIL without the rename fix
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)