### PR TITLE
fix: poll health dashboard visibility and adapter affinity

### DIFF
--- a/services/controller_manager/multiplexer/bt_discovery.py
+++ b/services/controller_manager/multiplexer/bt_discovery.py
@@ -12,6 +12,7 @@ Supports two discovery modes:
 from __future__ import annotations
 
 import logging
+import pathlib
 
 from services.controller_manager import bluetooth, metrics
 
@@ -63,6 +64,25 @@ class CentralizedBTDiscovery:
         Accepts addresses in any format (with/without colons).
         """
         return self._address_to_adapter.get(self._normalize_address(address))
+
+    @staticmethod
+    def _resolve_adapter_from_sysfs(hidraw_path: str | bytes) -> str | None:
+        """Resolve BT adapter from hidraw device path via sysfs.
+
+        For Bluetooth HID devices, the resolved sysfs path includes the
+        adapter name: .../bluetooth/hci0/hci0:XX/.../hidraw/hidrawN
+        """
+        if isinstance(hidraw_path, bytes):
+            hidraw_path = hidraw_path.decode("utf-8", errors="replace")
+        hidraw_name = pathlib.Path(hidraw_path).name  # e.g. "hidraw0"
+        sysfs = pathlib.Path(f"/sys/class/hidraw/{hidraw_name}")
+        if not sysfs.exists():
+            return None
+        resolved = str(sysfs.resolve())
+        for part in resolved.split("/"):
+            if part.startswith("hci") and ":" not in part:
+                return part
+        return None
 
     async def initialize(self) -> dict[str, str]:
         """Enumerate all BT adapters and enable them. Returns adapter dict."""
@@ -141,6 +161,27 @@ class CentralizedBTDiscovery:
                         self._address_to_adapter[key] = hci
             except Exception:
                 logger.exception(f"Failed to scan {hci} for adapter affinity")
+
+        # Sysfs fallback for devices not found in BlueZ (common with hidapi)
+        unresolved = seen - set(self._address_to_adapter.keys())
+        if unresolved:
+            for dev_info in devices:
+                serial = dev_info.get("serial_number", "")
+                if not serial:
+                    continue
+                normalized = self._normalize_address(serial)
+                if normalized in unresolved and normalized not in self._address_to_adapter:
+                    path = dev_info.get("path", b"")
+                    if path:
+                        hci = self._resolve_adapter_from_sysfs(path)
+                        if hci and hci in self._adapters:
+                            self._address_to_adapter[normalized] = hci
+
+            resolved_by_sysfs = len(seen) - len(unresolved - set(self._address_to_adapter.keys()))
+            if resolved_by_sysfs > len(seen) - len(unresolved):
+                logger.info(
+                    f"Sysfs resolved adapter affinity for {resolved_by_sysfs - (len(seen) - len(unresolved))} device(s)"
+                )
 
         return hid_serials
 

--- a/services/controller_manager/tests/test_bt_discovery.py
+++ b/services/controller_manager/tests/test_bt_discovery.py
@@ -5,6 +5,7 @@ Tests multi-adapter enumeration, scanning, affinity tracking, and hot-plug.
 Covers both discovery modes: "bluez" (default) and "hidapi".
 """
 
+import pathlib
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -331,6 +332,100 @@ class TestHidapiMode:
             addresses = await hidapi_discovery.get_all_attached_addresses()
 
         assert len(addresses) == 1
