### PR TITLE
test: add unit tests for 6 untested lib/ modules

### DIFF
--- a/lib/tests/test_flag_config_writer.py
+++ b/lib/tests/test_flag_config_writer.py
@@ -1,0 +1,189 @@
+"""Tests for lib/flag_config_writer.py"""
+
+import json
+import sys
+from pathlib import Path
+
+# Add lib to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from lib.flag_config_writer import FlagConfigWriter
+
+SAMPLE_FLAGS = {
+    "flags": {
+        "sensitivity": {
+            "state": "ENABLED",
+            "variants": {
+                "ultra_slow": 0,
+                "slow": 1,
+                "medium": 2,
+                "fast": 3,
+                "ultra_fast": 4,
+            },
+            "defaultVariant": "medium",
+        },
+        "game_mode": {
+            "state": "ENABLED",
+            "variants": {
+                "ffa": "JoustFFA",
+                "teams": "JoustTeams",
+            },
+            "defaultVariant": "ffa",
+        },
+    }
+}
+
+
+def _write_flag_file(tmp_path, data=None):
+    """Helper to create a flag file with sample data."""
+    path = tmp_path / "flags.json"
+    path.write_text(json.dumps(data or SAMPLE_FLAGS, indent=2) + "\n")
+    return str(path)
+
+
+class TestUpdateDefaultVariant:
+    """Tests for FlagConfigWriter.update_default_variant."""
+
+    def test_update_success(self, tmp_path):
+        path = _write_flag_file(tmp_path)
+        writer = FlagConfigWriter(path)
+
+        result = writer.update_default_variant("sensitivity", "fast")
+
+        assert result is True
+        data = json.loads(Path(path).read_text())
+        assert data["flags"]["sensitivity"]["defaultVariant"] == "fast"
+
+    def test_flag_not_found(self, tmp_path):
+        path = _write_flag_file(tmp_path)
+        writer = FlagConfigWriter(path)
+
+        result = writer.update_default_variant("nonexistent", "fast")
+
+        assert result is False
+
+    def test_variant_not_found(self, tmp_path):
+        path = _write_flag_file(tmp_path)
+        writer = FlagConfigWriter(path)
+
+        result = writer.update_default_variant("sensitivity", "nonexistent")
+
+        assert result is False
+
+    def test_file_not_found(self):
+        writer = FlagConfigWriter("/nonexistent/path/flags.json")
+
+        result = writer.update_default_variant("sensitivity", "fast")
+
+        assert result is False
+
+    def test_invalid_json(self, tmp_path):
+        path = tmp_path / "flags.json"
+        path.write_text("not valid json{{{")
+        writer = FlagConfigWriter(str(path))
+
+        result = writer.update_default_variant("sensitivity", "fast")
+
+        assert result is False
+
+    def test_atomic_write_produces_valid_json(self, tmp_path):
+        path = _write_flag_file(tmp_path)
+        writer = FlagConfigWriter(path)
+
+        writer.update_default_variant("sensitivity", "fast")
+
+        # File should be valid JSON after update
+        data = json.loads(Path(path).read_text())
+        assert "flags" in data
+        assert data["flags"]["sensitivity"]["defaultVariant"] == "fast"
+        # Other flags should be unchanged
+        assert data["flags"]["game_mode"]["defaultVariant"] == "ffa"
+
+
+class TestGetVariantNames:
+    """Tests for FlagConfigWriter.get_variant_names."""
+
+    def test_success(self, tmp_path):
+        path = _write_flag_file(tmp_path)
+        writer = FlagConfigWriter(path)
+
+        result = writer.get_variant_names("sensitivity")
+
+        assert result == ["ultra_slow", "slow", "medium", "fast", "ultra_fast"]
+
+    def test_missing_flag(self, tmp_path):
+        path = _write_flag_file(tmp_path)
+        writer = FlagConfigWriter(path)
+
+        result = writer.get_variant_names("nonexistent")
+
+        assert result == []
+
+    def test_file_error(self):
+        writer = FlagConfigWriter("/nonexistent/path/flags.json")
+
+        result = writer.get_variant_names("sensitivity")
+
+        assert result == []
+
+
+class TestGetCurrentVariant:
+    """Tests for FlagConfigWriter.get_current_variant."""
+
+    def test_success(self, tmp_path):
+        path = _write_flag_file(tmp_path)
+        writer = FlagConfigWriter(path)
+
+        result = writer.get_current_variant("sensitivity")
+
+        assert result == "medium"
+
+    def test_missing_flag(self, tmp_path):
+        path = _write_flag_file(tmp_path)
+        writer = FlagConfigWriter(path)
+
+        result = writer.get_current_variant("nonexistent")
+
+        assert result is None
+
+
+class TestCycleVariant:
+    """Tests for FlagConfigWriter.cycle_variant."""
+
+    def test_cycle_forward(self, tmp_path):
+        path = _write_flag_file(tmp_path)
+        writer = FlagConfigWriter(path)
+
+        # medium -> fast
+        result = writer.cycle_variant("sensitivity", forward=True)
+
+        assert result == "fast"
+        assert writer.get_current_variant("sensitivity") == "fast"
+
+    def test_cycle_backward(self, tmp_path):
+        path = _write_flag_file(tmp_path)
+        writer = FlagConfigWriter(path)
+
+        # medium -> slow
+        result = writer.cycle_variant("sensitivity", forward=False)
+
+        assert result == "slow"
+        assert writer.get_current_variant("sensitivity") == "slow"
+
+    def test_cycle_wraps_around(self, tmp_path):
+        path = _write_flag_file(tmp_path)
+        writer = FlagConfigWriter(path)
+
+        # Set to last variant, then cycle forward to wrap
+        writer.update_default_variant("sensitivity", "ultra_fast")
+        result = writer.cycle_variant("sensitivity", forward=True)
+
+        assert result == "ultra_slow"
+
+    def test_cycle_nonexistent_flag(self, tmp_path):
+        path = _write_flag_file(tmp_path)
+        writer = FlagConfigWriter(path)
+
+        result = writer.cycle_variant("nonexistent")
+
+        assert result is None

