### PR TITLE
feat: poll drop threshold and error status on degraded spans

### DIFF
--- a/services/flagd/performance.ci.json
+++ b/services/flagd/performance.ci.json
@@ -139,6 +139,16 @@
       "defaultVariant": "hidapi",
       "targeting": {}
     },
+    "poll_drop_threshold": {
+      "state": "ENABLED",
+      "variants": {
+        "off": 0,
+        "low": 2,
+        "default": 3,
+        "high": 5
+      },
+      "defaultVariant": "default"
+    },
     "chaos_fault_type": {
       "state": "ENABLED",
       "variants": {

--- a/services/flagd/performance.json
+++ b/services/flagd/performance.json
@@ -146,6 +146,16 @@
       "defaultVariant": "hidapi",
       "targeting": {}
     },
+    "poll_drop_threshold": {
+      "state": "ENABLED",
+      "variants": {
+        "off": 0,
+        "low": 2,
+        "default": 3,
+        "high": 5
+      },
+      "defaultVariant": "default"
+    },
     "chaos_fault_type": {
       "state": "ENABLED",
       "variants": {

--- a/services/game_coordinator/games/base.py
+++ b/services/game_coordinator/games/base.py
@@ -858,13 +858,19 @@ class BaseGameMode(ABC):
             controller_state: GameplayData protobuf (may have .health field)
         """
         health = controller_state.health if controller_state.HasField("health") else None
-        has_poll_issues = health and (health.poll_drops or health.poll_errors)
+        config = get_config_manager().get_config()
+        threshold = config.poll_drop_threshold
+        has_poll_issues = health and (health.poll_drops > threshold or health.poll_errors)
         has_led_issues = health and health.led_failures
 
-        # --- Poll degradation span ---
-        if has_poll_issues:
+        # Always accumulate totals for final summary, even below threshold
+        if health and health.poll_drops:
             player.total_poll_drops += health.poll_drops
+        if health and health.poll_errors:
             player.total_poll_errors += health.poll_errors
+
+        # --- Poll degradation span (only for drops exceeding threshold) ---
+        if has_poll_issues:
             # Open child span on transition healthy → degraded
             if player._poll_degraded_span is None and player.span:
                 ctx = trace.set_span_in_context(player.span)
@@ -884,8 +890,11 @@ class BaseGameMode(ABC):
         else:
             # Close child span on transition degraded → healthy
             if player._poll_degraded_span is not None:
+                from opentelemetry.trace import Status, StatusCode
+
                 player._poll_degraded_span.set_attribute("health.total_poll_drops", player.total_poll_drops)
                 player._poll_degraded_span.set_attribute("health.total_poll_errors", player.total_poll_errors)
+                player._poll_degraded_span.set_status(Status(StatusCode.ERROR, "poll degradation detected"))
                 player._poll_degraded_span.end()
                 player._poll_degraded_span = None
 
@@ -1355,8 +1364,11 @@ class BaseGameMode(ABC):
 
         # Close any open health degradation spans
         if player._poll_degraded_span is not None:
+            from opentelemetry.trace import Status, StatusCode
+
             player._poll_degraded_span.set_attribute("health.total_poll_drops", player.total_poll_drops)
             player._poll_degraded_span.set_attribute("health.total_poll_errors", player.total_poll_errors)
+            player._poll_degraded_span.set_status(Status(StatusCode.ERROR, "poll degradation detected"))
             player._poll_degraded_span.end()
             player._poll_degraded_span = None
         if player._led_degraded_span is not None:

--- a/services/game_coordinator/runtime_config.py
+++ b/services/game_coordinator/runtime_config.py
@@ -70,6 +70,11 @@ class GamePerformanceConfig:
     # Sensitivity
     sensitivity_mode: str = "MEDIUM"  # SLOW, MEDIUM, FAST
 
+    # Poll drop threshold: per-frame drops at or below this value are considered
+    # normal USB/Bluetooth noise and won't open a controller_poll_degraded span.
+    # At 1000Hz USB polling, 1-2 drops per 16.67ms frame is typical.
+    poll_drop_threshold: int = 3
+
 
 class RuntimeConfigManager:
     """
@@ -194,6 +199,18 @@ class RuntimeConfigManager:
 
                 # Track flag evaluation
                 metrics.flag_evaluations_total.labels(flag_key="sensitivity_mode").inc()
+
+                # Poll drop threshold (per-frame drops below this are normal noise)
+                old_threshold = self.config.poll_drop_threshold
+                new_threshold = self.flag_client.get_integer_value(
+                    "poll_drop_threshold", self.config.poll_drop_threshold, EvaluationContext()
+                )
+                if new_threshold != old_threshold:
+                    logger.info(f"Config updated: poll_drop_threshold {old_threshold} -> {new_threshold}")
+                    self.config.poll_drop_threshold = new_threshold
+                    metrics.config_changes_total.labels(parameter="poll_drop_threshold").inc()
+
+                metrics.flag_evaluations_total.labels(flag_key="poll_drop_threshold").inc()
 
                 # Update current config gauges
                 metrics.current_update_frequency_hz.set(self.config.update_frequency_hz)

--- a/services/game_coordinator/tests/test_health_spans.py
+++ b/services/game_coordinator/tests/test_health_spans.py
@@ -77,15 +77,17 @@ def _make_gameplay_data(serial="AA:BB:CC", poll_drops=0, poll_errors=0, led_fail
 class TestProcessHealthPollDegradation:
     """Tests for poll degradation child span lifecycle."""
 
+    @patch("services.game_coordinator.games.base.get_config_manager")
     @patch("services.game_coordinator.games.base.tracer")
-    def test_opens_span_on_first_poll_drops(self, mock_tracer):
-        """First frame with poll_drops should open a controller_poll_degraded span."""
+    def test_opens_span_on_first_poll_drops(self, mock_tracer, mock_get_config):
+        """First frame with poll_drops above threshold should open a controller_poll_degraded span."""
+        mock_get_config.return_value.get_config.return_value.poll_drop_threshold = 3
         game = _make_game()
         player = _make_player()
         mock_child_span = MagicMock()
         mock_tracer.start_span.return_value = mock_child_span
 
-        gd = _make_gameplay_data(poll_drops=3)
+        gd = _make_gameplay_data(poll_drops=5)
         game._process_health(player, "AA:BB:CC", gd)
 
         mock_tracer.start_span.assert_called_once_with(
@@ -94,44 +96,48 @@ class TestProcessHealthPollDegradation:
             attributes={"player.serial": "AA:BB:CC"},
         )
         assert player._poll_degraded_span is mock_child_span
-        assert player.total_poll_drops == 3
+        assert player.total_poll_drops == 5
 
+    @patch("services.game_coordinator.games.base.get_config_manager")
     @patch("services.game_coordinator.games.base.tracer")
-    def test_adds_event_per_frame(self, mock_tracer):
+    def test_adds_event_per_frame(self, mock_tracer, mock_get_config):
         """Each frame with issues should add an event to the child span."""
+        mock_get_config.return_value.get_config.return_value.poll_drop_threshold = 3
         game = _make_game()
         player = _make_player()
         mock_child_span = MagicMock()
         mock_tracer.start_span.return_value = mock_child_span
 
-        # Frame 1: opens span + adds event
-        gd1 = _make_gameplay_data(poll_drops=3)
+        # Frame 1: opens span + adds event (above threshold)
+        gd1 = _make_gameplay_data(poll_drops=5)
         game._process_health(player, "AA:BB:CC", gd1)
 
         # Frame 2: should add another event (span already open)
-        gd2 = _make_gameplay_data(poll_drops=5, poll_errors=1)
+        gd2 = _make_gameplay_data(poll_drops=6, poll_errors=1)
         game._process_health(player, "AA:BB:CC", gd2)
 
         # Should only open span once
         assert mock_tracer.start_span.call_count == 1
         # Should have two events
         assert mock_child_span.add_event.call_count == 2
-        mock_child_span.add_event.assert_any_call("poll_issues", {"poll_drops": 3})
-        mock_child_span.add_event.assert_any_call("poll_issues", {"poll_drops": 5, "poll_errors": 1})
+        mock_child_span.add_event.assert_any_call("poll_issues", {"poll_drops": 5})
+        mock_child_span.add_event.assert_any_call("poll_issues", {"poll_drops": 6, "poll_errors": 1})
 
-        assert player.total_poll_drops == 8
+        assert player.total_poll_drops == 11
         assert player.total_poll_errors == 1
 
+    @patch("services.game_coordinator.games.base.get_config_manager")
     @patch("services.game_coordinator.games.base.tracer")
-    def test_closes_span_on_recovery(self, mock_tracer):
+    def test_closes_span_on_recovery(self, mock_tracer, mock_get_config):
         """Healthy frame after degradation should close the child span."""
+        mock_get_config.return_value.get_config.return_value.poll_drop_threshold = 3
         game = _make_game()
         player = _make_player()
         mock_child_span = MagicMock()
         mock_tracer.start_span.return_value = mock_child_span
 
-        # Frame 1: degraded
-        gd1 = _make_gameplay_data(poll_drops=3)
+        # Frame 1: degraded (above threshold)
+        gd1 = _make_gameplay_data(poll_drops=5)
         game._process_health(player, "AA:BB:CC", gd1)
         assert player._poll_degraded_span is not None
 
@@ -140,31 +146,54 @@ class TestProcessHealthPollDegradation:
         game._process_health(player, "AA:BB:CC", gd2)
 
         assert player._poll_degraded_span is None
-        mock_child_span.set_attribute.assert_any_call("health.total_poll_drops", 3)
+        mock_child_span.set_attribute.assert_any_call("health.total_poll_drops", 5)
         mock_child_span.set_attribute.assert_any_call("health.total_poll_errors", 0)
+        mock_child_span.set_status.assert_called_once()
         mock_child_span.end.assert_called_once()
 
+    @patch("services.game_coordinator.games.base.get_config_manager")
     @patch("services.game_coordinator.games.base.tracer")
-    def test_no_span_without_player_span(self, mock_tracer):
+    def test_no_span_without_player_span(self, mock_tracer, mock_get_config):
         """No child span should be created if player has no parent span."""
+        mock_get_config.return_value.get_config.return_value.poll_drop_threshold = 3
         game = _make_game()
         player = _make_player(with_span=False)
 
-        gd = _make_gameplay_data(poll_drops=3)
+        gd = _make_gameplay_data(poll_drops=5)
         game._process_health(player, "AA:BB:CC", gd)
 
         mock_tracer.start_span.assert_not_called()
         assert player._poll_degraded_span is None
         # But counters should still accumulate
-        assert player.total_poll_drops == 3
+        assert player.total_poll_drops == 5
+
+    @patch("services.game_coordinator.games.base.get_config_manager")
+    @patch("services.game_coordinator.games.base.tracer")
+    def test_drops_at_threshold_no_span(self, mock_tracer, mock_get_config):
+        """Poll drops at or below threshold should NOT open a degraded span."""
+        mock_get_config.return_value.get_config.return_value.poll_drop_threshold = 3
+        game = _make_game()
+        player = _make_player()
+
+        # 1-2 drops per frame is normal Bluetooth noise
+        for drops in [1, 2, 3]:
+            gd = _make_gameplay_data(poll_drops=drops)
+            game._process_health(player, "AA:BB:CC", gd)
+
+        mock_tracer.start_span.assert_not_called()
+        assert player._poll_degraded_span is None
+        # Counters should still accumulate
+        assert player.total_poll_drops == 6
 
 
 class TestProcessHealthLedDegradation:
     """Tests for LED degradation child span lifecycle."""
 
+    @patch("services.game_coordinator.games.base.get_config_manager")
     @patch("services.game_coordinator.games.base.tracer")
-    def test_opens_led_span_on_failures(self, mock_tracer):
+    def test_opens_led_span_on_failures(self, mock_tracer, mock_get_config):
         """LED failures should open a controller_led_degraded span."""
+        mock_get_config.return_value.get_config.return_value.poll_drop_threshold = 3
         game = _make_game()
         player = _make_player()
         mock_child_span = MagicMock()
@@ -181,9 +210,11 @@ class TestProcessHealthLedDegradation:
         assert player._led_degraded_span is mock_child_span
         assert player.total_led_failures == 2
 
+    @patch("services.game_coordinator.games.base.get_config_manager")
     @patch("services.game_coordinator.games.base.tracer")
-    def test_closes_led_span_on_recovery(self, mock_tracer):
+    def test_closes_led_span_on_recovery(self, mock_tracer, mock_get_config):
         """Healthy frame should close LED degradation span."""
+        mock_get_config.return_value.get_config.return_value.poll_drop_threshold = 3
         game = _make_game()
         player = _make_player()
         mock_child_span = MagicMock()
@@ -205,25 +236,29 @@ class TestProcessHealthLedDegradation:
 class TestProcessHealthCombined:
     """Tests for combined poll + LED degradation."""
 
+    @patch("services.game_coordinator.games.base.get_config_manager")
     @patch("services.game_coordinator.games.base.tracer")
-    def test_both_poll_and_led_spans(self, mock_tracer):
+    def test_both_poll_and_led_spans(self, mock_tracer, mock_get_config):
         """Both poll and LED issues should open separate child spans."""
+        mock_get_config.return_value.get_config.return_value.poll_drop_threshold = 3
         game = _make_game()
         player = _make_player()
         mock_poll_span = MagicMock(name="poll_span")
         mock_led_span = MagicMock(name="led_span")
         mock_tracer.start_span.side_effect = [mock_poll_span, mock_led_span]
 
-        gd = _make_gameplay_data(poll_drops=3, led_failures=2)
+        gd = _make_gameplay_data(poll_drops=5, led_failures=2)
         game._process_health(player, "AA:BB:CC", gd)
 
         assert mock_tracer.start_span.call_count == 2
         assert player._poll_degraded_span is mock_poll_span
         assert player._led_degraded_span is mock_led_span
 
+    @patch("services.game_coordinator.games.base.get_config_manager")
     @patch("services.game_coordinator.games.base.tracer")
-    def test_healthy_game_no_spans(self, mock_tracer):
+    def test_healthy_game_no_spans(self, mock_tracer, mock_get_config):
         """Healthy data should create no child spans."""
+        mock_get_config.return_value.get_config.return_value.poll_drop_threshold = 3
         game = _make_game()
         player = _make_player()
 
@@ -257,9 +292,10 @@ class TestFinalizePlayerHealth:
 
         game._finalize_player_health(player)
 
-        # Health spans should be closed
+        # Health spans should be closed with error status
         mock_poll_span.set_attribute.assert_any_call("health.total_poll_drops", 42)
         mock_poll_span.set_attribute.assert_any_call("health.total_poll_errors", 5)
+        mock_poll_span.set_status.assert_called_once()
         mock_poll_span.end.assert_called_once()
 
         mock_led_span.set_attribute.assert_called_with("health.total_led_failures", 3)

--- a/services/game_coordinator/tests/test_runtime_config.py
+++ b/services/game_coordinator/tests/test_runtime_config.py
@@ -33,8 +33,9 @@ def test_runtime_config_flag_updates(mock_get_client, mock_add_handler):
     mock_get_client.return_value = mock_client
 
     # Configure mock evaluations
-    # get_integer_value is called for: update_frequency_hz, countdown_phase_duration_ms, winner_rainbow_duration_ms
-    mock_client.get_integer_value.side_effect = [30, 500, 1000]
+    # get_integer_value is called for: update_frequency_hz, poll_drop_threshold,
+    # countdown_phase_duration_ms, winner_rainbow_duration_ms
+    mock_client.get_integer_value.side_effect = [30, 3, 500, 1000]
     # get_string_value is called for: sensitivity_mode
     mock_client.get_string_value.return_value = "HIGH"
 
@@ -47,6 +48,7 @@ def test_runtime_config_flag_updates(mock_get_client, mock_add_handler):
     # Verify mock was called with correct keys and EvaluationContext
     mock_client.get_integer_value.assert_any_call("update_frequency_hz", 60, ANY)
     mock_client.get_string_value.assert_any_call("sensitivity_mode", "MEDIUM", ANY)
+    mock_client.get_integer_value.assert_any_call("poll_drop_threshold", 3, ANY)
     mock_client.get_integer_value.assert_any_call("countdown_phase_duration_ms", 750, ANY)
     mock_client.get_integer_value.assert_any_call("winner_rainbow_duration_ms", 3000, ANY)
 
@@ -65,7 +67,7 @@ def test_countdown_skip_via_flag(mock_get_client, _mock_add_handler):
     mock_get_client.return_value = mock_client
 
     # Return 0 for countdown_phase_duration_ms (the "skip" variant)
-    mock_client.get_integer_value.side_effect = [60, 0, 3000]
+    mock_client.get_integer_value.side_effect = [60, 3, 0, 3000]
     mock_client.get_string_value.return_value = "MEDIUM"
 
     manager = RuntimeConfigManager()
@@ -100,7 +102,7 @@ def test_on_flags_changed_event(mock_get_client, _mock_add_handler, caplog):
     mock_get_client.return_value = mock_client
 
     # Initial values
-    mock_client.get_integer_value.side_effect = [60, 750, 3000]
+    mock_client.get_integer_value.side_effect = [60, 3, 750, 3000]
     mock_client.get_string_value.return_value = "MEDIUM"
 
     manager = RuntimeConfigManager()
@@ -109,7 +111,7 @@ def test_on_flags_changed_event(mock_get_client, _mock_add_handler, caplog):
     assert config.countdown_phase_duration_ms == 750
 
     # Simulate flag change
-    mock_client.get_integer_value.side_effect = [30, 500, 1000]
+    mock_client.get_integer_value.side_effect = [30, 3, 500, 1000]
     mock_client.get_string_value.return_value = "HIGH"
 
     # Trigger event handler
@@ -134,7 +136,7 @@ def test_on_flags_changed_no_flag_list(mock_get_client, _mock_add_handler, caplo
     """Test that _on_flags_changed works when flags_changed is empty."""
     mock_client = MagicMock()
     mock_get_client.return_value = mock_client
-    mock_client.get_integer_value.side_effect = [45, 750, 3000]
+    mock_client.get_integer_value.side_effect = [45, 3, 750, 3000]
     mock_client.get_string_value.return_value = "LOW"
 
     manager = RuntimeConfigManager()
@@ -144,7 +146,7 @@ def test_on_flags_changed_no_flag_list(mock_get_client, _mock_add_handler, caplo
     mock_event.flags_changed = []
 
     # Reset side_effect for second refresh
-    mock_client.get_integer_value.side_effect = [45, 750, 3000]
+    mock_client.get_integer_value.side_effect = [45, 3, 750, 3000]
     mock_client.get_string_value.return_value = "LOW"
 
     with caplog.at_level(logging.INFO):
@@ -235,8 +237,9 @@ def test_refresh_from_flags_with_metrics(mock_get_client, _mock_add_handler):
     mock_get_client.return_value = mock_client
 
     # First call returns defaults, second call returns changed values
-    # Each refresh evaluates: update_frequency_hz, countdown_phase_duration_ms, winner_rainbow_duration_ms
-    mock_client.get_integer_value.side_effect = [60, 750, 3000, 45, 500, 1000]
+    # Each refresh evaluates: update_frequency_hz, poll_drop_threshold,
+    # countdown_phase_duration_ms, winner_rainbow_duration_ms
+    mock_client.get_integer_value.side_effect = [60, 3, 750, 3000, 45, 5, 500, 1000]
     mock_client.get_string_value.side_effect = ["MEDIUM", "HIGH"]
 
     with (
@@ -266,14 +269,14 @@ def test_on_flags_changed_with_metrics(mock_get_client, _mock_add_handler):
     """Test that _on_flags_changed increments metrics."""
     mock_client = MagicMock()
     mock_get_client.return_value = mock_client
-    mock_client.get_integer_value.side_effect = [60, 750, 3000]
+    mock_client.get_integer_value.side_effect = [60, 3, 750, 3000]
     mock_client.get_string_value.return_value = "MEDIUM"
 
     with patch("services.game_coordinator.metrics.flag_configuration_changes_total") as mock_counter:
         manager = RuntimeConfigManager()
 
         # Reset for next refresh
-        mock_client.get_integer_value.side_effect = [60, 750, 3000]
+        mock_client.get_integer_value.side_effect = [60, 3, 750, 3000]
 
         # Trigger event
         mock_event = MagicMock()
@@ -300,7 +303,7 @@ def test_game_settings_flags_read_on_init(mock_get_client, _mock_add_handler):
     mock_client = MagicMock()
     mock_get_client.return_value = mock_client
 
-    mock_client.get_integer_value.side_effect = [60, 500, 5000]
+    mock_client.get_integer_value.side_effect = [60, 3, 500, 5000]
     mock_client.get_string_value.return_value = "MEDIUM"
 
     manager = RuntimeConfigManager()
@@ -317,7 +320,7 @@ def test_game_settings_client_initialized(mock_get_client, _mock_add_handler):
     """Test that game_settings_client is initialized alongside performance client."""
     mock_client = MagicMock()
     mock_get_client.return_value = mock_client
-    mock_client.get_integer_value.side_effect = [60, 750, 3000]
+    mock_client.get_integer_value.side_effect = [60, 3, 750, 3000]
     mock_client.get_string_value.return_value = "MEDIUM"
 
     manager = RuntimeConfigManager()


### PR DESCRIPTION
## Summary
- Add `poll_drop_threshold` feature flag (default 3) to filter normal Bluetooth USB polling noise from health spans
- Mark `controller_poll_degraded` spans with `StatusCode.ERROR` so they show up red in Jaeger
- At 1000Hz USB polling, 1-2 drops per 16.67ms frame is typical (~6-12% miss rate) — previously this created degraded spans covering ~75% of game time

## Changes
- **`performance.json` / `performance.ci.json`**: New `poll_drop_threshold` flag with variants: `off` (0), `low` (2), `default` (3), `high` (5)
- **`runtime_config.py`**: Add `poll_drop_threshold` field to `GamePerformanceConfig`, read from flagd on init and config change events
- **`base.py`**: Apply threshold in `_process_health()` — only open span when `poll_drops > threshold`. Still accumulate totals for summary. Set `StatusCode.ERROR` on degraded spans
- **Tests**: Updated `test_health_spans.py` (mock config, new threshold test, error status assertions) and `test_runtime_config.py` (updated side_effect lists for new flag)

## Test plan
- [x] `make lint` passes
- [x] `cd services/game_coordinator && uv run pytest` — all 629 tests pass
- [ ] Live: Normal gameplay produces zero `controller_poll_degraded` spans (was ~150)
- [ ] Live: Genuine degradation (chaos fault injection) still produces red error spans in Jaeger

🤖 Generated with [Claude Code](https://claude.com/claude-code)