+
+    @pytest.mark.asyncio
+    async def test_sysfs_fallback_when_bluez_has_no_devices(self, hidapi_discovery):
+        """Should resolve adapter affinity via sysfs when BlueZ cross-ref fails."""
+        hidapi_discovery._adapters = {"hci0": "AA:00", "hci1": "BB:00"}
+
+        mock_hid = MagicMock()
+        mock_hid.enumerate.side_effect = [
+            [
+                {"serial_number": "0006F7AABBCC", "path": b"/dev/hidraw0"},
+                {"serial_number": "0006F7DDEEFF", "path": b"/dev/hidraw1"},
+            ],
+            [],  # ZCM2
+            [],  # ZCM2E
+        ]
+
+        with (
+            patch("services.controller_manager.multiplexer.bt_discovery.bluetooth") as mock_bt,
+            patch.dict("sys.modules", {"hidraw": mock_hid}),
+            patch("services.controller_manager.multiplexer.bt_discovery.hid", mock_hid, create=True),
+            patch.object(
+                CentralizedBTDiscovery,
+                "_resolve_adapter_from_sysfs",
+                side_effect=lambda path: "hci0" if b"hidraw0" in path else "hci1",
+            ),
+        ):
+            # BlueZ returns nothing — devices connected via hidraw, not BlueZ
+            mock_bt.get_attached_addresses = AsyncMock(return_value=[])
+            await hidapi_discovery.get_all_attached_addresses()
+
+        assert hidapi_discovery.get_adapter_for_address("0006F7AABBCC") == "hci0"
+        assert hidapi_discovery.get_adapter_for_address("0006F7DDEEFF") == "hci1"
+
+    @pytest.mark.asyncio
+    async def test_sysfs_fallback_skips_unknown_adapters(self, hidapi_discovery):
+        """Sysfs fallback should ignore adapters not in the known adapter list."""
+        hidapi_discovery._adapters = {"hci0": "AA:00"}
+
+        mock_hid = MagicMock()
+        mock_hid.enumerate.side_effect = [
+            [{"serial_number": "0006F7AABBCC", "path": b"/dev/hidraw0"}],
+            [],
+            [],
+        ]
+
+        with (
+            patch("services.controller_manager.multiplexer.bt_discovery.bluetooth") as mock_bt,
+            patch.dict("sys.modules", {"hidraw": mock_hid}),
+            patch("services.controller_manager.multiplexer.bt_discovery.hid", mock_hid, create=True),
+            patch.object(
+                CentralizedBTDiscovery,
+                "_resolve_adapter_from_sysfs",
+                return_value="hci9",  # Not in _adapters
+            ),
+        ):
+            mock_bt.get_attached_addresses = AsyncMock(return_value=[])
+            await hidapi_discovery.get_all_attached_addresses()
+
+        assert hidapi_discovery.get_adapter_for_address("0006F7AABBCC") is None
+
+    def test_resolve_adapter_from_sysfs_parses_hci(self):
+        """Should extract hci name from resolved sysfs path."""
+        with (
+            patch("pathlib.Path.exists", return_value=True),
+            patch(
+                "pathlib.Path.resolve",
+                return_value=pathlib.Path(
+                    "/sys/devices/pci0000:00/0000:00:14.0/usb1/1-1/1-1:1.0"
+                    "/bluetooth/hci0/hci0:11/0005:054C:03D5.0001/hidraw/hidraw0"
+                ),
+            ),
+        ):
+            result = CentralizedBTDiscovery._resolve_adapter_from_sysfs(b"/dev/hidraw0")
+        assert result == "hci0"
+
+    def test_resolve_adapter_from_sysfs_no_hci(self):
+        """Should return None when sysfs path has no hci adapter (e.g. USB device)."""
+        with (
+            patch("pathlib.Path.exists", return_value=True),
+            patch(
+                "pathlib.Path.resolve",
+                return_value=pathlib.Path(
+                    "/sys/devices/pci0000:00/0000:00:14.0/usb1/1-1/1-1:1.0/0003:054C:03D5.0001/hidraw/hidraw0"
+                ),
+            ),
+        ):
+            result = CentralizedBTDiscovery._resolve_adapter_from_sysfs(b"/dev/hidraw0")
+        assert result is None
+
+    def test_resolve_adapter_from_sysfs_missing(self):
+        """Should return None when sysfs path doesn't exist."""
+        with patch("pathlib.Path.exists", return_value=False):
+            result = CentralizedBTDiscovery._resolve_adapter_from_sysfs(b"/dev/hidraw99")
+        assert result is None
 
     @pytest.mark.asyncio
     async def test_bluez_mode_uses_bluez_scanning(self, discovery):

--- a/services/grafana/dashboards/controller-maintenance.json
+++ b/services/grafana/dashboards/controller-maintenance.json
@@ -85,7 +85,7 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 8,
+        "w": 6,
         "x": 0,
         "y": 1
       },
@@ -153,8 +153,8 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 8,
-        "x": 8,
+        "w": 6,
+        "x": 6,
         "y": 1
       },
       "id": 3,
