### PR TITLE
feat: per-controller adapter routing via OpenFeature targeting

### DIFF
--- a/lib/controller_constants.py
+++ b/lib/controller_constants.py
@@ -72,6 +72,7 @@ class ControllerInfoKey(StrEnum):
     ADDRESS = "address"
     NAME = "name"
     PAIRED = "paired"
+    ADAPTER = "adapter"  # Which adapter handles this controller (psmove, hidapi, mock)
 
 
 class LobbyState(StrEnum):

--- a/services/controller_manager/discovery_loop.py
+++ b/services/controller_manager/discovery_loop.py
@@ -499,6 +499,11 @@ class DiscoveryLoop:
             if self.name_manager:
                 name = self.name_manager.get_name(serial)
 
+            # Resolve adapter type if backend supports it (MultiplexerBackend)
+            adapter_type = ""
+            if hasattr(self.backend, "get_adapter_type"):
+                adapter_type = self.backend.get_adapter_type(serial)
+
             # Track controller
             self.tracked_controllers[serial] = {
                 ControllerInfoKey.SERIAL: serial,
@@ -506,6 +511,7 @@ class DiscoveryLoop:
                 ControllerInfoKey.TEAM: 0,
                 ControllerInfoKey.CONNECTED_AT: time.time(),
                 ControllerInfoKey.NAME: name,
+                ControllerInfoKey.ADAPTER: adapter_type,
             }
 
             # Store initial state

--- a/services/controller_manager/metrics.py
+++ b/services/controller_manager/metrics.py
@@ -61,6 +61,12 @@ controller_disconnect_total = Counter(
     "controller_disconnect_total", "Total number of controller disconnects", ["serial"]
 )
 
+controller_routing_decisions_total = Counter(
+    "controller_routing_decisions_total",
+    "Adapter routing decisions",
+    ["serial", "adapter", "method"],  # method: targeted, fallback, default
+)
+
 controller_reconnect_total = Counter("controller_reconnect_total", "Total number of controller reconnects", ["serial"])
 
 active_controllers = Gauge("active_controllers_total", "Number of currently active controllers")

--- a/services/controller_manager/multiplexer/multiplexer_backend.py
+++ b/services/controller_manager/multiplexer/multiplexer_backend.py
@@ -4,6 +4,11 @@ through ControllerIOAdapter instances with centralized state tracking.
 
 LED state, rumble, and effect tracking are centralized here instead of
 being duplicated across each backend.
