### PR TITLE
fix: type mismatch in _play_value_voice and add admin handler tests

### DIFF
--- a/services/menu/handlers/admin.py
+++ b/services/menu/handlers/admin.py
@@ -1171,13 +1171,13 @@ class AdminModeHandler:
         except Exception as e:
             logger.error(f"Error showing value feedback: {e}", exc_info=True)
 
-    async def _play_value_voice(self, option_name: str, value: str) -> None:
+    async def _play_value_voice(self, option_name: str, value: int | float | bool) -> None:
         """
         Play voice feedback for admin option value change.
 
         Args:
             option_name: Name of the option that changed
-            value: New value
+            value: New value (typed from _variant_to_value)
         """
         try:
             if option_name == "num_teams":
@@ -1189,12 +1189,12 @@ class AdminModeHandler:
                     "5": Sound.MENU_VOX_ADMINOP_5,
                     "6": Sound.MENU_VOX_ADMINOP_6,
                 }
-                voice = num_teams_voices.get(value)
+                voice = num_teams_voices.get(str(value))
                 if voice:
                     await self._play_voice(voice)
             elif option_name == "force_all_start":
                 # Play true/false voice
-                voice = Sound.MENU_VOX_ADMINOP_TRUE if value == "true" else Sound.MENU_VOX_ADMINOP_FALSE
+                voice = Sound.MENU_VOX_ADMINOP_TRUE if value is True else Sound.MENU_VOX_ADMINOP_FALSE
                 await self._play_voice(voice)
         except Exception as e:
             logger.error(f"Error playing value voice: {e}", exc_info=True)

--- a/services/menu/tests/test_admin_handler.py
+++ b/services/menu/tests/test_admin_handler.py
@@ -1,11 +1,15 @@
 """Unit tests for AdminModeHandler game settings."""
 
+import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from lib.colors import Colors
+from lib.controller_constants import ButtonTrackingKey
+from lib.types import Sound
 from services.menu.handlers.admin import AdminModeHandler
+from services.menu.handlers.base import ControllerState
 
 
 @pytest.fixture
@@ -67,7 +71,7 @@ def mock_state_manager():
 
 @pytest.fixture
 def handler(mock_tracer, mock_callbacks, mock_metrics, mock_state_manager):
