### PR TITLE
fix: close old adapter handle on controller route switch

### DIFF
--- a/services/controller_manager/multiplexer/multiplexer_backend.py
+++ b/services/controller_manager/multiplexer/multiplexer_backend.py
@@ -199,9 +199,10 @@ class MultiplexerBackend(ControllerBackend):
                 method=method,
             ).inc()
 
-            # Log dynamic switch
+            # Close old adapter handle on dynamic switch
             old = self._serial_to_adapter.get(serial)
             if old and old is not seen[serial]:
+                old.close(serial)
                 logger.info(f"Switched {serial}: {old.adapter_type} -> {seen[serial].adapter_type}")
 
         return seen

--- a/services/controller_manager/tests/test_multiplexer_backend.py
+++ b/services/controller_manager/tests/test_multiplexer_backend.py
@@ -487,6 +487,26 @@ class TestRouteControllers:
         assert "Switched AA:AA: psmove -> hidapi" in caplog.text
 
     @patch("services.controller_manager.multiplexer.multiplexer_backend.metrics")
+    def test_dynamic_switch_closes_old_adapter(self, mock_metrics):
+        """Switching adapter should close the handle on the old adapter."""
+        a1 = _make_adapter("psmove", serials=["AA:AA"])
+        a2 = _make_adapter("hidapi", serials=["AA:AA"])
+        mux = MultiplexerBackend(adapters=[a1, a2])
+
+        # First discovery: route to psmove
+        with patch.object(mux, "_resolve_adapter_for_serial", return_value=None):
+            mux.get_connected_controllers()
+
+        assert mux._serial_to_adapter["AA:AA"] is a1
+
+        # Second discovery: targeting switches to hidapi
+        with patch.object(mux, "_resolve_adapter_for_serial", return_value=a2):
+            mux.get_connected_controllers()
+
+        # Old adapter should have been closed
+        a1.close.assert_called_once_with("AA:AA")
+
+    @patch("services.controller_manager.multiplexer.multiplexer_backend.metrics")
     def test_different_serials_to_different_adapters(self, mock_metrics):
         """Each serial can route to a different adapter independently."""
         a1 = _make_adapter("psmove", serials=["AA:AA", "BB:BB"])


### PR DESCRIPTION
## Summary

- When a controller is dynamically routed from one adapter to another (e.g., psmove → hidapi via `controller_adapter_routing` flag), the old adapter's handle was never closed. This leaked `psmove.PSMove` C-extension objects and kept stale USB handles open.
- One-line fix: call `old.close(serial)` before logging the switch in `_route_controllers()`.

## Test plan

- [x] 58 multiplexer_backend tests pass (1 new: `test_dynamic_switch_closes_old_adapter`)
- [x] Lint clean
- [ ] Switch routing flag between psmove/hidapi, verify no stale handles

🤖 Generated with [Claude Code](https://claude.com/claude-code)