+
+Adapter routing uses OpenFeature targeting via the ``controller_adapter_routing``
+flag to decide which adapter handles each controller when multiple adapters
+discover the same serial.  Changing the flag value takes effect on the next
+discovery cycle — no reconnect needed.
 """
 
 from __future__ import annotations
@@ -52,6 +57,11 @@ class MultiplexerBackend(ControllerBackend):
         self._last_led_update: dict[str, float] = {}
         self._effect_active: set[str] = set()
         self._led_lock = threading.Lock()
+
+        # Build adapter_type -> adapter lookup for targeting resolution
+        self._adapter_by_type: dict[str, ControllerIOAdapter] = {}
+        for adapter in self._adapters:
+            self._adapter_by_type[adapter.adapter_type] = adapter
 
         adapter_names = [a.adapter_type for a in self._adapters]
         logger.info(f"MultiplexerBackend created with adapters: {adapter_names}")
@@ -103,22 +113,94 @@ class MultiplexerBackend(ControllerBackend):
         self._effect_active.clear()
 
     def get_connected_controllers(self, force_rescan: bool = False) -> list[str]:
-        seen = self._discover_all_adapters(force_rescan)
+        seen = self._route_controllers(force_rescan)
         self._serial_to_adapter = seen
         self._cleanup_stale_state(seen)
         self._update_controller_metrics(seen)
         return list(seen.keys())
 
-    def _discover_all_adapters(self, force: bool) -> dict[str, ControllerIOAdapter]:
-        """Discover controllers from all adapters, opening new ones."""
-        seen: dict[str, ControllerIOAdapter] = {}
+    def _route_controllers(self, force: bool) -> dict[str, ControllerIOAdapter]:
+        """Discover controllers from all adapters, then route via targeting.
+
+        Phase 1: All adapters discover independently (opens handles for new serials).
+        Phase 2: For each serial found by multiple adapters, evaluate the
+        ``controller_adapter_routing`` flag to pick the preferred adapter.
+        """
+        # Phase 1: discover — build serial -> list[adapter]
+        adapter_serials: dict[str, list[ControllerIOAdapter]] = {}
         for adapter in self._adapters:
             for serial in adapter.discover(force=force):
-                if serial not in seen:
-                    seen[serial] = adapter
-                    if serial not in self._serial_to_adapter:
-                        adapter.open(serial)
+                adapter_serials.setdefault(serial, []).append(adapter)
+                # Open handle if this adapter hasn't seen it before
+                if self._serial_to_adapter.get(serial) is not adapter:
+                    adapter.open(serial)
+
+        # Phase 2: route each serial
+        seen: dict[str, ControllerIOAdapter] = {}
+        for serial, discoverers in adapter_serials.items():
+            # Mock-only controllers skip targeting
+            if all(a.adapter_type == "mock" for a in discoverers):
+                seen[serial] = discoverers[0]
+                metrics.controller_routing_decisions_total.labels(
+                    serial=serial,
+                    adapter=discoverers[0].adapter_type,
+                    method="default",
+                ).inc()
+                continue
+
+            real = [a for a in discoverers if a.adapter_type != "mock"]
+            preferred = self._resolve_adapter_for_serial(serial)
+
+            if preferred and preferred in discoverers:
+                seen[serial] = preferred
+                method = "targeted"
+            elif len(real) == 1:
+                seen[serial] = real[0]
+                method = "default"
+            else:
+                seen[serial] = real[0]
+                method = "fallback"
+
+            metrics.controller_routing_decisions_total.labels(
+                serial=serial,
+                adapter=seen[serial].adapter_type,
+                method=method,
+            ).inc()
+
+            # Log dynamic switch
+            old = self._serial_to_adapter.get(serial)
+            if old and old is not seen[serial]:
+                logger.info(f"Switched {serial}: {old.adapter_type} -> {seen[serial].adapter_type}")
+
         return seen
+
+    def _resolve_adapter_for_serial(self, serial: str) -> ControllerIOAdapter | None:
+        """Evaluate the controller_adapter_routing flag for a serial.
+
+        Returns the matching adapter instance, or None if targeting is
+        unavailable, errors, or the result doesn't match any adapter.
+        """
+        try:
+            from openfeature.evaluation_context import EvaluationContext
+
+            from lib.feature_flags import get_flag_client
+
+            client = get_flag_client("performance")
+            adapter_type = client.get_string_value(
+                "controller_adapter_routing",
+                "",
+                EvaluationContext(targeting_key=serial),
+            )
+            if adapter_type:
+                return self._adapter_by_type.get(adapter_type)
+        except Exception:
+            logger.debug(f"Failed to evaluate controller_adapter_routing for {serial}", exc_info=True)
+        return None
+
+    def get_adapter_type(self, serial: str) -> str:
+        """Return the adapter_type string for a tracked serial."""
+        adapter = self._serial_to_adapter.get(serial)
+        return adapter.adapter_type if adapter else "unknown"
 
     def _cleanup_stale_state(self, seen: dict[str, ControllerIOAdapter]) -> None:
         """Remove centralized state for controllers no longer present."""
@@ -226,7 +308,20 @@ class MultiplexerBackend(ControllerBackend):
             self._effect_active.discard(serial)
 
     async def connect_controller(self, address: str) -> bool:
+        # Try targeted adapter first
+        preferred = self._resolve_adapter_for_serial(address)
+        if preferred:
+            try:
+                if preferred.open(address):
+                    self._serial_to_adapter[address] = preferred
+                    return True
+            except Exception:
+                logger.exception(f"connect_controller targeted failed for {preferred.adapter_type}")
+
+        # Fall back to iteration order
         for adapter in self._adapters:
+            if adapter is preferred:
+                continue  # Already tried
             try:
                 if adapter.open(address):
                     self._serial_to_adapter[address] = adapter

--- a/services/controller_manager/tests/test_multiplexer_backend.py
+++ b/services/controller_manager/tests/test_multiplexer_backend.py
@@ -108,13 +108,14 @@ class TestMultiplexerGetConnectedControllers:
 
     @patch("services.controller_manager.multiplexer.multiplexer_backend.metrics")
     def test_deduplicates_across_adapters(self, mock_metrics):
-        a1 = _make_adapter("mock", serials=["AA:AA"])
+        a1 = _make_adapter("psmove", serials=["AA:AA"])
         a2 = _make_adapter("hidapi", serials=["AA:AA"])
         mux = MultiplexerBackend(adapters=[a1, a2])
 
         result = mux.get_connected_controllers()
 
         assert result == ["AA:AA"]
+        # With no targeting, first real adapter wins
         assert mux._serial_to_adapter["AA:AA"] is a1
 
     @patch("services.controller_manager.multiplexer.multiplexer_backend.metrics")
@@ -400,3 +401,208 @@ class TestMultiplexerScanControllers:
         result = await mux.scan_controllers()
 
         assert len(result) == 2
+
+
+class TestRouteControllers:
+    """Tests for OpenFeature targeting-based adapter routing."""
+
+    @patch("services.controller_manager.multiplexer.multiplexer_backend.metrics")
+    def test_targeting_routes_to_preferred_adapter(self, mock_metrics):
+        """When targeting returns 'hidapi', that adapter should be chosen."""
+        a1 = _make_adapter("psmove", serials=["AA:AA"])
+        a2 = _make_adapter("hidapi", serials=["AA:AA"])
+        mux = MultiplexerBackend(adapters=[a1, a2])
+
+        with patch.object(mux, "_resolve_adapter_for_serial", return_value=a2):
+            result = mux.get_connected_controllers()
+
+        assert result == ["AA:AA"]
+        assert mux._serial_to_adapter["AA:AA"] is a2
+
+    @patch("services.controller_manager.multiplexer.multiplexer_backend.metrics")
+    def test_fallback_when_preferred_not_in_discoverers(self, mock_metrics):
+        """If targeting returns an adapter that didn't discover the serial, fall back."""
+        a1 = _make_adapter("psmove", serials=["AA:AA"])
+        a2 = _make_adapter("hidapi", serials=[])  # hidapi didn't find it
+        mux = MultiplexerBackend(adapters=[a1, a2])
+
+        with patch.object(mux, "_resolve_adapter_for_serial", return_value=a2):
+            result = mux.get_connected_controllers()
+
+        assert result == ["AA:AA"]
+        assert mux._serial_to_adapter["AA:AA"] is a1  # Falls back to psmove
+
+    @patch("services.controller_manager.multiplexer.multiplexer_backend.metrics")
+    def test_mock_excluded_from_targeting(self, mock_metrics):
+        """Mock-only controllers skip targeting entirely."""
+        a1 = _make_adapter("mock", serials=["MOCK01"])
+        a2 = _make_adapter("hidapi", serials=[])
+        mux = MultiplexerBackend(adapters=[a1, a2])
+
+        resolve_mock = MagicMock()
+        with patch.object(mux, "_resolve_adapter_for_serial", resolve_mock):
+            result = mux.get_connected_controllers()
+
+        assert result == ["MOCK01"]
+        assert mux._serial_to_adapter["MOCK01"] is a1
+        resolve_mock.assert_not_called()
+
+    @patch("services.controller_manager.multiplexer.multiplexer_backend.metrics")
+    def test_dynamic_switch_logs(self, mock_metrics, caplog):
+        """Switching adapter mid-session should log the change."""
+        import logging
+
+        caplog.set_level(logging.INFO)
+        a1 = _make_adapter("psmove", serials=["AA:AA"])
+        a2 = _make_adapter("hidapi", serials=["AA:AA"])
+        mux = MultiplexerBackend(adapters=[a1, a2])
+
+        # First discovery: route to psmove (no targeting)
+        with patch.object(mux, "_resolve_adapter_for_serial", return_value=None):
+            mux.get_connected_controllers()
+
+        assert mux._serial_to_adapter["AA:AA"] is a1
+
+        # Second discovery: targeting switches to hidapi
+        with patch.object(mux, "_resolve_adapter_for_serial", return_value=a2):
+            mux.get_connected_controllers()
+
+        assert mux._serial_to_adapter["AA:AA"] is a2
+        assert "Switched AA:AA: psmove -> hidapi" in caplog.text
+
+    @patch("services.controller_manager.multiplexer.multiplexer_backend.metrics")
+    def test_different_serials_to_different_adapters(self, mock_metrics):
+        """Each serial can route to a different adapter independently."""
+        a1 = _make_adapter("psmove", serials=["AA:AA", "BB:BB"])
+        a2 = _make_adapter("hidapi", serials=["AA:AA", "BB:BB"])
+        mux = MultiplexerBackend(adapters=[a1, a2])
+
+        def route(serial):
+            return a2 if serial == "AA:AA" else a1
+
+        with patch.object(mux, "_resolve_adapter_for_serial", side_effect=route):
+            mux.get_connected_controllers()
+
+        assert mux._serial_to_adapter["AA:AA"] is a2
+        assert mux._serial_to_adapter["BB:BB"] is a1
+
+    @patch("services.controller_manager.multiplexer.multiplexer_backend.metrics")
+    def test_single_real_adapter_skips_targeting(self, mock_metrics):
+        """When only one real adapter discovers a serial, use it directly."""
+        a1 = _make_adapter("psmove", serials=["AA:AA"])
+        a2 = _make_adapter("hidapi", serials=[])
+        mux = MultiplexerBackend(adapters=[a1, a2])
+
+        # _resolve returns None — but only one real adapter found it
+        with patch.object(mux, "_resolve_adapter_for_serial", return_value=None):
+            mux.get_connected_controllers()
+
+        assert mux._serial_to_adapter["AA:AA"] is a1
+
+    @patch("services.controller_manager.multiplexer.multiplexer_backend.metrics")
+    def test_opens_handles_for_all_discovering_adapters(self, mock_metrics):
+        """Both adapters should get open() called so they have handles ready."""
+        a1 = _make_adapter("psmove", serials=["AA:AA"])
+        a2 = _make_adapter("hidapi", serials=["AA:AA"])
+        mux = MultiplexerBackend(adapters=[a1, a2])
+
+        with patch.object(mux, "_resolve_adapter_for_serial", return_value=a1):
+            mux.get_connected_controllers()
+
+        a1.open.assert_called_with("AA:AA")
+        a2.open.assert_called_with("AA:AA")
+
+    @patch("services.controller_manager.multiplexer.multiplexer_backend.metrics")
+    def test_routing_metric_incremented(self, mock_metrics):
+        """Routing decisions should increment the counter metric."""
+        a1 = _make_adapter("psmove", serials=["AA:AA"])
+        a2 = _make_adapter("hidapi", serials=["AA:AA"])
+        mux = MultiplexerBackend(adapters=[a1, a2])
+
+        with patch.object(mux, "_resolve_adapter_for_serial", return_value=a2):
+            mux.get_connected_controllers()
+
+        mock_metrics.controller_routing_decisions_total.labels.assert_any_call(
+            serial="AA:AA",
+            adapter="hidapi",
+            method="targeted",
+        )
+
+
+class TestResolveAdapterForSerial:
+    """Tests for flag evaluation in _resolve_adapter_for_serial."""
+
+    def test_returns_matching_adapter(self):
+        a1 = _make_adapter("psmove")
+        a2 = _make_adapter("hidapi")
+        mux = MultiplexerBackend(adapters=[a1, a2])
+
+        mock_client = MagicMock()
+        mock_client.get_string_value.return_value = "hidapi"
+
+        with patch("lib.feature_flags.get_flag_client", return_value=mock_client):
+            result = mux._resolve_adapter_for_serial("AA:AA")
+
+        assert result is a2
+
+    def test_returns_none_when_no_match(self):
+        a1 = _make_adapter("psmove")
+        mux = MultiplexerBackend(adapters=[a1])
+
+        mock_client = MagicMock()
+        mock_client.get_string_value.return_value = "nonexistent"
+
+        with patch("lib.feature_flags.get_flag_client", return_value=mock_client):
+            result = mux._resolve_adapter_for_serial("AA:AA")
+
+        assert result is None
+
+    def test_returns_none_when_empty_value(self):
+        a1 = _make_adapter("psmove")
+        mux = MultiplexerBackend(adapters=[a1])
+
+        mock_client = MagicMock()
+        mock_client.get_string_value.return_value = ""
+
+        with patch("lib.feature_flags.get_flag_client", return_value=mock_client):
+            result = mux._resolve_adapter_for_serial("AA:AA")
+
+        assert result is None
+
+    def test_returns_none_on_exception(self):
+        a1 = _make_adapter("psmove")
+        mux = MultiplexerBackend(adapters=[a1])
+
+        with patch("lib.feature_flags.get_flag_client", side_effect=RuntimeError("flagd down")):
+            result = mux._resolve_adapter_for_serial("AA:AA")
+
+        assert result is None
+
+    def test_passes_serial_as_targeting_key(self):
+        a1 = _make_adapter("psmove")
+        mux = MultiplexerBackend(adapters=[a1])
+
+        mock_client = MagicMock()
+        mock_client.get_string_value.return_value = "psmove"
+
+        with patch("lib.feature_flags.get_flag_client", return_value=mock_client):
+            mux._resolve_adapter_for_serial("E0AE5EE111AB")
+
+        call_args = mock_client.get_string_value.call_args
+        ctx = call_args[0][2]  # Third positional arg is the EvaluationContext
+        assert ctx.targeting_key == "E0AE5EE111AB"
+
+
+class TestGetAdapterType:
+    @patch("services.controller_manager.multiplexer.multiplexer_backend.metrics")
+    def test_returns_adapter_type_for_known_serial(self, mock_metrics):
+        a1 = _make_adapter("hidapi", serials=["AA:AA"])
+        mux = MultiplexerBackend(adapters=[a1])
+        mux.get_connected_controllers()
+
+        assert mux.get_adapter_type("AA:AA") == "hidapi"
+
+    def test_returns_unknown_for_missing_serial(self):
+        mux = MultiplexerBackend(adapters=[_make_adapter()])
+
+        assert mux.get_adapter_type("ZZ:ZZ") == "unknown"