--- a/lib/tests/test_grpc_tracing.py
+++ b/lib/tests/test_grpc_tracing.py
@@ -1,0 +1,121 @@
+"""Tests for lib/grpc_tracing.py"""
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+# Add lib to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from lib.grpc_tracing import (
+    _extract_method_name,
+    _prepare_metadata,
+    _safe_detach,
+    get_context_propagation_interceptors,
+    get_server_interceptors,
+)
+
+
+class TestExtractMethodName:
+    """Tests for _extract_method_name helper."""
+
+    def test_string_with_slash(self):
+        result = _extract_method_name("/package.Service/Method")
+        assert result == "package.Service/Method"
+
+    def test_string_without_slash(self):
+        result = _extract_method_name("Method")
+        assert result == "Method"
+
+    def test_bytes_input(self):
+        result = _extract_method_name(b"/pkg.Svc/Method")
+        assert result == "pkg.Svc/Method"
+
+    def test_bytes_without_slash(self):
+        result = _extract_method_name(b"Method")
+        assert result == "Method"
+
+
+class TestPrepareMetadata:
+    """Tests for _prepare_metadata helper."""
+
+    def test_none_metadata(self):
+        result = _prepare_metadata(None)
+        # Should return a tuple (possibly with trace headers injected)
+        assert isinstance(result, tuple)
+
+    def test_tuple_metadata(self):
+        existing = (("key1", "value1"), ("key2", "value2"))
+        result = _prepare_metadata(existing)
+
+        assert isinstance(result, tuple)
+        result_dict = dict(result)
+        assert result_dict["key1"] == "value1"
+        assert result_dict["key2"] == "value2"
+
+    def test_list_metadata(self):
+        existing = [("key1", "value1")]
+        result = _prepare_metadata(existing)
+
+        assert isinstance(result, tuple)
+        result_dict = dict(result)
+        assert result_dict["key1"] == "value1"
+
+    def test_dict_metadata(self):
+        existing = {"key1": "value1", "key2": "value2"}
+        result = _prepare_metadata(existing)
+
+        assert isinstance(result, tuple)
+        result_dict = dict(result)
+        assert result_dict["key1"] == "value1"
+        assert result_dict["key2"] == "value2"
+
+
+class TestSafeDetach:
+    """Tests for _safe_detach helper."""
+
+    @patch("lib.grpc_tracing.otel_context")
+    def test_normal_detach(self, mock_otel_context):
+        token = object()
+
+        _safe_detach(token)
+
+        mock_otel_context.detach.assert_called_once_with(token)
+
+    @patch("lib.grpc_tracing.otel_context")
+    def test_value_error_suppressed(self, mock_otel_context):
+        mock_otel_context.detach.side_effect = ValueError("token from different context")
+        token = object()
+
+        # Should not raise
+        _safe_detach(token)
+
+        mock_otel_context.detach.assert_called_once_with(token)
+
+
+class TestGetInterceptors:
+    """Tests for get_context_propagation_interceptors and get_server_interceptors."""
+
+    def test_client_interceptors_count(self):
+        interceptors = get_context_propagation_interceptors()
+        assert len(interceptors) == 4
+
+    def test_client_interceptor_types(self):
+        import grpc.aio
+
+        interceptors = get_context_propagation_interceptors()
+
+        assert isinstance(interceptors[0], grpc.aio.UnaryUnaryClientInterceptor)
+        assert isinstance(interceptors[1], grpc.aio.StreamUnaryClientInterceptor)
+        assert isinstance(interceptors[2], grpc.aio.UnaryStreamClientInterceptor)
+        assert isinstance(interceptors[3], grpc.aio.StreamStreamClientInterceptor)
+
+    def test_server_interceptors_count(self):
+        interceptors = get_server_interceptors()
+        assert len(interceptors) == 1
+
+    def test_server_interceptor_type(self):
+        import grpc.aio
+
+        interceptors = get_server_interceptors()
+        assert isinstance(interceptors[0], grpc.aio.ServerInterceptor)

