### PR TITLE
fix: normalize controller serial numbers across all backends

### DIFF
--- a/lib/controller_constants.py
+++ b/lib/controller_constants.py
@@ -114,6 +114,23 @@ BUTTON_TRACKING_TO_STATE = {
 }
 
 
+def normalize_serial(serial: str) -> str:
+    """Normalize a controller serial to canonical format (uppercase, no colons).
+
+    MAC-format serials (12 hex chars with/without colons) are uppercased
+    and stripped of colons. Non-MAC serials (e.g. mock_controller_0) are
+    returned unchanged.
+    """
+    cleaned = serial.upper().replace(":", "")
+    if len(cleaned) == 12:
+        try:
+            int(cleaned, 16)
+            return cleaned
+        except ValueError:
+            pass
+    return serial
+
+
 # Default values
 DEFAULT_BATTERY = 5
 DEFAULT_ACCEL = {"x": 0.0, "y": 0.0, "z": 1.0}  # At rest (1g gravity)

--- a/services/controller_manager/bluetooth_backend.py
+++ b/services/controller_manager/bluetooth_backend.py
@@ -17,6 +17,7 @@ from lib.controller_constants import (
     AxisKey,
     ButtonKey,
     StateKey,
+    normalize_serial,
 )
 from services.controller_manager.backend import ControllerBackend
 
@@ -167,7 +168,7 @@ class BluetoothBackend(ControllerBackend):
                 if move is None:
                     continue
 
-                serial = move.get_serial()
+                serial = normalize_serial(move.get_serial())
                 if not serial:
                     logger.debug(f"Controller {move_num}: no serial, skipping")
                     continue
@@ -194,7 +195,7 @@ class BluetoothBackend(ControllerBackend):
                 # Check if it's a PS Move controller (MAC prefix 00:06:F7)
                 if address.startswith("00:06:F7"):
                     controllers.append(
-                        {"address": address, "serial": address.replace(":", ""), "name": "PS Move Controller"}
+                        {"address": address, "serial": normalize_serial(address), "name": "PS Move Controller"}
                     )
 
             # Also check currently connected via psmove
@@ -205,7 +206,7 @@ class BluetoothBackend(ControllerBackend):
                         move = psmove.PSMove(move_num)
                     if move is None:
                         continue
-                    serial = move.get_serial()
+                    serial = normalize_serial(move.get_serial())
                     if not serial:
                         continue
 
@@ -247,11 +248,11 @@ class BluetoothBackend(ControllerBackend):
                         move = psmove.PSMove(i)
                     if move is None:
                         continue
-                    serial = move.get_serial()
+                    serial = normalize_serial(move.get_serial())
                     if not serial:
                         continue
 
-                    if serial == address or serial.upper() == address.upper():
+                    if serial == normalize_serial(address):
                         # Track the controller
                         self.controllers[serial] = move
                         self.controller_states[serial] = ControllerState()
@@ -296,7 +297,7 @@ class BluetoothBackend(ControllerBackend):
             try:
                 with suppress_stderr():
                     move = psmove.PSMove(i)
-                if move and move.get_serial() == serial:
+                if move and normalize_serial(move.get_serial()) == serial:
                     return move
             except Exception:
                 continue
@@ -486,7 +487,7 @@ class BluetoothBackend(ControllerBackend):
                 logger.warning(f"Controller {move_num}/{count}: PSMove() returned None")
                 return None
 
-            serial = move.get_serial()
+            serial = normalize_serial(move.get_serial())
             if not serial:
                 logger.warning(f"Controller {move_num}/{count}: no serial returned")
                 return None