--- a/services/flagd/performance.ci.json
+++ b/services/flagd/performance.ci.json
@@ -137,6 +137,15 @@
         "off": false
       },
       "defaultVariant": "off"
+    },
+    "controller_adapter_routing": {
+      "state": "ENABLED",
+      "variants": {
+        "bluetooth": "psmove",
+        "hidapi": "hidapi"
+      },
+      "defaultVariant": "hidapi",
+      "targeting": {}
     }
   }
 }

--- a/services/flagd/performance.json
+++ b/services/flagd/performance.json
@@ -152,6 +152,15 @@
         "off": false
       },
       "defaultVariant": "on"
+    },
+    "controller_adapter_routing": {
+      "state": "ENABLED",
+      "variants": {
+        "bluetooth": "psmove",
+        "hidapi": "hidapi"
+      },
+      "defaultVariant": "hidapi",
+      "targeting": {}
     }
   }
 }


### PR DESCRIPTION
## Summary

- Adds OpenFeature targeting-based adapter routing to MultiplexerBackend, allowing per-controller control of which adapter (psmove, hidapi) handles each controller when both discover the same serial
- Dynamic switching — changing the `controller_adapter_routing` flag takes effect on the next discovery cycle without requiring reconnection
- New `controller_routing_decisions_total` metric tracks routing decisions with `serial`, `adapter`, and `method` (targeted/fallback/default) labels

