### PR TITLE
fix: improve ALSA audio reliability with retry and PCM fallback

### DIFF
--- a/services/audio/alsa_config.py
+++ b/services/audio/alsa_config.py
@@ -1,10 +1,19 @@
-"""Auto-detect ALSA audio card and configure /etc/asound.conf at startup."""
+"""Auto-detect ALSA audio card and configure /etc/asound.conf at startup.
+
+Includes retry logic for startup races (when /dev/snd is not yet ready)
+and stores the detected card number for fallback PCM device names.
+"""
 
 import logging
+import time
 
 logger = logging.getLogger(__name__)
 
 ASOUND_CONF_PATH = "/etc/asound.conf"
+
+# Module-level state: the card number detected at startup.
+# Used by music_player.py to build fallback device names when dmix fails.
+_detected_card: int = 0
 
 ASOUND_TEMPLATE = """\
 # ALSA configuration for JoustMania container
@@ -37,6 +46,15 @@ ctl.!default {{
 }}
 """
 
+# Retry parameters for auto-detection at startup
+_DETECT_MAX_RETRIES = 3
+_DETECT_RETRY_DELAY_S = 1.0
+
+
+def get_detected_card() -> int:
+    """Return the card number detected (or configured) at startup."""
+    return _detected_card
+
 
 def configure_alsa_device(card: str = "auto") -> None:
     """Detect the ALSA card and write /etc/asound.conf.
@@ -44,7 +62,9 @@ def configure_alsa_device(card: str = "auto") -> None:
     Args:
         card: "auto" to detect via alsaaudio, or a card number string (e.g. "1").
     """
+    global _detected_card
     card_number = _resolve_card_number(card)
+    _detected_card = card_number
     _write_asound_conf(card_number)
 
 
@@ -62,26 +82,46 @@ def _resolve_card_number(card: str) -> int:
 
 
 def _auto_detect_card() -> int:
-    """Auto-detect the first available ALSA card, falling back to 0."""
-    try:
-        import alsaaudio
+    """Auto-detect the first available ALSA card with retry, falling back to 0.
 
-        indexes = alsaaudio.card_indexes()
-    except Exception:
-        logger.warning("Failed to enumerate ALSA cards, falling back to card 0", exc_info=True)
-        return 0
+    Retries up to _DETECT_MAX_RETRIES times with a delay between attempts.
+    This handles the startup race where /dev/snd is not yet populated when
+    the container starts (common with USB audio on Raspberry Pi).
+    """
+    for attempt in range(_DETECT_MAX_RETRIES):
+        try:
+            import alsaaudio
 
-    if not indexes:
-        logger.warning("No ALSA cards found, falling back to card 0")
-        return 0
+            indexes = alsaaudio.card_indexes()
+        except Exception:
+            if attempt == _DETECT_MAX_RETRIES - 1:
+                logger.warning(
+                    "Failed to enumerate ALSA cards after %d attempts, falling back to card 0",
+                    _DETECT_MAX_RETRIES,
+                    exc_info=True,
+                )
+                return 0
+            logger.info("ALSA card enumeration failed (attempt %d/%d), retrying...", attempt + 1, _DETECT_MAX_RETRIES)
+            time.sleep(_DETECT_RETRY_DELAY_S)
+            continue
 
-    card_index = indexes[0]
-    try:
-        name = alsaaudio.card_name(card_index)[0]
-    except Exception:
-        name = "unknown"
-    logger.info("Detected ALSA card indexes: %s — using card %d (%s)", indexes, card_index, name)
-    return card_index
+        if not indexes:
+            if attempt == _DETECT_MAX_RETRIES - 1:
+                logger.warning("No ALSA cards found after %d attempts, falling back to card 0", _DETECT_MAX_RETRIES)
+                return 0
+            logger.info("No ALSA cards found (attempt %d/%d), retrying...", attempt + 1, _DETECT_MAX_RETRIES)
+            time.sleep(_DETECT_RETRY_DELAY_S)
+            continue
+
+        card_index = indexes[0]
+        try:
+            name = alsaaudio.card_name(card_index)[0]
+        except Exception:
+            name = "unknown"
+        logger.info("Detected ALSA card indexes: %s — using card %d (%s)", indexes, card_index, name)
+        return card_index
+
+    return 0
 
 
 def _write_asound_conf(card_number: int) -> None:

