### PR TITLE
fix: normalize controller serials in pairing daemon bluetooth monitor

### DIFF
--- a/lib/controller_constants.py
+++ b/lib/controller_constants.py
@@ -114,6 +114,23 @@ BUTTON_TRACKING_TO_STATE = {
 }
 
 
+def normalize_serial(serial: str) -> str:
+    """Normalize a controller serial to canonical format (uppercase, no colons).
+
+    MAC-format serials (12 hex chars with/without colons) are uppercased
+    and stripped of colons. Non-MAC serials (e.g. mock_controller_0) are
+    returned unchanged.
+    """
+    cleaned = serial.upper().replace(":", "")
+    if len(cleaned) == 12:
+        try:
+            int(cleaned, 16)
+            return cleaned
+        except ValueError:
+            pass
+    return serial
+
+
 # Default values
 DEFAULT_BATTERY = 5
 DEFAULT_ACCEL = {"x": 0.0, "y": 0.0, "z": 1.0}  # At rest (1g gravity)

--- a/services/pairing_daemon/psmove_pairing/bluetooth_monitor.py
+++ b/services/pairing_daemon/psmove_pairing/bluetooth_monitor.py
@@ -6,6 +6,8 @@ import time
 
 from opentelemetry import trace
 
+from lib.controller_constants import normalize_serial
+
 from .config import get_bt_monitor_interval
 from .metrics import (
     bluetooth_adapter_connections,
@@ -104,14 +106,15 @@ class BluetoothMonitor:
                 bluetooth_adapter_connections.labels(hci_adapter=hci).set(len(connections))
                 logger.debug(f"{hci}: {len(connections)} devices connected")
 
-                for serial in connections:
+                for bt_address in connections:
+                    serial = normalize_serial(bt_address)
                     currently_seen.add((serial, hci))
                     ts = time.time()
 
-                    # Get RSSI
-                    rssi = await self.get_rssi(hci, serial)
+                    # Get RSSI (hcitool needs raw colon-format address)
+                    rssi = await self.get_rssi(hci, bt_address)
 
-                    # Update metrics
+                    # Update metrics (normalized serial matches controller manager)
                     bluetooth_device_connected.labels(serial=serial, hci_adapter=hci).set(1)
                     bluetooth_device_last_seen.labels(serial=serial, hci_adapter=hci).set(ts)
 

--- a/services/pairing_daemon/tests/test_bluetooth_monitor.py
+++ b/services/pairing_daemon/tests/test_bluetooth_monitor.py
@@ -185,4 +185,4 @@ Connections:
 
         with patch("psmove_pairing.bluetooth_monitor.run_command", runner):
             await bt_monitor.monitor()
-            assert ("00:06:f7:aa:bb:cc", "hci0") in bt_monitor._known_devices
+            assert ("0006F7AABBCC", "hci0") in bt_monitor._known_devices


### PR DESCRIPTION
## Summary
- Pairing daemon's bluetooth monitor was using lowercase colon-separated MAC addresses (`e0:ae:5e:e1:11:ab`) as metric labels and device tracking keys
- Controller manager uses normalized uppercase no-colon format (`E0AE5EE111AB`)
- This mismatch made it impossible to correlate bluetooth RSSI/connection metrics with controller manager data in Grafana dashboards
- Now uses `normalize_serial()` from `joustmania-lib` at the metrics/tracking boundary while preserving raw BT addresses for `hcitool` commands

## Test plan
- [x] Updated `test_monitor_full_flow` to expect normalized serial format in `_known_devices`
- [x] All 64 pairing daemon tests pass
- [x] Lint passes
- [ ] Verify bluetooth adapter dashboard shows matching serials across panels

🤖 Generated with [Claude Code](https://claude.com/claude-code)