--- a/services/controller_manager/hidapi_backend.py
+++ b/services/controller_manager/hidapi_backend.py
@@ -25,6 +25,7 @@ from lib.controller_constants import (
     AxisKey,
     ButtonKey,
     StateKey,
+    normalize_serial,
 )
 from lib.psmove_hid import (
     INPUT_REPORT_SIZE,
@@ -145,8 +146,7 @@ class HidapiBackend(ControllerBackend):
                 logger.debug(f"HID device at {path!r}: no serial, skipping")
                 continue
 
-            # Normalize serial to uppercase without colons (match psmoveapi format)
-            serial = serial.upper().replace(":", "")
+            serial = normalize_serial(serial)
 
             if serial in self.controllers:
                 continue
@@ -169,7 +169,7 @@ class HidapiBackend(ControllerBackend):
             serial = dev_info.get("serial_number", "")
             if not serial:
                 continue
-            serial = serial.upper().replace(":", "")
+            serial = normalize_serial(serial)
             if not any(c["serial"] == serial for c in controllers):
                 controllers.append(
                     {
@@ -193,8 +193,8 @@ class HidapiBackend(ControllerBackend):
             serial = dev_info.get("serial_number", "")
             if not serial:
                 continue
-            serial = serial.upper().replace(":", "")
-            if serial == address.upper().replace(":", ""):
+            serial = normalize_serial(serial)
+            if serial == normalize_serial(address):
                 try:
                     device = hid.Device(path=dev_info["path"])
                     device.nonblocking = True
@@ -424,7 +424,7 @@ class HidapiBackend(ControllerBackend):
                 serial = dev_info.get("serial_number", "")
                 if not serial:
                     continue
-                serial = serial.upper().replace(":", "")
+                serial = normalize_serial(serial)
                 current_paths.add(path)
 
                 if serial not in self.controllers:

--- a/services/controller_manager/multiplexer/hidapi_adapter.py
+++ b/services/controller_manager/multiplexer/hidapi_adapter.py
@@ -11,7 +11,7 @@ import logging
 
 import hidraw as hid  # hidraw backend sees Bluetooth HID devices (libusb backend cannot)
 
-from lib.controller_constants import AxisKey, ButtonKey, StateKey
+from lib.controller_constants import AxisKey, ButtonKey, StateKey, normalize_serial
 from lib.psmove_hid import (
     INPUT_REPORT_SIZE,
     PRODUCT_ID_ZCM1,
@@ -75,7 +75,7 @@ class HidapiAdapter(ControllerIOAdapter):
             if not serial:
                 continue
 
-            serial = serial.upper().replace(":", "")
+            serial = normalize_serial(serial)
             current_paths.add(path)
 
             if serial not in self._devices:
@@ -111,8 +111,8 @@ class HidapiAdapter(ControllerIOAdapter):
             dev_serial = dev_info.get("serial_number", "")
             if not dev_serial:
                 continue
-            dev_serial = dev_serial.upper().replace(":", "")
-            if dev_serial == serial.upper().replace(":", ""):
+            dev_serial = normalize_serial(dev_serial)
+            if dev_serial == normalize_serial(serial):
                 try:
                     device = hid.Device(path=dev_info["path"])
                     device.nonblocking = True

--- a/services/controller_manager/multiplexer/psmove_adapter.py
+++ b/services/controller_manager/multiplexer/psmove_adapter.py
@@ -11,7 +11,7 @@ import logging
 import os
 import time
 
-from lib.controller_constants import AxisKey, ButtonKey, StateKey
+from lib.controller_constants import AxisKey, ButtonKey, StateKey, normalize_serial
 from services.controller_manager.multiplexer.adapter import ControllerIOAdapter
 
 
@@ -138,7 +138,7 @@ class PsMoveAdapter(ControllerIOAdapter):
                 logger.warning(f"Controller {move_num}/{count}: PSMove() returned None")
                 return None
 
-            serial = move.get_serial()
+            serial = normalize_serial(move.get_serial())
             if not serial:
                 logger.warning(f"Controller {move_num}/{count}: no serial returned")
                 return None

--- a/services/controller_manager/name_manager.py
+++ b/services/controller_manager/name_manager.py
@@ -12,6 +12,8 @@ import os
 import threading
 from pathlib import Path
 
+from lib.controller_constants import normalize_serial
+
 logger = logging.getLogger(__name__)
 
 # Default path, can be overridden by CONTROLLER_NAMES_FILE env var
@@ -93,7 +95,7 @@ class NameManager:
                     line = line.strip()
                     if line and not line.startswith("#") and "=" in line:
                         serial, name = line.split("=", 1)
-                        self._names[serial.strip()] = name.strip()
+                        self._names[normalize_serial(serial.strip())] = name.strip()
             logger.info(f"Loaded {len(self._names)} controller names from {self.names_file}")
         except Exception as e:
             logger.error(f"Error loading controller names: {e}")
@@ -141,6 +143,7 @@ class NameManager:
         Returns:
             Human-readable name for the controller.
         """
+        serial = normalize_serial(serial)
         with self._lock:
             if serial not in self._names:
                 self._names[serial] = self._generate_name(serial)
@@ -159,6 +162,7 @@ class NameManager:
         Returns:
             True if the name was set successfully.
         """
+        serial = normalize_serial(serial)
         with self._lock:
             old_name = self._names.get(serial)
             self._names[serial] = name

--- a/services/controller_manager/servicer.py
+++ b/services/controller_manager/servicer.py
@@ -18,7 +18,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspa
 
 import contextlib
 
-from lib.controller_constants import ControllerInfoKey
+from lib.controller_constants import ControllerInfoKey, normalize_serial
 from lib.telemetry import get_tracer
 from proto import controller_manager_pb2, controller_manager_pb2_grpc
 from services.controller_manager import metrics
@@ -521,14 +521,16 @@ class ControllerManagerServicer(controller_manager_pb2_grpc.ControllerManagerSer
                 if not request.name:
                     return controller_manager_pb2.RenameControllerResponse(success=False, error="Name is required")
 
+                serial = normalize_serial(request.serial)
+
                 # Update the name
-                self.name_manager.set_name(request.serial, request.name)
+                self.name_manager.set_name(serial, request.name)
 
                 # Update tracked_controllers if the controller is currently connected
-                if request.serial in self.tracked_controllers:
-                    self.tracked_controllers[request.serial][ControllerInfoKey.NAME] = request.name
+                if serial in self.tracked_controllers:
+                    self.tracked_controllers[serial][ControllerInfoKey.NAME] = request.name
 
-                logger.info(f"Renamed controller {request.serial} to '{request.name}'")
+                logger.info(f"Renamed controller {serial} to '{request.name}'")
                 return controller_manager_pb2.RenameControllerResponse(success=True, error="")
 
             except Exception as e:

--- a/services/controller_manager/tests/test_bluetooth_backend_helpers.py
+++ b/services/controller_manager/tests/test_bluetooth_backend_helpers.py
@@ -149,7 +149,7 @@ class TestProbeController:
         ):
             serial = backend._probe_controller(0, 1)
 
-        assert serial == "AA:BB:CC:DD:EE:00"
+        assert serial == "AABBCCDDEE00"
 
     def test_probe_registers_new_controller(self):
         """Probing a new controller should register it in controllers dict."""
@@ -166,14 +166,14 @@ class TestProbeController:
         ):
             backend._probe_controller(0, 1)
 
-        assert "AA:BB:CC:DD:EE:01" in backend.controllers
-        assert "AA:BB:CC:DD:EE:01" in backend.controller_states
+        assert "AABBCCDDEE01" in backend.controllers
+        assert "AABBCCDDEE01" in backend.controller_states
 
     def test_probe_skips_already_tracked_controller(self):
         """Probing an already-tracked serial should not overwrite the stored handle."""
         backend = _make_backend()
         original_move = MagicMock()
-        backend.controllers["AA:BB:CC:DD:EE:02"] = original_move
+        backend.controllers["AABBCCDDEE02"] = original_move
 
         new_move = MockPSMove.PSMove(0)
         new_move._serial = "AA:BB:CC:DD:EE:02"
@@ -187,9 +187,9 @@ class TestProbeController:
         ):
             serial = backend._probe_controller(0, 1)
 
-        assert serial == "AA:BB:CC:DD:EE:02"
+        assert serial == "AABBCCDDEE02"
         # Original handle preserved
-        assert backend.controllers["AA:BB:CC:DD:EE:02"] is original_move
+        assert backend.controllers["AABBCCDDEE02"] is original_move
 
     def test_probe_returns_none_when_psmove_returns_none(self):
         """Probing should return None when PSMove() returns None."""

--- a/services/controller_manager/tests/test_name_manager.py
+++ b/services/controller_manager/tests/test_name_manager.py
@@ -298,6 +298,63 @@ class TestGetAllNames:
                 os.unlink(names_file)
 
 
+class TestSerialNormalization:
+    """Tests that NameManager normalizes MAC-format serials."""
+
+    def test_get_name_normalizes_colon_format(self):
+        """get_name with colon-format serial returns same name as normalized form."""
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            names_file = f.name
+
+        try:
+            manager = NameManager(names_file)
+            name_colon = manager.get_name("aa:bb:cc:dd:ee:ff")
+            name_upper = manager.get_name("AABBCCDDEEFF")
+            assert name_colon == name_upper
+        finally:
+            if os.path.exists(names_file):
+                os.unlink(names_file)
+
+    def test_set_name_normalizes_then_get_retrieves(self):
+        """set_name with colon format, then get_name with uppercase retrieves it."""
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            names_file = f.name
+
+        try:
+            manager = NameManager(names_file)
+            manager.set_name("aa:bb:cc:dd:ee:ff", "Player 1")
+            assert manager.get_name("AABBCCDDEEFF") == "Player 1"
+        finally:
+            if os.path.exists(names_file):
+                os.unlink(names_file)
+
+    def test_load_normalizes_legacy_serials(self):
+        """Loading a file with colon-format serials normalizes them."""
+        with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".txt") as f:
+            f.write("aa:bb:cc:dd:ee:ff=Legacy Name\n")
+            names_file = f.name
+
+        try:
+            manager = NameManager(names_file)
+            assert manager.get_name("AABBCCDDEEFF") == "Legacy Name"
+        finally:
+            if os.path.exists(names_file):
+                os.unlink(names_file)
+
+    def test_non_mac_serials_unchanged(self):
+        """Non-MAC serials pass through normalization unchanged."""
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            names_file = f.name
+
+        try:
+            manager = NameManager(names_file)
+            manager.set_name("mock_controller_0", "Mock")
+            assert manager.get_name("mock_controller_0") == "Mock"
+        finally:
+            if os.path.exists(names_file):
+                os.unlink(names_file)
+
+
 class TestThreadSafety:
     """Tests for thread-safe operations."""
 

--- a/services/controller_manager/tests/test_normalize_serial.py
+++ b/services/controller_manager/tests/test_normalize_serial.py
@@ -1,0 +1,71 @@
+"""
+Unit tests for normalize_serial() in lib/controller_constants.py.
+"""
+
+from lib.controller_constants import normalize_serial
+
+
+class TestNormalizeSerialMAC:
+    """Tests for MAC-format serial normalization."""
+
+    def test_lowercase_with_colons(self):
+        assert normalize_serial("e0:ae:5e:e1:11:ab") == "E0AE5EE111AB"
+
+    def test_uppercase_with_colons(self):
+        assert normalize_serial("E0:AE:5E:E1:11:AB") == "E0AE5EE111AB"
+
+    def test_mixed_case_with_colons(self):
+        assert normalize_serial("e0:AE:5e:E1:11:Ab") == "E0AE5EE111AB"
+
+    def test_uppercase_no_colons(self):
+        assert normalize_serial("E0AE5EE111AB") == "E0AE5EE111AB"
+
+    def test_lowercase_no_colons(self):
+        assert normalize_serial("e0ae5ee111ab") == "E0AE5EE111AB"
+
+    def test_all_zeros(self):
+        assert normalize_serial("00:00:00:00:00:00") == "000000000000"
+
+    def test_all_f(self):
+        assert normalize_serial("ff:ff:ff:ff:ff:ff") == "FFFFFFFFFFFF"
+
+    def test_idempotent(self):
+        """Normalizing an already normalized serial returns the same value."""
+        normalized = normalize_serial("e0:ae:5e:e1:11:ab")
+        assert normalize_serial(normalized) == normalized
+
+    def test_idempotent_multiple_times(self):
+        result = "E0AE5EE111AB"
+        for _ in range(5):
+            result = normalize_serial(result)
+        assert result == "E0AE5EE111AB"
+
+
+class TestNormalizeSerialNonMAC:
+    """Tests for non-MAC serials that should pass through unchanged."""
+
+    def test_mock_controller_serial(self):
+        assert normalize_serial("mock_controller_0") == "mock_controller_0"
+
+    def test_mock_uppercase(self):
+        assert normalize_serial("MOCK0000") == "MOCK0000"
+
+    def test_test_serial(self):
+        assert normalize_serial("TEST_SERIAL_001") == "TEST_SERIAL_001"
+
+    def test_short_string(self):
+        assert normalize_serial("ABC") == "ABC"
+
+    def test_long_string(self):
+        assert normalize_serial("ABCDEF123456789") == "ABCDEF123456789"
+
+    def test_empty_string(self):
+        assert normalize_serial("") == ""
+
+    def test_twelve_chars_non_hex(self):
+        """12-char string with non-hex chars should pass through."""
+        assert normalize_serial("HELLO_WORLD!") == "HELLO_WORLD!"
+
+    def test_twelve_chars_with_g(self):
+        """12 uppercase chars with 'G' (non-hex) should pass through."""
+        assert normalize_serial("AABBCCDDEEFG") == "AABBCCDDEEFG"

--- a/services/controller_manager/tests/test_psmove_adapter.py
+++ b/services/controller_manager/tests/test_psmove_adapter.py
@@ -137,19 +137,19 @@ class TestPsMoveAdapterInit:
 class TestPsMoveAdapterDiscover:
     def test_discover_returns_serials(self):
         adapter = PsMoveAdapter()
-        fake_move = _make_fake_move("AA:BB:CC:DD:EE:01")
+        fake_move = _make_fake_move("AABBCCDDEE01")
         mock_psmove.count_connected.return_value = 1
         mock_psmove.PSMove.return_value = fake_move
 
         serials = adapter.discover()
 
-        assert "AA:BB:CC:DD:EE:01" in serials
+        assert "AABBCCDDEE01" in serials
         assert len(serials) == 1
 
     def test_discover_multiple_controllers(self):
         adapter = PsMoveAdapter()
         moves = [
-            _make_fake_move("AA:BB:CC:DD:EE:01"),
+            _make_fake_move("AABBCCDDEE01"),
             _make_fake_move("AA:BB:CC:DD:EE:02"),
         ]
         mock_psmove.count_connected.return_value = 2
@@ -158,12 +158,12 @@ class TestPsMoveAdapterDiscover:
         serials = adapter.discover()
 
         assert len(serials) == 2
-        assert "AA:BB:CC:DD:EE:01" in serials
-        assert "AA:BB:CC:DD:EE:02" in serials
+        assert "AABBCCDDEE01" in serials
+        assert "AABBCCDDEE02" in serials
 
     def test_discover_skips_no_change_without_force(self):
         adapter = PsMoveAdapter()
-        fake_move = _make_fake_move("AA:BB:CC:DD:EE:01")
+        fake_move = _make_fake_move("AABBCCDDEE01")
         mock_psmove.count_connected.return_value = 1
         mock_psmove.PSMove.return_value = fake_move
 
@@ -177,21 +177,21 @@ class TestPsMoveAdapterDiscover:
 
     def test_discover_rescans_on_force(self):
         adapter = PsMoveAdapter()
-        fake_move = _make_fake_move("AA:BB:CC:DD:EE:01")
+        fake_move = _make_fake_move("AABBCCDDEE01")
         mock_psmove.count_connected.return_value = 1
         mock_psmove.PSMove.return_value = fake_move
 
         adapter.discover()
         # Reset mock to track new calls
         mock_psmove.PSMove.reset_mock()
-        mock_psmove.PSMove.return_value = _make_fake_move("AA:BB:CC:DD:EE:01")
+        mock_psmove.PSMove.return_value = _make_fake_move("AABBCCDDEE01")
         adapter.discover(force=True)
 
         mock_psmove.PSMove.assert_called()
 
     def test_discover_rescans_on_count_change(self):
         adapter = PsMoveAdapter()
-        move1 = _make_fake_move("AA:BB:CC:DD:EE:01")
+        move1 = _make_fake_move("AABBCCDDEE01")
         mock_psmove.count_connected.return_value = 1
         mock_psmove.PSMove.return_value = move1
 
@@ -201,7 +201,7 @@ class TestPsMoveAdapterDiscover:
         move2 = _make_fake_move("AA:BB:CC:DD:EE:02")
         mock_psmove.count_connected.return_value = 2
         mock_psmove.PSMove.side_effect = [
-            _make_fake_move("AA:BB:CC:DD:EE:01"),
+            _make_fake_move("AABBCCDDEE01"),
             move2,
         ]
 
@@ -213,7 +213,7 @@ class TestPsMoveAdapterDiscover:
         # First scan: 2 controllers
         mock_psmove.count_connected.return_value = 2
         mock_psmove.PSMove.side_effect = [
-            _make_fake_move("AA:BB:CC:DD:EE:01"),
+            _make_fake_move("AABBCCDDEE01"),
             _make_fake_move("AA:BB:CC:DD:EE:02"),
         ]
         adapter.discover()
@@ -222,13 +222,13 @@ class TestPsMoveAdapterDiscover:
         # Second scan: only 1 controller (count changed)
         mock_psmove.count_connected.return_value = 1
         mock_psmove.PSMove.side_effect = [
-            _make_fake_move("AA:BB:CC:DD:EE:01"),
+            _make_fake_move("AABBCCDDEE01"),
         ]
         serials = adapter.discover()
 
         assert len(serials) == 1
-        assert "AA:BB:CC:DD:EE:01" in serials
-        assert "AA:BB:CC:DD:EE:02" not in serials
+        assert "AABBCCDDEE01" in serials
+        assert "AABBCCDDEE02" not in serials
 
     def test_discover_handles_psmove_returning_none(self):
         adapter = PsMoveAdapter()
@@ -267,36 +267,61 @@ class TestPsMoveAdapterDiscover:
         # First attempt: exception. Second attempt: success.
         mock_psmove.PSMove.side_effect = [
             RuntimeError("USB busy"),
-            _make_fake_move("AA:BB:CC:DD:EE:01"),
+            _make_fake_move("AABBCCDDEE01"),
         ]
 
         with patch("services.controller_manager.multiplexer.psmove_adapter.time.sleep"):
             serials = adapter.discover()
 
-        assert "AA:BB:CC:DD:EE:01" in serials
+        assert "AABBCCDDEE01" in serials
 
     def test_discover_does_not_duplicate_existing_handle(self):
         adapter = PsMoveAdapter()
         mock_psmove.count_connected.return_value = 1
-        first_move = _make_fake_move("AA:BB:CC:DD:EE:01")
+        first_move = _make_fake_move("AABBCCDDEE01")
         mock_psmove.PSMove.return_value = first_move
 
         adapter.discover()
 
         # Force rescan, same serial appears again
-        second_move = _make_fake_move("AA:BB:CC:DD:EE:01")
+        second_move = _make_fake_move("AABBCCDDEE01")
         mock_psmove.PSMove.return_value = second_move
         adapter.discover(force=True)
 
         # Should still use the first handle, not replace it
-        assert adapter._handles["AA:BB:CC:DD:EE:01"] is first_move
+        assert adapter._handles["AABBCCDDEE01"] is first_move
+
+
+class TestPsMoveAdapterSerialNormalization:
+    def test_discover_normalizes_colon_format(self):
+        """Serials from psmoveapi (colon format) are normalized to uppercase no-colon."""
+        adapter = PsMoveAdapter()
+        fake_move = _make_fake_move("e0:ae:5e:e1:11:ab")
+        mock_psmove.count_connected.return_value = 1
+        mock_psmove.PSMove.return_value = fake_move
+
+        serials = adapter.discover()
+
+        assert serials == ["E0AE5EE111AB"]
+        assert "E0AE5EE111AB" in adapter._handles
+
+    def test_discover_normalizes_mixed_case(self):
+        """Mixed-case serials without colons are uppercased."""
+        adapter = PsMoveAdapter()
+        fake_move = _make_fake_move("aaBBccDDeeFF")
+        mock_psmove.count_connected.return_value = 1
+        mock_psmove.PSMove.return_value = fake_move
+
+        serials = adapter.discover()
+
+        assert serials == ["AABBCCDDEEFF"]
 
 
 class TestPsMoveAdapterOpen:
     def test_open_returns_true_for_known_serial(self):
         adapter = PsMoveAdapter()
-        adapter._handles["AA:BB:CC:DD:EE:01"] = _make_fake_move()
-        assert adapter.open("AA:BB:CC:DD:EE:01") is True
+        adapter._handles["AABBCCDDEE01"] = _make_fake_move()
+        assert adapter.open("AABBCCDDEE01") is True
 
     def test_open_returns_false_for_unknown_serial(self):
         adapter = PsMoveAdapter()
@@ -306,19 +331,19 @@ class TestPsMoveAdapterOpen:
 class TestPsMoveAdapterPoll:
     def test_poll_returns_state_dict(self):
         adapter = PsMoveAdapter()
-        move = _make_fake_move("AA:BB:CC:DD:EE:01")
+        move = _make_fake_move("AABBCCDDEE01")
         move.get_trigger.return_value = 200
         move.get_buttons.return_value = 0
         move.get_accelerometer_frame.return_value = (100.0, 200.0, 4096.0)
         move.get_gyroscope_frame.return_value = (0.5, 1.0, 1.5)
         move.get_battery.return_value = mock_psmove.Batt_80Percent
         move.get_temperature.return_value = 30.5
-        adapter._handles["AA:BB:CC:DD:EE:01"] = move
+        adapter._handles["AABBCCDDEE01"] = move
 
-        state = adapter.poll("AA:BB:CC:DD:EE:01")
+        state = adapter.poll("AABBCCDDEE01")
 
         assert state is not None
-        assert state[StateKey.SERIAL] == "AA:BB:CC:DD:EE:01"
+        assert state[StateKey.SERIAL] == "AABBCCDDEE01"
         assert state[StateKey.TRIGGER] == 200
         assert state[StateKey.BATTERY] == 80
         assert state[StateKey.TEMPERATURE] == 30.5
@@ -339,12 +364,12 @@ class TestPsMoveAdapterPoll:
 
     def test_poll_button_flags(self):
         adapter = PsMoveAdapter()
-        move = _make_fake_move("AA:BB:CC:DD:EE:01")
+        move = _make_fake_move("AABBCCDDEE01")
         # Set MOVE and TRIGGER buttons
         move.get_buttons.return_value = mock_psmove.Btn_MOVE | mock_psmove.Btn_T
-        adapter._handles["AA:BB:CC:DD:EE:01"] = move
+        adapter._handles["AABBCCDDEE01"] = move
 
-        state = adapter.poll("AA:BB:CC:DD:EE:01")
+        state = adapter.poll("AABBCCDDEE01")
 
         assert state[ButtonKey.MOVE] is True
         assert state[ButtonKey.TRIGGER] is True
@@ -358,7 +383,7 @@ class TestPsMoveAdapterPoll:
 
     def test_poll_all_buttons_pressed(self):
         adapter = PsMoveAdapter()
-        move = _make_fake_move("AA:BB:CC:DD:EE:01")
+        move = _make_fake_move("AABBCCDDEE01")
         all_buttons = (
             mock_psmove.Btn_MOVE
             | mock_psmove.Btn_T
@@ -371,9 +396,9 @@ class TestPsMoveAdapterPoll:
             | mock_psmove.Btn_START
         )
         move.get_buttons.return_value = all_buttons
-        adapter._handles["AA:BB:CC:DD:EE:01"] = move
+        adapter._handles["AABBCCDDEE01"] = move
 
-        state = adapter.poll("AA:BB:CC:DD:EE:01")
+        state = adapter.poll("AABBCCDDEE01")
 
         assert state[ButtonKey.MOVE] is True
         assert state[ButtonKey.TRIGGER] is True
@@ -387,44 +412,44 @@ class TestPsMoveAdapterPoll:
 
     def test_poll_drains_event_queue(self):
         adapter = PsMoveAdapter()
-        move = _make_fake_move("AA:BB:CC:DD:EE:01")
+        move = _make_fake_move("AABBCCDDEE01")
         # poll() returns True three times then False (drains 3 queued reports)
         move.poll.side_effect = [True, True, True, False]
-        adapter._handles["AA:BB:CC:DD:EE:01"] = move
+        adapter._handles["AABBCCDDEE01"] = move
 
-        adapter.poll("AA:BB:CC:DD:EE:01")
+        adapter.poll("AABBCCDDEE01")
 
         assert move.poll.call_count == 4
 
     def test_poll_returns_none_on_exception(self):
         adapter = PsMoveAdapter()
-        move = _make_fake_move("AA:BB:CC:DD:EE:01")
+        move = _make_fake_move("AABBCCDDEE01")
         move.poll.side_effect = RuntimeError("Device disconnected")
-        adapter._handles["AA:BB:CC:DD:EE:01"] = move
+        adapter._handles["AABBCCDDEE01"] = move
 
-        state = adapter.poll("AA:BB:CC:DD:EE:01")
+        state = adapter.poll("AABBCCDDEE01")
 
         assert state is None
 
     def test_poll_returns_none_on_get_trigger_exception(self):
         adapter = PsMoveAdapter()
-        move = _make_fake_move("AA:BB:CC:DD:EE:01")
+        move = _make_fake_move("AABBCCDDEE01")
         move.poll.side_effect = [False]  # drain completes immediately
         move.get_trigger.side_effect = RuntimeError("Read error")
-        adapter._handles["AA:BB:CC:DD:EE:01"] = move
+        adapter._handles["AABBCCDDEE01"] = move
 
-        state = adapter.poll("AA:BB:CC:DD:EE:01")
+        state = adapter.poll("AABBCCDDEE01")
 
         assert state is None
 
     def test_poll_accel_scaling(self):
         """Accelerometer raw values are divided by ACCEL_SCALE (4096.0)."""
         adapter = PsMoveAdapter()
-        move = _make_fake_move("AA:BB:CC:DD:EE:01")
+        move = _make_fake_move("AABBCCDDEE01")
         move.get_accelerometer_frame.return_value = (4096.0, -4096.0, 8192.0)
-        adapter._handles["AA:BB:CC:DD:EE:01"] = move
+        adapter._handles["AABBCCDDEE01"] = move
 
-        state = adapter.poll("AA:BB:CC:DD:EE:01")
+        state = adapter.poll("AABBCCDDEE01")
 
         assert abs(state[StateKey.ACCEL][AxisKey.X] - 1.0) < 1e-9
         assert abs(state[StateKey.ACCEL][AxisKey.Y] - (-1.0)) < 1e-9
@@ -434,10 +459,10 @@ class TestPsMoveAdapterPoll:
 class TestPsMoveAdapterSetOutput:
     def test_set_output_calls_psmove_methods(self):
         adapter = PsMoveAdapter()
-        move = _make_fake_move("AA:BB:CC:DD:EE:01")
-        adapter._handles["AA:BB:CC:DD:EE:01"] = move
+        move = _make_fake_move("AABBCCDDEE01")
+        adapter._handles["AABBCCDDEE01"] = move
 
-        result = adapter.set_output("AA:BB:CC:DD:EE:01", 255, 128, 64, 200)
+        result = adapter.set_output("AABBCCDDEE01", 255, 128, 64, 200)
 
         assert result is True
         move.set_leds.assert_called_once_with(255, 128, 64)
@@ -451,20 +476,20 @@ class TestPsMoveAdapterSetOutput:
 
     def test_set_output_returns_false_on_exception(self):
         adapter = PsMoveAdapter()
-        move = _make_fake_move("AA:BB:CC:DD:EE:01")
+        move = _make_fake_move("AABBCCDDEE01")
         move.set_leds.side_effect = RuntimeError("USB write error")
-        adapter._handles["AA:BB:CC:DD:EE:01"] = move
+        adapter._handles["AABBCCDDEE01"] = move
 
-        result = adapter.set_output("AA:BB:CC:DD:EE:01", 255, 0, 0, 0)
+        result = adapter.set_output("AABBCCDDEE01", 255, 0, 0, 0)
 
         assert result is False
 
     def test_set_output_zero_values(self):
         adapter = PsMoveAdapter()
-        move = _make_fake_move("AA:BB:CC:DD:EE:01")
-        adapter._handles["AA:BB:CC:DD:EE:01"] = move
+        move = _make_fake_move("AABBCCDDEE01")
+        adapter._handles["AABBCCDDEE01"] = move
 
-        result = adapter.set_output("AA:BB:CC:DD:EE:01", 0, 0, 0, 0)
+        result = adapter.set_output("AABBCCDDEE01", 0, 0, 0, 0)
 
         assert result is True
         move.set_leds.assert_called_once_with(0, 0, 0)
@@ -474,12 +499,12 @@ class TestPsMoveAdapterSetOutput:
 class TestPsMoveAdapterClose:
     def test_close_removes_handle(self):
         adapter = PsMoveAdapter()
-        adapter._handles["AA:BB:CC:DD:EE:01"] = _make_fake_move()
+        adapter._handles["AABBCCDDEE01"] = _make_fake_move()
         adapter._handles["AA:BB:CC:DD:EE:02"] = _make_fake_move()
 
-        adapter.close("AA:BB:CC:DD:EE:01")
+        adapter.close("AABBCCDDEE01")
 
-        assert "AA:BB:CC:DD:EE:01" not in adapter._handles
+        assert "AABBCCDDEE01" not in adapter._handles
         assert "AA:BB:CC:DD:EE:02" in adapter._handles
 
     def test_close_nonexistent_does_not_raise(self):
@@ -488,9 +513,9 @@ class TestPsMoveAdapterClose:
 
     def test_close_all_turns_off_leds_and_clears_handles(self):
         adapter = PsMoveAdapter()
-        move1 = _make_fake_move("AA:BB:CC:DD:EE:01")
+        move1 = _make_fake_move("AABBCCDDEE01")
         move2 = _make_fake_move("AA:BB:CC:DD:EE:02")
-        adapter._handles["AA:BB:CC:DD:EE:01"] = move1
+        adapter._handles["AABBCCDDEE01"] = move1
         adapter._handles["AA:BB:CC:DD:EE:02"] = move2
 
         adapter.close_all()
@@ -505,9 +530,9 @@ class TestPsMoveAdapterClose:
 
     def test_close_all_suppresses_exceptions(self):
         adapter = PsMoveAdapter()
-        move = _make_fake_move("AA:BB:CC:DD:EE:01")
+        move = _make_fake_move("AABBCCDDEE01")
         move.set_leds.side_effect = RuntimeError("Device gone")
-        adapter._handles["AA:BB:CC:DD:EE:01"] = move
+        adapter._handles["AABBCCDDEE01"] = move
 
         # Should not raise even when set_leds fails
         adapter.close_all()
@@ -523,24 +548,24 @@ class TestPsMoveAdapterClose:
 class TestPsMoveAdapterProbeHelpers:
     def test_probe_controller_indices_returns_seen_and_failed(self):
         adapter = PsMoveAdapter()
-        move1 = _make_fake_move("AA:BB:CC:DD:EE:01")
+        move1 = _make_fake_move("AABBCCDDEE01")
         # Second PSMove call raises to simulate failure
         mock_psmove.PSMove.side_effect = [move1, RuntimeError("USB error")]
 
         seen, failed = adapter._probe_controller_indices(2)
 
-        assert "AA:BB:CC:DD:EE:01" in seen
+        assert "AABBCCDDEE01" in seen
         assert 1 in failed
 
     def test_probe_single_controller_success(self):
         adapter = PsMoveAdapter()
-        move = _make_fake_move("AA:BB:CC:DD:EE:01")
+        move = _make_fake_move("AABBCCDDEE01")
         mock_psmove.PSMove.return_value = move
 
         serial = adapter._probe_single_controller(0, 1)
 
-        assert serial == "AA:BB:CC:DD:EE:01"
-        assert "AA:BB:CC:DD:EE:01" in adapter._handles
+        assert serial == "AABBCCDDEE01"
+        assert "AABBCCDDEE01" in adapter._handles
 
     def test_probe_single_controller_none_returned(self):
         adapter = PsMoveAdapter()
@@ -570,25 +595,25 @@ class TestPsMoveAdapterProbeHelpers:
 
     def test_remove_stale_handles(self):
         adapter = PsMoveAdapter()
-        adapter._handles["AA:BB:CC:DD:EE:01"] = _make_fake_move()
+        adapter._handles["AABBCCDDEE01"] = _make_fake_move()
         adapter._handles["AA:BB:CC:DD:EE:02"] = _make_fake_move()
 
-        adapter._remove_stale_handles(["AA:BB:CC:DD:EE:01"])
+        adapter._remove_stale_handles(["AABBCCDDEE01"])
 
-        assert "AA:BB:CC:DD:EE:01" in adapter._handles
+        assert "AABBCCDDEE01" in adapter._handles
         assert "AA:BB:CC:DD:EE:02" not in adapter._handles
 
     def test_remove_stale_handles_none_stale(self):
         adapter = PsMoveAdapter()
-        adapter._handles["AA:BB:CC:DD:EE:01"] = _make_fake_move()
+        adapter._handles["AABBCCDDEE01"] = _make_fake_move()
 
-        adapter._remove_stale_handles(["AA:BB:CC:DD:EE:01"])
+        adapter._remove_stale_handles(["AABBCCDDEE01"])
 
-        assert "AA:BB:CC:DD:EE:01" in adapter._handles
+        assert "AABBCCDDEE01" in adapter._handles
 
     def test_remove_stale_handles_all_stale(self):
         adapter = PsMoveAdapter()
-        adapter._handles["AA:BB:CC:DD:EE:01"] = _make_fake_move()
+        adapter._handles["AABBCCDDEE01"] = _make_fake_move()
         adapter._handles["AA:BB:CC:DD:EE:02"] = _make_fake_move()
 
         adapter._remove_stale_handles([])


### PR DESCRIPTION
## Summary

- Add shared `normalize_serial()` function to `lib/controller_constants.py` that converts MAC-format serials to canonical uppercase-no-colons format (e.g. `e0:ae:5e:e1:11:ab` → `E0AE5EE111AB`) while leaving non-MAC serials unchanged
- Apply normalization at all serial entry points: PsMoveAdapter, BluetoothBackend, HidapiBackend, HidapiAdapter, NameManager, and servicer RenameController
- Fixes two bugs: NameManager giving different names for the same controller depending on backend, and MultiplexerBackend unable to match serials across adapters for adapter routing

## Test plan

- [x] `make lint` passes
- [x] `uv run pytest -v` — all 603 tests pass
- [x] New `test_normalize_serial.py` covers MAC formats, idempotency, mock serial passthrough, edge cases
- [x] Updated `test_psmove_adapter.py` assertions to expect normalized serials from discover()
- [x] Added normalization tests to `test_name_manager.py` (colon ↔ uppercase lookup, legacy file migration)
- [x] Updated `test_bluetooth_backend_helpers.py` for normalized probe results
- [ ] Manual test with real PS Move controllers on both psmove and hidapi backends

🤖 Generated with [Claude Code](https://claude.com/claude-code)