### PR TITLE
feat: per-controller poll health metrics and dashboard panels

### DIFF
--- a/services/controller_manager/discovery_loop.py
+++ b/services/controller_manager/discovery_loop.py
@@ -425,10 +425,12 @@ class DiscoveryLoop:
                 if isinstance(state, Exception):
                     logger.debug(f"Error updating state for {serial}: {state}")
                     self._poll_errors[serial] = self._poll_errors.get(serial, 0) + 1
+                    metrics.controller_poll_errors_total.labels(serial=serial).inc()
                     continue
 
                 if not state:
                     self._poll_drops[serial] = self._poll_drops.get(serial, 0) + 1
+                    metrics.controller_poll_drops_total.labels(serial=serial).inc()
                     continue
 
                 # Update stored state

--- a/services/controller_manager/metrics.py
+++ b/services/controller_manager/metrics.py
@@ -272,9 +272,22 @@ stream_current_frequency_hz = Gauge(
     "Current streaming frequency in Hz (from flagd override)",
 )
 
+# Per-controller health metrics (observable connection quality)
+controller_poll_drops_total = Counter(
+    "controller_poll_drops_total",
+    "Total poll() calls returning None per controller",
+    ["serial"],
+)
+
+controller_poll_errors_total = Counter(
+    "controller_poll_errors_total",
+    "Total poll() exceptions per controller",
+    ["serial"],
+)
+
 # Chaos fault injection metrics (Issue #548)
 chaos_faults_injected_total = Counter(
     "controller_chaos_faults_injected_total",
     "Total chaos faults injected by ChaosAdapter",
-    ["fault"],  # poll_drop, accel_spike, led_failure, disconnect
+    ["fault", "serial"],
 )

--- a/services/controller_manager/multiplexer/chaos_adapter.py
+++ b/services/controller_manager/multiplexer/chaos_adapter.py
@@ -62,7 +62,7 @@ class ChaosAdapter(ControllerIOAdapter):
         if fault == "disconnect":
             return None
         if fault == "poll_drop" and random.random() < 0.3:
-            metrics.chaos_faults_injected_total.labels(fault="poll_drop").inc()
+            metrics.chaos_faults_injected_total.labels(fault="poll_drop", serial=serial).inc()
             return None
         result = self._inner.poll(serial)
         if fault == "accel_spike" and result and random.random() < 0.05:
@@ -71,16 +71,16 @@ class ChaosAdapter(ControllerIOAdapter):
                 AxisKey.Y: random.gauss(0, 3.0),
                 AxisKey.Z: random.gauss(0, 3.0),
             }
-            metrics.chaos_faults_injected_total.labels(fault="accel_spike").inc()
+            metrics.chaos_faults_injected_total.labels(fault="accel_spike", serial=serial).inc()
         return result
 
     def set_output(self, serial: str, r: int, g: int, b: int, rumble: int) -> bool:
         fault = self._get_fault(serial)
         if fault == "disconnect":
-            metrics.chaos_faults_injected_total.labels(fault="disconnect").inc()
+            metrics.chaos_faults_injected_total.labels(fault="disconnect", serial=serial).inc()
             return False
         if fault == "led_failure" and random.random() < 0.5:
-            metrics.chaos_faults_injected_total.labels(fault="led_failure").inc()
+            metrics.chaos_faults_injected_total.labels(fault="led_failure", serial=serial).inc()
             return False
         return self._inner.set_output(serial, r, g, b, rumble)
 

--- a/services/controller_manager/tests/test_chaos_adapter.py
+++ b/services/controller_manager/tests/test_chaos_adapter.py
@@ -122,7 +122,7 @@ class TestChaosAdapterPollDrop:
         ):
             mock_random.random.return_value = 0.1  # < 0.3, will drop
             chaos.poll("SERIAL001")
-            mock_metrics.chaos_faults_injected_total.labels.assert_called_with(fault="poll_drop")
+            mock_metrics.chaos_faults_injected_total.labels.assert_called_with(fault="poll_drop", serial="SERIAL001")
 
 
 class TestChaosAdapterAccelSpike:
@@ -166,7 +166,7 @@ class TestChaosAdapterAccelSpike:
             mock_random.random.return_value = 0.01  # < 0.05
             mock_random.gauss.return_value = 3.0
             chaos.poll("SERIAL001")
-            mock_metrics.chaos_faults_injected_total.labels.assert_called_with(fault="accel_spike")
+            mock_metrics.chaos_faults_injected_total.labels.assert_called_with(fault="accel_spike", serial="SERIAL001")
 
 
 class TestChaosAdapterLedFailure:
@@ -200,7 +200,7 @@ class TestChaosAdapterLedFailure:
         ):
             mock_random.random.return_value = 0.3  # < 0.5
             chaos.set_output("SERIAL001", 255, 0, 0, 0)
