### PR TITLE
fix: add PS Move ZCM2E (product ID 0x0C5E) to HID enumeration

### DIFF
--- a/lib/psmove_hid.py
+++ b/lib/psmove_hid.py
@@ -20,6 +20,8 @@ from enum import IntEnum, IntFlag
 VENDOR_ID = 0x054C  # Sony
 PRODUCT_ID_ZCM1 = 0x03D5  # PS Move (PS3 era, ZCM1)
 PRODUCT_ID_ZCM2 = 0x042F  # PS Move (PS4 era, ZCM2)
+PRODUCT_ID_ZCM2E = 0x0C5E  # PS Move (PS4 era, ZCM2E variant)
+ALL_PRODUCT_IDS = (PRODUCT_ID_ZCM1, PRODUCT_ID_ZCM2, PRODUCT_ID_ZCM2E)
 
 # HID report sizes
 INPUT_REPORT_SIZE = 49

--- a/services/controller_manager/hidapi_backend.py
+++ b/services/controller_manager/hidapi_backend.py
@@ -27,9 +27,8 @@ from lib.controller_constants import (
     StateKey,
 )
 from lib.psmove_hid import (
+    ALL_PRODUCT_IDS,
     INPUT_REPORT_SIZE,
-    PRODUCT_ID_ZCM1,
-    PRODUCT_ID_ZCM2,
     VENDOR_ID,
     Button,
     battery_to_percent,
@@ -135,7 +134,7 @@ class HidapiBackend(ControllerBackend):
 
     def _scan_and_open(self) -> None:
         """Enumerate HID devices and open PS Move controllers."""
-        devices = hid.enumerate(VENDOR_ID, PRODUCT_ID_ZCM1) + hid.enumerate(VENDOR_ID, PRODUCT_ID_ZCM2)
+        devices = [d for pid in ALL_PRODUCT_IDS for d in hid.enumerate(VENDOR_ID, pid)]
 
         for dev_info in devices:
             path = dev_info["path"]
@@ -163,7 +162,7 @@ class HidapiBackend(ControllerBackend):
     async def scan_controllers(self) -> list[dict]:
         """Scan for available PS Move controllers."""
         controllers = []
-        devices = hid.enumerate(VENDOR_ID, PRODUCT_ID_ZCM1) + hid.enumerate(VENDOR_ID, PRODUCT_ID_ZCM2)
+        devices = [d for pid in ALL_PRODUCT_IDS for d in hid.enumerate(VENDOR_ID, pid)]
 
         for dev_info in devices:
             serial = dev_info.get("serial_number", "")
@@ -187,7 +186,7 @@ class HidapiBackend(ControllerBackend):
             return True
 
         # Search for the device
-        devices = hid.enumerate(VENDOR_ID, PRODUCT_ID_ZCM1) + hid.enumerate(VENDOR_ID, PRODUCT_ID_ZCM2)
+        devices = [d for pid in ALL_PRODUCT_IDS for d in hid.enumerate(VENDOR_ID, pid)]
 
         for dev_info in devices:
             serial = dev_info.get("serial_number", "")
@@ -416,7 +415,7 @@ class HidapiBackend(ControllerBackend):
         """
         if force_rescan:
             # Re-enumerate to find new controllers
-            devices = hid.enumerate(VENDOR_ID, PRODUCT_ID_ZCM1) + hid.enumerate(VENDOR_ID, PRODUCT_ID_ZCM2)
+            devices = [d for pid in ALL_PRODUCT_IDS for d in hid.enumerate(VENDOR_ID, pid)]
             current_paths = set()
 
             for dev_info in devices:

--- a/services/controller_manager/multiplexer/bt_discovery.py
+++ b/services/controller_manager/multiplexer/bt_discovery.py
@@ -116,9 +116,9 @@ class CentralizedBTDiscovery:
         """Scan via hid.enumerate() with BlueZ cross-reference for adapter affinity."""
         import hidraw as hid  # hidraw backend sees Bluetooth HID devices
 
-        from lib.psmove_hid import PRODUCT_ID_ZCM1, PRODUCT_ID_ZCM2, VENDOR_ID
+        from lib.psmove_hid import ALL_PRODUCT_IDS, VENDOR_ID
 
-        devices = hid.enumerate(VENDOR_ID, PRODUCT_ID_ZCM1) + hid.enumerate(VENDOR_ID, PRODUCT_ID_ZCM2)
+        devices = [d for pid in ALL_PRODUCT_IDS for d in hid.enumerate(VENDOR_ID, pid)]
         hid_serials: list[str] = []
         seen: set[str] = set()
         for dev_info in devices:

--- a/services/controller_manager/multiplexer/hidapi_adapter.py
+++ b/services/controller_manager/multiplexer/hidapi_adapter.py
@@ -13,9 +13,8 @@ import hidraw as hid  # hidraw backend sees Bluetooth HID devices (libusb backen
 
 from lib.controller_constants import AxisKey, ButtonKey, StateKey
 from lib.psmove_hid import (
+    ALL_PRODUCT_IDS,
     INPUT_REPORT_SIZE,
-    PRODUCT_ID_ZCM1,
-    PRODUCT_ID_ZCM2,
     VENDOR_ID,
     Button,
     battery_to_percent,
@@ -66,7 +65,7 @@ class HidapiAdapter(ControllerIOAdapter):
 
     def _enumerate_and_open_new(self) -> set[str]:
         """Enumerate HID devices, open new ones. Returns set of current device paths."""
-        devices = hid.enumerate(VENDOR_ID, PRODUCT_ID_ZCM1) + hid.enumerate(VENDOR_ID, PRODUCT_ID_ZCM2)
+        devices = [d for pid in ALL_PRODUCT_IDS for d in hid.enumerate(VENDOR_ID, pid)]
         current_paths: set[str] = set()
 
         for dev_info in devices:
@@ -106,7 +105,7 @@ class HidapiAdapter(ControllerIOAdapter):
         if serial in self._devices:
             return True
 
-        devices = hid.enumerate(VENDOR_ID, PRODUCT_ID_ZCM1) + hid.enumerate(VENDOR_ID, PRODUCT_ID_ZCM2)
+        devices = [d for pid in ALL_PRODUCT_IDS for d in hid.enumerate(VENDOR_ID, pid)]
         for dev_info in devices:
             dev_serial = dev_info.get("serial_number", "")
             if not dev_serial:

--- a/services/controller_manager/tests/test_bt_discovery.py
+++ b/services/controller_manager/tests/test_bt_discovery.py
@@ -267,6 +267,7 @@ class TestHidapiMode:
         mock_hid.enumerate.side_effect = [
             [{"serial_number": "00:06:F7:AA:BB:CC"}, {"serial_number": "00:06:F7:DD:EE:FF"}],
             [],  # ZCM2 returns nothing
+            [],  # ZCM2E returns nothing
         ]
 
         with (
@@ -289,7 +290,8 @@ class TestHidapiMode:
         mock_hid = MagicMock()
         mock_hid.enumerate.side_effect = [
             [{"serial_number": "0006F7AABBCC"}, {"serial_number": "0006F7DDEEFF"}],
-            [],
+            [],  # ZCM2
+            [],  # ZCM2E
         ]
 
         with (
@@ -316,7 +318,8 @@ class TestHidapiMode:
         mock_hid = MagicMock()
         mock_hid.enumerate.side_effect = [
             [{"serial_number": "0006F7AABBCC"}, {"serial_number": "0006F7AABBCC"}],  # Duplicate
-            [],
+            [],  # ZCM2
+            [],  # ZCM2E
         ]
 
         with (

--- a/services/controller_manager/tests/test_hidapi_adapter.py
+++ b/services/controller_manager/tests/test_hidapi_adapter.py
@@ -91,7 +91,7 @@ class TestHidapiAdapterInit:
 class TestDiscover:
     @patch("services.controller_manager.multiplexer.hidapi_adapter.hid")
     def test_discover_opens_new_devices(self, mock_hid):
-        """discover() should enumerate ZCM1+ZCM2 and open new controllers."""
+        """discover() should enumerate all PS Move product IDs and open new controllers."""
         mock_device = MagicMock()
         mock_hid.enumerate.return_value = [_make_dev_info()]
         mock_hid.Device.return_value = mock_device
@@ -99,7 +99,7 @@ class TestDiscover:
         adapter = HidapiAdapter()
         serials = adapter.discover()
 
-        assert mock_hid.enumerate.call_count == 2  # ZCM1 + ZCM2
+        assert mock_hid.enumerate.call_count == 3  # ZCM1 + ZCM2 + ZCM2E
         assert FAKE_SERIAL_NORMALIZED in serials
         mock_hid.Device.assert_called_once_with(path=FAKE_PATH_1)
         assert mock_device.nonblocking is True
@@ -198,6 +198,7 @@ class TestDiscover:
         mock_hid.enumerate.side_effect = [
             [_make_dev_info(FAKE_PATH_1, FAKE_SERIAL_RAW)],
             [_make_dev_info(FAKE_PATH_2, FAKE_SERIAL_2_RAW)],
+            [],  # ZCM2E returns nothing
         ]
         mock_hid.Device.return_value = MagicMock()
 
@@ -599,6 +600,7 @@ class TestClose:
         mock_hid.enumerate.side_effect = [
             [_make_dev_info(FAKE_PATH_1, FAKE_SERIAL_RAW)],
             [_make_dev_info(FAKE_PATH_2, FAKE_SERIAL_2_RAW)],
+            [],  # ZCM2E returns nothing
         ]
         mock_hid.Device.side_effect = [mock_device_1, mock_device_2]
         mock_build.return_value = b"\x00" * 49


### PR DESCRIPTION
## Summary
- A ZCM2E PS Move controller (`DC:0C:2D:09:4D:7B`, Modalias `v054Cp0C5E`) was connected via Bluetooth but not recognized by the controller manager
- Root cause: `hid.enumerate()` only searched for ZCM1 (`0x03D5`) and ZCM2 (`0x042F`) product IDs, missing ZCM2E (`0x0C5E`)
- Added `PRODUCT_ID_ZCM2E = 0x0C5E` and `ALL_PRODUCT_IDS` tuple to `lib/psmove_hid.py`
- Updated all 7 enumerate call sites across `hidapi_adapter.py`, `bt_discovery.py`, and `hidapi_backend.py` to use `ALL_PRODUCT_IDS`

## Files changed
| File | Change |
|------|--------|
| `lib/psmove_hid.py` | Add `PRODUCT_ID_ZCM2E` and `ALL_PRODUCT_IDS` |
| `services/controller_manager/multiplexer/hidapi_adapter.py` | Use `ALL_PRODUCT_IDS` |
| `services/controller_manager/multiplexer/bt_discovery.py` | Use `ALL_PRODUCT_IDS` |
| `services/controller_manager/hidapi_backend.py` | Use `ALL_PRODUCT_IDS` |
| Tests (2 files) | Add third enumerate mock for ZCM2E |

## Test plan
- [x] All 580 controller manager tests pass
- [x] All 281 lib tests pass
- [x] Lint passes
- [ ] Deploy and verify ZCM2E controller (`DC:0C:2D:09:4D:7B`) appears in controller list

🤖 Generated with [Claude Code](https://claude.com/claude-code)