### PR TITLE
fix: prevent concurrent USB writes and reduce LED keepalive to 2s

### DIFF
--- a/services/controller_manager/multiplexer/multiplexer_backend.py
+++ b/services/controller_manager/multiplexer/multiplexer_backend.py
@@ -256,8 +256,9 @@ class MultiplexerBackend(ControllerBackend):
     def update_all_leds(self) -> int:
         """Centralized LED refresh with keep-alive and color-change detection.
 
-        Issue #542: Collects all pending updates first, then acquires the lock
-        once for the entire batch instead of per-controller.
+        Collects pending updates outside the lock (pure reads), then acquires
+        _led_lock once for the entire batch of set_output() calls + bookkeeping.
+        This prevents concurrent USB writes with set_led_color()/set_rumble().
         """
         current_time = time.time()
 
@@ -277,7 +278,7 @@ class MultiplexerBackend(ControllerBackend):
             last_update = self._last_led_update.get(serial, 0)
 
             color_changed = stored_color != last_sent
-            keepalive_needed = current_time - last_update >= 4.0
+            keepalive_needed = current_time - last_update >= 2.0
 
             if color_changed or keepalive_needed:
                 r, g, b = stored_color
@@ -287,24 +288,19 @@ class MultiplexerBackend(ControllerBackend):
         if not batch:
             return 0
 
-        # Phase 2: Execute all I/O under a single lock acquisition
+        # Phase 2: Execute I/O and update bookkeeping under a single lock.
+        # Bookkeeping must be inside the lock to prevent set_led_color() from
+        # racing with stale _last_sent_color/_last_led_update overwrites.
         updated_count = 0
         with self._led_lock:
             for serial, adapter, r, g, b, rumble in batch:
                 try:
                     adapter.set_output(serial, r, g, b, rumble)
+                    self._last_sent_color[serial] = (r, g, b)
+                    self._last_led_update[serial] = current_time
                     updated_count += 1
                 except Exception as e:
                     logger.debug(f"Error updating LED for {serial}: {e}")
-
-        # Phase 3: Update bookkeeping outside lock
-        for serial, _adapter, r, g, b, _rumble in batch:
-            stored_color = (r, g, b)
-            last_sent = self._last_sent_color.get(serial)
-            self._last_sent_color[serial] = stored_color
-            self._last_led_update[serial] = current_time
-            if stored_color != last_sent:
-                logger.debug(f"LED color changed for {serial}: {last_sent} -> {stored_color}")
 
         return updated_count
 
@@ -336,11 +332,19 @@ class MultiplexerBackend(ControllerBackend):
             return False
         self._led_colors[serial] = (r, g, b)
         rumble = self._rumble.get(serial, 0)
-        result = adapter.set_output(serial, r, g, b, rumble)
-        if result:
-            self._last_sent_color[serial] = (r, g, b)
-            self._last_led_update[serial] = time.time()
-        return result
+        # Non-blocking lock: if update_all_leds() batch is in progress, skip
+        # the direct USB write to avoid concurrent set_output() calls.
+        # _led_colors is already set, so the 20Hz loop picks it up within 50ms.
+        if self._led_lock.acquire(blocking=False):
+            try:
+                result = adapter.set_output(serial, r, g, b, rumble)
+                if result:
+                    self._last_sent_color[serial] = (r, g, b)
+                    self._last_led_update[serial] = time.time()
+                return result
+            finally:
+                self._led_lock.release()
+        return True
 
     async def set_rumble(self, serial: str, intensity: int) -> bool:
         adapter = self._serial_to_adapter.get(serial)
@@ -348,7 +352,15 @@ class MultiplexerBackend(ControllerBackend):
             return False
         self._rumble[serial] = intensity
         r, g, b = self._led_colors.get(serial, (0, 0, 0))
-        return adapter.set_output(serial, r, g, b, intensity)
+        # Non-blocking lock: same pattern as set_led_color() — skip direct
+        # USB write if batch is in progress. Rumble + color state is stored,
+        # next update_all_leds() cycle sends the combined output.
+        if self._led_lock.acquire(blocking=False):
+            try:
+                return adapter.set_output(serial, r, g, b, intensity)
+            finally:
+                self._led_lock.release()
+        return True
 
     def set_effect_active(self, serial: str, active: bool):
         if active:

--- a/services/controller_manager/tests/test_multiplexer_backend.py
+++ b/services/controller_manager/tests/test_multiplexer_backend.py
@@ -278,6 +278,75 @@ class TestMultiplexerUpdateAllLeds:
 
         a1.set_output.assert_called_once_with("AA:AA", 255, 0, 0, 128)
 
