### PR TITLE
fix: respawn dead music player subprocess on start()

### DIFF
--- a/services/audio/music_player.py
+++ b/services/audio/music_player.py
@@ -301,13 +301,29 @@ class MusicPlayer:
         self._transition_task = None
 
         if self._use_alsa:
-            # Start audio process
-            args = (self._song_array, self._ratio, self._volume, self._stop_proc)
-            self._process = Process(target=_linux_audio_loop, args=args, daemon=True)
-            self._process.start()
+            self._spawn_audio_process()
             logger.info(f"MusicPlayer '{name}' initialized with ALSA backend")
         else:
             logger.info(f"MusicPlayer '{name}' initialized (no tempo control - using pygame fallback)")
+
+    def _spawn_audio_process(self):
+        """Spawn (or respawn) the audio playback subprocess."""
+        if self._process and self._process.is_alive():
+            self._process.terminate()
+            self._process.join(timeout=1.0)
+        args = (self._song_array, self._ratio, self._volume, self._stop_proc)
+        self._process = Process(target=_linux_audio_loop, args=args, daemon=True)
+        self._process.start()
+
+    def _ensure_process_alive(self):
+        """Check if the audio process is alive; respawn if dead."""
+        if not self._use_alsa:
+            return
+        if self._process and self._process.is_alive():
+            return
+        exit_code = self._process.exitcode if self._process else None
+        logger.warning(f"MusicPlayer '{self.name}': audio process died (exit code {exit_code}), respawning")
+        self._spawn_audio_process()
 
     def load(self, file_pattern: str):
         """
@@ -328,6 +344,7 @@ class MusicPlayer:
         """
         import uuid
 
+        self._ensure_process_alive()
         self._track_id = str(uuid.uuid4())
         self._stop_proc.value = 0
         logger.info(f"Music started: {self._track_id}")

--- a/services/audio/tests/test_music_player.py
+++ b/services/audio/tests/test_music_player.py
@@ -488,3 +488,92 @@ class TestDummyMusicPlayer:
         p.start()
         # Should not raise
         p.cleanup()
+
+
+class TestProcessRespawn:
+    """Tests for automatic respawn of dead audio subprocess."""
+
+    def test_start_respawns_dead_process(self):
+        """If the audio process has died, start() respawns it."""
+        with (
+            patch("services.audio.music_player.HAS_ALSA", True),
+            patch("services.audio.music_player.Process") as mock_process_cls,
+        ):
+            mock_proc = MagicMock()
+            mock_proc.is_alive.return_value = True
+            mock_process_cls.return_value = mock_proc
+
+            from services.audio.music_player import MusicPlayer
+
+            player = MusicPlayer(name="test-respawn")
+            assert mock_proc.start.call_count == 1
+
+            # Simulate process death
+            mock_proc.is_alive.return_value = False
+            mock_proc.exitcode = -9
+
+            # Create a new mock for the respawned process
+            new_proc = MagicMock()
+            new_proc.is_alive.return_value = True
+            mock_process_cls.return_value = new_proc
+
+            player.start()
+
+            # New process was spawned
+            assert new_proc.start.call_count == 1
+
+    def test_start_does_not_respawn_alive_process(self):
+        """If the audio process is alive, start() does not respawn."""
+        with (
+            patch("services.audio.music_player.HAS_ALSA", True),
+            patch("services.audio.music_player.Process") as mock_process_cls,
+        ):
+            mock_proc = MagicMock()
+            mock_proc.is_alive.return_value = True
+            mock_process_cls.return_value = mock_proc
+
+            from services.audio.music_player import MusicPlayer
+
+            player = MusicPlayer(name="test-alive")
+            assert mock_process_cls.call_count == 1
+
+            player.start()
+
+            # No additional Process created
+            assert mock_process_cls.call_count == 1
+
+    def test_ensure_process_alive_noop_without_alsa(self):
+        """_ensure_process_alive does nothing when ALSA is disabled."""
+        with patch("services.audio.music_player.HAS_ALSA", False):
+            from services.audio.music_player import MusicPlayer
+
+            player = MusicPlayer(name="test-no-alsa")
+            assert player._process is None
+            # Should not raise
+            player._ensure_process_alive()
+            assert player._process is None
+
+    def test_respawn_terminates_zombie_process(self):
+        """_spawn_audio_process terminates an existing alive process before spawning."""
+        with (
+            patch("services.audio.music_player.HAS_ALSA", True),
+            patch("services.audio.music_player.Process") as mock_process_cls,
+        ):
+            mock_proc = MagicMock()
+            mock_proc.is_alive.return_value = True
+            mock_process_cls.return_value = mock_proc
+
+            from services.audio.music_player import MusicPlayer
+
+            player = MusicPlayer(name="test-terminate")
+
+            # Force a respawn while process is "alive"
+            new_proc = MagicMock()
+            new_proc.is_alive.return_value = True
+            mock_process_cls.return_value = new_proc
+
+            player._spawn_audio_process()
+
+            # Old process should have been terminated
+            mock_proc.terminate.assert_called_once()
+            mock_proc.join.assert_called_once_with(timeout=1.0)


### PR DESCRIPTION
## Summary
- The audio playback subprocess could die silently (OOM, ALSA error) after the first game, and `start()` would just write to shared memory that nobody reads — causing permanent music silence
- `start()` now calls `_ensure_process_alive()` which checks if the subprocess is alive and respawns it if dead, logging the exit code for debugging
- Extracted `_spawn_audio_process()` helper used by both `__init__` and the respawn path

## Test plan
- [x] 4 new tests in `TestProcessRespawn`: respawn on dead process, no respawn when alive, noop without ALSA, terminates zombie before respawn
- [x] All 61 music player tests pass
- [x] `make lint` passes
- [ ] Manual: play multiple games back-to-back, verify music plays each time

🤖 Generated with [Claude Code](https://claude.com/claude-code)