### PR TITLE
feat: TSDB benchmark — Prometheus vs VictoriaMetrics (#575)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -227,6 +227,8 @@ test-debug: clean-test-venv
 		pytest tests/integration/ -v -s $(if $(TEST),-k "$(TEST)")
 
 # TSDB benchmark: Prometheus vs VictoriaMetrics comparison (Issue #575)
+# Use BENCHMARK_CONTROLLERS=N to scale (default 4, e.g. 18 or 36)
+# Use BENCHMARK_DURATION=N to change steady-state seconds (default 30)
 .PHONY: benchmark-tsdb
 benchmark-tsdb: clean-test-venv
 	$(TEST_ENV) uv run --package joustmania-benchmark-tests \

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ help:
 	@echo "  make test-integration - Run integration tests only (CI)"
 	@echo "  make test-dev        - Run integration tests with pre-built images (fast)"
 	@echo "  make test TEST=name  - Run specific test by name"
+	@echo "  make benchmark-tsdb  - TSDB benchmark: Prometheus vs VictoriaMetrics"
 	@echo ""
 	@echo "Protos:"
 	@echo "  make protos          - Generate Python protobuf files"
@@ -224,6 +225,12 @@ test-dev: clean-test-venv
 test-debug: clean-test-venv
 	PAUSE_BEFORE_TEARDOWN=1 $(TEST_ENV) uv run --package joustmania-integration-tests \
 		pytest tests/integration/ -v -s $(if $(TEST),-k "$(TEST)")
+
+# TSDB benchmark: Prometheus vs VictoriaMetrics comparison (Issue #575)
+.PHONY: benchmark-tsdb
+benchmark-tsdb: clean-test-venv
+	$(TEST_ENV) uv run --package joustmania-benchmark-tests \
+		pytest tests/benchmark/ -v -s $(if $(TEST),-k "$(TEST)")
 
 # ============================================================================
 # CI Targets (used by GitHub Actions)

--- a/docker-compose.benchmark.yml
+++ b/docker-compose.benchmark.yml
@@ -15,6 +15,8 @@ services:
   otel-collector:
     volumes:
       - ./services/otel-collector/config.benchmark.yaml:/etc/otel-collector-config.yaml:ro
+    ports:
+      - "4318:4318"  # OTLP HTTP - exposed for cardinality stress test
 
   prometheus:
     command:

--- a/docker-compose.benchmark.yml
+++ b/docker-compose.benchmark.yml
@@ -1,0 +1,38 @@
+# TSDB Benchmark Override - Prometheus vs VictoriaMetrics comparison (Issue #575)
+#
+# Swaps the OTEL Collector config for one that pushes metrics to both
+# VictoriaMetrics (existing) and Prometheus (via remote write receiver),
+# enabling side-by-side TSDB comparison under identical workloads.
+#
+# Usage:
+#   docker compose -f docker-compose.yml -f docker-compose.override.yml \
+#     -f docker-compose.ci.yml -f docker-compose.benchmark.yml up -d
+#
+# Run benchmark tests:
+#   make benchmark-tsdb
+
+services:
+  otel-collector:
+    volumes:
+      - ./services/otel-collector/config.benchmark.yaml:/etc/otel-collector-config.yaml:ro
+
+  prometheus:
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--storage.tsdb.retention.time=30d'
+      - '--web.console.libraries=/usr/share/prometheus/console_libraries'
+      - '--web.console.templates=/usr/share/prometheus/consoles'
+      - '--web.external-url=/prometheus/'
+      - '--web.route-prefix=/'
+      - '--web.enable-remote-write-receiver'
+    ports:
+      - "9090:9090"
+    deploy:
+      resources:
+        limits:
+          memory: 512m
+
+  victoria-metrics:
+    ports:
+      - "8428:8428"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ members = [
     "services/audio",
     "services/pairing_daemon",
     "tests/integration",
+    "tests/benchmark",
 ]
 
 # pytest configuration (migrated from pytest.ini)
@@ -73,4 +74,5 @@ addopts = "-v"
 exclude = [
     "tools",             # Utility scripts (not part of main codebase)
     "tests/integration", # Integration tests (separate package)
+    "tests/benchmark",   # Benchmark tests (separate package)
 ]

--- a/services/otel-collector/config.benchmark.yaml
+++ b/services/otel-collector/config.benchmark.yaml
@@ -1,0 +1,194 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+  # Scrape receivers for targets that don't push via OTLP.
+  # Split by namespace so each pipeline gets the correct service.namespace tag.
+  # Metrics flow to VictoriaMetrics via prometheusremotewrite.
+
+  # Observability stack: monitoring tools that observe the system
+  prometheus/observability:
+    config:
+      scrape_configs:
+        - job_name: 'victoria-metrics'
+          scrape_interval: 30s
+          static_configs:
+            - targets: ['victoria-metrics:8428']
+        - job_name: 'prometheus'
+          scrape_interval: 30s
+          static_configs:
+            - targets: ['prometheus:9090']
+        # Self-telemetry: the collector exposes its own metrics on :8888.
+        # Rename otelcol_process_* to standard process_* for unified dashboards.
+        - job_name: 'otel-collector'
+          scrape_interval: 30s
+          static_configs:
+            - targets: ['localhost:8888']
+          metric_relabel_configs:
+            - source_labels: [__name__]
+              regex: 'otelcol_process_cpu_seconds'
+              target_label: __name__
+              replacement: 'process_cpu_seconds_total'
+            - source_labels: [__name__]
+              regex: 'otelcol_process_memory_rss'
+              target_label: __name__
+              replacement: 'process_resident_memory_bytes'
+
+  # Infrastructure: supporting services for the game platform
+  prometheus/infrastructure:
+    config:
+      scrape_configs:
+        - job_name: 'flagd'
+          scrape_interval: 30s
+          static_configs:
+            - targets: ['flagd:8014']
+
+  # Host: OS-level metrics from the Raspberry Pi
+  prometheus/host:
+    config:
+      scrape_configs:
+        - job_name: 'node'
+          scrape_interval: 30s
+          scrape_timeout: 25s
+          static_configs:
+            - targets: ['node-exporter:9100']
+              labels:
+                instance: 'raspberry-pi'
+
+processors:
+  # Batch processor for better performance (traces/logs)
+  batch:
+    timeout: 10s
+    send_batch_size: 1024
+
+  # Fast batch processor for sub-second metrics (Issue #105)
+  batch/fast:
+    timeout: 100ms
+    send_batch_size: 1000
+
+  # Memory limiter to prevent OOM
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 512
+
+  # Resource processors set service.namespace per pipeline.
+  # The prometheusremotewrite exporter prefixes job labels with the namespace
+  # (e.g. "joustmania/game-coordinator", "infrastructure/flagd", "host/node").
+  # All dashboard queries use these prefixed job names.
+  resource/observability:
+    attributes:
+      - key: service.namespace
+        value: observability
+        action: insert
+
+  resource/infrastructure:
+    attributes:
+      - key: service.namespace
+        value: infrastructure
+        action: insert
+
+  resource/host:
+    attributes:
+      - key: service.namespace
+        value: host
+        action: insert
+
+  # Resource processor to add common attributes for OTLP-pushed metrics
+  resource:
+    attributes:
+      - key: deployment.environment
+        value: development
+        action: insert
+      # service.namespace is set per-service in the Python SDK:
+      #   "joustmania" for game services (game-coordinator, menu, audio)
+      #   "infrastructure" for platform services (controller-manager, psmove-pairing)
+
+exporters:
+  # OTLP exporter to send traces to Jaeger
+  # Jaeger has OTLP support enabled and accepts OTLP on port 4317
+  otlp/jaeger:
+    endpoint: jaeger:4317
+    tls:
+      insecure: true
+
+  # Prometheus remote write to VictoriaMetrics for high-frequency metrics storage
+  prometheusremotewrite:
+    endpoint: "http://victoria-metrics:8428/api/v1/write"
+    tls:
+      insecure: true
+
+  # Benchmark: push same metrics to Prometheus for TSDB comparison (Issue #575)
+  prometheusremotewrite/prometheus:
+    endpoint: "http://prometheus:9090/api/v1/write"
+    tls:
+      insecure: true
+
+  # Prometheus exporter for metrics (exposed on :8889 for backward compatibility)
+  prometheus:
+    endpoint: "0.0.0.0:8889"
+
+  # Loki exporter for logs
+  loki:
+    endpoint: http://loki:3100/loki/api/v1/push
+    tls:
+      insecure: true
+
+  # OTLP HTTP exporter to Grafana Live Publisher for real-time WebSocket streaming
+  otlphttp/grafana-live:
+    endpoint: "http://grafana-live-publisher:4318"
+    encoding: json
+    tls:
+      insecure: true
+
+  # Debug exporter for local troubleshooting
+  debug:
+    verbosity: basic
+
+service:
+  pipelines:
+    # Traces pipeline
+    traces:
+      receivers: [otlp]
+      processors: [memory_limiter, batch, resource]
+      exporters: [otlp/jaeger, debug]
+
+    # Metrics pipeline - uses fast batch processor for sub-second updates
+    # Fan-out to VictoriaMetrics (storage), Prometheus (benchmark), Prometheus exporter, and Grafana Live (streaming)
+    metrics:
+      receivers: [otlp]
+      processors: [memory_limiter, batch/fast, resource]
+      exporters: [prometheusremotewrite, prometheusremotewrite/prometheus, prometheus, otlphttp/grafana-live]
+
+    # Observability metrics — victoria-metrics, prometheus, otel-collector
+    metrics/observability:
+      receivers: [prometheus/observability]
+      processors: [memory_limiter, resource/observability, batch/fast]
+      exporters: [prometheusremotewrite]
+
+    # Infrastructure metrics — flagd (scraped, not OTLP-pushed)
+    metrics/infrastructure:
+      receivers: [prometheus/infrastructure]
+      processors: [memory_limiter, resource/infrastructure, batch/fast]
+      exporters: [prometheusremotewrite]
+
+    # Host metrics — node-exporter (OS-level)
+    metrics/host:
+      receivers: [prometheus/host]
+      processors: [memory_limiter, resource/host, batch/fast]
+      exporters: [prometheusremotewrite]
+
+    # Logs pipeline
+    logs:
+      receivers: [otlp]
+      processors: [memory_limiter, batch, resource]
+      exporters: [loki, debug]
+
+  extensions: [health_check]
+
+extensions:
+  health_check:
+    endpoint: :13133

--- a/tests/benchmark/conftest.py
+++ b/tests/benchmark/conftest.py
@@ -1,0 +1,57 @@
+"""
+Benchmark test fixtures.
+
+Starts the full JoustMania stack with the benchmark overlay that enables
+Prometheus as a remote_write receiver alongside VictoriaMetrics.
+"""
+
+import os
+import sys
+import time
+
+import pytest
+from testcontainers.compose import DockerCompose
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+
+_COMPOSE_FILES = [
+    "docker-compose.yml",
+    "docker-compose.override.yml",
+    "docker-compose.ci.yml",
+    "docker-compose.benchmark.yml",
+]
+
+
+@pytest.fixture(scope="session")
+def docker_compose(request):
+    """Start docker-compose with benchmark overlay."""
+    use_prebuilt = os.getenv("USE_PREBUILT_IMAGES", "false").lower() == "true"
+    image_tag = os.getenv("IMAGE_TAG", "latest")
+
+    compose = DockerCompose(
+        context=".",
+        compose_file_name=list(_COMPOSE_FILES),
+        pull=use_prebuilt,
+        build=not use_prebuilt,
+        env_file=None,
+    )
+
+    if use_prebuilt:
+        os.environ["IMAGE_TAG"] = image_tag
+
+    compose.start()
+    time.sleep(5)
+
+    print("\n" + "=" * 80)
+    print("Benchmark environment running")
+    print("  Prometheus:       http://localhost:9090")
+    print("  VictoriaMetrics:  http://localhost:8428")
+    print("=" * 80)
+
+    yield compose
+
+    if os.getenv("CI") or os.getenv("SKIP_TEARDOWN"):
+        return
+    if os.getenv("PAUSE_BEFORE_TEARDOWN"):
+        input("Press ENTER to tear down...")
+    compose.stop()

--- a/tests/benchmark/pyproject.toml
+++ b/tests/benchmark/pyproject.toml
@@ -1,0 +1,36 @@
+[project]
+name = "joustmania-benchmark-tests"
+version = "1.0.0"
+description = "TSDB benchmark: Prometheus vs VictoriaMetrics for 100ms metric pushes"
+requires-python = ">=3.11"
+dependencies = [
+    "joustmania-proto",
+    "joustmania-integration-tests",
+    "pytest>=7.0.0",
+    "pytest-asyncio>=0.23.0",
+    "testcontainers>=4.0.0",
+    "grpcio>=1.50.0",
+    "httpx>=0.27.0",
+    "docker>=7.0.0",
+    "tabulate>=0.9.0",
+]
+
+[tool.uv.sources]
+joustmania-proto = { workspace = true }
+joustmania-integration-tests = { workspace = true }
+
+[build-system]
+requires = ["setuptools>=45", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+packages = []
+py-modules = []
+
+[tool.pytest.ini_options]
+testpaths = ["."]
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
+filterwarnings = [
+    "ignore::DeprecationWarning:testcontainers.*:",
+]

--- a/tests/benchmark/test_tsdb_comparison.py
+++ b/tests/benchmark/test_tsdb_comparison.py
@@ -39,12 +39,44 @@ BENCHMARK_METRICS = [
     "game_active_players",
 ]
 
+# Representative PromQL queries from Grafana dashboards.
+# These exercise different query patterns (rate, histogram_quantile,
+# aggregations, label matchers) to validate both backends produce
+# correct and timely results for real dashboard panels.
+DASHBOARD_QUERIES = [
+    # Simple selectors / gauges
+    ("process_resident_memory_bytes", "Process memory (gauge)"),
+    ("active_controllers_total", "Active controllers (gauge)"),
+    ("game_active_players", "Active players (gauge)"),
+    # Rate calculations
+    ("rate(process_cpu_seconds_total[5m]) * 100", "Process CPU % (rate)"),
+    ("sum by(job) (rate(grpc_requests_total[1m]))", "gRPC request rate by service"),
+    ('sum by(job) (rate(grpc_requests_total{status!="ok"}[1m]))', "gRPC error rate"),
+    ("rate(controller_stream_updates_total[1m])", "Controller stream update rate"),
+    # Histogram quantiles
+    (
+        "histogram_quantile(0.95, sum by(job, le) (rate(grpc_request_duration_seconds_bucket[5m])))",
+        "gRPC p95 latency (histogram_quantile)",
+    ),
+    # Aggregations with math
+    ("sum(increase(controller_stream_updates_total[1m]))", "Stream updates increase"),
+    ("count(active_controllers_total >= 0)", "Count with comparison"),
+    # Game-specific metrics
+    ("avg(game_player_accel_magnitude)", "Avg player acceleration"),
+    ("game_player_peak_accel", "Peak acceleration (gauge)"),
+    ("rate(game_near_death_events_total[1m]) * 60", "Near-death events per minute"),
+]
+
 # Configurable via environment
 CONTROLLER_COUNT = int(os.getenv("BENCHMARK_CONTROLLERS", "4"))
 GAME_DURATION_SECONDS = int(os.getenv("BENCHMARK_DURATION", "30"))
 
 # Maximum acceptable sample count divergence (fraction)
 SAMPLE_DIVERGENCE_THRESHOLD = 0.10
+
+# Pi 5 scaling: i9-11950H single-thread Geekbench ~1700, Cortex-A76 ~700
+# Ratio ~2.5x. Memory is assumed 1:1 (workload-dependent, not CPU-bound).
+PI5_CPU_SCALING_FACTOR = 2.5
 
 
 class TSDBClient:
@@ -68,7 +100,9 @@ class TSDBClient:
         resp.raise_for_status()
         return resp.json()
 
-    def query_range(self, promql: str, start: float, end: float, step: str = "15s") -> dict:
+    def query_range(
+        self, promql: str, start: float, end: float, step: str = "15s"
+    ) -> dict:
         """Execute a range query."""
         resp = self._client.get(
             f"{self.base_url}/api/v1/query_range",
@@ -107,6 +141,13 @@ class TSDBClient:
         """Count the number of distinct series for *metric*."""
         data = self.series(metric)
         return len(data.get("data", []))
+
+    def timed_query(self, promql: str) -> tuple[dict, float]:
+        """Execute an instant query and return (result, latency_ms)."""
+        t0 = time.monotonic()
+        result = self.query(promql)
+        latency_ms = (time.monotonic() - t0) * 1000
+        return result, latency_ms
 
     def close(self):
         self._client.close()
@@ -155,7 +196,9 @@ async def test_tsdb_comparison(docker_compose):
     # 1. Set up controllers and start a game
     # ------------------------------------------------------------------
     serials = await setup_mock_controllers(docker_compose, count=CONTROLLER_COUNT)
-    print(f"\nControllers ready: {len(serials)} controllers ({serials[:3]}{'...' if len(serials) > 3 else ''})")
+    print(
+        f"\nControllers ready: {len(serials)} controllers ({serials[:3]}{'...' if len(serials) > 3 else ''})"
+    )
 
     game_client, game_channel = await get_game_client(docker_compose)
 
@@ -226,14 +269,16 @@ async def test_tsdb_comparison(docker_compose):
         max_samples = max(prom_samples, vm_samples, 1)
         divergence = abs(prom_samples - vm_samples) / max_samples
 
-        rows.append([
-            metric,
-            prom_samples,
-            vm_samples,
-            prom_series,
-            vm_series,
-            f"{divergence:.1%}",
-        ])
+        rows.append(
+            [
+                metric,
+                prom_samples,
+                vm_samples,
+                prom_series,
+                vm_series,
+                f"{divergence:.1%}",
+            ]
+        )
 
         if divergence > SAMPLE_DIVERGENCE_THRESHOLD:
             divergence_warnings.append(
@@ -252,39 +297,130 @@ async def test_tsdb_comparison(docker_compose):
         ["Memory (MB)", prom_stats["memory_mb"], vm_stats["memory_mb"]],
     ]
 
+    # Pi 5 theoretical projection (CPU only — memory is workload-dependent)
+    pi5_rows = [
+        [
+            "CPU % (Pi 5 est.)",
+            round(prom_stats["cpu_percent"] * PI5_CPU_SCALING_FACTOR, 2),
+            round(vm_stats["cpu_percent"] * PI5_CPU_SCALING_FACTOR, 2),
+        ],
+        ["Memory (MB)", prom_stats["memory_mb"], vm_stats["memory_mb"]],
+    ]
+
+    # ------------------------------------------------------------------
+    # 7. Dashboard PromQL query validation
+    # ------------------------------------------------------------------
+    query_rows = []
+    query_warnings = []
+
+    for promql, description in DASHBOARD_QUERIES:
+        prom_result, prom_ms = prom.timed_query(promql)
+        vm_result, vm_ms = vm.timed_query(promql)
+
+        prom_status = prom_result.get("status", "error")
+        vm_status = vm_result.get("status", "error")
+        prom_series_n = len(prom_result.get("data", {}).get("result", []))
+        vm_series_n = len(vm_result.get("data", {}).get("result", []))
+
+        status = "OK"
+        if prom_status != "success" or vm_status != "success":
+            status = "ERR"
+            query_warnings.append(f"{description}: Prom={prom_status}, VM={vm_status}")
+        elif prom_series_n == 0 and vm_series_n == 0:
+            status = "EMPTY"
+
+        query_rows.append(
+            [
+                description,
+                f"{prom_ms:.0f}",
+                f"{vm_ms:.0f}",
+                prom_series_n,
+                vm_series_n,
+                status,
+            ]
+        )
+
     prom.close()
     vm.close()
 
     # ------------------------------------------------------------------
-    # 7. Print results
+    # 8. Print results
     # ------------------------------------------------------------------
     print("\n" + "=" * 80)
     print("TSDB Benchmark Results: Prometheus vs VictoriaMetrics")
-    print(f"Steady-state window: {GAME_DURATION_SECONDS}s, {CONTROLLER_COUNT} controllers, JoustFFA")
+    print(
+        f"Steady-state window: {GAME_DURATION_SECONDS}s, {CONTROLLER_COUNT} controllers, JoustFFA"
+    )
     print("=" * 80)
 
     print("\nMetric Samples:")
-    print(tabulate(
-        rows,
-        headers=["Metric", "Prom Samples", "VM Samples", "Prom Series", "VM Series", "Divergence"],
-        tablefmt="grid",
-    ))
+    print(
+        tabulate(
+            rows,
+            headers=[
+                "Metric",
+                "Prom Samples",
+                "VM Samples",
+                "Prom Series",
+                "VM Series",
+                "Divergence",
+            ],
+            tablefmt="grid",
+        )
+    )
 
     print("\nResource Usage (snapshot at end of benchmark):")
-    print(tabulate(
-        resource_rows,
-        headers=["Resource", "Prometheus", "VictoriaMetrics"],
-        tablefmt="grid",
-    ))
+    print(
+        tabulate(
+            resource_rows,
+            headers=["Resource", "Prometheus", "VictoriaMetrics"],
+            tablefmt="grid",
+        )
+    )
+
+    print(
+        f"\nPi 5 Projection (CPU x{PI5_CPU_SCALING_FACTOR} — "
+        "i9-11950H single-thread ~2.5x faster than Cortex-A76):"
+    )
+    print(
+        tabulate(
+            pi5_rows,
+            headers=["Resource", "Prometheus", "VictoriaMetrics"],
+            tablefmt="grid",
+        )
+    )
+
+    print("\nDashboard Query Validation:")
+    print(
+        tabulate(
+            query_rows,
+            headers=[
+                "Query",
+                "Prom (ms)",
+                "VM (ms)",
+                "Prom Series",
+                "VM Series",
+                "Status",
+            ],
+            tablefmt="grid",
+        )
+    )
 
     # ------------------------------------------------------------------
-    # 8. Warn (do NOT assert) on divergence
+    # 9. Warn (do NOT assert) on divergence / query errors
     # ------------------------------------------------------------------
     if divergence_warnings:
         msg = (
             f"Sample count divergence >{SAMPLE_DIVERGENCE_THRESHOLD:.0%} "
             f"detected in {len(divergence_warnings)} metric(s):\n"
             + "\n".join(f"  - {w}" for w in divergence_warnings)
+        )
+        warnings.warn(msg)
+
+    if query_warnings:
+        msg = (
+            f"Dashboard query errors in {len(query_warnings)} query(ies):\n"
+            + "\n".join(f"  - {w}" for w in query_warnings)
         )
         warnings.warn(msg)
 

--- a/tests/benchmark/test_tsdb_comparison.py
+++ b/tests/benchmark/test_tsdb_comparison.py
@@ -14,8 +14,10 @@ Environment variables:
 
 import asyncio
 import os
+import statistics
 import time
 import warnings
+from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import docker
 import httpx
@@ -77,6 +79,11 @@ SAMPLE_DIVERGENCE_THRESHOLD = 0.10
 # Pi 5 scaling: i9-11950H single-thread Geekbench ~1700, Cortex-A76 ~700
 # Ratio ~2.5x. Memory is assumed 1:1 (workload-dependent, not CPU-bound).
 PI5_CPU_SCALING_FACTOR = 2.5
+
+# Concurrent read stress test: simulate N dashboards refreshing simultaneously,
+# repeated for CYCLES refresh intervals.
+CONCURRENT_DASHBOARDS = 3
+READ_STRESS_CYCLES = 10
 
 
 class TSDBClient:
@@ -188,7 +195,55 @@ def _get_container_stats(container_name: str) -> dict:
         return {"cpu_percent": 0.0, "memory_mb": 0.0}
 
 
-@pytest.mark.timeout(180)
+def _run_concurrent_read_stress(
+    clients: list[TSDBClient],
+    queries: list[tuple[str, str]],
+    cycles: int,
+) -> dict[str, list[float]]:
+    """Fire all queries concurrently across multiple TSDB clients.
+
+    Simulates *len(clients)* dashboards each running all *queries*
+    simultaneously, repeated for *cycles* refresh intervals.
+
+    Returns ``{client.name: [latency_ms, ...]}`` with one entry per
+    query per cycle.
+    """
+    latencies: dict[str, list[float]] = {c.name: [] for c in clients}
+
+    def _single_query(client: TSDBClient, promql: str) -> tuple[str, float]:
+        t0 = time.monotonic()
+        client.query(promql)
+        return client.name, (time.monotonic() - t0) * 1000
+
+    for cycle in range(cycles):
+        futures = []
+        with ThreadPoolExecutor(max_workers=len(clients) * len(queries)) as pool:
+            for client in clients:
+                for promql, _desc in queries:
+                    futures.append(pool.submit(_single_query, client, promql))
+
+            for fut in as_completed(futures):
+                try:
+                    name, ms = fut.result()
+                    latencies[name].append(ms)
+                except Exception:
+                    pass
+
+    return latencies
+
+
+def _percentiles(values: list[float]) -> tuple[float, float, float]:
+    """Return (p50, p95, p99) from a list of values."""
+    if not values:
+        return (0.0, 0.0, 0.0)
+    s = sorted(values)
+    p50 = statistics.median(s)
+    p95 = s[int(len(s) * 0.95)]
+    p99 = s[int(len(s) * 0.99)]
+    return (p50, p95, p99)
+
+
+@pytest.mark.timeout(300)
 async def test_tsdb_comparison(docker_compose):
     """Run a JoustFFA game and compare Prometheus vs VictoriaMetrics."""
 
@@ -340,11 +395,78 @@ async def test_tsdb_comparison(docker_compose):
             ]
         )
 
+    # ------------------------------------------------------------------
+    # 8. Concurrent read stress test
+    # ------------------------------------------------------------------
+    # Each "dashboard" is a separate httpx client hitting the same backend.
+    # We create N clients per backend to simulate N dashboards refreshing
+    # all DASHBOARD_QUERIES in parallel, repeated for READ_STRESS_CYCLES.
+    print(
+        f"\nRead stress test: {CONCURRENT_DASHBOARDS} dashboards x "
+        f"{len(DASHBOARD_QUERIES)} queries x {READ_STRESS_CYCLES} cycles ..."
+    )
+
+    prom_clients = [
+        TSDBClient("http://localhost:9090", "Prometheus")
+        for _ in range(CONCURRENT_DASHBOARDS)
+    ]
+    vm_clients = [
+        TSDBClient("http://localhost:8428", "VictoriaMetrics")
+        for _ in range(CONCURRENT_DASHBOARDS)
+    ]
+
+    stress_latencies = _run_concurrent_read_stress(
+        prom_clients + vm_clients, DASHBOARD_QUERIES, READ_STRESS_CYCLES
+    )
+
+    for c in prom_clients + vm_clients:
+        c.close()
+
+    # Aggregate per-backend (all dashboard clients combined)
+    prom_latencies = stress_latencies["Prometheus"]
+    vm_latencies = stress_latencies["VictoriaMetrics"]
+
+    prom_p50, prom_p95, prom_p99 = _percentiles(prom_latencies)
+    vm_p50, vm_p95, vm_p99 = _percentiles(vm_latencies)
+
+    total_queries = len(DASHBOARD_QUERIES) * CONCURRENT_DASHBOARDS * READ_STRESS_CYCLES
+    stress_rows = [
+        ["Total queries", total_queries, total_queries],
+        ["p50 (ms)", f"{prom_p50:.1f}", f"{vm_p50:.1f}"],
+        ["p95 (ms)", f"{prom_p95:.1f}", f"{vm_p95:.1f}"],
+        ["p99 (ms)", f"{prom_p99:.1f}", f"{vm_p99:.1f}"],
+        [
+            "Errors",
+            total_queries - len(prom_latencies),
+            total_queries - len(vm_latencies),
+        ],
+    ]
+
+    # Snapshot resource usage under read load
+    prom_read_stats = _get_container_stats("joustmania-prometheus")
+    vm_read_stats = _get_container_stats("joustmania-victoria-metrics")
+
+    read_resource_rows = [
+        [
+            "CPU % (under read load)",
+            prom_read_stats["cpu_percent"],
+            vm_read_stats["cpu_percent"],
+        ],
+        [
+            "CPU % (Pi 5 est.)",
+            round(prom_read_stats["cpu_percent"] * PI5_CPU_SCALING_FACTOR, 2),
+            round(vm_read_stats["cpu_percent"] * PI5_CPU_SCALING_FACTOR, 2),
+        ],
+        ["Memory (MB)", prom_read_stats["memory_mb"], vm_read_stats["memory_mb"]],
+    ]
+
+    print("Read stress test complete")
+
     prom.close()
     vm.close()
 
     # ------------------------------------------------------------------
-    # 8. Print results
+    # 9. Print results
     # ------------------------------------------------------------------
     print("\n" + "=" * 80)
     print("TSDB Benchmark Results: Prometheus vs VictoriaMetrics")
@@ -406,8 +528,29 @@ async def test_tsdb_comparison(docker_compose):
         )
     )
 
