### PR TITLE
feat: chaos trigger API and presentation dashboard

### DIFF
--- a/docker-compose.lite.yml
+++ b/docker-compose.lite.yml
@@ -215,6 +215,9 @@ services:
       - CONTROLLER_MANAGER_SERVICE=controller-manager:50052
       - GAME_COORDINATOR_SERVICE=game-coordinator:50053
       - MENU_SERVICE=menu:50054
+      - FLAGD_CONFIG_PATH=/etc/flagd/flags/performance.json
+    volumes:
+      - ./services/flagd:/etc/flagd/flags
     networks:
       - joustmania
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -617,6 +617,9 @@ services:
       - CONTROLLER_MANAGER_SERVICE=controller-manager:50052
       - GAME_COORDINATOR_SERVICE=game-coordinator:50053
       - MENU_SERVICE=menu:50054
+      - FLAGD_CONFIG_PATH=/etc/flagd/flags/performance.json
+    volumes:
+      - ./services/flagd:/etc/flagd/flags
     networks:
       - joustmania
     restart: unless-stopped

--- a/services/connect-proxy/chaos.go
+++ b/services/connect-proxy/chaos.go
@@ -1,0 +1,243 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"strconv"
+	"sync"
+)
+
+// flagdConfig represents the top-level flagd JSON file structure.
+type flagdConfig struct {
+	Metadata map[string]interface{} `json:"metadata"`
+	Flags    map[string]*flagdFlag  `json:"flags"`
+}
+
+// flagdFlag represents a single feature flag in flagd.
+type flagdFlag struct {
+	State          string                 `json:"state"`
+	Variants       map[string]interface{} `json:"variants"`
+	DefaultVariant string                 `json:"defaultVariant"`
+	Targeting      interface{}            `json:"targeting,omitempty"`
+}
+
+var (
+	flagdConfigPath string
+	flagdMu         sync.Mutex
+)
+
+func init() {
+	flagdConfigPath = getEnv("FLAGD_CONFIG_PATH", "/etc/flagd/flags/performance.json")
+}
+
+// registerChaosHandlers adds chaos fault injection endpoints to the mux.
+func registerChaosHandlers(mux *http.ServeMux) {
+	faults := []string{"poll-drop", "accel-spike", "led-failure", "disconnect"}
+	for _, fault := range faults {
+		f := fault
+		mux.HandleFunc("/chaos/"+f, chaosSetHandler(f))
+	}
+	mux.HandleFunc("/chaos/reset", chaosResetHandler)
+	mux.HandleFunc("/chaos/status", chaosStatusHandler)
+
+	log.Printf("Chaos handlers registered (flagd config: %s)", flagdConfigPath)
+}
+
+// faultRouteToVariant maps URL path segments to flagd variant names.
+func faultRouteToVariant(route string) string {
+	switch route {
+	case "poll-drop":
+		return "poll_drop"
+	case "accel-spike":
+		return "accel_spike"
+	case "led-failure":
+		return "led_failure"
+	case "disconnect":
+		return "disconnect"
+	default:
+		return "none"
+	}
+}
+
+// parseFraction reads the ?fraction= query param (1-100, default 100).
+func parseFraction(r *http.Request) (int, error) {
+	q := r.URL.Query().Get("fraction")
+	if q == "" {
+		return 100, nil
+	}
+	v, err := strconv.Atoi(q)
+	if err != nil || v < 1 || v > 100 {
+		return 0, fmt.Errorf("fraction must be 1-100, got %q", q)
+	}
+	return v, nil
+}
+
+// chaosSetHandler returns a handler that activates a specific fault type.
+// Supports ?fraction=N (1-100) to target only a percentage of controllers.
+func chaosSetHandler(fault string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		fraction, err := parseFraction(r)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		variant := faultRouteToVariant(fault)
+		if err := setChaosVariant(variant, fraction); err != nil {
+			log.Printf("chaos: failed to set %s: %v", variant, err)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		log.Printf("chaos: activated fault %s (fraction=%d%%)", variant, fraction)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"status":   "ok",
+			"fault":    variant,
+			"fraction": fraction,
+		})
+	}
+}
+
+// chaosResetHandler clears all chaos faults.
+func chaosResetHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	if err := setChaosVariant("none", 100); err != nil {
+		log.Printf("chaos: failed to reset: %v", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	log.Printf("chaos: reset to none")
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{
+		"status": "ok",
+		"fault":  "none",
+	})
+}
+
+// chaosStatusHandler returns the current chaos_fault_type flag config.
+func chaosStatusHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	flagdMu.Lock()
+	defer flagdMu.Unlock()
+
+	cfg, err := readFlagdConfig()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	flag, ok := cfg.Flags["chaos_fault_type"]
+	if !ok {
+		http.Error(w, "chaos_fault_type flag not found", http.StatusNotFound)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(flag)
+}
+
+// buildFractionalTargeting creates flagd fractional targeting rules.
+// With fraction=100, returns nil (use defaultVariant for all).
+// With fraction<100, returns a fractional rule that hashes targetingKey (serial)
+// to give `fraction`% of controllers the fault and the rest "none".
+func buildFractionalTargeting(variant string, fraction int) interface{} {
+	if fraction >= 100 {
+		return nil
+	}
+	// flagd fractional operator: deterministic bucketing by targetingKey
+	// https://flagd.dev/reference/custom-operations/fractional-operation/
+	return map[string]interface{}{
+		"fractional": []interface{}{
+			[]interface{}{variant, fraction},
+			[]interface{}{"none", 100 - fraction},
+		},
+	}
+}
+
+// setChaosVariant updates the chaos_fault_type flag in the flagd config file.
+// fraction=100 targets all controllers (defaultVariant only).
+// fraction<100 uses flagd fractional targeting to affect a subset of controllers.
+func setChaosVariant(variant string, fraction int) error {
+	flagdMu.Lock()
+	defer flagdMu.Unlock()
+
+	cfg, err := readFlagdConfig()
+	if err != nil {
+		return fmt.Errorf("read config: %w", err)
+	}
+
+	flag, ok := cfg.Flags["chaos_fault_type"]
+	if !ok {
+		return fmt.Errorf("chaos_fault_type flag not found in %s", flagdConfigPath)
+	}
+
+	if _, ok := flag.Variants[variant]; !ok {
+		return fmt.Errorf("unknown variant %q", variant)
+	}
+
+	if variant == "none" {
+		// Reset: clear targeting and set default to none
+		flag.DefaultVariant = "none"
+		flag.Targeting = nil
+	} else if fraction >= 100 {
+		// All controllers: set default, clear targeting
+		flag.DefaultVariant = variant
+		flag.Targeting = nil
+	} else {
+		// Fractional: keep default as "none" (fallback), set targeting
+		flag.DefaultVariant = "none"
+		flag.Targeting = buildFractionalTargeting(variant, fraction)
+	}
+
+	return writeFlagdConfig(cfg)
+}
+
+// readFlagdConfig reads and parses the flagd JSON config file.
+func readFlagdConfig() (*flagdConfig, error) {
+	data, err := os.ReadFile(flagdConfigPath)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", flagdConfigPath, err)
+	}
+
+	var cfg flagdConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", flagdConfigPath, err)
+	}
+
+	return &cfg, nil
+}
+
+// writeFlagdConfig writes the flagd config back to disk with consistent formatting.
+func writeFlagdConfig(cfg *flagdConfig) error {
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal config: %w", err)
+	}
+
+	// Append newline for POSIX compliance
+	data = append(data, '\n')
+
+	if err := os.WriteFile(flagdConfigPath, data, 0644); err != nil {
+		return fmt.Errorf("write %s: %w", flagdConfigPath, err)
+	}
+
+	return nil
+}

