### PR TITLE
fix: clean up stale Docker containers after unclean Pi shutdown

### DIFF
--- a/scripts/setup/joustmania-start.sh
+++ b/scripts/setup/joustmania-start.sh
@@ -77,7 +77,12 @@ else
     echo "Could not pull images (offline) - continuing with cached images"
 fi
 
-# Clean up any orphaned containers
+# Force-remove any stale joustmania containers from previous unclean shutdown
+echo "Cleaning up stale containers..."
+docker ps -aq --filter "name=joustmania-" | xargs -r docker rm -f 2>/dev/null || true
+docker container prune -f 2>/dev/null || true
+
+# Normal compose cleanup
 echo "Cleaning up..."
 docker compose down --remove-orphans || true
 

--- a/scripts/setup/joustmania.service
+++ b/scripts/setup/joustmania.service
@@ -8,6 +8,10 @@ Wants=network-online.target
 Type=oneshot
 RemainAfterExit=yes
 WorkingDirectory=/home/pi/JoustMania
+ExecStartPre=+/bin/bash -c '\
+  docker ps -aq --filter "name=joustmania-" | xargs -r docker rm -f 2>/dev/null; \
+  docker container prune -f 2>/dev/null; \
+  true'
 ExecStart=/home/pi/JoustMania/scripts/setup/joustmania-start.sh
 ExecStop=/usr/bin/docker compose down
 TimeoutStartSec=600


### PR DESCRIPTION
## Summary

- Add `ExecStartPre` (root-level via `+` prefix) to the systemd service to force-remove stale `joustmania-*` containers before the start script runs
- Add the same stale container cleanup inside `joustmania-start.sh` as a belt-and-suspenders layer before `docker compose down`
- Fixes "No such container" errors after sudden Pi power loss, where Docker's container metadata survives but runtime state is gone

## Test plan

- [ ] Reinstall service on Pi: `sudo ./scripts/setup/install_autostart.sh`
- [ ] Verify: `sudo systemctl cat joustmania` shows the new `ExecStartPre`
- [ ] Start containers, `sudo reboot -f` (simulates power loss), check `journalctl -u joustmania` for clean startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)