--- a/lib/tests/test_grpc_utils.py
+++ b/lib/tests/test_grpc_utils.py
@@ -1,0 +1,102 @@
+"""Tests for lib/grpc_utils.py"""
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+# Add lib to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from lib.grpc_utils import get_optimized_channel_options, get_server_options, is_local_address
+
+
+class TestIsLocalAddress:
+    """Tests for is_local_address function."""
+
+    def test_localhost(self):
+        assert is_local_address("localhost:50051") is True
+
+    def test_127_0_0_1(self):
+        assert is_local_address("127.0.0.1:50051") is True
+
+    def test_127_x_range(self):
+        assert is_local_address("127.0.1.1:50051") is True
+
+    def test_ipv6_loopback_not_supported(self):
+        # Current implementation splits on ":" so IPv6 "::1:port" isn't detected
+        assert is_local_address("::1:50051") is False
+
+    def test_unix_socket(self):
+        assert is_local_address("unix:/tmp/test.sock") is True
+
+    def test_remote_address(self):
+        assert is_local_address("game-coordinator:50053") is False
+
+    def test_empty_string(self):
+        assert is_local_address("") is False
+
+    def test_remote_ip(self):
+        assert is_local_address("192.168.1.100:50051") is False
+
+
+class TestGetOptimizedChannelOptions:
+    """Tests for get_optimized_channel_options function."""
+
+    def test_with_compression(self):
+        options = get_optimized_channel_options(enable_compression=True)
+        option_names = [name for name, _ in options]
+
+        assert "grpc.default_compression_algorithm" in option_names
+        assert "grpc.keepalive_time_ms" in option_names
+
+    def test_without_compression(self):
+        options = get_optimized_channel_options(enable_compression=False)
+        option_names = [name for name, _ in options]
+
+        assert "grpc.default_compression_algorithm" not in option_names
+        # Other options should still be present
+        assert "grpc.keepalive_time_ms" in option_names
+        assert "grpc.max_receive_message_length" in option_names
+
+
+class TestGetServerOptions:
+    """Tests for get_server_options function."""
+
+    def test_returns_options(self):
+        options = get_server_options()
+
+        assert len(options) > 0
+        option_names = [name for name, _ in options]
+        assert "grpc.keepalive_time_ms" in option_names
+        assert "grpc.max_receive_message_length" in option_names
+
+    def test_ping_interval_set(self):
+        options = get_server_options()
+        option_dict = dict(options)
+
+        assert option_dict["grpc.http2.min_recv_ping_interval_without_data_ms"] == 20000
+
+
+class TestCreateChannel:
+    """Tests for create_channel function."""
+
+    @patch("lib.grpc_utils.grpc.aio.insecure_channel")
+    def test_creates_channel_with_defaults(self, mock_channel):
+        from lib.grpc_utils import create_channel
+
+        create_channel("localhost:50051", enable_tracing=False, enable_metrics=False)
+
+        mock_channel.assert_called_once()
+        args, kwargs = mock_channel.call_args
+        assert args[0] == "localhost:50051"
+
+    @patch("lib.grpc_utils.grpc.aio.insecure_channel")
+    def test_local_address_disables_compression(self, mock_channel):
+        from lib.grpc_utils import create_channel
+
+        create_channel("localhost:50051", enable_tracing=False, enable_metrics=False)
+
+        _, kwargs = mock_channel.call_args
+        option_names = [name for name, _ in kwargs["options"]]
+        # Local address should not have compression options
+        assert "grpc.default_compression_algorithm" not in option_names