-            mock_metrics.chaos_faults_injected_total.labels.assert_called_with(fault="led_failure")
+            mock_metrics.chaos_faults_injected_total.labels.assert_called_with(fault="led_failure", serial="SERIAL001")
 
     def test_led_failure_poll_unaffected(self):
         inner = _make_inner()
@@ -238,7 +238,7 @@ class TestChaosAdapterDisconnect:
 
         with patch("services.controller_manager.multiplexer.chaos_adapter.metrics") as mock_metrics:
             chaos.set_output("SERIAL001", 255, 0, 0, 0)
-            mock_metrics.chaos_faults_injected_total.labels.assert_called_with(fault="disconnect")
+            mock_metrics.chaos_faults_injected_total.labels.assert_called_with(fault="disconnect", serial="SERIAL001")
 
 
 class TestChaosAdapterFlagListener:

--- a/services/grafana/dashboards/bluetooth-adapter.json
+++ b/services/grafana/dashboards/bluetooth-adapter.json
@@ -604,6 +604,135 @@
         }
       ],
       "type": "table"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 13
+      },
+      "id": 107,
+      "panels": [],
+      "title": "Connection Quality",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Poll drop rate aggregated by Bluetooth adapter (hci device)",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisLabel": "drops/sec",
+            "fillOpacity": 20,
+            "lineWidth": 2,
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 14
+      },
+      "id": 108,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max"],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by(adapter) (rate(controller_poll_drops_total[1m]) * on(serial) group_left(adapter) controller_adapter_info)",
+          "legendFormat": "{{adapter}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Poll Drop Rate (per adapter)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Poll error rate aggregated by Bluetooth adapter (hci device)",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisLabel": "errors/sec",
+            "fillOpacity": 20,
+            "lineWidth": 2,
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 14
+      },
+      "id": 109,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max"],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by(adapter) (rate(controller_poll_errors_total[1m]) * on(serial) group_left(adapter) controller_adapter_info)",
+          "legendFormat": "{{adapter}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Poll Error Rate (per adapter)",
+      "type": "timeseries"
     }
   ],
   "refresh": "5s",

--- a/services/grafana/dashboards/controller-maintenance.json
+++ b/services/grafana/dashboards/controller-maintenance.json
@@ -970,6 +970,331 @@
       ],
       "title": "Signal Strength History",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Cumulative reconnects over time",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "stepAfter",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 38
+      },
+      "id": 32,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.2.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "controller_reconnect_total * on(serial) group_left(name) controller_info",
+          "legendFormat": "{{name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Total Reconnects (Cumulative)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 46
+      },
+      "id": 104,
+      "panels": [],
+      "title": "Poll Health",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Rate of poll() calls returning None per controller (includes chaos-injected drops)",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisLabel": "drops/sec",
+            "fillOpacity": 20,
+            "lineWidth": 2,
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 47
+      },
+      "id": 33,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max"],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(controller_poll_drops_total[1m]) * on(serial) group_left(name) controller_info",
+          "legendFormat": "{{name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Poll Drop Rate (per controller)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Rate of poll() exceptions per controller",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisLabel": "errors/sec",
+            "fillOpacity": 20,
+            "lineWidth": 2,
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none"
+            }
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 47
+      },
+      "id": 34,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max"],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(controller_poll_errors_total[1m]) * on(serial) group_left(name) controller_info",
+          "legendFormat": "{{name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Poll Error Rate (per controller)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Total accumulated poll drops per controller",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "drops",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "spanNulls": false
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 55
+      },
+      "id": 35,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "controller_poll_drops_total * on(serial) group_left(name) controller_info",
+          "legendFormat": "{{name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Total Poll Drops (Cumulative)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Total accumulated poll errors per controller",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "errors",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "spanNulls": false
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 55
+      },
+      "id": 36,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "controller_poll_errors_total * on(serial) group_left(name) controller_info",
+          "legendFormat": "{{name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Total Poll Errors (Cumulative)",
+      "type": "timeseries"
     }
   ],
   "refresh": "10s",


### PR DESCRIPTION
## Summary
- Add `controller_poll_drops_total{serial}` and `controller_poll_errors_total{serial}` counters, emitted on every `poll()` failure in the discovery loop
- Add `serial` label to `controller_chaos_faults_injected_total` so chaos faults can be attributed to specific controllers
- Add dashboard panels to Controller Maintenance and Bluetooth Adapter dashboards

## Dashboard additions
- **Controller Maintenance** → "Poll Health" row: drop/error rate and cumulative timeseries per controller
- **Bluetooth Adapter** → "Connection Quality" row: drop/error rate aggregated per adapter (hci device)

## Test plan
- [x] 606 controller_manager unit tests pass
- [x] `make lint` passes
- [ ] Verify new panels populate on live system with connected controllers
- [ ] Verify chaos adapter poll_drop faults appear with serial label

🤖 Generated with [Claude Code](https://claude.com/claude-code)