+    @patch("services.controller_manager.multiplexer.multiplexer_backend.metrics")
+    def test_bookkeeping_updated_under_lock(self, mock_metrics):
+        """Verify _last_sent_color and _last_led_update are set after set_output."""
+        a1 = _make_adapter("mock", serials=["AA:AA"])
+        mux = MultiplexerBackend(adapters=[a1])
+        mux.get_connected_controllers()
+        mux._led_colors["AA:AA"] = (0, 255, 0)
+        mux._last_led_update["AA:AA"] = 0
+
+        mux.update_all_leds()
+
+        assert mux._last_sent_color["AA:AA"] == (0, 255, 0)
+        assert mux._last_led_update["AA:AA"] > 0
+
+    @patch("services.controller_manager.multiplexer.multiplexer_backend.metrics")
+    def test_keepalive_interval_is_two_seconds(self, mock_metrics):
+        """Keepalive fires at 2s, not 4s (safety margin for hardware LED timeout)."""
+        import time
+
+        a1 = _make_adapter("mock", serials=["AA:AA"])
+        mux = MultiplexerBackend(adapters=[a1])
+        mux.get_connected_controllers()
+        mux._led_colors["AA:AA"] = (255, 0, 0)
+        mux._last_sent_color["AA:AA"] = (255, 0, 0)  # No color change
+        mux._last_led_update["AA:AA"] = time.time() - 2.5  # 2.5s ago
+
+        count = mux.update_all_leds()
+
+        assert count == 1  # Keepalive should fire at 2s
+
+    @pytest.mark.asyncio
+    @patch("services.controller_manager.multiplexer.multiplexer_backend.metrics")
+    async def test_set_led_skips_io_when_lock_held(self, mock_metrics):
+        """set_led_color() skips USB write when _led_lock is held by batch."""
+        a1 = _make_adapter("mock", serials=["AA:AA"])
+        mux = MultiplexerBackend(adapters=[a1])
+        mux.get_connected_controllers()
+
+        # Hold the lock (simulating update_all_leds batch in progress)
+        mux._led_lock.acquire()
+        try:
+            result = await mux.set_led_color("AA:AA", 0, 255, 0)
+        finally:
+            mux._led_lock.release()
+
+        # Returns True (optimistic) but doesn't call set_output
+        assert result is True
+        a1.set_output.assert_not_called()
+        # Color is stored for next batch cycle
+        assert mux._led_colors["AA:AA"] == (0, 255, 0)
+
+    @pytest.mark.asyncio
+    @patch("services.controller_manager.multiplexer.multiplexer_backend.metrics")
+    async def test_set_rumble_skips_io_when_lock_held(self, mock_metrics):
+        """set_rumble() skips USB write when _led_lock is held by batch."""
+        a1 = _make_adapter("mock", serials=["AA:AA"])
+        mux = MultiplexerBackend(adapters=[a1])
+        mux.get_connected_controllers()
+
+        mux._led_lock.acquire()
+        try:
+            result = await mux.set_rumble("AA:AA", 128)
+        finally:
+            mux._led_lock.release()
+
+        assert result is True
+        a1.set_output.assert_not_called()
+        assert mux._rumble["AA:AA"] == 128
+
 
 class TestMultiplexerShutdown:
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
PR #546 introduced batch LED updates under a single `_led_lock` acquisition, but `set_led_color()` and `set_rumble()` still called `adapter.set_output()` without the lock. This caused concurrent USB writes from two threads (event loop vs thread pool), corrupting LED state on PS Move controllers (interleaved `set_leds`/`update_leds` calls caused wrong colors).

Three fixes:
- **Non-blocking lock in `set_led_color()`/`set_rumble()`**: If the batch lock is held, skip the direct USB write — `_led_colors` is already stored, so the 20Hz loop picks it up within 50ms
- **Bookkeeping under lock in `update_all_leds()`**: `_last_sent_color`/`_last_led_update` updates moved inside the lock to prevent stale overwrites from the Phase 3 race
- **Keepalive 4.0s → 2.0s**: PS Move hardware LED timeout is ~4.8s; 4.0s was too close with jitter

## Test plan
- [x] 533 controller_manager unit tests pass
- [x] 4 new tests for non-blocking lock behavior and keepalive interval
- [x] Lint clean
- [ ] Verify controllers light up reliably with 8+ controllers connected

🤖 Generated with [Claude Code](https://claude.com/claude-code)