### PR TITLE
feat: player span hierarchy with names and game_cycle grouping

### DIFF
--- a/services/game_coordinator/games/base.py
+++ b/services/game_coordinator/games/base.py
@@ -114,6 +114,7 @@ class Player:
     """Represents a player in the game."""
 
     serial: str
+    name: str = ""  # Human-readable controller name (e.g., "Blue Phoenix")
     team: int = 0
     alive: bool = True
     color: tuple = (255, 255, 255)
@@ -998,6 +999,13 @@ class BaseGameMode(ABC):
         if not player.alive:
             return  # Dead player, ignore
 
+        # Capture controller name on first frame and update span title
+        if not player.name and controller_state.name:
+            player.name = controller_state.name
+            if player.span:
+                player.span.update_name(f"player: {player.name}")
+                player.span.set_attribute("player.name", player.name)
+
         # Process controller health counters (#571)
         self._process_health(player, serial, controller_state)
 
@@ -1109,12 +1117,20 @@ class BaseGameMode(ABC):
         metrics.players_alive.set(alive_count)
 
         # Extract trace context BEFORE _kill_player_impl() which may close the span.
-        # This ensures the death effect is parented to the player_lifecycle
+        # This ensures the death effect and sound are parented to the player_lifecycle
         # span even after the subclass impl ends it. (#456)
         trace_parent, trace_state = inject_trace_context(player.span)
 
-        # Play death explosion sound (parented to game_cycle via _play_sound)
-        await self._play_sound(Sound.SFX_EXPLOSION, priority=2)
+        # Play death explosion sound under the player's span (player-specific)
+        if player.span:
+            ctx = trace.set_span_in_context(player.span)
+            token = otel_context.attach(ctx)
+            try:
+                await self._play_sound(Sound.SFX_EXPLOSION, priority=2)
+            finally:
+                otel_context.detach(token)
+        else:
+            await self._play_sound(Sound.SFX_EXPLOSION, priority=2)
 
         # Add death event to player's lifecycle span (Phase 3: Per-Player Sensitivity)
         if player.span:
@@ -1715,17 +1731,20 @@ class BaseGameMode(ABC):
         Runs alongside the main game loop and periodically checks
         if tempo should change based on game progression.
 
