### PR TITLE
docs: Raspberry Pi audio setup (ALSA card + disable PipeWire)

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -827,3 +827,21 @@ grpcurl -plaintext localhost:4317 list
 ---
 
 Happy coding! 🎮
+
+## Raspberry Pi Audio Setup
+
+The audio service needs direct ALSA access to the USB audio device (card 2). The host's PipeWire/WirePlumber stack conflicts with this and must be masked:
+
+```bash
+systemctl --user mask wireplumber pipewire pipewire-pulse pipewire.socket pipewire-pulse.socket
+systemctl --user stop wireplumber pipewire.socket pipewire-pulse.socket
+```
+
+Also set `ALSA_CARD=2` in `docker-compose.yml` (the USB audio device — cards 0 and 1 are HDMI outputs with no slave device when no display is connected).
+
+To re-enable PipeWire/WirePlumber later:
+```bash
+systemctl --user unmask wireplumber pipewire pipewire-pulse pipewire.socket pipewire-pulse.socket
+systemctl --user enable wireplumber
+systemctl --user start pipewire wireplumber
+```


### PR DESCRIPTION
## Summary

- Documents the `ALSA_CARD=2` requirement for Raspberry Pi deployments (cards 0 and 1 are HDMI outputs — unavailable without a connected display)
- Explains why PipeWire/WirePlumber must be masked on the host (it holds exclusive control of the USB audio device, blocking the Docker container's direct ALSA access)
- Includes commands to re-enable WirePlumber if needed later

## Test plan

- [ ] Documentation is accurate and commands work on a fresh Pi setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)