--- a/lib/tests/test_profiling.py
+++ b/lib/tests/test_profiling.py
@@ -1,0 +1,104 @@
+"""Tests for lib/profiling.py"""
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Add lib to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+import lib.profiling as profiling_module
+from lib.profiling import disable_profiling_for_tests, init_profiling
+
+
+@pytest.fixture(autouse=True)
+def _reset_profiling_state():
+    """Reset module-level globals between tests."""
+    original_initialized = profiling_module._initialized
+    original_test_mode = profiling_module._test_mode
+    yield
+    profiling_module._initialized = original_initialized
+    profiling_module._test_mode = original_test_mode
+
+
+class TestDisableProfiling:
+    """Tests for disable_profiling_for_tests."""
+
+    def test_sets_flags(self):
+        profiling_module._test_mode = False
+        profiling_module._initialized = False
+
+        disable_profiling_for_tests()
+
+        assert profiling_module._test_mode is True
+        assert profiling_module._initialized is True
+
+
+class TestIsProfilingEnabled:
+    """Tests for _is_profiling_enabled."""
+
+    @patch("lib.feature_flags.get_flag_client")
+    def test_flag_enabled(self, mock_get_client):
+        mock_client = mock_get_client.return_value
+        mock_client.get_boolean_value.return_value = True
+
+        from lib.profiling import _is_profiling_enabled
+
+        assert _is_profiling_enabled() is True
+
+    @patch("lib.feature_flags.get_flag_client")
+    def test_flag_disabled(self, mock_get_client):
+        mock_client = mock_get_client.return_value
+        mock_client.get_boolean_value.return_value = False
+
+        from lib.profiling import _is_profiling_enabled
+
+        assert _is_profiling_enabled() is False
+
+    @patch("lib.feature_flags.get_flag_client", side_effect=Exception("connection refused"))
+    def test_flag_client_error(self, mock_get_client):
+        from lib.profiling import _is_profiling_enabled
+
+        assert _is_profiling_enabled() is False
+
+
+class TestInitProfiling:
+    """Tests for init_profiling."""
+
+    def test_already_initialized(self):
+        profiling_module._initialized = True
+
+        init_profiling()
+
+        # Should be a no-op, no errors
+        assert profiling_module._initialized is True
+
+    @patch("lib.profiling._is_profiling_enabled", return_value=False)
+    def test_profiling_disabled(self, mock_enabled):
+        profiling_module._initialized = False
+
+        init_profiling()
+
+        assert profiling_module._initialized is True
+
+    @patch("lib.profiling._is_profiling_enabled", return_value=True)
+    def test_pyroscope_not_installed(self, mock_enabled):
+        profiling_module._initialized = False
+
+        with patch.dict(sys.modules, {"pyroscope": None}):
+            init_profiling()
+
+        assert profiling_module._initialized is True
+
+    @patch("lib.profiling._is_profiling_enabled", return_value=False)
+    def test_idempotent(self, mock_enabled):
+        profiling_module._initialized = False
+
+        init_profiling()
+        init_profiling()  # Second call should be no-op
+
+        assert profiling_module._initialized is True
+        # _is_profiling_enabled called only once (second call short-circuits)
+        mock_enabled.assert_called_once()

