### PR TITLE
fix: retry next music file when decode fails

### DIFF
--- a/services/audio/music_player.py
+++ b/services/audio/music_player.py
@@ -60,24 +60,32 @@ def _load_song_from_pattern(pattern: str) -> bytes | None:
     """
     Load a random song matching the glob pattern and return WAV bytes.
 
-    Returns None if no files match or loading fails.
+    Tries files in random order until one loads successfully.
+    Returns None if no files match or all files fail to decode.
     """
     files = glob.glob(pattern)
     if not files:
         logger.error(f"No files match pattern: {pattern}")
         return None
 
-    random_song = random.choice(files)
-    logger.info(f"Loading music: {random_song}")
+    random.shuffle(files)
+    for song_path in files:
+        try:
+            logger.info(f"Loading music: {song_path}")
+            segment = AudioSegment.from_file(song_path)
+            segment = segment.set_channels(2).set_frame_rate(44100).set_sample_width(2)
 
-    segment = AudioSegment.from_file(random_song)
-    segment = segment.set_channels(2).set_frame_rate(44100).set_sample_width(2)
+            buf = io.BytesIO()
+            segment.export(buf, format="wav")
+            wav_bytes = buf.getvalue()
+            logger.info(f"Music loaded: {song_path} ({len(wav_bytes)} bytes)")
+            return wav_bytes
+        except Exception as e:
+            logger.warning(f"Failed to load music file {song_path}: {e}")
+            continue
 
-    buf = io.BytesIO()
-    segment.export(buf, format="wav")
-    wav_bytes = buf.getvalue()
-    logger.info(f"Music loaded: {random_song} ({len(wav_bytes)} bytes)")
-    return wav_bytes
+    logger.error(f"All {len(files)} files failed to load for pattern: {pattern}")
+    return None
 
 
 def _read_samples(wf, read_size):

--- a/services/audio/tests/test_music_player.py
+++ b/services/audio/tests/test_music_player.py
@@ -310,7 +310,6 @@ class TestLoadSongFromPattern:
 
         with (
             patch("services.audio.music_player.glob.glob", return_value=["/music/song1.ogg"]),
-            patch("services.audio.music_player.random.choice", return_value="/music/song1.ogg"),
             patch("services.audio.music_player.AudioSegment.from_file", return_value=mock_segment),
         ):
             result = _load_song_from_pattern("/music/*.ogg")
@@ -319,7 +318,7 @@ class TestLoadSongFromPattern:
         assert isinstance(result, bytes)
         assert len(result) > 0
 
-    def test_selects_random_file_from_matches(self):
+    def test_shuffles_files_before_loading(self):
         mock_segment = MagicMock()
         mock_segment.set_channels.return_value = mock_segment
         mock_segment.set_frame_rate.return_value = mock_segment
@@ -330,12 +329,41 @@ class TestLoadSongFromPattern:
 
         with (
             patch("services.audio.music_player.glob.glob", return_value=files),
-            patch("services.audio.music_player.random.choice", return_value="/music/b.ogg") as mock_choice,
+            patch("services.audio.music_player.random.shuffle") as mock_shuffle,
             patch("services.audio.music_player.AudioSegment.from_file", return_value=mock_segment),
         ):
             _load_song_from_pattern("/music/*.ogg")
 
-        mock_choice.assert_called_once_with(files)
+        mock_shuffle.assert_called_once_with(files)
+
+    def test_skips_broken_file_and_loads_next(self):
+        """If first file fails to decode, tries the next one."""
+        mock_segment = MagicMock()
+        mock_segment.set_channels.return_value = mock_segment
+        mock_segment.set_frame_rate.return_value = mock_segment
+        mock_segment.set_sample_width.return_value = mock_segment
+        mock_segment.export.side_effect = lambda buf, **_kwargs: buf.write(b"wav")
+
+        with (
+            patch("services.audio.music_player.glob.glob", return_value=["/music/bad.ogg", "/music/good.ogg"]),
+            patch(
+                "services.audio.music_player.AudioSegment.from_file",
+                side_effect=[Exception("decode error"), mock_segment],
+            ),
+        ):
+            result = _load_song_from_pattern("/music/*.ogg")
+
+        assert result is not None
+
+    def test_returns_none_when_all_files_fail(self):
+        """Returns None if every file in the glob fails to decode."""
+        with (
+            patch("services.audio.music_player.glob.glob", return_value=["/music/a.ogg", "/music/b.ogg"]),
+            patch("services.audio.music_player.AudioSegment.from_file", side_effect=Exception("decode error")),
+        ):
+            result = _load_song_from_pattern("/music/*.ogg")
+
+        assert result is None
 
 
 class TestMusicPlayerStartStop:


### PR DESCRIPTION
## Summary
- `_load_song_from_pattern` previously picked one random file — if it failed to decode (pydub/ffmpeg error), the entire load returned `None`
- The audio loop would retry the same pattern, potentially picking the same broken file again — causing intermittent silence
- Now shuffles the file list and tries each file until one succeeds, with per-file warning logs for failed decodes
- If ALL files fail, logs the count and returns `None`

## Test plan
- [x] `cd services/audio && uv run pytest -v` — 65 music player tests pass (3 new: shuffle, skip-broken, all-fail)
- [x] `make lint` — clean
- [ ] Deploy and check logs for `Failed to load music file` warnings to identify which files are problematic

🤖 Generated with [Claude Code](https://claude.com/claude-code)