--- a/services/connect-proxy/main.go
+++ b/services/connect-proxy/main.go
@@ -91,6 +91,9 @@ func main() {
 	)
 	mux.Handle(menuPath, menuHandler)
 
+	// Chaos fault injection endpoints (for presentation demos)
+	registerChaosHandlers(mux)
+
 	// Health check endpoint
 	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)

--- a/services/envoy/envoy.yaml
+++ b/services/envoy/envoy.yaml
@@ -93,6 +93,13 @@ static_resources:
                           redirect:
                             path_redirect: "/victoria-metrics/"
 
+                        # Chaos fault injection API
+                        # PRESERVE prefix - connect-proxy handles /chaos/* paths
+                        - match:
+                            prefix: "/chaos/"
+                          route:
+                            cluster: connect_proxy
+
                         # Health check endpoint
                         - match:
                             path: "/health"

--- a/services/grafana/dashboards/presentation-chaos.json
+++ b/services/grafana/dashboards/presentation-chaos.json
@@ -1,0 +1,397 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Chaos fault injection demo panels for Slidev presentation (solo-panel kiosk mode)",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Acceleration magnitude showing gaps (poll_drop), spikes (accel_spike), and flatlines (disconnect)",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "green",
+            "mode": "fixed"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Acceleration (g)",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "gradientMode": "scheme",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 2,
+          "max": 5,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "g"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "lastNotNull"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "controller_accel_magnitude{serial=~\"$serial\"}",
+          "instant": false,
+          "legendFormat": "{{serial}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Acceleration with Fault Effects",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Rate of chaos faults injected by type. Spikes when chaos is activated.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Faults / sec",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "poll_drop"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "disconnect"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "accel_spike"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "led_failure"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "purple",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 24,
+        "x": 0,
+        "y": 12
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": ["sum"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "rate(controller_chaos_faults_injected_total{serial=~\"$serial\"}[30s])",
+          "instant": false,
+          "legendFormat": "{{fault_type}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Fault Injection Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Live connection status per controller. Green=connected, Red=disconnected.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "red",
+                  "index": 1,
+                  "text": "Disconnected"
+                },
+                "1": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "Connected"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 24,
+        "x": 0,
+        "y": 24
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "controller_connected{serial=~\"$serial\"}",
+          "instant": true,
+          "legendFormat": "{{serial}}",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Controller Connection Status",
+      "type": "stat"
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 38,
+  "tags": ["presentation", "chaos", "demo"],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "definition": "label_values(controller_info, serial)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Controller",
+        "multi": true,
+        "name": "serial",
+        "options": [],
+        "query": {
+          "query": "label_values(controller_info, serial)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-5m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Presentation: Chaos Demo",
+  "uid": "presentation-chaos",
+  "version": 1,
+  "weekStart": ""
+}


### PR DESCRIPTION
## Summary
- Add HTTP endpoints to connect-proxy for toggling chaos faults from Slidev presentation buttons
- Support fractional targeting (`?fraction=N`) to affect only a subset of controllers
- New Grafana dashboard with 3 panels optimized for solo-panel kiosk mode embedding

Closes #561

## Chaos API Endpoints

All endpoints go through envoy at `http://localhost/chaos/...` and are routed to connect-proxy, which reads/writes the `chaos_fault_type` flag in flagd's `performance.json`. flagd picks up changes via inotify in <100ms.

### Activate a fault (all controllers)

```bash
# Drop 30% of poll data
curl -X POST http://localhost/chaos/poll-drop

# Inject random acceleration spikes
curl -X POST http://localhost/chaos/accel-spike

# 50% chance LED writes fail
curl -X POST http://localhost/chaos/led-failure

# Fully disconnect controllers from chaos adapter
curl -X POST http://localhost/chaos/disconnect
```

### Fractional targeting (subset of controllers)

Use `?fraction=N` (1-100) to only affect N% of controllers. flagd uses deterministic hashing on controller serial, so the same controllers are consistently targeted.

```bash
# Drop polls on ~25% of controllers
curl -X POST http://localhost/chaos/poll-drop?fraction=25

# Disconnect ~50% of controllers
curl -X POST http://localhost/chaos/disconnect?fraction=50
```

### Reset (clear all faults)

```bash
curl -X POST http://localhost/chaos/reset
```

### Check current status

```bash
curl http://localhost/chaos/status
```

Returns the full flagd flag config including targeting rules:
```json
{
  "state": "ENABLED",
  "variants": { "poll_drop": "poll_drop", "none": "none", ... },
  "defaultVariant": "none",
  "targeting": { "fractional": [["poll_drop", 25], ["none", 75]] }
}
```

### From Slidev slides (JavaScript)

```js
// Activate fault
await fetch("/chaos/poll-drop", { method: "POST" });

// Fractional — only 30% of controllers
await fetch("/chaos/disconnect?fraction=30", { method: "POST" });

// Reset
await fetch("/chaos/reset", { method: "POST" });
```

## Grafana Dashboard Panels

Dashboard UID: `presentation-chaos` — embed individual panels as iframes in Slidev:

```
/grafana/d-solo/presentation-chaos/presentation-chaos?panelId=1&kiosk
/grafana/d-solo/presentation-chaos/presentation-chaos?panelId=2&kiosk
/grafana/d-solo/presentation-chaos/presentation-chaos?panelId=3&kiosk
```

| Panel | ID | Type | Shows |
|-------|----|------|-------|
| Acceleration with Fault Effects | 1 | timeseries | Accel magnitude — gaps (poll_drop), spikes (accel_spike), flatlines (disconnect) |
| Fault Injection Rate | 2 | timeseries | `rate(controller_chaos_faults_injected_total[30s])` by fault type, color-coded |
| Controller Connection Status | 3 | stat | `controller_connected` per controller, green/red |

## Test plan
- [ ] `docker compose up` — connect-proxy starts with flagd volume mounted
- [ ] `curl -X POST http://localhost/chaos/poll-drop` → 200, `performance.json` updated
- [ ] `curl -X POST http://localhost/chaos/disconnect?fraction=50` → 200, targeting rules set
- [ ] `curl http://localhost/chaos/status` → shows current flag config with targeting
- [ ] `curl -X POST http://localhost/chaos/reset` → resets to `none`, clears targeting
- [ ] `curl -X POST http://localhost/chaos/poll-drop?fraction=0` → 400 (invalid fraction)
- [ ] Open Grafana solo panels in kiosk mode — verify panels render
- [ ] Slidev `fetch("/chaos/poll-drop", {method: "POST"})` triggers visible effect in Grafana

🤖 Generated with [Claude Code](https://claude.com/claude-code)