--- a/lib/tests/test_system_metrics.py
+++ b/lib/tests/test_system_metrics.py
@@ -1,0 +1,200 @@
+"""Tests for lib/system_metrics.py"""
+
+import asyncio
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+# Add lib to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from lib.system_metrics import (
+    collect_system_metrics,
+    start_system_metrics_collector,
+    start_system_metrics_collector_thread,
+)
+
+
+def _make_mock_metrics():
+    """Create mock counter and gauge objects."""
+    cpu_counter = MagicMock()
+    memory_gauge = MagicMock()
+    threads_gauge = MagicMock()
+    return cpu_counter, memory_gauge, threads_gauge
+
+
+def _make_mock_cpu_times(user=1.0, system=0.5):
+    """Create a mock cpu_times result."""
+    mock = MagicMock()
+    mock.user = user
+    mock.system = system
+    return mock
+
+
+def _make_mock_mem_info(rss=1024 * 1024):
+    """Create a mock memory_info result."""
+    mock = MagicMock()
+    mock.rss = rss
+    return mock
+
+
+class TestCollectSystemMetrics:
+    """Tests for collect_system_metrics async function."""
+
+    @patch("lib.system_metrics.psutil.Process")
+    async def test_collects_cpu_delta(self, mock_process_cls):
+        cpu_counter, memory_gauge, threads_gauge = _make_mock_metrics()
+
+        process = MagicMock()
+        mock_process_cls.return_value = process
+
+        # Initial cpu_times and then one iteration
+        initial_cpu = _make_mock_cpu_times(user=1.0, system=0.5)
+        updated_cpu = _make_mock_cpu_times(user=2.0, system=1.0)
+        process.cpu_times.side_effect = [initial_cpu, updated_cpu]
+        process.memory_info.return_value = _make_mock_mem_info()
+        process.num_threads.return_value = 5
+
+        task = asyncio.create_task(collect_system_metrics(cpu_counter, memory_gauge, threads_gauge, interval=0.01))
+        await asyncio.sleep(0.05)
+        task.cancel()
+        with __import__("contextlib").suppress(asyncio.CancelledError):
+            await task
+
+        # Delta = (2.0 + 1.0) - (1.0 + 0.5) = 1.5
+        cpu_counter.inc.assert_called_with(1.5)
+
+    @patch("lib.system_metrics.psutil.Process")
+    async def test_sets_memory_gauge(self, mock_process_cls):
+        cpu_counter, memory_gauge, threads_gauge = _make_mock_metrics()
+
+        process = MagicMock()
+        mock_process_cls.return_value = process
+
+        initial_cpu = _make_mock_cpu_times()
+        process.cpu_times.side_effect = [initial_cpu, _make_mock_cpu_times()]
+        process.memory_info.return_value = _make_mock_mem_info(rss=2048)
+        process.num_threads.return_value = 3
+
+        task = asyncio.create_task(collect_system_metrics(cpu_counter, memory_gauge, threads_gauge, interval=0.01))
+        await asyncio.sleep(0.05)
+        task.cancel()
+        with __import__("contextlib").suppress(asyncio.CancelledError):
+            await task
+
+        memory_gauge.set.assert_called_with(2048)
+
+    @patch("lib.system_metrics.psutil.Process")
+    async def test_sets_thread_gauge(self, mock_process_cls):
+        cpu_counter, memory_gauge, threads_gauge = _make_mock_metrics()
+
+        process = MagicMock()
+        mock_process_cls.return_value = process
+
+        initial_cpu = _make_mock_cpu_times()
+        process.cpu_times.side_effect = [initial_cpu, _make_mock_cpu_times()]
+        process.memory_info.return_value = _make_mock_mem_info()
+        process.num_threads.return_value = 7
+
+        task = asyncio.create_task(collect_system_metrics(cpu_counter, memory_gauge, threads_gauge, interval=0.01))
+        await asyncio.sleep(0.05)
+        task.cancel()
+        with __import__("contextlib").suppress(asyncio.CancelledError):
+            await task
+
+        threads_gauge.set.assert_called_with(7)
+
+    @patch("lib.system_metrics.psutil.Process")
+    async def test_handles_error(self, mock_process_cls):
+        cpu_counter, memory_gauge, threads_gauge = _make_mock_metrics()
+
+        process = MagicMock()
+        mock_process_cls.return_value = process
+
+        initial_cpu = _make_mock_cpu_times()
+        # First call for init, then error on iteration, then success
+        process.cpu_times.side_effect = [initial_cpu, RuntimeError("psutil error"), _make_mock_cpu_times()]
+        process.memory_info.return_value = _make_mock_mem_info()
+        process.num_threads.return_value = 1
+
+        task = asyncio.create_task(collect_system_metrics(cpu_counter, memory_gauge, threads_gauge, interval=0.01))
+        await asyncio.sleep(0.05)
+        task.cancel()
+        with __import__("contextlib").suppress(asyncio.CancelledError):
+            await task
+
+        # Should not crash — loop continues after error
+
+    @patch("lib.system_metrics.psutil.Process")
+    async def test_zero_delta_skipped(self, mock_process_cls):
+        cpu_counter, memory_gauge, threads_gauge = _make_mock_metrics()
+
+        process = MagicMock()
+        mock_process_cls.return_value = process
+
+        # Same CPU times = zero delta
+        same_cpu = _make_mock_cpu_times(user=1.0, system=0.5)
+        process.cpu_times.side_effect = [same_cpu, same_cpu]
+        process.memory_info.return_value = _make_mock_mem_info()
+        process.num_threads.return_value = 1
+
+        task = asyncio.create_task(collect_system_metrics(cpu_counter, memory_gauge, threads_gauge, interval=0.01))
+        await asyncio.sleep(0.05)
+        task.cancel()
+        with __import__("contextlib").suppress(asyncio.CancelledError):
+            await task
+
+        cpu_counter.inc.assert_not_called()
+
+
+class TestStartCollector:
+    """Tests for start_system_metrics_collector."""
+
+    @patch("lib.system_metrics.psutil.Process")
+    async def test_returns_task(self, mock_process_cls):
+        cpu_counter, memory_gauge, threads_gauge = _make_mock_metrics()
+
+        process = MagicMock()
+        mock_process_cls.return_value = process
+        process.cpu_times.return_value = _make_mock_cpu_times()
+        process.memory_info.return_value = _make_mock_mem_info()
+        process.num_threads.return_value = 1
+
+        task = start_system_metrics_collector(cpu_counter, memory_gauge, threads_gauge, interval=0.01)
+
+        assert isinstance(task, asyncio.Task)
+        task.cancel()
+        with __import__("contextlib").suppress(asyncio.CancelledError):
+            await task
+
+
+class TestStartCollectorThread:
+    """Tests for start_system_metrics_collector_thread."""
+
+    @patch("lib.system_metrics.psutil.Process")
+    def test_returns_thread(self, mock_process_cls):
+        import threading
+
+        process = MagicMock()
+        mock_process_cls.return_value = process
+        process.cpu_times.return_value = _make_mock_cpu_times()
+        process.memory_info.return_value = _make_mock_mem_info()
+        process.num_threads.return_value = 1
+
+        cpu_counter, memory_gauge, threads_gauge = _make_mock_metrics()
+        thread = start_system_metrics_collector_thread(cpu_counter, memory_gauge, threads_gauge, interval=60)
+
+        assert isinstance(thread, threading.Thread)
+
+    @patch("lib.system_metrics.psutil.Process")
+    def test_thread_is_daemon(self, mock_process_cls):
+        process = MagicMock()
+        mock_process_cls.return_value = process
+        process.cpu_times.return_value = _make_mock_cpu_times()
+        process.memory_info.return_value = _make_mock_mem_info()
+        process.num_threads.return_value = 1
+
+        cpu_counter, memory_gauge, threads_gauge = _make_mock_metrics()
+        thread = start_system_metrics_collector_thread(cpu_counter, memory_gauge, threads_gauge, interval=60)
+
+        assert thread.daemon is True

