### PR TITLE
feat: preload music during countdown and reactive playAudio flag

### DIFF
--- a/services/audio/servicer.py
+++ b/services/audio/servicer.py
@@ -427,10 +427,10 @@ class AudioServiceServicer(audio_pb2_grpc.AudioServiceServicer):
         # If flagd is unavailable, default to audio enabled (hardware initialized).
         self.audio_enabled = self._load_play_audio_flag()
         self.audio_manager = AudioManager(silent=not self.audio_enabled)
-        self.menu_voice = "ivy"  # Controlled by menu_voice setting
-        self._settings_loaded = False  # Lazy load full settings on first audio request
+        self.menu_voice = self._load_menu_voice_flag()
         self.sound_registry: dict[str, tuple[str, str]] = {}  # sound_name -> (type, base_dir)
         self._build_sound_registry()
+        self._register_flag_change_handler()
         logger.info("AudioServiceServicer initialized (audio_enabled=%s)", self.audio_enabled)
 
     @staticmethod
@@ -450,6 +450,66 @@ class AudioServiceServicer(audio_pb2_grpc.AudioServiceServicer):
         except Exception as e:
             logger.debug("Could not load play_audio flag from flagd: %s, defaulting to enabled", e)
             return True
+
+    @staticmethod
+    def _load_menu_voice_flag() -> str:
+        """Load menu_voice flag from flagd at startup.
+
+        Returns "ivy" if flagd is unavailable or flag is not set.
+        """
+        try:
+            from lib.feature_flags import get_flag_client, init_flag_domain
+
+            init_flag_domain("user_preferences")
+            client = get_flag_client("user_preferences")
+            voice = client.get_string_value("menu_voice", "ivy")
+            if voice in ("aaron", "ivy"):
+                logger.info("menu_voice flag loaded at startup: %s", voice)
+                return voice
+            logger.warning("Invalid menu_voice value '%s', defaulting to ivy", voice)
+            return "ivy"
+        except Exception as e:
+            logger.debug("Could not load menu_voice flag from flagd: %s, defaulting to ivy", e)
+            return "ivy"
+
+    def _register_flag_change_handler(self):
+        """Register event handler for reactive flag updates from flagd."""
+        try:
+            from openfeature import api
+            from openfeature.provider import ProviderEvent
+
+            api.add_handler(ProviderEvent.PROVIDER_CONFIGURATION_CHANGED, self._on_flags_changed)
+            logger.info("Registered flag change handler for reactive audio settings")
+        except Exception as e:
+            logger.debug("Could not register flag change handler: %s", e)
+
+    def _on_flags_changed(self, _event_details):
+        """Handle flag configuration changes from flagd.
+
+        Re-reads play_audio and menu_voice flags. If play_audio is toggled off,
+        stops any currently playing music immediately.
+        """
+        try:
+            from lib.feature_flags import get_flag_client
+
+            client = get_flag_client("user_preferences")
+
+            # Check play_audio
+            new_audio_enabled = client.get_boolean_value("play_audio", True)
+            if new_audio_enabled != self.audio_enabled:
+                logger.info("play_audio flag changed: %s -> %s", self.audio_enabled, new_audio_enabled)
+                self.audio_enabled = new_audio_enabled
+                if not new_audio_enabled:
+                    self.audio_manager.stop_music()
+
+            # Check menu_voice
+            new_voice = client.get_string_value("menu_voice", "ivy")
+            if new_voice in ("aaron", "ivy") and new_voice != self.menu_voice:
+                logger.info("menu_voice flag changed: %s -> %s", self.menu_voice, new_voice)
+                self.menu_voice = new_voice
+
+        except Exception as e:
+            logger.warning("Error handling flag change: %s", e)
 
     def _build_sound_registry(self):
         """
@@ -572,37 +632,8 @@ class AudioServiceServicer(audio_pb2_grpc.AudioServiceServicer):
             return sound_input
         return f"{parts[0]}/vox/{self.menu_voice}/{remainder}"
 
-    async def _load_audio_setting(self):
-        """Load audio settings from flagd (user_preferences domain)."""
-        if self._settings_loaded:
-            return  # Already loaded
-
-        try:
-            from lib.feature_flags import get_flag_client, init_flag_domain
-
-            init_flag_domain("user_preferences")
-            client = get_flag_client("user_preferences")
-
-            # Load play_audio setting
-            self.audio_enabled = client.get_boolean_value("play_audio", True)
-            logger.info(f"Audio enabled setting loaded: {self.audio_enabled}")
-
-            # Load menu_voice setting
-            voice = client.get_string_value("menu_voice", "ivy")
-            if voice in ("aaron", "ivy"):
-                self.menu_voice = voice
-            logger.info(f"Menu voice setting loaded: {self.menu_voice}")
-
-            self._settings_loaded = True
-        except Exception as e:
-            logger.debug(f"Could not load audio settings from flagd: {e}, using defaults")
-            # Mark as loaded even on failure to avoid repeated attempts
-            self._settings_loaded = True
-
     async def PlaySound(self, request, _context):
         """Play a sound effect."""
-        # Lazy load settings on first audio request (avoids blocking startup)
-        await self._load_audio_setting()
 
         # Resolve sound name/path to full path with voice selection
         resolved_path = self._resolve_sound_path(request.file_path)
@@ -626,8 +657,6 @@ class AudioServiceServicer(audio_pb2_grpc.AudioServiceServicer):
 
     async def PlayMusic(self, request, _context):
         """Play background music."""
-        # Lazy load settings on first audio request (avoids blocking startup)
-        await self._load_audio_setting()
 
         # Extract music directory for span (e.g., "Joust" from "Joust/music/*.ogg")
         music_dir = request.file_pattern.split("/")[0] if "/" in request.file_pattern else "music"

--- a/services/audio/tests/conftest.py
+++ b/services/audio/tests/conftest.py
@@ -49,7 +49,6 @@ def mock_audio_servicer():
         servicer = AudioServiceServicer()
     # Enable audio at the servicer level so RPCs execute their full logic.
     servicer.audio_enabled = True
-    servicer._settings_loaded = True
     return servicer
 
 

--- a/services/audio/tests/test_grpc_integration.py
+++ b/services/audio/tests/test_grpc_integration.py
@@ -35,7 +35,6 @@ async def grpc_service():
     with patch.object(AudioServiceServicer, "_load_play_audio_flag", return_value=False):
         servicer = AudioServiceServicer()
     servicer.audio_enabled = True
-    servicer._settings_loaded = True
 
     server = grpc.aio.server()
     audio_pb2_grpc.add_AudioServiceServicer_to_server(servicer, server)

--- a/services/audio/tests/test_servicer.py
+++ b/services/audio/tests/test_servicer.py
@@ -57,18 +57,15 @@ class TestPlaySound:
         assert "aaron" in resolved_path
 
     @pytest.mark.asyncio
-    async def test_play_sound_lazy_settings_load(self, mock_grpc_context):
+    async def test_play_sound_respects_audio_disabled(self, mock_grpc_context):
         from services.audio.servicer import AudioServiceServicer
 
         with patch.object(AudioServiceServicer, "_load_play_audio_flag", return_value=False):
             servicer = AudioServiceServicer()
-        servicer._settings_loaded = False
-        servicer.audio_manager.play_sound = MagicMock(return_value=True)
-
-        with patch.object(servicer, "_load_audio_setting") as mock_load:
-            request = audio_pb2.PlaySoundRequest(file_path="beep_loud", volume=1.0, priority=2)
-            await servicer.PlaySound(request, mock_grpc_context)
-            mock_load.assert_called_once()
+        servicer.audio_enabled = False
+        request = audio_pb2.PlaySoundRequest(file_path="beep_loud", volume=1.0, priority=2)
+        response = await servicer.PlaySound(request, mock_grpc_context)
+        assert response.success is True  # Silently succeeds when disabled
 
     @pytest.mark.asyncio
     async def test_play_sound_default_volume(self, servicer, mock_grpc_context):
@@ -240,65 +237,81 @@ class TestResolvePath:
         assert result == os.path.join(mock_audio_manager.assets_dir, "Joust/sounds/beep.ogg")
 
 
-class TestLoadAudioSetting:
-    """Tests for _load_audio_setting lazy flagd loading."""
+class TestOnFlagsChanged:
+    """Tests for reactive flag change handler."""
 
     @pytest.fixture
     def servicer(self, mock_audio_servicer):
         return mock_audio_servicer
 
-    @pytest.mark.asyncio
-    async def test_skips_load_if_already_loaded(self, servicer):
-        servicer._settings_loaded = True
-        original_voice = servicer.menu_voice
-        # Even if flagd would return different values, we skip the load
-        await servicer._load_audio_setting()
-        assert servicer.menu_voice == original_voice
+    def test_disables_audio_and_stops_music(self, servicer):
+        servicer.audio_enabled = True
+        servicer.audio_manager.stop_music = MagicMock(return_value=True)
+        mock_client = MagicMock()
+        mock_client.get_boolean_value.return_value = False
+        mock_client.get_string_value.return_value = "ivy"
 
-    @pytest.mark.asyncio
-    async def test_loads_settings_from_flagd(self, servicer):
-        servicer._settings_loaded = False
+        with patch("lib.feature_flags.get_flag_client", return_value=mock_client):
+            servicer._on_flags_changed(None)
+
+        assert servicer.audio_enabled is False
+        servicer.audio_manager.stop_music.assert_called_once()
+
+    def test_enables_audio(self, servicer):
+        servicer.audio_enabled = False
+        mock_client = MagicMock()
+        mock_client.get_boolean_value.return_value = True
+        mock_client.get_string_value.return_value = "ivy"
+
+        with patch("lib.feature_flags.get_flag_client", return_value=mock_client):
+            servicer._on_flags_changed(None)
+
+        assert servicer.audio_enabled is True
+
+    def test_changes_menu_voice(self, servicer):
+        servicer.menu_voice = "ivy"
         mock_client = MagicMock()
         mock_client.get_boolean_value.return_value = True
         mock_client.get_string_value.return_value = "aaron"
 
-        with (
-            patch("lib.feature_flags.get_flag_client", return_value=mock_client),
-            patch("lib.feature_flags.init_flag_domain"),
-        ):
-            await servicer._load_audio_setting()
+        with patch("lib.feature_flags.get_flag_client", return_value=mock_client):
+            servicer._on_flags_changed(None)
 
-        assert servicer.audio_enabled is True
         assert servicer.menu_voice == "aaron"
-        assert servicer._settings_loaded is True
 
-    @pytest.mark.asyncio
-    async def test_handles_flagd_failure_gracefully(self, servicer):
-        servicer._settings_loaded = False
-        with patch(
-            "lib.feature_flags.get_flag_client",
-            side_effect=Exception("flagd unavailable"),
-        ):
-            await servicer._load_audio_setting()
-        # Should still mark as loaded to avoid retries
-        assert servicer._settings_loaded is True
-
-    @pytest.mark.asyncio
-    async def test_rejects_invalid_voice(self, servicer):
-        servicer._settings_loaded = False
+    def test_rejects_invalid_voice(self, servicer):
         servicer.menu_voice = "ivy"
         mock_client = MagicMock()
         mock_client.get_boolean_value.return_value = True
         mock_client.get_string_value.return_value = "invalid_voice"
 
-        with (
-            patch("lib.feature_flags.get_flag_client", return_value=mock_client),
-            patch("lib.feature_flags.init_flag_domain"),
-        ):
-            await servicer._load_audio_setting()
+        with patch("lib.feature_flags.get_flag_client", return_value=mock_client):
+            servicer._on_flags_changed(None)
 
-        # Invalid voice should be rejected, keeping the default
         assert servicer.menu_voice == "ivy"
+
+    def test_handles_flagd_failure_gracefully(self, servicer):
+        servicer.audio_enabled = True
+        with patch(
+            "lib.feature_flags.get_flag_client",
+            side_effect=Exception("flagd unavailable"),
+        ):
+            servicer._on_flags_changed(None)
+        # Should not crash, audio_enabled unchanged
+        assert servicer.audio_enabled is True
+
+    def test_no_stop_music_when_audio_already_disabled(self, servicer):
+        servicer.audio_enabled = False
+        servicer.audio_manager.stop_music = MagicMock()
+        mock_client = MagicMock()
+        mock_client.get_boolean_value.return_value = False
+        mock_client.get_string_value.return_value = "ivy"
+
+        with patch("lib.feature_flags.get_flag_client", return_value=mock_client):
+            servicer._on_flags_changed(None)
+
+        # No change, so stop_music should not be called
+        servicer.audio_manager.stop_music.assert_not_called()
 
 
 class TestSoundRegistry:

--- a/services/game_coordinator/games/base.py
+++ b/services/game_coordinator/games/base.py
@@ -82,6 +82,7 @@ END_MAX_MUSIC_SLOW_TIME = 12
 
 # Volume levels
 GAME_VOLUME = 0.7
+COUNTDOWN_MUSIC_VOLUME = 0.15  # Soft background music during countdown
 
 
 # Threshold arrays from original JoustMania (in g-force units, 1.0 = 1g)
@@ -1145,12 +1146,19 @@ class BaseGameMode(ABC):
                 # Start gameplay stream before countdown (needed for countdown effects)
                 await self._start_gameplay_stream()
 
+                # Start game music BEFORE countdown at low volume.
+                # OGG decode happens during countdown, so music is ready instantly after.
+                await self._start_game_music(volume=COUNTDOWN_MUSIC_VOLUME)
+
                 # Countdown phase (child of initialization_phase)
                 with tracer.start_as_current_span("countdown_phase"):
                     await self._countdown()
 
-                # Start game music (after countdown, still part of initialization)
-                await self._start_game_music()
+                # Ramp music volume up to game level after countdown
+                if self.audio_client:
+                    from proto import audio_pb2
+
+                    await self.audio_client.SetVolume(audio_pb2.SetVolumeRequest(volume=GAME_VOLUME))
 
             # Game starts
             self.state = GameState.RUNNING
@@ -1320,11 +1328,11 @@ class BaseGameMode(ABC):
         metrics.effective_warning_threshold.set(effective_warn)
         metrics.effective_death_threshold.set(effective_death)
 
-    async def _start_game_music(self):
+    async def _start_game_music(self, volume: float = GAME_VOLUME):
         """
         Start game music with tempo control (Phase 70).
 
