### PR TITLE
fix: pass verify_only kwarg through ChaosAdapter.discover()

### DIFF
--- a/services/controller_manager/multiplexer/chaos_adapter.py
+++ b/services/controller_manager/multiplexer/chaos_adapter.py
@@ -44,8 +44,8 @@ class ChaosAdapter(ControllerIOAdapter):
     def adapter_type(self) -> str:
         return self._inner.adapter_type  # transparent to routing
 
-    def discover(self, force: bool = False) -> list[str]:
-        serials = self._inner.discover(force=force)
+    def discover(self, force: bool = False, verify_only: bool = False) -> list[str]:
+        serials = self._inner.discover(force=force, verify_only=verify_only)
         # Track and evaluate new serials
         for s in serials:
             if s not in self._known_serials:

--- a/services/controller_manager/tests/test_chaos_adapter.py
+++ b/services/controller_manager/tests/test_chaos_adapter.py
@@ -48,6 +48,15 @@ class TestChaosAdapterPassthrough:
             serials = chaos.discover()
         assert "SERIAL001" in serials
 
+    def test_discover_passes_verify_only(self):
+        inner = _make_inner()
+        chaos = ChaosAdapter(inner)
+        mock_discover = MagicMock(return_value=["SERIAL001"])
+        inner.discover = mock_discover
+        with patch.object(chaos, "_evaluate_flag", return_value="none"):
+            chaos.discover(force=True, verify_only=True)
+        mock_discover.assert_called_with(force=True, verify_only=True)
+
     def test_open_delegates(self):
         inner = _make_inner()
         chaos = _make_chaos(inner, "none")


### PR DESCRIPTION
## Summary
- `ChaosAdapter.discover()` was missing the `verify_only` parameter from the `ControllerIOAdapter` base class
- `MultiplexerBackend._route_controllers()` calls `adapter.discover(force=force, verify_only=verify_only)`, causing a `TypeError` at runtime
- One-line fix: add `verify_only: bool = False` to `ChaosAdapter.discover()` and pass it through to the inner adapter

## Root cause
The `ChaosAdapter` was added in #549 but the `verify_only` parameter (added to the base class in #558) was missed since the two PRs were developed in parallel.

## Test plan
- [x] `uv run pytest tests/test_chaos_adapter.py -v` — 30/30 pass (new test: `test_discover_passes_verify_only`)
- [x] `make lint` passes
- [ ] `docker compose up` — controller-manager no longer throws `TypeError: ChaosAdapter.discover() got an unexpected keyword argument 'verify_only'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)