### PR TITLE
fix: link ChangeTempo spans to main game trace

### DIFF
--- a/services/game_coordinator/games/base.py
+++ b/services/game_coordinator/games/base.py
@@ -1553,8 +1553,8 @@ class BaseGameMode(ABC):
         """
         Apply a tempo change to the music track.
 
-        Sends gRPC request with gameplay span context, logs the change,
-        records span events, and updates internal state and metrics.
+        Creates a child span of music_tempo_control, sends gRPC request,
+        logs the change, and updates internal state and metrics.
 
         Args:
             target_tempo: The target tempo to transition to
@@ -1562,13 +1562,16 @@ class BaseGameMode(ABC):
         from proto import audio_pb2
 
         old_tempo = self.music_speed
+        direction = "speed_up" if self.speed_up else "slow_down"
 
-        # Use gameplay context so gRPC span appears as child of gameplay_phase
-        token = None
-        if self.gameplay_span_context:
-            token = otel_context.attach(self.gameplay_span_context)
+        # Create a child span — the gRPC ChangeTempo call inherits this context
+        # naturally, so the audio service span links back to the game trace.
+        with tracer.start_as_current_span("music_tempo_change") as span:
+            span.set_attribute("old_tempo", old_tempo)
+            span.set_attribute("new_tempo", target_tempo)
+            span.set_attribute("dead_count", self.dead_count)
+            span.set_attribute("direction", direction)
 
-        try:
             await self.audio_client.ChangeTempo(
                 audio_pb2.ChangeTempoRequest(
                     track_id=self.music_track_id,
@@ -1576,23 +1579,8 @@ class BaseGameMode(ABC):
                     transition_duration=MUSIC_TRANSITION_DURATION,
                 )
             )
-        finally:
-            if token:
-                otel_context.detach(token)
 
         logger.info(f"Music tempo changing: {old_tempo:.2f} -> {target_tempo:.2f}")
-
-        # Add span event to gameplay span for tempo change
-        if self.gameplay_span:
-            self.gameplay_span.add_event(
-                "music_tempo_change",
-                attributes={
-                    "old_tempo": old_tempo,
-                    "new_tempo": target_tempo,
-                    "dead_count": self.dead_count,
-                    "direction": "speed_up" if self.speed_up else "slow_down",
-                },
-            )
 
         # Update state
         self.music_speed = target_tempo
@@ -1627,13 +1615,20 @@ class BaseGameMode(ABC):
 
         Runs alongside the main game loop and periodically checks
         if tempo should change based on game progression.
+
+        Creates a music_tempo_control span explicitly parented to the
+        gameplay_phase span. This ensures all ChangeTempo gRPC calls
+        appear in the main game trace (asyncio.create_task copies context
+        but the gRPC interceptor needs an active span to propagate).
         """
         logger.info("Music loop started")
 
         try:
-            while self.running:
-                await self._check_music_speed()
-                await asyncio.sleep(0.1)  # Check every 100ms
+            with tracer.start_as_current_span("music_tempo_control", context=self.gameplay_span_context) as span:
+                span.set_attribute("game.id", self.game_id)
+                while self.running:
+                    await self._check_music_speed()
+                    await asyncio.sleep(0.1)  # Check every 100ms
         except asyncio.CancelledError:
             logger.info("Music loop cancelled")
             raise  # Re-raise to properly propagate cancellation

--- a/services/game_coordinator/tests/test_base_helpers.py
+++ b/services/game_coordinator/tests/test_base_helpers.py
@@ -642,27 +642,12 @@ class TestApplyTempoChange:
         assert game.speed_up is True  # Toggled back
 
     @pytest.mark.asyncio
-    async def test_adds_span_event_when_span_exists(self, game):
-        """Should add span event if gameplay_span is set."""
-        mock_span = MagicMock()
-        game.gameplay_span = mock_span
+    async def test_creates_child_span(self, game):
+        """Should create a music_tempo_change child span wrapping the gRPC call."""
+        # The span is created by tracer.start_as_current_span inside _apply_tempo_change.
+        # Verify the method completes successfully (span creation is internal).
         await game._apply_tempo_change(FAST_MUSIC_SPEED)
-        mock_span.add_event.assert_called_once_with(
-            "music_tempo_change",
-            attributes={
-                "old_tempo": SLOW_MUSIC_SPEED,
-                "new_tempo": FAST_MUSIC_SPEED,
-                "dead_count": 0,
-                "direction": "speed_up",
-            },
-        )
-
-    @pytest.mark.asyncio
-    async def test_no_span_event_when_no_span(self, game):
-        """Should not fail when gameplay_span is None."""
-        game.gameplay_span = None
-        # Should not raise
-        await game._apply_tempo_change(FAST_MUSIC_SPEED)
+        game.audio_client.ChangeTempo.assert_called_once()
 
 
 # ========================================================================


### PR DESCRIPTION
## Summary
- ChangeTempo gRPC calls from the `_music_loop()` background task were appearing as separate traces in Jaeger
- Root cause: `asyncio.create_task()` copies context, but the `otel_context.attach/detach` approach didn't propagate correctly through the gRPC interceptor
- Fix: wrap `_music_loop()` in a `music_tempo_control` span explicitly parented to `gameplay_phase` via `context=` parameter, and create `music_tempo_change` child spans for each tempo change

New span hierarchy in Jaeger (collapsible):
```
gameplay_phase
├── player_lifecycle (per player)
└── music_tempo_control              ← new
    ├── music_tempo_change
    │   └── ChangeTempo:1.3x        (audio service)
    └── music_tempo_change
        └── ChangeTempo:1.0x        (audio service)
```

## Test plan
- [x] All 628 game coordinator tests pass
- [x] `make lint` clean
- [ ] Start a game, verify ChangeTempo spans appear under `gameplay_phase > music_tempo_control` in Jaeger
- [ ] Verify `music_tempo_control` span can be collapsed in Jaeger UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)