@@ -213,8 +213,8 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 8,
-        "x": 16,
+        "w": 6,
+        "x": 12,
         "y": 1
       },
       "id": 6,
@@ -245,6 +245,74 @@
         }
       ],
       "title": "Connected",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Controllers with poll drop rate above degradation threshold (10 drops/sec). Matches controller_poll_degraded spans in Jaeger.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 3
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 1
+      },
+      "id": 37,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.2.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "count(rate(controller_poll_drops_total[1m]) > 10) or vector(0)",
+          "legendFormat": "Controllers",
+          "refId": "A"
+        }
+      ],
+      "title": "Degraded (Poll Drops)",
       "type": "stat"
     },
     {
@@ -434,6 +502,53 @@
                 "value": 80
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Poll Drops/s"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "gradient",
+                  "type": "gauge"
+                }
+              },
+              {
+                "id": "decimals",
+                "value": 1
+              },
+              {
+                "id": "max",
+                "value": 100
+              },
+              {
+                "id": "min",
+                "value": 0
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 10
+                    },
+                    {
+                      "color": "red",
+                      "value": 30
+                    }
+                  ]
+                }
+              }
+            ]
           }
         ]
       },
@@ -502,6 +617,17 @@
           "instant": true,
           "legendFormat": "__auto",
           "refId": "RSSI"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(controller_poll_drops_total[1m])",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "__auto",
+          "refId": "PollDrops"
         }
       ],
       "title": "Controller Health Status",
@@ -553,7 +679,8 @@
               "hci_adapter": 2,
               "Value #Status": 3,
               "Value #Battery": 4,
-              "Value #RSSI": 5
+              "Value #RSSI": 5,
+              "Value #PollDrops": 6
             },
             "renameByName": {
               "name": "Name",
@@ -562,7 +689,8 @@
               "Value #Status": "Status",
               "Value #Battery": "Battery",
               "Value #RSSI": "RSSI (dBm)",
-              "Value #Info": ""
+              "Value #Info": "",
+              "Value #PollDrops": "Poll Drops/s"
             }
           }
         }
@@ -1077,7 +1205,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "Rate of poll() calls returning None per controller (includes chaos-injected drops)",
+      "description": "Rate of poll() calls returning None per controller. Red zone (>10 drops/sec) matches the degradation threshold used by Jaeger health spans.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1091,7 +1219,23 @@
             "spanNulls": false,
             "stacking": {
               "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "line+area"
             }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "transparent",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 10
+              }
+            ]
           },
           "unit": "ops"
         },
@@ -1135,7 +1279,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "Rate of poll() exceptions per controller",
+      "description": "Rate of poll() exceptions per controller. Any errors are highlighted red — errors indicate connection problems.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1149,7 +1293,23 @@
             "spanNulls": false,
             "stacking": {
               "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "line+area"
             }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "transparent",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
           },
           "unit": "ops"
         },


### PR DESCRIPTION
## Summary

- **Dashboard**: Poll drops are tracked per controller (#601) but aren't visually distinguishable in Grafana — all controllers show drops, with no threshold coloring to highlight degraded ones. Adds threshold lines at 10 drops/sec (matching the `poll_drop_threshold` used by `controller_poll_degraded` Jaeger spans), a "Degraded (Poll Drops)" stat panel in the Health Summary row, and a "Poll Drops/s" gauge column in the Controller Health Table.
- **Adapter affinity**: `controller_adapter_info` was empty for all real (hidapi) controllers because the BlueZ D-Bus cross-reference can't find hidapi-connected devices (they bypass BlueZ's device registry). Adds a sysfs fallback that resolves the BT adapter from the hidraw device's sysfs path hierarchy.

## Test plan

- [x] `make lint` passes
- [x] `uv run pytest tests/test_bt_discovery.py` — 26 tests pass (5 new for sysfs fallback)
- [ ] Deploy to Pi and verify "Degraded (Poll Drops)" stat panel shows count
- [ ] Verify Poll Drop Rate panel shows red threshold line at 10 drops/sec
- [ ] Verify Controller Health Table shows "Poll Drops/s" gauge column
- [ ] Verify `controller_adapter_info` populates for real controllers

🤖 Generated with [Claude Code](https://claude.com/claude-code)