### PR TITLE
fix: prevent instant death on game start from first-frame EMA spike

### DIFF
--- a/services/game_coordinator/games/base.py
+++ b/services/game_coordinator/games/base.py
@@ -515,6 +515,36 @@ class BaseGameMode(ABC):
         """
         await self._create_gameplay_stream()
 
+    async def _warmup_ema(self):
+        """
+        Drain buffered stream data and prime EMA filters before game loop.
+
+        The gameplay stream opens ~2.25s before the game loop starts (before
+        countdown). Data buffered during that time can contain stale spikes
+        that cause instant deaths when the EMA is uninitialized. This method
+        reads and discards buffered frames while priming each player's EMA
+        with real sensor data — no death checks run.
+        """
+        warmup_duration = 0.1  # 100ms — enough to drain buffer and get ~6 frames at 60Hz
+        warmup_start = time.time()
+        frames_consumed = 0
+
+        try:
+            async for gameplay_update in self.gameplay_stream:
+                for controller_data in gameplay_update.controllers:
+                    serial = controller_data.serial
+                    if serial in self.players and self.players[serial].alive:
+                        accel_mag = self._compute_accel_magnitude(controller_data.accel)
+                        self._update_ema(self.players[serial], accel_mag)
+                frames_consumed += 1
+
+                if time.time() - warmup_start >= warmup_duration:
+                    break
+        except Exception as e:
+            logger.warning(f"EMA warmup interrupted: {e}")
+
+        logger.info(f"EMA warmup complete: drained {frames_consumed} buffered frames")
+
     async def _process_gameplay_update(self, gameplay_update) -> bool:
         """
         Process a single gameplay update: handle disconnects then run death detection.
@@ -689,8 +719,13 @@ class BaseGameMode(ABC):
 
             logger.info("Starting game loop (stream rate controlled by controller-manager)")
 
-            # Stream was already created in _start_gameplay_stream() before countdown
-            # EMA filter was primed during countdown by _warmup_ema()
+            # Stream was already created in _start_gameplay_stream() before countdown.
+            # EMA filters were primed and buffered data drained by _warmup_ema().
+            # Apply startup grace period so any residual spikes can't cause instant death.
+            grace_until = time.time() + 0.3
+            for player in self.players.values():
+                if player.alive:
+                    player.grace_until = grace_until
 
             # Track current alive set for detecting changes
             last_alive_serials = {p.serial for p in self.players.values() if p.alive}
@@ -1358,6 +1393,9 @@ class BaseGameMode(ABC):
                     from proto import audio_pb2
 
                     await self.audio_client.SetVolume(audio_pb2.SetVolumeRequest(volume=GAME_VOLUME))
+
+                # Drain buffered stream data and prime EMA filters
+                await self._warmup_ema()
 
                 # Start music loop as background task (uses game_cycle_context)
                 self.music_loop_task = asyncio.create_task(self._music_loop())

--- a/services/game_coordinator/tests/test_base_game.py
+++ b/services/game_coordinator/tests/test_base_game.py
@@ -1267,3 +1267,84 @@ class TestGameLifecycleCleanup:
             await game.run()
 
         assert len(cleanup_called) >= 1
+
+
+class TestStartupGracePeriod:
+    """Tests for startup grace period preventing instant death on first frame."""
+
+    @pytest.fixture
+    def game_with_player(self):
+        """Create game with a player whose EMA is uninitialized (first frame scenario)."""
+        mock_cm = MockControllerManagerService(num_controllers=2)
+
+        game = FFAGame(
+            controller_manager_client=mock_cm,
+            event_publisher=async_noop,
+            audio_client=None,
+            game_id="test_startup_grace",
+        )
+
+        game.players["test_serial"] = Player(
+            serial="test_serial",
+            team=0,
+            alive=True,
+            color=(255, 0, 0),
+            smoothed_accel=1.0,  # Prime EMA so it doesn't auto-prime
+        )
+        game.gameplay_stream = MockGameplayStream()
+        game.music_speed = SLOW_MUSIC_SPEED
+        game.start_time = time.time()
+
+        return game
+
+    @pytest.mark.asyncio
+    async def test_startup_grace_prevents_first_frame_death(self, game_with_player):
+        """Player should survive a spike during startup grace period."""
+        game = game_with_player
+        player = game.players["test_serial"]
+
+        # Set grace period in the future (simulates startup grace)
+        player.grace_until = time.time() + 0.3
+
+        # Create a massive spike that would normally kill instantly
+        controller_state = controller_manager_pb2.GameplayData(
+            serial="test_serial",
+            accel=controller_manager_pb2.Vector3(x=10.0, y=10.0, z=10.0),
+        )
+
+        # Process several frames during grace period
+        for _ in range(5):
+            await game._process_controller_state(controller_state)
+
+        # Player should survive — grace period blocks death checks
+        assert player.alive is True
+
+    @pytest.mark.asyncio
+    async def test_startup_grace_expires_and_death_works(self, game_with_player):
+        """After grace period expires, death detection works normally."""
+        game = game_with_player
+        player = game.players["test_serial"]
+
+        # Set grace period in the past (expired)
+        player.grace_until = time.time() - 1.0
+
+        kill_called = []
+
+        async def mock_kill(serial, accel_mag):
+            kill_called.append((serial, accel_mag))
+            player.alive = False
+
+        game._kill_player = mock_kill
+
+        # Create lethal acceleration
+        controller_state = controller_manager_pb2.GameplayData(
+            serial="test_serial",
+            accel=controller_manager_pb2.Vector3(x=10.0, y=10.0, z=10.0),
+        )
+
+        # Process enough frames for EMA to exceed death threshold
+        for _ in range(10):
+            if player.alive:
+                await game._process_controller_state(controller_state)
+
+        assert len(kill_called) > 0, "Player should die after grace period expires"


### PR DESCRIPTION
## Summary

- **Add `_warmup_ema()`** to drain buffered stream data and prime EMA filters with real sensor data before the game loop starts — eliminates stale spikes from the ~2.25s countdown phase
- **Add 300ms startup grace period** for all players when the game loop begins, using the existing `grace_until` mechanism that already skips death checks
- **Add tests** for startup grace period (spike during grace survives, death works after grace expires)

## Context

Players die immediately when a game starts (2ms after first frame, peak=13.05g) even with controllers lying flat on a table. Root cause: the gameplay stream opens before countdown, buffering stale data. The uninitialized EMA filter (`smoothed_accel=0.0`) primes with whatever spike arrives, and death checks run on that same frame with no grace period.

## Test plan

- [x] `cd services/game_coordinator && uv run pytest -v` — all 62 tests pass (2 new)
- [x] `make lint` — clean
- [ ] Manual: start a game with controllers on table, verify no instant deaths

🤖 Generated with [Claude Code](https://claude.com/claude-code)