--- a/services/audio/music_player.py
+++ b/services/audio/music_player.py
@@ -177,6 +177,50 @@ def _write_samples(device, write_size, samples, stop_proc, generation, play_gen)
             return
 
 
+def _get_fallback_devices() -> list[str]:
+    """Return a list of PCM device names to try, in priority order.
+
+    Order: "default" (dmix) → "plughw:N,0" (direct + format conversion) → "hw:N,0" (raw).
+    The card number N comes from the startup auto-detection in alsa_config.
+    """
+    try:
+        from services.audio.alsa_config import get_detected_card
+
+        card = get_detected_card()
+    except Exception:
+        card = 0
+    return ["default", f"plughw:{card},0", f"hw:{card},0"]
+
+
+def _open_pcm(channels: int, rate: int, period: int) -> alsaaudio.PCM:
+    """Open an ALSA PCM device, trying fallback devices if dmix fails.
+
+    Tries each device in the fallback chain. This handles:
+    - Stale dmix IPC (error 524 / ENOTRECOVERABLE) after container crash
+    - Wrong card in asound.conf
+    - Permission issues with dmix shared memory
+    """
+    devices = _get_fallback_devices()
+    last_error = None
+
+    for device_name in devices:
+        try:
+            pcm = alsaaudio.PCM(
+                channels=channels,
+                rate=rate,
+                format=alsaaudio.PCM_FORMAT_S16_LE,
+                periodsize=period,
+                device=device_name,
+            )
+            logger.info("Opened ALSA PCM device: %s", device_name)
+            return pcm
+        except Exception as e:
+            logger.warning("Failed to open ALSA device '%s': %s", device_name, e)
+            last_error = e
+
+    raise last_error  # type: ignore[misc]
+
+
 def _play_loaded_song(wav_data, period, period_bytes, ratio, volume, stop_proc, generation, play_gen):
     """
     Open and play a loaded WAV through ALSA with real-time resampling.
@@ -189,12 +233,10 @@ def _play_loaded_song(wav_data, period, period_bytes, ratio, volume, stop_proc, 
         return False
     wf.rewind()
 
-    device = alsaaudio.PCM(
+    device = _open_pcm(
         channels=wf.getnchannels(),
         rate=wf.getframerate(),
-        format=alsaaudio.PCM_FORMAT_S16_LE,
-        periodsize=period,
-        device="default",
+        period=period,
     )
 
     _write_samples(

--- a/services/audio/tests/test_alsa_config.py
+++ b/services/audio/tests/test_alsa_config.py
@@ -8,6 +8,7 @@ from services.audio.alsa_config import (
     _resolve_card_number,
     _write_asound_conf,
     configure_alsa_device,
+    get_detected_card,
 )
 
 
@@ -30,23 +31,46 @@ class TestResolveCardNumber:
 
 
 class TestAutoDetectCard:
+    @patch("services.audio.alsa_config.time.sleep")
     @patch("alsaaudio.card_name", return_value=("Headphones", "Headphones Audio"))
     @patch("alsaaudio.card_indexes", return_value=[0, 1])
-    def test_returns_first_card_index(self, mock_indexes, mock_name):
+    def test_returns_first_card_index(self, mock_indexes, mock_name, _mock_sleep):
         assert _auto_detect_card() == 0
 
+    @patch("services.audio.alsa_config.time.sleep")
     @patch("alsaaudio.card_name", return_value=("USB Audio", "USB Audio Device"))
     @patch("alsaaudio.card_indexes", return_value=[2, 5])
-    def test_returns_nonzero_first_index(self, mock_indexes, mock_name):
+    def test_returns_nonzero_first_index(self, mock_indexes, mock_name, _mock_sleep):
         assert _auto_detect_card() == 2
 
+    @patch("services.audio.alsa_config.time.sleep")
     @patch("alsaaudio.card_indexes", return_value=[])
-    def test_empty_cards_returns_zero(self, mock_indexes):
+    def test_empty_cards_returns_zero_after_retries(self, mock_indexes, mock_sleep):
         assert _auto_detect_card() == 0
+        # Should have retried _DETECT_MAX_RETRIES times
+        assert mock_indexes.call_count == 3
+        assert mock_sleep.call_count == 2  # sleeps between retries, not after last
 
+    @patch("services.audio.alsa_config.time.sleep")
     @patch("alsaaudio.card_indexes", side_effect=Exception("no ALSA"))
-    def test_exception_returns_zero(self, mock_indexes):
+    def test_exception_returns_zero_after_retries(self, mock_indexes, mock_sleep):
         assert _auto_detect_card() == 0
+        assert mock_indexes.call_count == 3
+
+    @patch("services.audio.alsa_config.time.sleep")
+    @patch("alsaaudio.card_name", return_value=("USB Audio", "USB Audio Device"))
+    @patch("alsaaudio.card_indexes", side_effect=[[], [1]])
+    def test_retry_succeeds_on_second_attempt(self, mock_indexes, mock_name, mock_sleep):
+        assert _auto_detect_card() == 1
+        assert mock_indexes.call_count == 2
+        mock_sleep.assert_called_once()
+
+    @patch("services.audio.alsa_config.time.sleep")
+    @patch("alsaaudio.card_name", return_value=("Headphones", "Headphones Audio"))
+    @patch("alsaaudio.card_indexes", side_effect=[Exception("not ready"), [0]])
+    def test_retry_after_exception_succeeds(self, mock_indexes, mock_name, mock_sleep):
+        assert _auto_detect_card() == 0
+        assert mock_indexes.call_count == 2
 
 
 class TestWriteAsoundConf:
@@ -78,3 +102,27 @@ class TestConfigureAlsaDevice:
         configure_alsa_device("3")
         mock_resolve.assert_called_once_with("3")
         mock_write.assert_called_once_with(3)
+
+    @patch("services.audio.alsa_config._write_asound_conf")
+    @patch("services.audio.alsa_config._resolve_card_number", return_value=2)
+    def test_stores_detected_card(self, mock_resolve, mock_write):
+        configure_alsa_device("auto")
+        assert get_detected_card() == 2
+
+
+class TestGetDetectedCard:
+    def test_default_is_zero(self):
+        import services.audio.alsa_config as mod
+
+        original = mod._detected_card
+        try:
+            mod._detected_card = 0
+            assert get_detected_card() == 0
+        finally:
+            mod._detected_card = original
+
+    @patch("services.audio.alsa_config._write_asound_conf")
+    @patch("services.audio.alsa_config._resolve_card_number", return_value=5)
+    def test_updated_by_configure(self, _mock_resolve, _mock_write):
+        configure_alsa_device("5")
+        assert get_detected_card() == 5

--- a/services/audio/tests/test_music_player.py
+++ b/services/audio/tests/test_music_player.py
@@ -10,8 +10,10 @@ import pytest
 from services.audio.music_player import (
     DummyMusicPlayer,
     _clamp_ratio,
+    _get_fallback_devices,
     _get_song_pattern,
     _load_song_from_pattern,
+    _open_pcm,
     _read_samples,
     _resample_audio,
     _resample_chunk,
@@ -637,3 +639,77 @@ class TestProcessRespawn:
             # Old process should have been terminated
             mock_proc.terminate.assert_called_once()
             mock_proc.join.assert_called_once_with(timeout=1.0)
+
+
+class TestGetFallbackDevices:
+    """Tests for _get_fallback_devices."""
+
+    @patch("services.audio.alsa_config.get_detected_card", return_value=0)
+    def test_default_card_zero(self, _mock_card):
+        devices = _get_fallback_devices()
+        assert devices == ["default", "plughw:0,0", "hw:0,0"]
+
+    @patch("services.audio.alsa_config.get_detected_card", return_value=2)
+    def test_nonzero_card(self, _mock_card):
+        devices = _get_fallback_devices()
+        assert devices == ["default", "plughw:2,0", "hw:2,0"]
+
+    def test_fallback_on_import_error(self):
+        with patch("services.audio.alsa_config.get_detected_card", side_effect=Exception("import error")):
+            devices = _get_fallback_devices()
+        assert devices == ["default", "plughw:0,0", "hw:0,0"]
+
+
+class TestOpenPcm:
+    """Tests for _open_pcm with fallback device chain."""
+
+    @patch("services.audio.music_player._get_fallback_devices", return_value=["default", "plughw:0,0", "hw:0,0"])
+    @patch("services.audio.music_player.alsaaudio")
+    def test_opens_default_device_first(self, mock_alsa, _mock_devices):
+        mock_pcm = MagicMock()
+        mock_alsa.PCM.return_value = mock_pcm
+        mock_alsa.PCM_FORMAT_S16_LE = 2
+
+        result = _open_pcm(channels=2, rate=44100, period=4096)
+
+        assert result is mock_pcm
+        mock_alsa.PCM.assert_called_once_with(channels=2, rate=44100, format=2, periodsize=4096, device="default")
+
+    @patch("services.audio.music_player._get_fallback_devices", return_value=["default", "plughw:1,0", "hw:1,0"])
+    @patch("services.audio.music_player.alsaaudio")
+    def test_falls_back_to_plughw_on_dmix_failure(self, mock_alsa, _mock_devices):
+        mock_pcm = MagicMock()
+        mock_alsa.PCM.side_effect = [Exception("unable to open slave"), mock_pcm]
+        mock_alsa.PCM_FORMAT_S16_LE = 2
+
+        result = _open_pcm(channels=2, rate=44100, period=4096)
+
+        assert result is mock_pcm
+        assert mock_alsa.PCM.call_count == 2
+        # Second call should use plughw
+        assert mock_alsa.PCM.call_args_list[1][1]["device"] == "plughw:1,0"
+
+    @patch("services.audio.music_player._get_fallback_devices", return_value=["default", "plughw:0,0", "hw:0,0"])
+    @patch("services.audio.music_player.alsaaudio")
+    def test_falls_back_to_hw_when_all_others_fail(self, mock_alsa, _mock_devices):
+        mock_pcm = MagicMock()
+        mock_alsa.PCM.side_effect = [
+            Exception("dmix error 524"),
+            Exception("plughw failed"),
+            mock_pcm,
+        ]
+        mock_alsa.PCM_FORMAT_S16_LE = 2
+
+        result = _open_pcm(channels=2, rate=44100, period=4096)
+
+        assert result is mock_pcm
+        assert mock_alsa.PCM.call_count == 3
+
+    @patch("services.audio.music_player._get_fallback_devices", return_value=["default", "plughw:0,0", "hw:0,0"])
+    @patch("services.audio.music_player.alsaaudio")
+    def test_raises_when_all_devices_fail(self, mock_alsa, _mock_devices):
+        mock_alsa.PCM.side_effect = Exception("no audio hardware")
+        mock_alsa.PCM_FORMAT_S16_LE = 2
+
+        with pytest.raises(Exception, match="no audio hardware"):
+            _open_pcm(channels=2, rate=44100, period=4096)


### PR DESCRIPTION
## Summary
- Add retry logic (3 attempts, 1s delay) to ALSA card auto-detection for the startup race where `/dev/snd` isn't populated yet (common with USB audio on Raspberry Pi 5)
- Add PCM device fallback chain: when dmix fails (error 524 / stale IPC after container crash), fall back to `plughw:N,0` then direct `hw:N,0` access
- Store detected card number in module state via `get_detected_card()` so the fallback chain knows which hardware card to target

## Test plan
- [x] All 215 audio service unit tests pass
- [x] `make lint` clean
- [ ] Verify on Pi 5 with USB audio: container restart no longer produces ALSA errors
- [ ] Verify dmix recovery: kill audio container, restart, confirm music plays

🤖 Generated with [Claude Code](https://claude.com/claude-code)