### PR TITLE
fix: call psmove_disconnect on close to release HID handles

### DIFF
--- a/services/controller_manager/multiplexer/psmove_adapter.py
+++ b/services/controller_manager/multiplexer/psmove_adapter.py
@@ -151,12 +151,27 @@ class PsMoveAdapter(ControllerIOAdapter):
             logger.warning(f"Controller {move_num}/{count}: {e}")
             return None
 
+    def _disconnect_handle(self, serial: str) -> None:
+        """Disconnect and release a single PSMove handle.
+
+        The SWIG destructor (~PSMove) calls psmove_disconnect() which closes
+        the underlying HID/USB handle. We must delete the Python object
+        explicitly so resources are freed immediately, not at GC time.
+        """
+        move = self._handles.pop(serial, None)
+        if move is not None:
+            with contextlib.suppress(Exception):
+                move.set_leds(0, 0, 0)
+                move.set_rumble(0)
+                move.update_leds()
+            del move
+
     def _remove_stale_handles(self, seen_serials: list[str]) -> None:
         """Remove handles for controllers no longer in scan."""
         stale = set(self._handles.keys()) - set(seen_serials)
         for serial in stale:
             logger.info(f"Controller {serial} no longer in scan - removing stale handle")
-            del self._handles[serial]
+            self._disconnect_handle(serial)
 
     def open(self, serial: str) -> bool:
         """Open is a no-op for psmove — handles are created during discover()."""
@@ -223,14 +238,10 @@ class PsMoveAdapter(ControllerIOAdapter):
             return False
 
     def close(self, serial: str) -> None:
-        """Release controller handle."""
-        self._handles.pop(serial, None)
+        """Disconnect controller and release its HID handle."""
+        self._disconnect_handle(serial)
 
     def close_all(self) -> None:
-        """Turn off all LEDs/rumble and release all handles."""
-        for move in self._handles.values():
-            with contextlib.suppress(Exception):
-                move.set_leds(0, 0, 0)
-                move.set_rumble(0)
-                move.update_leds()
-        self._handles.clear()
+        """Turn off all LEDs/rumble and disconnect all handles."""
+        for serial in list(self._handles.keys()):
+            self._disconnect_handle(serial)

--- a/services/controller_manager/tests/test_psmove_adapter.py
+++ b/services/controller_manager/tests/test_psmove_adapter.py
@@ -507,6 +507,17 @@ class TestPsMoveAdapterClose:
         assert "AABBCCDDEE01" not in adapter._handles
         assert "AA:BB:CC:DD:EE:02" in adapter._handles
 
+    def test_close_turns_off_leds(self):
+        adapter = PsMoveAdapter()
+        move = _make_fake_move("AABBCCDDEE01")
+        adapter._handles["AABBCCDDEE01"] = move
+
+        adapter.close("AABBCCDDEE01")
+
+        move.set_leds.assert_called_with(0, 0, 0)
+        move.set_rumble.assert_called_with(0)
+        move.update_leds.assert_called()
+
     def test_close_nonexistent_does_not_raise(self):
         adapter = PsMoveAdapter()
         adapter.close("NONEXISTENT")  # Should not raise
@@ -596,12 +607,16 @@ class TestPsMoveAdapterProbeHelpers:
     def test_remove_stale_handles(self):
         adapter = PsMoveAdapter()
         adapter._handles["AABBCCDDEE01"] = _make_fake_move()
-        adapter._handles["AA:BB:CC:DD:EE:02"] = _make_fake_move()
+        stale_move = _make_fake_move()
+        adapter._handles["AA:BB:CC:DD:EE:02"] = stale_move
 
         adapter._remove_stale_handles(["AABBCCDDEE01"])
 
         assert "AABBCCDDEE01" in adapter._handles
         assert "AA:BB:CC:DD:EE:02" not in adapter._handles
+        # Stale handle should have LEDs turned off
+        stale_move.set_leds.assert_called_with(0, 0, 0)
+        stale_move.set_rumble.assert_called_with(0)
 
     def test_remove_stale_handles_none_stale(self):
         adapter = PsMoveAdapter()


### PR DESCRIPTION
## Summary
- `PsMoveAdapter.close()` only did `dict.pop()` — it never triggered the SWIG destructor (`~PSMove` → `psmove_disconnect()` → `hid_close()`), leaking USB/HID handles
- When controllers switched from psmove → hidapi, the leaked handles kept the kernel polling the device, causing persistent CPU utilization that never went down
- Added `_disconnect_handle()` helper that turns off LEDs, then `del`s the Python object to trigger `psmove_disconnect()` deterministically
- `close()`, `close_all()`, and `_remove_stale_handles()` all go through `_disconnect_handle()` now

## Test plan
- [x] New test: `test_close_turns_off_leds` verifies LEDs off on single close
- [x] Updated test: `test_remove_stale_handles` verifies LEDs off on stale removal
- [x] All 54 psmove adapter tests pass
- [x] `make lint` passes
- [ ] Manual: switch controllers from psmove to hidapi via flag, verify CPU drops back down

🤖 Generated with [Claude Code](https://claude.com/claude-code)