-        Sets volume higher than lobby and starts music at normal speed.
+        Sets volume and starts music at normal speed.
         Note: play_audio setting is checked centrally in audio service.
         """
         if not self.audio_client:
@@ -1333,8 +1341,8 @@ class BaseGameMode(ABC):
         try:
             from proto import audio_pb2
 
-            # Set game volume (louder than lobby)
-            await self.audio_client.SetVolume(audio_pb2.SetVolumeRequest(volume=GAME_VOLUME))
+            # Set initial volume (may be low during countdown, then ramped up)
+            await self.audio_client.SetVolume(audio_pb2.SetVolumeRequest(volume=volume))
 
             # Start game music
             response = await self.audio_client.PlayMusic(


### PR DESCRIPTION
## Summary
- **#527**: Start game music at low volume (`0.15`) before countdown, so OGG→WAV decode happens during countdown beeps. After countdown, ramp volume to normal game level (`0.7`). Eliminates the music gap after countdown.
- **#528**: Add reactive flag change handler (`_on_flags_changed`) to audio servicer. Toggling `play_audio` off in flagd now immediately stops music. Toggling it back on re-enables future audio playback. Replaces lazy `_load_audio_setting` pattern with OpenFeature `PROVIDER_CONFIGURATION_CHANGED` events.

Fixes #527, Fixes #528

## Changes
- `services/game_coordinator/games/base.py`: Add `COUNTDOWN_MUSIC_VOLUME` constant, move `_start_game_music()` before countdown, add `volume` parameter to `_start_game_music()`, ramp volume after countdown
- `services/audio/servicer.py`: Add `_load_menu_voice_flag()`, `_register_flag_change_handler()`, `_on_flags_changed()` methods. Remove lazy `_load_audio_setting()` and `_settings_loaded` pattern
- Tests updated to match new behavior (7 new tests for flag change handler)

## Test plan
- [x] `cd services/game_coordinator && uv run pytest` — 613 passed
- [x] `cd services/audio && uv run pytest` — 195 passed
- [x] `make lint` — all checks passed
- [ ] Manual: start game → music audible during countdown (quiet), louder after
- [ ] Manual: toggle `play_audio` off while music playing → music stops immediately
- [ ] Manual: toggle `play_audio` back on → future PlayMusic requests work

🤖 Generated with [Claude Code](https://claude.com/claude-code)