-        Creates a music_tempo_control span parented to the game_cycle
-        span so all music instrumentation is grouped together in traces.
+        Sets game_cycle as active context so each music_tempo_change span
+        appears directly under game_cycle in traces.
         """
         logger.info("Music loop started")
 
         try:
-            with tracer.start_as_current_span("music_tempo_control", context=self.game_cycle_context) as span:
-                span.set_attribute("game.id", self.game_id)
+            token = otel_context.attach(self.game_cycle_context) if self.game_cycle_context else None
+            try:
                 while self.running:
                     await self._check_music_speed()
                     await asyncio.sleep(0.1)  # Check every 100ms
+            finally:
+                if token is not None:
+                    otel_context.detach(token)
         except asyncio.CancelledError:
             logger.info("Music loop cancelled")
             raise  # Re-raise to properly propagate cancellation

--- a/services/game_coordinator/tests/test_base_helpers.py
+++ b/services/game_coordinator/tests/test_base_helpers.py
@@ -276,6 +276,94 @@ class TestComputeEffectiveThresholds:
 
 
 # ========================================================================
+# _process_controller_state (player name capture)
+# ========================================================================
+
+
+class TestPlayerNameCapture:
+    """Tests for player name capture from gameplay data."""
+
+    @pytest.fixture
+    def game(self):
+        """Create game with a player for name capture tests."""
+        mock_cm = MockControllerManagerService(num_controllers=2)
+        game = FFAGame(
+            controller_manager_client=mock_cm,
+            event_publisher=async_noop,
+            audio_client=None,
+            game_id="test_name",
+        )
+        game.gameplay_stream = MockGameplayStream()
+        game.running = True
+        game.music_speed = SLOW_MUSIC_SPEED
+        game.start_time = time.time()
+        game.players["p1"] = Player(
+            serial="p1",
+            alive=True,
+            color=(255, 0, 0),
+            smoothed_accel=1.0,
+        )
+        game.players["p2"] = Player(
+            serial="p2",
+            alive=True,
+            color=(0, 255, 0),
+            smoothed_accel=1.0,
+        )
+        return game
+
+    @pytest.mark.asyncio
+    async def test_captures_name_from_first_frame(self, game):
+        """Should store controller name on first gameplay data with name."""
+        controller_state = controller_manager_pb2.GameplayData(
+            serial="p1",
+            name="Blue Phoenix",
+            accel=controller_manager_pb2.Vector3(x=0.0, y=0.0, z=1.0),
+        )
+        await game._process_controller_state(controller_state)
+        assert game.players["p1"].name == "Blue Phoenix"
+
+    @pytest.mark.asyncio
+    async def test_updates_span_name(self, game):
+        """Should call update_name on player span with controller name."""
+        mock_span = MagicMock()
+        game.players["p1"].span = mock_span
+        controller_state = controller_manager_pb2.GameplayData(
+            serial="p1",
+            name="Swift Tiger",
+            accel=controller_manager_pb2.Vector3(x=0.0, y=0.0, z=1.0),
+        )
+        await game._process_controller_state(controller_state)
+        mock_span.update_name.assert_called_once_with("player: Swift Tiger")
+        mock_span.set_attribute.assert_any_call("player.name", "Swift Tiger")
+
+    @pytest.mark.asyncio
+    async def test_name_captured_only_once(self, game):
+        """Should not overwrite name on subsequent frames."""
+        game.players["p1"].name = "Blue Phoenix"
+        mock_span = MagicMock()
+        game.players["p1"].span = mock_span
+        controller_state = controller_manager_pb2.GameplayData(
+            serial="p1",
+            name="Different Name",
+            accel=controller_manager_pb2.Vector3(x=0.0, y=0.0, z=1.0),
+        )
+        await game._process_controller_state(controller_state)
+        assert game.players["p1"].name == "Blue Phoenix"
+        mock_span.update_name.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_empty_name_not_captured(self, game):
+        """Should not capture empty name string."""
+        controller_state = controller_manager_pb2.GameplayData(
+            serial="p1",
+            name="",
+            accel=controller_manager_pb2.Vector3(x=0.0, y=0.0, z=1.0),
+        )
+        await game._process_controller_state(controller_state)
+        assert game.players["p1"].name == ""
+
+
+# ========================================================================
 # _process_gameplay_update
 # ========================================================================
 


### PR DESCRIPTION
## Summary

- Add `players` parent span under `gameplay_phase` to group all `player_lifecycle` spans (collapsible in Jaeger)
- Add `game_cycle` span under `gameplay_phase` to group shared instrumentation (countdown sounds, music tempo)
- Player spans renamed to include controller name via `span.update_name()` (e.g. `player: Blue Phoenix`)
- Death explosion sounds stay under `player_lifecycle` (player-specific)
- Countdown sounds (beeps, start) parented to `game_cycle` (shared, not player-specific)
- `music_tempo_change` spans appear directly under `game_cycle` (no intermediate wrapper)
- Timeline marker events on `gameplay_span` for tempo changes

### Before

```
game_coordinator ─ FFA Joust ─────────────────────────────────────────────────
  │
  ├─ initialization_phase ────────────────────┐
  │    └─ (setup, player init, stream, music) │
  │                                           │
  ├─ gameplay_phase ──────────────────────────────────────────────────────────
  │    │
  │    ├─ player_lifecycle [serial=AA:BB:CC] ─────────────────────────────────
  │    │    ├─ countdown_phase
  │    │    │    └─ effect_countdown (controller-manager)
  │    │    ├─ ★ death_warning (event)
  │    │    ├─ PlaySound:explosion (audio)
  │    │    ├─ ★ player_death (event)
  │    │    └─ controller_poll_degraded (if issues)
  │    │
  │    ├─ player_lifecycle [serial=DD:EE:FF] ─────────────────────────────────
  │    │    ├─ countdown_phase
  │    │    │    └─ effect_countdown (controller-manager)
  │    │    └─ ★ game_ended (event)
  │    │
  │    ├─ PlaySound:beep (audio)
  │    ├─ PlaySound:beep (audio)
  │    ├─ PlaySound:start3 (audio)
  │    │
  │    └─ music_tempo_control ────────────────────────────
  │         ├─ music_tempo_change [1.0→1.3]
  │         │    └─ ChangeTempo (audio)
  │         └─ music_tempo_change [1.3→1.0]
  │              └─ ChangeTempo (audio)
  │
  └─ teardown_phase ──────────────────────────┐
       └─ StopMusic, winner effects           │
```

### After

```
game_coordinator ─ FFA Joust ─────────────────────────────────────────────────
  │
  ├─ initialization_phase ────────────────────┐
  │    └─ (setup, player init, stream, music) │
  │                                           │
  ├─ gameplay_phase ──────────────────────────────────────────────────────────
  │    │  ★ music_tempo_change (timeline marker event)
  │    │  ★ music_tempo_change (timeline marker event)
  │    │
  │    ├─ players ────────────────────────────────────────◄── collapsible
  │    │    │
  │    │    ├─ player: Blue Phoenix [serial=AA:BB:CC] ───────────◄── named!
  │    │    │    ├─ countdown_phase
  │    │    │    │    └─ effect_countdown (controller-manager)
  │    │    │    ├─ ★ death_warning (event)
  │    │    │    ├─ PlaySound:explosion (audio)        ◄── stays under player
  │    │    │    ├─ ★ player_death (event)
  │    │    │    ├─ effect_player_death (controller-manager)
  │    │    │    └─ controller_poll_degraded (if issues)
  │    │    │
  │    │    └─ player: Swift Tiger [serial=DD:EE:FF] ────────────◄── named!
  │    │         ├─ countdown_phase
  │    │         │    └─ effect_countdown (controller-manager)
  │    │         └─ ★ game_ended (event)
  │    │
  │    └─ game_cycle ─────────────────────────────────────◄── collapsible
  │         │
  │         ├─ PlaySound:beep (audio)                 ◄── shared sounds
  │         ├─ PlaySound:beep (audio)
  │         ├─ PlaySound:start3 (audio)
  │         │
  │         ├─ music_tempo_change [1.0→1.3]           ◄── flat (no wrapper)
  │         │    └─ ChangeTempo (audio)
  │         └─ music_tempo_change [1.3→1.0]
  │              └─ ChangeTempo (audio)
  │
  └─ teardown_phase ──────────────────────────┐
       └─ StopMusic, winner effects           │
```

### Teams mode variant

```
  ├─ gameplay_phase
  │    │
  │    ├─ players ────────────────────────────────────────
  │    │    │
  │    │    ├─ team_lifecycle [team=Blue] ────────────────
  │    │    │    ├─ player: Blue Phoenix [serial=AA:BB:CC]
  │    │    │    │    ├─ countdown_phase
  │    │    │    │    ├─ PlaySound:explosion (audio)
  │    │    │    │    └─ events...
  │    │    │    └─ player: Swift Tiger [serial=DD:EE:FF]
  │    │    │
  │    │    └─ team_lifecycle [team=Red] ─────────────────
  │    │         ├─ player: Gold Eagle [serial=GG:HH:II]
  │    │         └─ player: Brave Lion [serial=JJ:KK:LL]
  │    │
  │    └─ game_cycle ─────────────────────────────────────
  │         ├─ PlaySound:beep/start (shared sounds)
  │         └─ music_tempo_change [...]
```

## Test plan

- [x] All 654 game_coordinator unit tests pass
- [x] `make lint` passes
- [ ] Deploy and verify in Jaeger: player spans show controller name
- [ ] Verify `players` and `game_cycle` groups collapse correctly
- [ ] Verify countdown beeps under `game_cycle`, death sounds under `player`
- [ ] Verify tempo changes appear directly under `game_cycle` (no wrapper)

🤖 Generated with [Claude Code](https://claude.com/claude-code)