### PR TITLE
perf: throttle redundant HID discovery scanning

### DIFF
--- a/services/controller_manager/discovery.py
+++ b/services/controller_manager/discovery.py
@@ -15,7 +15,7 @@ import time
 logger = logging.getLogger(__name__)
 
 # Default interval between forced rescans (seconds)
-DEFAULT_RESCAN_INTERVAL = 5.0
+DEFAULT_RESCAN_INTERVAL = 10.0
 
 
 class PeriodicRescanTimer:

--- a/services/controller_manager/metrics.py
+++ b/services/controller_manager/metrics.py
@@ -163,6 +163,17 @@ battery_check_duration_seconds = Histogram(
     buckets=[0.001, 0.005, 0.010, 0.025, 0.050, 0.100],
 )
 
+# Discovery throttle metrics
+discovery_full_enumerate_total = Counter(
+    "controller_discovery_full_enumerate_total",
+    "Full discovery enumerations (with HID/psmove scanning)",
+)
+
+discovery_verify_only_total = Counter(
+    "controller_discovery_verify_only_total",
+    "Verify-only discovery cycles (skipped enumeration)",
+)
+
 # Parallel polling metrics (Phase 62)
 poll_batch_duration_seconds = Histogram(
     "controller_poll_batch_duration_seconds",

--- a/services/controller_manager/multiplexer/adapter.py
+++ b/services/controller_manager/multiplexer/adapter.py
@@ -23,8 +23,14 @@ class ControllerIOAdapter(ABC):
         """Identifier: 'psmove', 'hidapi', 'mock'."""
 
     @abstractmethod
-    def discover(self, force: bool = False) -> list[str]:
-        """Scan for available controllers. Returns list of serials."""
+    def discover(self, force: bool = False, verify_only: bool = False) -> list[str]:
+        """Scan for available controllers. Returns list of serials.
+
+        Args:
+            force: Force a full rescan, removing stale devices.
+            verify_only: When True, only verify existing devices are
+                accessible — skip expensive enumeration for new devices.
+        """
 
     @abstractmethod
     def open(self, serial: str) -> bool:

--- a/services/controller_manager/multiplexer/hidapi_adapter.py
+++ b/services/controller_manager/multiplexer/hidapi_adapter.py
@@ -40,15 +40,16 @@ class HidapiAdapter(ControllerIOAdapter):
     def adapter_type(self) -> str:
         return "hidapi"
 
-    def discover(self, force: bool = False) -> list[str]:
+    def discover(self, force: bool = False, verify_only: bool = False) -> list[str]:
         """Enumerate HID devices and open new PS Move controllers."""
         if not force and self._devices:
             self._verify_existing_devices()
 
-        current_paths = self._enumerate_and_open_new()
+        if not verify_only:
+            current_paths = self._enumerate_and_open_new()
 
-        if force:
-            self._remove_disappeared_devices(current_paths)
+            if force:
+                self._remove_disappeared_devices(current_paths)
 
         return list(self._devices.keys())
 

--- a/services/controller_manager/multiplexer/mock_adapter.py
+++ b/services/controller_manager/multiplexer/mock_adapter.py
@@ -65,7 +65,7 @@ class MockAdapter(ControllerIOAdapter):
     def adapter_type(self) -> str:
         return "mock"
 
-    def discover(self, force: bool = False) -> list[str]:  # noqa: ARG002
+    def discover(self, force: bool = False, verify_only: bool = False) -> list[str]:  # noqa: ARG002
         """Return all mock controller serials.
 
         On first call (empty controllers dict), creates the initial set

--- a/services/controller_manager/multiplexer/multiplexer_backend.py
+++ b/services/controller_manager/multiplexer/multiplexer_backend.py
@@ -63,6 +63,10 @@ class MultiplexerBackend(ControllerBackend):
         for adapter in self._adapters:
             self._adapter_by_type[adapter.adapter_type] = adapter
 
+        # Discovery throttle: only run full enumeration every N seconds
+        self._last_full_discovery: float = 0.0
+        self._full_discovery_interval: float = 0.5  # seconds
+
         adapter_names = [a.adapter_type for a in self._adapters]
         logger.info(f"MultiplexerBackend created with adapters: {adapter_names}")
 
@@ -126,10 +130,23 @@ class MultiplexerBackend(ControllerBackend):
         Phase 2: For each serial found by multiple adapters, evaluate the
         ``controller_adapter_routing`` flag to pick the preferred adapter.
         """
+        # Determine discovery mode: full enumeration or verify-only
+        now = time.monotonic()
+        if force or (now - self._last_full_discovery >= self._full_discovery_interval):
+            verify_only = False
+            self._last_full_discovery = now
+        else:
+            verify_only = True
+
+        if verify_only:
+            metrics.discovery_verify_only_total.inc()
+        else:
+            metrics.discovery_full_enumerate_total.inc()
+
         # Phase 1: discover — build serial -> list[adapter]
         adapter_serials: dict[str, list[ControllerIOAdapter]] = {}
         for adapter in self._adapters:
-            for serial in adapter.discover(force=force):
+            for serial in adapter.discover(force=force, verify_only=verify_only):
                 adapter_serials.setdefault(serial, []).append(adapter)
                 # Open handle if this adapter hasn't seen it before
                 if self._serial_to_adapter.get(serial) is not adapter:

--- a/services/controller_manager/multiplexer/psmove_adapter.py
+++ b/services/controller_manager/multiplexer/psmove_adapter.py
@@ -81,7 +81,7 @@ class PsMoveAdapter(ControllerIOAdapter):
     def adapter_type(self) -> str:
         return "psmove"
 
-    def discover(self, force: bool = False) -> list[str]:
+    def discover(self, force: bool = False, verify_only: bool = False) -> list[str]:  # noqa: ARG002
         """Scan for connected PS Move controllers via psmove index API.
 
         Returns list of serials for all currently connected controllers.

--- a/services/controller_manager/servicer.py
+++ b/services/controller_manager/servicer.py
@@ -108,7 +108,7 @@ class ControllerManagerServicer(controller_manager_pb2_grpc.ControllerManagerSer
         )
 
         # Phase 79: Periodic rescan timer for externally paired controllers
-        self.rescan_timer = PeriodicRescanTimer(interval=5.0)
+        self.rescan_timer = PeriodicRescanTimer(interval=10.0)
 
         # Issue #7: Name manager for human-readable controller names
         self.name_manager = NameManager()

--- a/services/controller_manager/tests/test_multiplexer_backend.py
+++ b/services/controller_manager/tests/test_multiplexer_backend.py
@@ -125,7 +125,7 @@ class TestMultiplexerGetConnectedControllers:
 
         mux.get_connected_controllers(force_rescan=True)
 
-        a1.discover.assert_called_once_with(force=True)
+        a1.discover.assert_called_once_with(force=True, verify_only=False)
 
     @patch("services.controller_manager.multiplexer.multiplexer_backend.metrics")
     def test_cleans_stale_state_on_disconnect(self, mock_metrics):
@@ -622,3 +622,83 @@ class TestGetAdapterType:
         mux = MultiplexerBackend(adapters=[_make_adapter()])
 
         assert mux.get_adapter_type("ZZ:ZZ") == "unknown"
+
+
+class TestDiscoveryThrottling:
+    """Tests for verify_only discovery throttling."""
+
+    @patch("services.controller_manager.multiplexer.multiplexer_backend.metrics")
+    def test_first_call_is_full_discovery(self, mock_metrics):
+        """First call should always do full discovery (verify_only=False)."""
+        a1 = _make_adapter(serials=["AA:AA"])
+        mux = MultiplexerBackend(adapters=[a1])
+
+        mux.get_connected_controllers()
+
+        a1.discover.assert_called_once_with(force=False, verify_only=False)
+
+    @patch("services.controller_manager.multiplexer.multiplexer_backend.metrics")
+    def test_rapid_second_call_uses_verify_only(self, mock_metrics):
+        """Immediate second call should use verify_only=True."""
+        a1 = _make_adapter(serials=["AA:AA"])
+        mux = MultiplexerBackend(adapters=[a1])
+
+        mux.get_connected_controllers()
+        a1.discover.reset_mock()
+
+        mux.get_connected_controllers()
+
+        a1.discover.assert_called_once_with(force=False, verify_only=True)
+
+    @patch("services.controller_manager.multiplexer.multiplexer_backend.metrics")
+    def test_force_always_does_full_discovery(self, mock_metrics):
+        """force=True should bypass throttle and use verify_only=False."""
+        a1 = _make_adapter(serials=["AA:AA"])
+        mux = MultiplexerBackend(adapters=[a1])
+
+        # First call to set _last_full_discovery
+        mux.get_connected_controllers()
+        a1.discover.reset_mock()
+
+        # Immediate force call should still do full discovery
+        mux.get_connected_controllers(force_rescan=True)
+
+        a1.discover.assert_called_once_with(force=True, verify_only=False)
+
+    @patch("services.controller_manager.multiplexer.multiplexer_backend.metrics")
+    def test_verify_only_still_returns_controllers(self, mock_metrics):
+        """Known controllers should still be reported during verify_only cycles."""
+        a1 = _make_adapter(serials=["AA:AA", "BB:BB"])
+        mux = MultiplexerBackend(adapters=[a1])
+
+        # First call — full discovery
+        result1 = mux.get_connected_controllers()
+        assert sorted(result1) == ["AA:AA", "BB:BB"]
+
+        # Second call — verify_only, but adapter still returns known serials
+        result2 = mux.get_connected_controllers()
+        assert sorted(result2) == ["AA:AA", "BB:BB"]
+
+    @patch("services.controller_manager.multiplexer.multiplexer_backend.metrics")
+    @patch("services.controller_manager.multiplexer.multiplexer_backend.time")
+    def test_after_interval_does_full_discovery_again(self, mock_time, mock_metrics):
+        """After the throttle interval elapses, full discovery should run again."""
+        a1 = _make_adapter(serials=["AA:AA"])
+        mux = MultiplexerBackend(adapters=[a1])
+
+        # First call at t=0
+        mock_time.monotonic.return_value = 0.0
+        mock_time.time = MagicMock(return_value=1000.0)
+        mux.get_connected_controllers()
+        a1.discover.reset_mock()
+
+        # Second call at t=0.1 — within interval, should be verify_only
+        mock_time.monotonic.return_value = 0.1
+        mux.get_connected_controllers()
+        a1.discover.assert_called_once_with(force=False, verify_only=True)
+        a1.discover.reset_mock()
+
+        # Third call at t=0.6 — past the 0.5s interval, should be full
+        mock_time.monotonic.return_value = 0.6
+        mux.get_connected_controllers()
+        a1.discover.assert_called_once_with(force=False, verify_only=False)


### PR DESCRIPTION
## Summary
- Add `verify_only` mode to adapter `discover()` — between full discovery cycles, adapters only verify existing devices are healthy (cheap `device.read()` check), skipping expensive `hid.enumerate()` calls
- Full enumeration runs every 500ms or on forced rescan, reducing HID scanning from ~100/s to ~2/s
- Increase forced rescan interval from 5s to 10s (the 500ms throttle now handles normal discovery)
- Add `discovery_full_enumerate_total` and `discovery_verify_only_total` counter metrics

## Impact
- **CPU reduction**: `hid.enumerate()` (OS-level HID scan) drops from 100 calls/s to 2 calls/s
- **New controller latency**: ~10ms → ~500ms (imperceptible — BT pairing takes seconds)
- **Disconnect detection**: Unchanged — health checks still run every poll cycle

## Test plan
- [x] All 609 controller_manager unit tests pass
- [x] 5 new throttle-specific tests (`TestDiscoveryThrottling`)
- [x] `make lint` passes
- [ ] Integration test with mock controllers
- [ ] Verify new metrics appear in Grafana

🤖 Generated with [Claude Code](https://claude.com/claude-code)