--- a/lib/tests/test_telemetry.py
+++ b/lib/tests/test_telemetry.py
@@ -1,0 +1,156 @@
+"""Tests for lib/telemetry.py"""
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Add lib to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+import lib.telemetry as telemetry_module
+from lib.telemetry import (
+    SpanAttr,
+    extract_trace_context,
+    get_tracer,
+    init_telemetry,
+    inject_trace_context,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_telemetry_state():
+    """Reset module-level globals between tests."""
+    original_initialized = telemetry_module._initialized
+    original_test_mode = telemetry_module._test_mode
+    # Set test mode to prevent real OTLP initialization
+    telemetry_module._test_mode = True
+    telemetry_module._initialized = True
+    yield
+    telemetry_module._initialized = original_initialized
+    telemetry_module._test_mode = original_test_mode
+
+
+class TestDisableTelemetry:
+    """Tests for disable_telemetry_for_tests."""
+
+    def test_sets_test_mode(self):
+        telemetry_module._test_mode = False
+        telemetry_module._initialized = False
+
+        telemetry_module.disable_telemetry_for_tests()
+
+        assert telemetry_module._test_mode is True
+        assert telemetry_module._initialized is True
+
+    def test_sets_env_vars(self):
+        telemetry_module.disable_telemetry_for_tests()
+
+        assert os.environ.get("OTEL_SDK_DISABLED") == "true"
+        assert os.environ.get("OTEL_TRACES_EXPORTER") == "none"
+        assert os.environ.get("OTEL_METRICS_EXPORTER") == "none"
+
+    def test_is_test_mode_true(self):
+        telemetry_module.disable_telemetry_for_tests()
+
+        assert telemetry_module.is_test_mode() is True
+
+
+class TestSpanAttr:
+    """Tests for SpanAttr constants."""
+
+    def test_constants_exist(self):
+        assert isinstance(SpanAttr.CONTROLLER_SERIAL, str)
+        assert isinstance(SpanAttr.ADMIN_OPTION, str)
+        assert isinstance(SpanAttr.VALIDATION_RESULT, str)
+        assert isinstance(SpanAttr.VALIDATION_REASON, str)
+
+    def test_constants_are_dotted_names(self):
+        assert "." in SpanAttr.CONTROLLER_SERIAL
+        assert "." in SpanAttr.ADMIN_OPTION
+
+
+class TestInjectTraceContext:
+    """Tests for inject_trace_context."""
+
+    def test_no_active_span(self):
+        traceparent, tracestate = inject_trace_context()
+        # Without an active span, should return empty strings
+        assert isinstance(traceparent, str)
+        assert isinstance(tracestate, str)
+
+    def test_returns_tuple_of_two_strings(self):
+        result = inject_trace_context()
+        assert len(result) == 2
+        assert isinstance(result[0], str)
+        assert isinstance(result[1], str)
+
+
+class TestExtractTraceContext:
+    """Tests for extract_trace_context."""
+
+    def test_empty_traceparent(self):
+        result = extract_trace_context("", "")
+        assert result is None
+
+    def test_valid_traceparent(self):
+        # W3C traceparent format: version-trace_id-span_id-flags
+        traceparent = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
+        result = extract_trace_context(traceparent, "")
+        assert result is not None
+
+    def test_with_tracestate(self):
+        traceparent = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
+        tracestate = "congo=t61rcWkgMzE"
+        result = extract_trace_context(traceparent, tracestate)
+        assert result is not None
+
+
+class TestGetTracer:
+    """Tests for get_tracer."""
+
+    def test_returns_tracer(self):
+        from opentelemetry import trace
+
+        tracer = get_tracer("test-service")
+        assert isinstance(tracer, trace.Tracer)
+
+    def test_with_none_name(self):
+        from opentelemetry import trace
+
+        tracer = get_tracer(None)
+        assert isinstance(tracer, trace.Tracer)
+
+
+class TestInitTelemetry:
+    """Tests for init_telemetry (legacy API)."""
+
+    def test_returns_tracer(self):
+        from opentelemetry import trace
+
+        tracer = init_telemetry()
+        assert isinstance(tracer, trace.Tracer)
+
+
+class TestEnsureInitialized:
+    """Tests for _ensure_initialized."""
+
+    def test_idempotent(self):
+        telemetry_module._initialized = True
+
+        # Should be a no-op when already initialized
+        telemetry_module._ensure_initialized()
+
+        assert telemetry_module._initialized is True
+
+    @patch.object(telemetry_module, "_do_init")
+    def test_calls_do_init_when_not_initialized(self, mock_do_init):
+        telemetry_module._initialized = False
+        telemetry_module._test_mode = False
+
+        telemetry_module._ensure_initialized()
+
+        mock_do_init.assert_called_once()
+        assert telemetry_module._initialized is True


### PR DESCRIPTION
## Summary
- Add 74 unit tests across 6 new test files for previously untested `lib/` modules
- Covers `flag_config_writer`, `grpc_utils`, `grpc_tracing`, `telemetry`, `system_metrics`, and `profiling`
- Tests cover core functionality, error paths, edge cases, and module initialization

## Test plan
- [x] All 74 new tests pass (`uv run pytest tests/ -v` in `lib/`)
- [x] All 281 lib tests pass (existing + new)
- [x] `make lint` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)