## Changes

- **`multiplexer_backend.py`**: Replace `_discover_all_adapters()` with `_route_controllers()` (2-phase: discover all, then route via flag). Add `_resolve_adapter_for_serial()`, `get_adapter_type()`. Update `connect_controller()` to prefer targeted adapter.
- **`lib/controller_constants.py`**: Add `ADAPTER` to `ControllerInfoKey`
- **`discovery_loop.py`**: Store adapter type in `tracked_controllers`
- **`metrics.py`**: Add `controller_routing_decisions_total` counter
- **`flagd/performance.json` + `performance.ci.json`**: Add `controller_adapter_routing` flag with `psmove`/`hidapi` variants

## Progressive rollout example

Move one specific controller to hidapi while keeping the rest on psmove:
```json
"controller_adapter_routing": {
  "defaultVariant": "bluetooth",
  "targeting": {
    "if": [
      {"in": [{"var": "targetingKey"}, ["E0AE5EE111AB"]]},
      "hidapi",
      null
    ]
  }
}
```

## Test plan

- [x] `make lint` passes
- [x] 580 controller_manager tests pass (14 new)
- [ ] Manual: set `controller_backend=bluetooth,hidapi`, add targeting for one serial, verify logs show routing decisions and live switching

🤖 Generated with [Claude Code](https://claude.com/claude-code)