### PR TITLE
fix: prevent OTEL ended span warnings from stale task contexts

### DIFF
--- a/services/menu/controller_events.py
+++ b/services/menu/controller_events.py
@@ -7,6 +7,8 @@ import contextlib
 import logging
 from typing import TYPE_CHECKING, Protocol
 
+from opentelemetry import context as otel_context
+
 from proto import controller_manager_pb2, controller_manager_pb2_grpc, menu_pb2
 
 logger = logging.getLogger(__name__)
@@ -137,19 +139,26 @@ class ControllerEventLoop:
 
     async def _run(self) -> None:
         """Main event loop with reconnection logic."""
+        # Detach from any inherited span context to prevent stale span
+        # references when this task is created inside _restart_lobby's
+        # restart_button_monitor span block.
+        token = otel_context.attach(otel_context.Context())
         retry_delay = 1.0
         max_retry_delay = 30.0
 
-        while self._running:
-            try:
-                retry_delay = await self._run_stream_connection()
-            except asyncio.CancelledError:
-                logger.info("Controller event loop cancelled")
-                raise
-            except Exception as e:
-                retry_delay = await self._handle_connection_error(e, retry_delay, max_retry_delay)
-            finally:
-                await self._clear_stream_state()
+        try:
+            while self._running:
+                try:
+                    retry_delay = await self._run_stream_connection()
+                except asyncio.CancelledError:
+                    logger.info("Controller event loop cancelled")
+                    raise
+                except Exception as e:
+                    retry_delay = await self._handle_connection_error(e, retry_delay, max_retry_delay)
+                finally:
+                    await self._clear_stream_state()
+        finally:
+            otel_context.detach(token)
 
     async def _run_stream_connection(self) -> float:  # NOSONAR(python:S3516)
         """

--- a/services/menu/handlers/admin.py
+++ b/services/menu/handlers/admin.py
@@ -678,7 +678,16 @@ class AdminModeHandler:
                     speed=10,
                 )
 
-                # Exit admin mode
+                # Record span event before exit() ends the parent session span
+                span.add_event(
+                    "force_start_triggered",
+                    {
+                        "game": self._current_game_mode,
+                        "player_count": len(controllers),
+                    },
+                )
+
+                # Exit admin mode (ends session_span)
                 await self.exit()
 
                 # Small delay for visual feedback
@@ -698,13 +707,6 @@ class AdminModeHandler:
                     },
                 )
 
-                span.add_event(
-                    "force_start_triggered",
-                    {
-                        "game": self._current_game_mode,
-                        "player_count": len(controllers),
-                    },
-                )
                 logger.info(
                     f"Force starting game '{self._current_game_mode}' via admin controller {serial} "
                     f"with {len(controllers)} players"

--- a/services/menu/idle_monitor.py
+++ b/services/menu/idle_monitor.py
@@ -16,6 +16,8 @@ import math
 import time
 from typing import TYPE_CHECKING
 
+from opentelemetry import context as otel_context
+
 from services.menu import metrics
 from services.menu.handlers.base import ControllerState
 
@@ -181,6 +183,10 @@ class IdleMonitor:
 
     async def _monitor_loop(self) -> None:
         """Background task monitoring lobby idle time."""
+        # Detach from any inherited span context to prevent the OpenFeature
+        # TracingHook from calling add_event on stale ended spans (e.g., the
+        # start_game span inherited when _restart_lobby creates this task).
+        token = otel_context.attach(otel_context.Context())
         try:
             while True:
                 await asyncio.sleep(1.0)
@@ -202,6 +208,8 @@ class IdleMonitor:
 
         except asyncio.CancelledError:  # NOSONAR — intentional: background loop exits on cancellation
             logger.debug("Idle monitor loop cancelled")
+        finally:
+            otel_context.detach(token)
 
     async def _enter_idle_mode(self) -> None:
         """Transition all CONNECTED controllers to IDLE and start sentinels."""


### PR DESCRIPTION
## Summary
- After a game ends, `_restart_lobby` creates background tasks (idle monitor, controller event loop) via `asyncio.create_task()` that inherit the caller's OTEL span context
- When parent spans (`start_game`, `restart_button_monitor`) end, the tasks retain stale references
- The OpenFeature `TracingHook` calls `span.add_event()` on the current span during every flag evaluation
- The idle monitor evaluates 2 flags per second → 2 "Tried calling _add_event on an ended span" warnings per second

## Changes
- **`idle_monitor.py`**: Attach clean OTEL context at start of `_monitor_loop` to prevent `TracingHook` from calling `add_event` on inherited ended spans
- **`controller_events.py`**: Attach clean OTEL context at start of `_run` for robustness (prevents any future OTEL-aware code in the event loop from hitting the same issue)
- **`admin.py`**: Move `span.add_event("force_start_triggered")` before `self.exit()` in `handle_force_start` — `exit()` ends the parent `session_span`, so span events should be recorded before that

## Test plan
- [x] `make lint` passes
- [x] Menu service unit tests pass (317/317)
- [ ] Deploy and verify no more "Tried calling _add_event on an ended span" warnings in menu logs after a game ends

🤖 Generated with [Claude Code](https://claude.com/claude-code)