-    """Create AdminModeHandler instance with mocks."""
+    """Create AdminModeHandler instance with mocks (pre-activated)."""
     handler = AdminModeHandler(
         controller_channel=MagicMock(),
         tracer=mock_tracer,
@@ -77,6 +81,20 @@ def handler(mock_tracer, mock_callbacks, mock_metrics, mock_state_manager):
     handler.set_state_manager(mock_state_manager)
     handler.active = True
     handler.controller_serial = "test_serial"
+    handler.entry_time = time.time()
+    return handler
+
+
+@pytest.fixture
+def inactive_handler(mock_tracer, mock_callbacks, mock_metrics, mock_state_manager):
+    """Create AdminModeHandler instance that is NOT pre-activated."""
+    handler = AdminModeHandler(
+        controller_channel=MagicMock(),
+        tracer=mock_tracer,
+        callbacks=mock_callbacks,
+        metrics=mock_metrics,
+    )
+    handler.set_state_manager(mock_state_manager)
     return handler
 
 
@@ -400,3 +418,783 @@ class TestHandleForceStartFlagd:
         handler._publish_event.assert_called()
         call_args = handler._publish_event.call_args[0]
         assert call_args[0] == "game_requested"
+
+
+# ============================================================================
+# Tier 1 — Core Lifecycle
+# ============================================================================
+
+
+class TestEnter:
+    """Tests for entering admin mode."""
+
+    @pytest.mark.asyncio
+    async def test_enter_sets_active(self, inactive_handler):
+        """enter() should set active=True."""
+        await inactive_handler.enter("s1")
+        assert inactive_handler.active is True
+
+    @pytest.mark.asyncio
+    async def test_enter_sets_serial(self, inactive_handler):
+        """enter() should record the admin controller serial."""
+        await inactive_handler.enter("s1")
+        assert inactive_handler.controller_serial == "s1"
+
+    @pytest.mark.asyncio
+    async def test_enter_sets_entry_time(self, inactive_handler):
+        """enter() should record the entry time."""
+        before = time.time()
+        await inactive_handler.enter("s1")
+        assert inactive_handler.entry_time >= before
+
+    @pytest.mark.asyncio
+    async def test_enter_resets_option_to_zero(self, inactive_handler):
+        """enter() should reset current_option to 0."""
+        inactive_handler.current_option = 5
+        await inactive_handler.enter("s1")
+        assert inactive_handler.current_option == 0
+
+    @pytest.mark.asyncio
+    async def test_enter_records_metric(self, inactive_handler, mock_metrics):
+        """enter() should increment button_presses_total for admin_combo."""
+        await inactive_handler.enter("s1")
+        mock_metrics.button_presses_total.labels.assert_called_with(button="admin_combo", action="hold")
+        mock_metrics.button_presses_total.labels().inc.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_enter_sends_admin_enter_effect(self, inactive_handler, mock_state_manager):
+        """enter() should send GAME_EFFECT_ADMIN_ENTER."""
+        from proto import controller_manager_pb2
+
+        await inactive_handler.enter("s1")
+        call_args = mock_state_manager.led.send_game_effect.call_args
+        assert call_args[0][0] == "s1"
+        assert call_args[0][1] == controller_manager_pb2.GAME_EFFECT_ADMIN_ENTER
+
+    @pytest.mark.asyncio
+    async def test_enter_starts_timeout_task(self, inactive_handler):
+        """enter() should create a timeout task."""
+        await inactive_handler.enter("s1")
+        assert inactive_handler._timeout_task is not None
+        assert not inactive_handler._timeout_task.done()
+        # Clean up
+        inactive_handler._timeout_task.cancel()
+
+    @pytest.mark.asyncio
+    async def test_enter_creates_session_span(self, inactive_handler, mock_tracer):
+        """enter() should create a session span."""
+        await inactive_handler.enter("s1")
+        mock_tracer.start_span.assert_called_with("admin_mode_session")
+        assert inactive_handler.session_span is not None
+        # Clean up
+        if inactive_handler._timeout_task:
+            inactive_handler._timeout_task.cancel()
+
+
+class TestExit:
+    """Tests for exiting admin mode."""
+
+    @pytest.mark.asyncio
+    async def test_exit_returns_early_if_not_active(self, inactive_handler, mock_state_manager):
+        """exit() should return immediately if not active."""
+        await inactive_handler.exit()
+        mock_state_manager.led.send_game_effect.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_exit_clears_active(self, handler):
+        """exit() should set active=False."""
+        await handler.exit()
+        assert handler.active is False
+
+    @pytest.mark.asyncio
+    async def test_exit_clears_serial(self, handler):
+        """exit() should clear controller_serial."""
+        await handler.exit()
+        assert handler.controller_serial is None
+
+    @pytest.mark.asyncio
+    async def test_exit_clears_entry_time(self, handler):
+        """exit() should reset entry_time to 0."""
+        await handler.exit()
+        assert handler.entry_time == 0
+
+    @pytest.mark.asyncio
+    async def test_exit_sends_admin_exit_effect(self, handler, mock_state_manager):
+        """exit() should send GAME_EFFECT_ADMIN_EXIT."""
+        from proto import controller_manager_pb2
+
+        await handler.exit()
+        call_args = mock_state_manager.led.send_game_effect.call_args
+        assert call_args[0][0] == "test_serial"
+        assert call_args[0][1] == controller_manager_pb2.GAME_EFFECT_ADMIN_EXIT
+
+    @pytest.mark.asyncio
+    async def test_exit_cancels_timeout_task(self, handler):
+        """exit() should cancel the timeout task."""
+        # Create a fake timeout task
+        mock_task = MagicMock()
+        mock_task.done.return_value = False
+        handler._timeout_task = mock_task
+
+        await handler.exit()
+
+        mock_task.cancel.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_exit_ends_session_span(self, handler):
+        """exit() should end the session span."""
+        span = MagicMock()
+        handler.session_span = span
+
+        await handler.exit()
+
+        span.end.assert_called_once()
+        assert handler.session_span is None
+        assert handler.session_span_context is None
+
+
+class TestHandleButtonEventDispatch:
+    """Tests for button event routing in handle_button_event."""
+
+    @pytest.mark.asyncio
+    async def test_dispatch_move_to_cycle_option(self, handler):
+        """MOVE button should dispatch to handle_cycle_option."""
+        handler.handle_cycle_option = AsyncMock()
+        await handler.handle_button_event("test_serial", ButtonTrackingKey.MOVE)
+        handler.handle_cycle_option.assert_called_once_with("test_serial")
+
+    @pytest.mark.asyncio
+    async def test_dispatch_trigger_to_hold_tracking(self, handler):
+        """TRIGGER button should dispatch to _start_trigger_hold_tracking."""
+        handler._start_trigger_hold_tracking = AsyncMock()
+        await handler.handle_button_event("test_serial", ButtonTrackingKey.TRIGGER)
+        handler._start_trigger_hold_tracking.assert_called_once_with("test_serial")
+
+    @pytest.mark.asyncio
+    async def test_dispatch_select_to_increase(self, handler):
+        """SELECT button should dispatch to handle_increase_value."""
+        handler.handle_increase_value = AsyncMock()
+        await handler.handle_button_event("test_serial", ButtonTrackingKey.SELECT)
+        handler.handle_increase_value.assert_called_once_with("test_serial")
+
+    @pytest.mark.asyncio
+    async def test_dispatch_start_to_decrease(self, handler):
+        """START button should dispatch to handle_decrease_value."""
+        handler.handle_decrease_value = AsyncMock()
+        await handler.handle_button_event("test_serial", ButtonTrackingKey.START)
+        handler.handle_decrease_value.assert_called_once_with("test_serial")
+
+    @pytest.mark.asyncio
+    async def test_dispatch_cross_to_game_mode(self, handler):
+        """CROSS button should dispatch to handle_game_mode."""
+        handler.handle_game_mode = AsyncMock()
+        await handler.handle_button_event("test_serial", ButtonTrackingKey.CROSS)
+        handler.handle_game_mode.assert_called_once_with("test_serial")
+
+    @pytest.mark.asyncio
+    async def test_dispatch_circle_to_sensitivity(self, handler):
+        """CIRCLE button should dispatch to handle_sensitivity."""
+        handler.handle_sensitivity = AsyncMock()
+        await handler.handle_button_event("test_serial", ButtonTrackingKey.CIRCLE)
+        handler.handle_sensitivity.assert_called_once_with("test_serial")
+
+    @pytest.mark.asyncio
+    async def test_dispatch_triangle_to_battery(self, handler):
+        """TRIANGLE button should dispatch to handle_battery."""
+        handler.handle_battery = AsyncMock()
+        await handler.handle_button_event("test_serial", ButtonTrackingKey.TRIANGLE)
+        handler.handle_battery.assert_called_once_with("test_serial")
+
+    @pytest.mark.asyncio
+    async def test_dispatch_square_to_instructions(self, handler):
+        """SQUARE button should dispatch to handle_instructions."""
+        handler.handle_instructions = AsyncMock()
+        await handler.handle_button_event("test_serial", ButtonTrackingKey.SQUARE)
+        handler.handle_instructions.assert_called_once_with("test_serial")
+
+    @pytest.mark.asyncio
+    async def test_dispatch_ps_to_exit(self, handler):
+        """PS button should dispatch to _exit_to_connected."""
+        handler._exit_to_connected = AsyncMock()
+        await handler.handle_button_event("test_serial", ButtonTrackingKey.PS)
+        handler._exit_to_connected.assert_called_once_with("test_serial")
+
+    @pytest.mark.asyncio
+    async def test_timeout_exits_after_60_seconds(self, handler):
+        """Should auto-exit if entry_time was more than 60 seconds ago."""
+        handler.entry_time = time.time() - 61
+        handler._exit_to_connected = AsyncMock()
+
+        await handler.handle_button_event("test_serial", ButtonTrackingKey.CROSS)
+
+        handler._exit_to_connected.assert_called_once_with("test_serial")
+
+    @pytest.mark.asyncio
+    async def test_debounce_rejects_rapid_presses(self, handler):
+        """Rapid presses should be debounced."""
+        handler.handle_game_mode = AsyncMock()
+
+        # First press should go through
+        await handler.handle_button_event("test_serial", ButtonTrackingKey.CROSS)
+        assert handler.handle_game_mode.call_count == 1
+
+        # Immediate second press should be debounced
+        await handler.handle_button_event("test_serial", ButtonTrackingKey.CROSS)
+        assert handler.handle_game_mode.call_count == 1
+
+
+class TestResetOnDisconnect:
+    """Tests for admin mode reset on controller disconnect."""
+
+    def test_clears_state_for_matching_serial(self, handler):
+        """reset_on_disconnect should clear state when serial matches."""
+        handler.reset_on_disconnect("test_serial")
+
+        assert handler.active is False
+        assert handler.controller_serial is None
+        assert handler.entry_time == 0
+
+    def test_ignores_different_serial(self, handler):
+        """reset_on_disconnect should ignore non-admin controller."""
+        handler.reset_on_disconnect("other_serial")
+
+        assert handler.active is True
+        assert handler.controller_serial == "test_serial"
+
+    def test_ignores_when_inactive(self, inactive_handler):
+        """reset_on_disconnect should do nothing when not active."""
+        inactive_handler.reset_on_disconnect("s1")
+        assert inactive_handler.active is False
+
+    def test_cancels_timeout_task(self, handler):
+        """reset_on_disconnect should cancel timeout task."""
+        mock_task = MagicMock()
+        mock_task.done.return_value = False
+        handler._timeout_task = mock_task
+
+        handler.reset_on_disconnect("test_serial")
+
+        mock_task.cancel.assert_called_once()
+
+    def test_ends_session_span(self, handler):
+        """reset_on_disconnect should end the session span."""
+        span = MagicMock()
+        handler.session_span = span
+
+        handler.reset_on_disconnect("test_serial")
+
+        span.set_attribute.assert_called_with("disconnect", True)
+        span.end.assert_called_once()
+        assert handler.session_span is None
+
+
+# ============================================================================
+# Tier 2 — Pure Logic
+# ============================================================================
+
+
+class TestVariantToValue:
+    """Tests for _variant_to_value static method."""
+
+    def test_sensitivity_ultra_slow(self):
+        assert AdminModeHandler._variant_to_value("sensitivity", "ultra_slow") == 0
+
+    def test_sensitivity_ultra_fast(self):
+        assert AdminModeHandler._variant_to_value("sensitivity", "ultra_fast") == 4
+
+    def test_num_teams_two(self):
+        assert AdminModeHandler._variant_to_value("num_teams", "two") == 2
+
+    def test_num_teams_six(self):
+        assert AdminModeHandler._variant_to_value("num_teams", "six") == 6
+
+    def test_random_assignment_on(self):
+        assert AdminModeHandler._variant_to_value("random_assignment", "on") is True
+
+    def test_random_assignment_off(self):
+        assert AdminModeHandler._variant_to_value("random_assignment", "off") is False
+
+    def test_nonstop_time_limit_unlimited(self):
+        assert AdminModeHandler._variant_to_value("nonstop_time_limit", "unlimited") == 0
+
+    def test_nonstop_time_limit_five_min(self):
+        assert AdminModeHandler._variant_to_value("nonstop_time_limit", "five_min") == 300
+
+    def test_invincibility_2s(self):
+        assert AdminModeHandler._variant_to_value("invincibility", "2s") == 2.0
+
+    def test_invincibility_8s(self):
+        assert AdminModeHandler._variant_to_value("invincibility", "8s") == 8.0
+
+    def test_fight_club_min_rounds_five(self):
+        assert AdminModeHandler._variant_to_value("fight_club_min_rounds", "five") == 5
+
+    def test_fight_club_min_rounds_twenty(self):
+        assert AdminModeHandler._variant_to_value("fight_club_min_rounds", "twenty") == 20
+
+    def test_werewolf_reveal_time_20s(self):
+        assert AdminModeHandler._variant_to_value("werewolf_reveal_time", "20s") == 20.0
+
+    def test_werewolf_reveal_time_60s(self):
+        assert AdminModeHandler._variant_to_value("werewolf_reveal_time", "60s") == 60.0
+
+    def test_force_all_start_on(self):
+        assert AdminModeHandler._variant_to_value("force_all_start", "on") is True
+
+    def test_force_all_start_off(self):
+        assert AdminModeHandler._variant_to_value("force_all_start", "off") is False
+
+    def test_unknown_option_returns_zero(self):
+        assert AdminModeHandler._variant_to_value("unknown_option", "whatever") == 0
+
+    def test_unknown_variant_returns_zero(self):
+        assert AdminModeHandler._variant_to_value("sensitivity", "nonexistent") == 0
+
+
+class TestCheckCombo:
+    """Tests for admin combo detection."""
+
+    def test_all_four_buttons_true(self, handler):
+        """All 4 face buttons pressed should return True."""
+        state = {"cross": True, "circle": True, "square": True, "triangle": True}
+        assert handler.check_combo_from_state(state) is True
+
+    def test_missing_one_button(self, handler):
+        """Missing any button should return False."""
+        state = {"cross": True, "circle": True, "square": True, "triangle": False}
+        assert handler.check_combo_from_state(state) is False
+
+    def test_empty_state(self, handler):
+        """Empty dict should return False."""
+        assert handler.check_combo_from_state({}) is False
+
+    def test_combo_from_controller(self, handler):
+        """check_combo_from_controller with all pressed should return True."""
+        controller = MagicMock()
+        controller.cross_pressed = True
+        controller.circle_pressed = True
+        controller.square_pressed = True
+        controller.triangle_pressed = True
+        assert handler.check_combo_from_controller(controller) is True
+
+    def test_combo_from_controller_missing(self, handler):
+        """check_combo_from_controller with one missing should return False."""
+        controller = MagicMock()
+        controller.cross_pressed = True
+        controller.circle_pressed = False
+        controller.square_pressed = True
+        controller.triangle_pressed = True
+        assert handler.check_combo_from_controller(controller) is False
+
+
+class TestIsAdminController:
+    """Tests for is_admin_controller."""
+
+    def test_matching_active_returns_true(self, handler):
+        """Matching serial when active should return True."""
+        assert handler.is_admin_controller("test_serial") is True
+
+    def test_wrong_serial_returns_false(self, handler):
+        """Wrong serial should return False."""
+        assert handler.is_admin_controller("other_serial") is False
+
+    def test_inactive_returns_false(self, inactive_handler):
+        """Inactive handler should return False for any serial."""
+        assert inactive_handler.is_admin_controller("s1") is False
+
+
+class TestStateProperty:
+    """Tests for the state property."""
+
+    def test_state_is_admin(self, handler):
+        """state property should return ControllerState.ADMIN."""
+        assert handler.state == ControllerState.ADMIN
+
+
+# ============================================================================
+# Tier 3 — Button Handlers
+# ============================================================================
+
+
+class TestHandleGameMode:
+    """Tests for game mode cycling (cross button)."""
+
+    @pytest.mark.asyncio
+    async def test_cycles_to_next_mode(self, handler, mock_state_manager):
+        """Should cycle to next game mode."""
+        mock_state_manager.current_game_mode.name = "JoustFFA"
+        handler.callbacks.get_game_options.return_value = ["JoustFFA", "JoustTeams", "Werewolf"]
+
+        await handler.handle_game_mode("test_serial")
+
+        mock_state_manager.publish_event.assert_called_once()
+        call_args = mock_state_manager.publish_event.call_args[0]
+        assert call_args[0] == "game_selection_changed"
+        assert call_args[1]["game_name"] == "JoustTeams"
+
+    @pytest.mark.asyncio
+    async def test_wraps_to_first_mode(self, handler, mock_state_manager):
+        """Should wrap to first mode when at end."""
+        mock_state_manager.current_game_mode.name = "JoustTeams"
+        handler.callbacks.get_game_options.return_value = ["JoustFFA", "JoustTeams"]
+
+        await handler.handle_game_mode("test_serial")
+
+        call_args = mock_state_manager.publish_event.call_args[0]
+        assert call_args[1]["game_name"] == "JoustFFA"
+
+    @pytest.mark.asyncio
+    async def test_sends_pulse_and_plays_voice(self, handler, mock_state_manager):
+        """Should send color pulse and play game mode voice."""
+        from proto import controller_manager_pb2
+
+        await handler.handle_game_mode("test_serial")
+
+        mock_state_manager.led.send_game_effect.assert_called_once()
+        call_args = mock_state_manager.led.send_game_effect.call_args
+        assert call_args[0][1] == controller_manager_pb2.GAME_EFFECT_PULSE
+        mock_state_manager.audio.play_game_mode_voice.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_empty_options_returns_early(self, handler, mock_state_manager):
+        """Should return early if no game options available."""
+        handler.callbacks.get_game_options.return_value = []
+
+        await handler.handle_game_mode("test_serial")
+
+        mock_state_manager.publish_event.assert_not_called()
+
+
+class TestHandleGameModeChange:
+    """Tests for handle_game_mode_change with direction."""
+
+    @pytest.mark.asyncio
+    async def test_forward_sends_green_pulse(self, handler, mock_state_manager):
+        """Forward mode change should send green pulse."""
+        await handler.handle_game_mode_change("test_serial", forward=True)
+
+        call_kwargs = mock_state_manager.led.send_game_effect.call_args[1]
+        assert call_kwargs["color"] == (0, 255, 0)
+
+    @pytest.mark.asyncio
+    async def test_backward_sends_blue_pulse(self, handler, mock_state_manager):
+        """Backward mode change should send blue pulse."""
+        await handler.handle_game_mode_change("test_serial", forward=False)
+
+        call_kwargs = mock_state_manager.led.send_game_effect.call_args[1]
+        assert call_kwargs["color"] == (0, 0, 255)
+
+    @pytest.mark.asyncio
+    async def test_empty_options_returns_early(self, handler, mock_state_manager):
+        """Should return early if no game options."""
+        handler.callbacks.get_game_options.return_value = []
+
+        await handler.handle_game_mode_change("test_serial")
+
+        mock_state_manager.publish_event.assert_not_called()
+
+
+class TestHandleBattery:
+    """Tests for battery display (triangle button)."""
+
+    @pytest.mark.asyncio
+    async def test_sends_show_battery_with_empty_serial(self, handler, mock_state_manager):
+        """Should send GAME_EFFECT_SHOW_BATTERY with empty serial (affects all)."""
+        from proto import controller_manager_pb2
+
+        await handler.handle_battery("test_serial")
+
+        call_args = mock_state_manager.led.send_game_effect.call_args
+        assert call_args[0][0] == ""
+        assert call_args[0][1] == controller_manager_pb2.GAME_EFFECT_SHOW_BATTERY
+
+    @pytest.mark.asyncio
+    async def test_handles_stream_unavailable(self, handler, mock_state_manager):
+        """Should handle stream not available gracefully."""
+        mock_state_manager.led.send_game_effect = AsyncMock(return_value=False)
+
+        # Should not raise
+        await handler.handle_battery("test_serial")
+
+
+class TestHandleInstructions:
+    """Tests for instruction toggle (square button)."""
+
+    @pytest.mark.asyncio
+    async def test_cycles_variant(self, handler, mock_state_manager):
+        """Should cycle game_instructions variant."""
+        await handler.handle_instructions("test_serial")
+
+        mock_state_manager.user_prefs_writer.cycle_variant.assert_called_once_with("game_instructions", forward=True)
+
+    @pytest.mark.asyncio
+    async def test_enabled_shows_green_and_on_voice(self, handler, mock_state_manager):
+        """When toggled to 'on', should show green and play on voice."""
+        mock_state_manager.user_prefs_writer.cycle_variant.return_value = "on"
+
+        await handler.handle_instructions("test_serial")
+
+        call_kwargs = mock_state_manager.led.send_game_effect.call_args[1]
+        assert call_kwargs["color"] == (0, 255, 0)
+        mock_state_manager.audio.play_voice.assert_called_once_with(Sound.MENU_VOX_INSTRUCTIONS_ON)
+
+    @pytest.mark.asyncio
+    async def test_disabled_shows_red_and_off_voice(self, handler, mock_state_manager):
+        """When toggled to 'off', should show red and play off voice."""
+        mock_state_manager.user_prefs_writer.cycle_variant.return_value = "off"
+
+        await handler.handle_instructions("test_serial")
+
+        call_kwargs = mock_state_manager.led.send_game_effect.call_args[1]
+        assert call_kwargs["color"] == (255, 0, 0)
+        mock_state_manager.audio.play_voice.assert_called_once_with(Sound.MENU_VOX_INSTRUCTIONS_OFF)
+
+    @pytest.mark.asyncio
+    async def test_no_state_manager_returns_early(self, handler, mock_state_manager):
+        """Should return early if state_manager is None."""
+        handler._state_manager = None
+        await handler.handle_instructions("test_serial")
+        mock_state_manager.user_prefs_writer.cycle_variant.assert_not_called()
+
+
+class TestTriggerHoldAndRelease:
+    """Tests for trigger hold tracking and force start."""
+
+    @pytest.mark.asyncio
+    async def test_hold_starts_effect_and_creates_task(self, handler, mock_state_manager):
+        """Trigger press should start force start effect and create hold task."""
+        from proto import controller_manager_pb2
+
+        await handler._start_trigger_hold_tracking("test_serial")
+
+        assert handler._trigger_press_time is not None
+        assert handler._trigger_hold_task is not None
+        call_args = mock_state_manager.led.send_game_effect.call_args
+        assert call_args[0][0] == "test_serial"
+        assert call_args[0][1] == controller_manager_pb2.GAME_EFFECT_FORCE_START_CHARGE
+        # Clean up
+        handler._trigger_hold_task.cancel()
+
+    @pytest.mark.asyncio
+    async def test_release_cancels_task_and_restores_white(self, handler, mock_state_manager):
+        """Trigger release should cancel hold task and restore white."""
+        # Start the hold first
+        await handler._start_trigger_hold_tracking("test_serial")
+        mock_state_manager.led.send_game_effect.reset_mock()
+
+        # Release
+        await handler.handle_trigger_release("test_serial")
+
+        assert handler._trigger_press_time is None
+        assert handler._trigger_hold_task is None
+        mock_state_manager.led.send_base_color.assert_called_with("test_serial", (255, 255, 255))
+
+    @pytest.mark.asyncio
+    async def test_release_ignored_for_non_admin(self, handler, mock_state_manager):
+        """Trigger release should be ignored for non-admin controller."""
+        await handler.handle_trigger_release("other_serial")
+        mock_state_manager.led.send_base_color.assert_not_called()
+
+
+class TestExitToConnected:
+    """Tests for _exit_to_connected."""
+
+    @pytest.mark.asyncio
+    async def test_with_state_manager_calls_transition(self, handler, mock_state_manager):
+        """Should call state_manager.transition_to with CONNECTED."""
+        mock_state_manager.transition_to = AsyncMock()
+
+        await handler._exit_to_connected("test_serial")
+
+        mock_state_manager.transition_to.assert_called_once_with("test_serial", ControllerState.CONNECTED)
+
+    @pytest.mark.asyncio
+    async def test_without_state_manager_calls_exit(self, handler):
+        """Should fall back to self.exit() if no state manager."""
+        handler._state_manager = None
+        handler.exit = AsyncMock()
+
+        await handler._exit_to_connected("test_serial")
+
+        handler.exit.assert_called_once()
+
+
+class TestForceStartEffect:
+    """Tests for force start LED effects."""
+
+    @pytest.mark.asyncio
+    async def test_start_sends_charge_effect(self, handler, mock_state_manager):
+        """start_force_start_effect should send GAME_EFFECT_FORCE_START_CHARGE."""
+        from proto import controller_manager_pb2
+
+        await handler.start_force_start_effect("test_serial")
+
+        call_args = mock_state_manager.led.send_game_effect.call_args
+        assert call_args[0][0] == "test_serial"
+        assert call_args[0][1] == controller_manager_pb2.GAME_EFFECT_FORCE_START_CHARGE
+
+    @pytest.mark.asyncio
+    async def test_cancel_sends_white_base_color(self, handler, mock_state_manager):
+        """cancel_force_start_effect should restore white base color."""
+        await handler.cancel_force_start_effect("test_serial")
+
+        mock_state_manager.led.send_base_color.assert_called_once_with("test_serial", (255, 255, 255))
+
+
+# ============================================================================
+# Tier 4 — Feedback Details
+# ============================================================================
+
+
+class TestShowValueFeedbackDetails:
+    """Detailed tests for _show_value_feedback color calculations."""
+
+    @pytest.mark.asyncio
+    async def test_num_teams_2_is_green(self, handler, mock_state_manager):
+        """num_teams=2 should produce green (0, 255, 0)."""
+        await handler._show_value_feedback("test_serial", "num_teams", 2)
+        call_kwargs = mock_state_manager.led.send_game_effect.call_args[1]
+        assert call_kwargs["color"] == (0, 255, 0)
+
+    @pytest.mark.asyncio
+    async def test_num_teams_6_is_red(self, handler, mock_state_manager):
+        """num_teams=6 should produce red (255, 0, 0)."""
+        await handler._show_value_feedback("test_serial", "num_teams", 6)
+        call_kwargs = mock_state_manager.led.send_game_effect.call_args[1]
+        assert call_kwargs["color"] == (255, 0, 0)
+
+    @pytest.mark.asyncio
+    async def test_nonstop_unlimited_dim_purple(self, handler, mock_state_manager):
+        """nonstop_time_limit=0 (unlimited) should produce dim purple (50, 0, 50)."""
+        await handler._show_value_feedback("test_serial", "nonstop_time_limit", 0)
+        call_kwargs = mock_state_manager.led.send_game_effect.call_args[1]
+        assert call_kwargs["color"] == (50, 0, 50)
+
+    @pytest.mark.asyncio
+    async def test_nonstop_300_bright_purple(self, handler, mock_state_manager):
+        """nonstop_time_limit=300 should produce bright purple (255, 0, 255)."""
+        await handler._show_value_feedback("test_serial", "nonstop_time_limit", 300)
+        call_kwargs = mock_state_manager.led.send_game_effect.call_args[1]
+        assert call_kwargs["color"] == (255, 0, 255)
+
+    @pytest.mark.asyncio
+    async def test_unknown_option_shows_white(self, handler, mock_state_manager):
+        """Unknown option should default to white."""
+        await handler._show_value_feedback("test_serial", "unknown_option", 0)
+        call_kwargs = mock_state_manager.led.send_game_effect.call_args[1]
+        assert call_kwargs["color"] == Colors.White.value
+
+
+class TestPlayValueVoice:
+    """Tests for _play_value_voice (verifies bug fix for type mismatch)."""
+
+    @pytest.mark.asyncio
+    async def test_num_teams_voice_plays_with_int(self, handler, mock_state_manager):
+        """num_teams voice should play when value is int (bug fix proof).
+
+        Before fix: num_teams_voices.get(2) returned None because keys were strings.
+        After fix: num_teams_voices.get(str(2)) returns the correct Sound.
+        """
+        await handler._play_value_voice("num_teams", 3)
+        mock_state_manager.audio.play_voice.assert_called_once_with(Sound.MENU_VOX_ADMINOP_3)
+
+    @pytest.mark.asyncio
+    async def test_num_teams_voice_all_values(self, handler, mock_state_manager):
+        """All num_teams values (2-6) should play correct voice."""
+        expected = {
+            2: Sound.MENU_VOX_ADMINOP_2,
+            3: Sound.MENU_VOX_ADMINOP_3,
+            4: Sound.MENU_VOX_ADMINOP_4,
+            5: Sound.MENU_VOX_ADMINOP_5,
+            6: Sound.MENU_VOX_ADMINOP_6,
+        }
+        for value, expected_sound in expected.items():
+            mock_state_manager.audio.play_voice.reset_mock()
+            await handler._play_value_voice("num_teams", value)
+            mock_state_manager.audio.play_voice.assert_called_once_with(expected_sound)
+
+    @pytest.mark.asyncio
+    async def test_force_all_start_true_plays_true_voice(self, handler, mock_state_manager):
+        """force_all_start=True should play TRUE voice (bug fix proof).
+
+        Before fix: value == "true" never matched bool True.
+        After fix: value is True correctly matches.
+        """
+        await handler._play_value_voice("force_all_start", True)
+        mock_state_manager.audio.play_voice.assert_called_once_with(Sound.MENU_VOX_ADMINOP_TRUE)
+
+    @pytest.mark.asyncio
+    async def test_force_all_start_false_plays_false_voice(self, handler, mock_state_manager):
+        """force_all_start=False should play FALSE voice."""
+        await handler._play_value_voice("force_all_start", False)
+        mock_state_manager.audio.play_voice.assert_called_once_with(Sound.MENU_VOX_ADMINOP_FALSE)
+
+    @pytest.mark.asyncio
+    async def test_other_option_no_voice(self, handler, mock_state_manager):
+        """Non num_teams/force_all_start options should not play voice."""
+        await handler._play_value_voice("sensitivity", 2)
+        mock_state_manager.audio.play_voice.assert_not_called()
+
+
+class TestControllerHandlerProtocol:
+    """Tests for the ControllerHandler protocol methods."""
+
+    @pytest.mark.asyncio
+    async def test_handle_button_delegates(self, handler):
+        """handle_button should delegate to handle_button_event."""
+        handler.handle_button_event = AsyncMock()
+        await handler.handle_button("s1", "cross")
+        handler.handle_button_event.assert_called_once_with("s1", "cross")
+
+    @pytest.mark.asyncio
+    async def test_on_enter_delegates(self, inactive_handler):
+        """on_enter should delegate to enter."""
+        inactive_handler.enter = AsyncMock()
+        await inactive_handler.on_enter("s1")
+        inactive_handler.enter.assert_called_once_with("s1")
+
+    @pytest.mark.asyncio
+    async def test_on_exit_delegates(self, handler):
+        """on_exit should delegate to exit."""
+        handler.exit = AsyncMock()
+        await handler.on_exit("s1")
+        handler.exit.assert_called_once()
+
+    def test_set_state_manager(self, inactive_handler, mock_state_manager):
+        """set_state_manager should store the manager."""
+        inactive_handler._state_manager = None
+        inactive_handler.set_state_manager(mock_state_manager)
+        assert inactive_handler._state_manager is mock_state_manager
+
+
+class TestHelperProperties:
+    """Tests for StateManager helper properties."""
+
+    def test_connected_controllers_with_manager(self, handler, mock_state_manager):
+        """Should return connected_controllers from state_manager."""
+        mock_state_manager.connected_controllers = {"s1", "s2"}
+        assert handler._connected_controllers == {"s1", "s2"}
+
+    def test_connected_controllers_without_manager(self, handler):
+        """Should return empty set without state_manager."""
+        handler._state_manager = None
+        assert handler._connected_controllers == set()
+
+    def test_ready_controllers_with_manager(self, handler, mock_state_manager):
+        """Should return ready_controllers from state_manager."""
+        mock_state_manager.ready_controllers = {"s1"}
+        assert handler._ready_controllers == {"s1"}
+
+    def test_ready_controllers_without_manager(self, handler):
+        """Should return empty set without state_manager."""
+        handler._state_manager = None
+        assert handler._ready_controllers == set()
+
+    def test_current_game_mode_with_manager(self, handler, mock_state_manager):
+        """Should return game mode name from state_manager."""
+        assert handler._current_game_mode == "JoustFFA"
+
+    def test_current_game_mode_without_manager(self, handler):
+        """Should return 'JoustFFA' default without state_manager."""
+        handler._state_manager = None
+        assert handler._current_game_mode == "JoustFFA"


### PR DESCRIPTION
## Summary
- **Bug fix**: `_play_value_voice()` declared `value: str` but callers pass `int|float|bool` from `_variant_to_value()`. This caused `num_teams` voice to never play (dict lookup with int key against string keys) and `force_all_start` to always play FALSE voice (`True == "true"` is always False)
- **Test coverage**: Added 98 new tests (26 existing → 124 total) covering enter/exit lifecycle, button dispatch routing, combo detection, game mode cycling, battery/instructions handlers, trigger hold/release, disconnect cleanup, variant-to-value mappings, value feedback details, protocol methods, and helper properties

## Test plan
- [x] `uv run pytest tests/test_admin_handler.py -v` — 124 tests pass
- [x] `make lint` — clean
- [ ] CI passes

Fixes #514

🤖 Generated with [Claude Code](https://claude.com/claude-code)