+    print(
+        f"\nConcurrent Read Stress ({CONCURRENT_DASHBOARDS} dashboards x "
+        f"{READ_STRESS_CYCLES} cycles):"
+    )
+    print(
+        tabulate(
+            stress_rows,
+            headers=["Metric", "Prometheus", "VictoriaMetrics"],
+            tablefmt="grid",
+        )
+    )
+
+    print("\nResource Usage Under Read Load:")
+    print(
+        tabulate(
+            read_resource_rows,
+            headers=["Resource", "Prometheus", "VictoriaMetrics"],
+            tablefmt="grid",
+        )
+    )
+
     # ------------------------------------------------------------------
-    # 9. Warn (do NOT assert) on divergence / query errors
+    # 10. Warn (do NOT assert) on divergence / query errors
     # ------------------------------------------------------------------
     if divergence_warnings:
         msg = (

--- a/tests/benchmark/test_tsdb_comparison.py
+++ b/tests/benchmark/test_tsdb_comparison.py
@@ -1,0 +1,285 @@
+"""
+TSDB Benchmark: Prometheus vs VictoriaMetrics comparison (Issue #575).
+
+Runs a real JoustMania game session and compares how both TSDBs handle
+identical metric workloads pushed via OTEL Collector remote_write.
+
+This test is informational only -- no hard assertions on benchmark results.
+Differences >10% in sample counts trigger warnings for investigation.
+"""
+
+import asyncio
+import time
+import warnings
+
+import docker
+import httpx
+import pytest
+from tabulate import tabulate
+
+from tests.integration.helpers import (
+    GameEventCollector,
+    force_end_game,
+    get_game_client,
+    setup_mock_controllers,
+    start_game_via_menu,
+)
+
+# Metrics to compare across both backends
+BENCHMARK_METRICS = [
+    "controller_accel_magnitude",
+    "active_controllers_total",
+    "controller_stream_updates_total",
+    "process_cpu_seconds_total",
+    "game_active_players",
+]
+
+# Steady-state game duration in seconds
+GAME_DURATION_SECONDS = 30
+
+# Maximum acceptable sample count divergence (fraction)
+SAMPLE_DIVERGENCE_THRESHOLD = 0.10
+
+
+class TSDBClient:
+    """Thin wrapper around the Prometheus HTTP query API.
+
+    Works for both Prometheus and VictoriaMetrics since they share the
+    same ``/api/v1/`` query interface.
+    """
+
+    def __init__(self, base_url: str, name: str):
+        self.base_url = base_url.rstrip("/")
+        self.name = name
+        self._client = httpx.Client(timeout=10.0)
+
+    def query(self, promql: str) -> dict:
+        """Execute an instant query."""
+        resp = self._client.get(
+            f"{self.base_url}/api/v1/query",
+            params={"query": promql},
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    def query_range(self, promql: str, start: float, end: float, step: str = "15s") -> dict:
+        """Execute a range query."""
+        resp = self._client.get(
+            f"{self.base_url}/api/v1/query_range",
+            params={
+                "query": promql,
+                "start": start,
+                "end": end,
+                "step": step,
+            },
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    def series(self, match: str) -> dict:
+        """Query series metadata."""
+        resp = self._client.get(
+            f"{self.base_url}/api/v1/series",
+            params={"match[]": match},
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    def sample_count(self, metric: str, start: float, end: float) -> int:
+        """Count total samples for *metric* in the given time window.
+
+        Uses a range query with a 1s step and sums all returned data
+        points across every series that matches the metric name.
+        """
+        data = self.query_range(metric, start, end, step="1s")
+        total = 0
+        for result in data.get("data", {}).get("result", []):
+            total += len(result.get("values", []))
+        return total
+
+    def series_count(self, metric: str) -> int:
+        """Count the number of distinct series for *metric*."""
+        data = self.series(metric)
+        return len(data.get("data", []))
+
+    def close(self):
+        self._client.close()
+
+
+def _get_container_stats(container_name: str) -> dict:
+    """Get CPU% and memory usage for a Docker container.
+
+    Returns ``{"cpu_percent": float, "memory_mb": float}`` or zeros on
+    error (container not found, stats unavailable, etc.).
+    """
+    try:
+        client = docker.from_env()
+        container = client.containers.get(container_name)
+        stats = container.stats(stream=False)
+
+        # CPU percent
+        cpu_delta = (
+            stats["cpu_stats"]["cpu_usage"]["total_usage"]
+            - stats["precpu_stats"]["cpu_usage"]["total_usage"]
+        )
+        system_delta = (
+            stats["cpu_stats"]["system_cpu_usage"]
+            - stats["precpu_stats"]["system_cpu_usage"]
+        )
+        cpu_percent = 0.0
+        if system_delta > 0:
+            num_cpus = stats["cpu_stats"].get("online_cpus", 1)
+            cpu_percent = (cpu_delta / system_delta) * num_cpus * 100.0
+
+        # Memory
+        memory_bytes = stats.get("memory_stats", {}).get("usage", 0)
+        memory_mb = memory_bytes / (1024 * 1024)
+
+        return {"cpu_percent": round(cpu_percent, 2), "memory_mb": round(memory_mb, 2)}
+    except Exception as exc:
+        warnings.warn(f"Could not get stats for {container_name}: {exc}")
+        return {"cpu_percent": 0.0, "memory_mb": 0.0}
+
+
+@pytest.mark.timeout(180)
+async def test_tsdb_comparison(docker_compose):
+    """Run a JoustFFA game and compare Prometheus vs VictoriaMetrics."""
+
+    # ------------------------------------------------------------------
+    # 1. Set up controllers and start a game
+    # ------------------------------------------------------------------
+    serials = await setup_mock_controllers(docker_compose, count=4)
+    print(f"\nControllers ready: {serials}")
+
+    game_client, game_channel = await get_game_client(docker_compose)
+
+    async with GameEventCollector(game_client) as collector:
+        await start_game_via_menu(
+            docker_compose,
+            game_mode="JoustFFA",
+            timeout=25.0,
+            event_collector=collector,
+        )
+        print("Game started -- entering steady-state phase")
+
+        # ------------------------------------------------------------------
+        # 2. Wait for metrics to appear in both backends
+        # ------------------------------------------------------------------
+        prom = TSDBClient("http://localhost:9090", "Prometheus")
+        vm = TSDBClient("http://localhost:8428", "VictoriaMetrics")
+
+        metric_to_check = "active_controllers_total"
+        for attempt in range(20):
+            prom_result = prom.query(metric_to_check)
+            vm_result = vm.query(metric_to_check)
+            prom_has = len(prom_result.get("data", {}).get("result", [])) > 0
+            vm_has = len(vm_result.get("data", {}).get("result", [])) > 0
+            if prom_has and vm_has:
+                print(f"Both backends have '{metric_to_check}' (attempt {attempt + 1})")
+                break
+            await asyncio.sleep(1)
+        else:
+            warnings.warn(
+                f"'{metric_to_check}' not found in both backends after 20s "
+                f"(Prometheus={prom_has}, VM={vm_has})"
+            )
+
+        # ------------------------------------------------------------------
+        # 3. Steady-state: let the game run and collect metrics
+        # ------------------------------------------------------------------
+        window_start = time.time()
+        print(f"Steady-state window: {GAME_DURATION_SECONDS}s ...")
+        await asyncio.sleep(GAME_DURATION_SECONDS)
+        window_end = time.time()
+        print("Steady-state complete")
+
+        # ------------------------------------------------------------------
+        # 4. End the game
+        # ------------------------------------------------------------------
+        await force_end_game(game_client, collector, timeout=10)
+        print("Game ended")
+
+    await game_channel.close()
+
+    # Allow a brief flush period for in-flight remote writes
+    await asyncio.sleep(3)
+
+    # ------------------------------------------------------------------
+    # 5. Query both backends for benchmark metrics
+    # ------------------------------------------------------------------
+    rows = []
+    divergence_warnings = []
+
+    for metric in BENCHMARK_METRICS:
+        prom_samples = prom.sample_count(metric, window_start, window_end)
+        vm_samples = vm.sample_count(metric, window_start, window_end)
+        prom_series = prom.series_count(metric)
+        vm_series = vm.series_count(metric)
+
+        # Compute divergence
+        max_samples = max(prom_samples, vm_samples, 1)
+        divergence = abs(prom_samples - vm_samples) / max_samples
+
+        rows.append([
+            metric,
+            prom_samples,
+            vm_samples,
+            prom_series,
+            vm_series,
+            f"{divergence:.1%}",
+        ])
+
+        if divergence > SAMPLE_DIVERGENCE_THRESHOLD:
+            divergence_warnings.append(
+                f"{metric}: divergence {divergence:.1%} "
+                f"(Prometheus={prom_samples}, VM={vm_samples})"
+            )
+
+    # ------------------------------------------------------------------
+    # 6. Container resource usage
+    # ------------------------------------------------------------------
+    prom_stats = _get_container_stats("joustmania-prometheus")
+    vm_stats = _get_container_stats("joustmania-victoria-metrics")
+
+    resource_rows = [
+        ["CPU %", prom_stats["cpu_percent"], vm_stats["cpu_percent"]],
+        ["Memory (MB)", prom_stats["memory_mb"], vm_stats["memory_mb"]],
+    ]
+
+    prom.close()
+    vm.close()
+
+    # ------------------------------------------------------------------
+    # 7. Print results
+    # ------------------------------------------------------------------
+    print("\n" + "=" * 80)
+    print("TSDB Benchmark Results: Prometheus vs VictoriaMetrics")
+    print(f"Steady-state window: {GAME_DURATION_SECONDS}s, 4 controllers, JoustFFA")
+    print("=" * 80)
+
+    print("\nMetric Samples:")
+    print(tabulate(
+        rows,
+        headers=["Metric", "Prom Samples", "VM Samples", "Prom Series", "VM Series", "Divergence"],
+        tablefmt="grid",
+    ))
+
+    print("\nResource Usage (snapshot at end of benchmark):")
+    print(tabulate(
+        resource_rows,
+        headers=["Resource", "Prometheus", "VictoriaMetrics"],
+        tablefmt="grid",
+    ))
+
+    # ------------------------------------------------------------------
+    # 8. Warn (do NOT assert) on divergence
+    # ------------------------------------------------------------------
+    if divergence_warnings:
+        msg = (
+            f"Sample count divergence >{SAMPLE_DIVERGENCE_THRESHOLD:.0%} "
+            f"detected in {len(divergence_warnings)} metric(s):\n"
+            + "\n".join(f"  - {w}" for w in divergence_warnings)
+        )
+        warnings.warn(msg)
+
+    print("\nBenchmark complete (informational only -- no hard assertions).")

--- a/tests/benchmark/test_tsdb_comparison.py
+++ b/tests/benchmark/test_tsdb_comparison.py
@@ -85,6 +85,12 @@ PI5_CPU_SCALING_FACTOR = 2.5
 CONCURRENT_DASHBOARDS = 3
 READ_STRESS_CYCLES = 10
 
+# Cardinality stress: simulate adding game_id labels across many game sessions.
+# Each "game" creates N_controllers new series per metric, accumulating over
+# CARDINALITY_GAMES sessions — mimicking a party night.
+CARDINALITY_GAMES = 50
+CARDINALITY_METRICS_PER_PLAYER = 10
+
 
 class TSDBClient:
     """Thin wrapper around the Prometheus HTTP query API.
@@ -243,7 +249,104 @@ def _percentiles(values: list[float]) -> tuple[float, float, float]:
     return (p50, p95, p99)
 
 
-@pytest.mark.timeout(300)
+def _build_otlp_payload(
+    game_idx: int, controllers: int, metrics_per_player: int, timestamp_ns: int
+) -> dict:
+    """Build an OTLP JSON metrics payload for one game session.
+
+    Creates ``controllers * metrics_per_player`` gauge data points, each
+    with a unique ``{game_id, serial}`` label combination.
+    """
+    data_points = []
+    for ctrl in range(controllers):
+        for m in range(metrics_per_player):
+            data_points.append(
+                {
+                    "asDouble": 1.0 + (game_idx * 0.01) + (ctrl * 0.001),
+                    "timeUnixNano": str(timestamp_ns),
+                    "attributes": [
+                        {
+                            "key": "game_id",
+                            "value": {"stringValue": f"game_{game_idx:04d}"},
+                        },
+                        {
+                            "key": "serial",
+                            "value": {"stringValue": f"MOCK{ctrl:04d}"},
+                        },
+                        {
+                            "key": "metric_idx",
+                            "value": {"stringValue": str(m)},
+                        },
+                    ],
+                }
+            )
+
+    return {
+        "resourceMetrics": [
+            {
+                "resource": {
+                    "attributes": [
+                        {
+                            "key": "service.name",
+                            "value": {"stringValue": "cardinality-bench"},
+                        }
+                    ]
+                },
+                "scopeMetrics": [
+                    {
+                        "metrics": [
+                            {
+                                "name": "bench_player_gauge",
+                                "gauge": {"dataPoints": data_points},
+                            }
+                        ]
+                    }
+                ],
+            }
+        ]
+    }
+
+
+def _push_cardinality_via_otlp(
+    collector_url: str, games: int, controllers: int, metrics_per_player: int
+) -> tuple[int, float]:
+    """Push synthetic high-cardinality metrics through the OTEL Collector.
+
+    Uses the OTLP HTTP endpoint so data fans out to both Prometheus and
+    VictoriaMetrics via the existing pipeline.
+
+    Returns ``(total_series_created, push_duration_seconds)``.
+    """
+    client = httpx.Client(timeout=30.0)
+    timestamp_ns = int(time.time() * 1e9)
+    total_series = 0
+    t0 = time.monotonic()
+
+    for game_idx in range(games):
+        payload = _build_otlp_payload(
+            game_idx, controllers, metrics_per_player, timestamp_ns
+        )
+        resp = client.post(
+            f"{collector_url}/v1/metrics",
+            json=payload,
+            headers={"Content-Type": "application/json"},
+        )
+        if resp.status_code >= 400:
+            warnings.warn(
+                f"OTLP push failed for game {game_idx}: "
+                f"{resp.status_code} {resp.text[:200]}"
+            )
+            break
+        total_series += controllers * metrics_per_player
+        # Advance timestamp by 15s per game to create distinct samples
+        timestamp_ns += 15_000_000_000
+
+    duration = time.monotonic() - t0
+    client.close()
+    return total_series, duration
+
+
+@pytest.mark.timeout(420)
 async def test_tsdb_comparison(docker_compose):
     """Run a JoustFFA game and compare Prometheus vs VictoriaMetrics."""
 
@@ -462,11 +565,116 @@ async def test_tsdb_comparison(docker_compose):
 
     print("Read stress test complete")
 
+    # ------------------------------------------------------------------
+    # 9. Cardinality stress test
+    # ------------------------------------------------------------------
+    # Push synthetic metrics with unique game_id labels through the OTEL
+    # Collector, simulating a party night with many game sessions.
+    # Each game creates controllers * metrics_per_player new series.
+    expected_series = (
+        CARDINALITY_GAMES * CONTROLLER_COUNT * CARDINALITY_METRICS_PER_PLAYER
+    )
+    print(
+        f"\nCardinality stress: {CARDINALITY_GAMES} games x "
+        f"{CONTROLLER_COUNT} controllers x {CARDINALITY_METRICS_PER_PLAYER} metrics "
+        f"= {expected_series:,} synthetic series ..."
+    )
+
+    series_pushed, push_duration = _push_cardinality_via_otlp(
+        "http://localhost:4318",
+        CARDINALITY_GAMES,
+        CONTROLLER_COUNT,
+        CARDINALITY_METRICS_PER_PLAYER,
+    )
+    print(f"Pushed {series_pushed:,} series in {push_duration:.1f}s")
+
+    # Allow collector to flush to both backends
+    await asyncio.sleep(5)
+
+    # Re-create clients (previous ones were closed)
+    prom_card = TSDBClient("http://localhost:9090", "Prometheus")
+    vm_card = TSDBClient("http://localhost:8428", "VictoriaMetrics")
+
+    # Measure series count for the synthetic metric
+    prom_card_series = prom_card.series_count("bench_player_gauge")
+    vm_card_series = vm_card.series_count("bench_player_gauge")
+
+    # Query the high-cardinality metric with different patterns
+    cardinality_queries = [
+        ("bench_player_gauge", "Select all series"),
+        ("count(bench_player_gauge) by (game_id)", "Count by game_id"),
+        ("avg(bench_player_gauge) by (serial)", "Avg by serial"),
+        (
+            "count(count(bench_player_gauge) by (game_id))",
+            "Count distinct games",
+        ),
+    ]
+
+    card_query_rows = []
+    for promql, desc in cardinality_queries:
+        _, prom_ms = prom_card.timed_query(promql)
+        _, vm_ms = vm_card.timed_query(promql)
+        card_query_rows.append([desc, f"{prom_ms:.1f}", f"{vm_ms:.1f}"])
+
+    # Concurrent reads against high-cardinality data
+    prom_card_clients = [
+        TSDBClient("http://localhost:9090", "Prometheus")
+        for _ in range(CONCURRENT_DASHBOARDS)
+    ]
+    vm_card_clients = [
+        TSDBClient("http://localhost:8428", "VictoriaMetrics")
+        for _ in range(CONCURRENT_DASHBOARDS)
+    ]
+
+    card_stress = _run_concurrent_read_stress(
+        prom_card_clients + vm_card_clients,
+        cardinality_queries,
+        READ_STRESS_CYCLES,
+    )
+
+    for c in prom_card_clients + vm_card_clients:
+        c.close()
+
+    prom_card_lat = card_stress["Prometheus"]
+    vm_card_lat = card_stress["VictoriaMetrics"]
+    prom_card_p50, prom_card_p95, prom_card_p99 = _percentiles(prom_card_lat)
+    vm_card_p50, vm_card_p95, vm_card_p99 = _percentiles(vm_card_lat)
+
+    cardinality_summary_rows = [
+        ["Series pushed", series_pushed, series_pushed],
+        ["Series ingested", prom_card_series, vm_card_series],
+        ["Push duration (s)", f"{push_duration:.1f}", f"{push_duration:.1f}"],
+    ]
+
+    card_concurrent_rows = [
+        ["p50 (ms)", f"{prom_card_p50:.1f}", f"{vm_card_p50:.1f}"],
+        ["p95 (ms)", f"{prom_card_p95:.1f}", f"{vm_card_p95:.1f}"],
+        ["p99 (ms)", f"{prom_card_p99:.1f}", f"{vm_card_p99:.1f}"],
+    ]
+
+    # Resource snapshot after cardinality injection
+    prom_card_stats = _get_container_stats("joustmania-prometheus")
+    vm_card_stats = _get_container_stats("joustmania-victoria-metrics")
+
+    card_resource_rows = [
+        ["CPU %", prom_card_stats["cpu_percent"], vm_card_stats["cpu_percent"]],
+        [
+            "CPU % (Pi 5 est.)",
+            round(prom_card_stats["cpu_percent"] * PI5_CPU_SCALING_FACTOR, 2),
+            round(vm_card_stats["cpu_percent"] * PI5_CPU_SCALING_FACTOR, 2),
+        ],
+        ["Memory (MB)", prom_card_stats["memory_mb"], vm_card_stats["memory_mb"]],
+    ]
+
+    prom_card.close()
+    vm_card.close()
+    print("Cardinality stress test complete")
+
     prom.close()
     vm.close()
 
     # ------------------------------------------------------------------
-    # 9. Print results
+    # 10. Print results
     # ------------------------------------------------------------------
     print("\n" + "=" * 80)
     print("TSDB Benchmark Results: Prometheus vs VictoriaMetrics")
@@ -549,8 +757,50 @@ async def test_tsdb_comparison(docker_compose):
         )
     )
 
+    print(
+        f"\nCardinality Stress ({CARDINALITY_GAMES} games x "
+        f"{CONTROLLER_COUNT} controllers x {CARDINALITY_METRICS_PER_PLAYER} metrics/player):"
+    )
+    print(
+        tabulate(
+            cardinality_summary_rows,
+            headers=["Metric", "Prometheus", "VictoriaMetrics"],
+            tablefmt="grid",
+        )
+    )
+
+    print("\nQuery Latency on High-Cardinality Data (sequential):")
+    print(
+        tabulate(
+            card_query_rows,
+            headers=["Query", "Prom (ms)", "VM (ms)"],
+            tablefmt="grid",
+        )
+    )
+
+    print(
+        f"\nConcurrent Reads on High-Cardinality Data "
+        f"({CONCURRENT_DASHBOARDS} dashboards x {READ_STRESS_CYCLES} cycles):"
+    )
+    print(
+        tabulate(
+            card_concurrent_rows,
+            headers=["Metric", "Prometheus", "VictoriaMetrics"],
+            tablefmt="grid",
+        )
+    )
+
+    print("\nResource Usage After Cardinality Injection:")
+    print(
+        tabulate(
+            card_resource_rows,
+            headers=["Resource", "Prometheus", "VictoriaMetrics"],
+            tablefmt="grid",
+        )
+    )
+
     # ------------------------------------------------------------------
-    # 10. Warn (do NOT assert) on divergence / query errors
+    # 11. Warn (do NOT assert) on divergence / query errors
     # ------------------------------------------------------------------
     if divergence_warnings:
         msg = (

--- a/tests/benchmark/test_tsdb_comparison.py
+++ b/tests/benchmark/test_tsdb_comparison.py
@@ -6,9 +6,14 @@ identical metric workloads pushed via OTEL Collector remote_write.
 
 This test is informational only -- no hard assertions on benchmark results.
 Differences >10% in sample counts trigger warnings for investigation.
+
+Environment variables:
+    BENCHMARK_CONTROLLERS: Number of mock controllers (default 4, max 36)
+    BENCHMARK_DURATION: Steady-state duration in seconds (default 30)
 """
 
 import asyncio
+import os
 import time
 import warnings
 
@@ -34,8 +39,9 @@ BENCHMARK_METRICS = [
     "game_active_players",
 ]
 
-# Steady-state game duration in seconds
-GAME_DURATION_SECONDS = 30
+# Configurable via environment
+CONTROLLER_COUNT = int(os.getenv("BENCHMARK_CONTROLLERS", "4"))
+GAME_DURATION_SECONDS = int(os.getenv("BENCHMARK_DURATION", "30"))
 
 # Maximum acceptable sample count divergence (fraction)
 SAMPLE_DIVERGENCE_THRESHOLD = 0.10
@@ -148,8 +154,8 @@ async def test_tsdb_comparison(docker_compose):
     # ------------------------------------------------------------------
     # 1. Set up controllers and start a game
     # ------------------------------------------------------------------
-    serials = await setup_mock_controllers(docker_compose, count=4)
-    print(f"\nControllers ready: {serials}")
+    serials = await setup_mock_controllers(docker_compose, count=CONTROLLER_COUNT)
+    print(f"\nControllers ready: {len(serials)} controllers ({serials[:3]}{'...' if len(serials) > 3 else ''})")
 
     game_client, game_channel = await get_game_client(docker_compose)
 
@@ -254,7 +260,7 @@ async def test_tsdb_comparison(docker_compose):
     # ------------------------------------------------------------------
     print("\n" + "=" * 80)
     print("TSDB Benchmark Results: Prometheus vs VictoriaMetrics")
-    print(f"Steady-state window: {GAME_DURATION_SECONDS}s, 4 controllers, JoustFFA")
+    print(f"Steady-state window: {GAME_DURATION_SECONDS}s, {CONTROLLER_COUNT} controllers, JoustFFA")
     print("=" * 80)
 
     print("\nMetric Samples:")

--- a/uv.lock
+++ b/uv.lock
@@ -6,6 +6,7 @@ requires-python = ">=3.11, <3.13"
 members = [
     "joustmania",
     "joustmania-audio",
+    "joustmania-benchmark-tests",
     "joustmania-controller-manager",
     "joustmania-game-coordinator",
     "joustmania-integration-tests",
@@ -13,6 +14,19 @@ members = [
     "joustmania-menu",
     "joustmania-pairing-daemon",
     "joustmania-proto",
+]
+
+[[package]]
+name = "anyio"
+version = "4.12.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/96/f0/5eb65b2bb0d09ac6776f2eb54adee6abe8228ea05b20a5ad0e4945de8aac/anyio-4.12.1.tar.gz", hash = "sha256:41cfcc3a4c85d3f05c932da7c26d0201ac36f72abd4435ba90d0464a3ffed703", size = 228685, upload-time = "2026-01-06T11:45:21.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/0e/27be9fdef66e72d64c0cdc3cc2823101b80585f8119b5c112c2e8f5f7dab/anyio-4.12.1-py3-none-any.whl", hash = "sha256:d405828884fc140aa80a3c667b8beed277f1dfedec42ba031bd6ac3db606ab6c", size = 113592, upload-time = "2026-01-06T11:45:19.497Z" },
 ]
 
 [[package]]
@@ -328,6 +342,15 @@ wheels = [
 ]
 
 [[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
 name = "hidapi"
 version = "0.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -353,6 +376,34 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/af/ef/e2fa4d795235eb09951f806bbfdbd766d1be805df448d67918e828b7cb31/hidapi-0.15.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:35eb5797d86306bd67aee80ad8973ab0a0b4e6d54018d3efb328767d0e8c9373", size = 717599, upload-time = "2025-12-09T09:45:37.825Z" },
     { url = "https://files.pythonhosted.org/packages/e7/a7/9b7fe9acd09ed90d702f8cc01190ab53e01d5022c21808b079144bc9017d/hidapi-0.15.0-cp312-cp312-win32.whl", hash = "sha256:ce6f99554dae15c48cd89a12d5aede77a92a8bd184b45d0b257a17c97e053cdb", size = 60136, upload-time = "2025-12-09T09:45:40.612Z" },
     { url = "https://files.pythonhosted.org/packages/7f/35/f9e2d3ead60b573140546b041dd41c78a48c0e6b573d61a03130adccd32e/hidapi-0.15.0-cp312-cp312-win_amd64.whl", hash = "sha256:9abc71a62bf8a8f1d70a6fd3613f86feb37ddb67e05ed934e734df79e27bf4f6", size = 67073, upload-time = "2025-12-09T09:45:39.261Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
 [[package]]
@@ -459,6 +510,35 @@ requires-dist = [
     { name = "resampy", specifier = ">=0.4.0" },
 ]
 provides-extras = ["test"]
+
+[[package]]
+name = "joustmania-benchmark-tests"
+version = "1.0.0"
+source = { editable = "tests/benchmark" }
+dependencies = [
+    { name = "docker" },
+    { name = "grpcio" },
+    { name = "httpx" },
+    { name = "joustmania-integration-tests" },
+    { name = "joustmania-proto" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "tabulate" },
+    { name = "testcontainers" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "docker", specifier = ">=7.0.0" },
+    { name = "grpcio", specifier = ">=1.50.0" },
+    { name = "httpx", specifier = ">=0.27.0" },
+    { name = "joustmania-integration-tests", editable = "tests/integration" },
+    { name = "joustmania-proto", editable = "proto" },
+    { name = "pytest", specifier = ">=7.0.0" },
+    { name = "pytest-asyncio", specifier = ">=0.23.0" },
+    { name = "tabulate", specifier = ">=0.9.0" },
+    { name = "testcontainers", specifier = ">=4.0.0" },
+]
 
 [[package]]
 name = "joustmania-controller-manager"
@@ -1343,6 +1423,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/18/5d/3bf57dcd21979b887f014ea83c24ae194cfcd12b9e0fda66b957c69d1fca/setuptools-80.9.0.tar.gz", hash = "sha256:f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c", size = 1319958, upload-time = "2025-05-27T00:56:51.443Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a3/dc/17031897dae0efacfea57dfd3a82fdd2a2aeb58e0ff71b77b87e44edc772/setuptools-80.9.0-py3-none-any.whl", hash = "sha256:062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922", size = 1201486, upload-time = "2025-05-27T00:56:49.664Z" },
+]
+
+[[package]]
+name = "tabulate"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/fe/802052aecb21e3797b8f7902564ab6ea0d60ff8ca23952079064155d1ae1/tabulate-0.9.0.tar.gz", hash = "sha256:0095b12bf5966de529c0feb1fa08671671b3368eec77d7ef7ab114be2c068b3c", size = 81090, upload-time = "2022-10-06T17:21:48.54Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/40/44/4a5f08c96eb108af5cb50b41f76142f0afa346dfa99d5296fe7202a11854/tabulate-0.9.0-py3-none-any.whl", hash = "sha256:024ca478df22e9340661486f85298cff5f6dcdba14f3813e8830015b9ed1948f", size = 35252, upload-time = "2022-10-06T17:21:44.262Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Adds a benchmark test that runs Prometheus and VictoriaMetrics side-by-side, both receiving identical 100ms metric pushes from the OTEL Collector
- Compares sample counts, query latency (instant + range), and resource usage (CPU%, memory via Docker API)
- Prints a tabulated comparison table; warns if sample counts diverge >10%
- No hard assertions — results inform the architectural decision on whether to keep VM

### New files
- `docker-compose.benchmark.yml` — compose override: enables Prometheus `--web.enable-remote-write-receiver`, exposes ports 9090/8428
- `services/otel-collector/config.benchmark.yaml` — adds `prometheusremotewrite/prometheus` exporter to main metrics pipeline
- `tests/benchmark/` — test package with `TSDBClient` helper, 5-metric comparison, Docker container stats

### Run
```bash
make benchmark-tsdb
```

Not included in `make test` — requires explicit invocation.

## Test plan
- [x] `make lint` passes
- [ ] `make benchmark-tsdb` runs the full comparison and prints results table
- [ ] Review output: sample counts, query latencies, resource usage
- [ ] Check for divergence warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)