### PR TITLE
refactor: migrate pairing daemon from psmoveapi to hidapi

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -237,7 +237,6 @@ services:
       dockerfile: services/pairing_daemon/Dockerfile
       args:
         BUILDER_IMAGE: ${BUILDER_IMAGE:-ghcr.io/watchmejoustmyflags/joustmania/builder:latest}
-        PSMOVE_BUILDER_IMAGE: ${PSMOVE_BUILDER_IMAGE:-ghcr.io/watchmejoustmyflags/joustmania/psmove-builder:latest}
     container_name: joustmania-pairing-daemon
     privileged: true
     pid: "host"
@@ -251,12 +250,9 @@ services:
       - /var/lib/bluetooth:/var/lib/bluetooth
       # USB device access
       - /dev:/dev:rslave
-      # PS Move calibration data (shared with controller-manager)
-      - psmoveapi-data:/root/.psmoveapi
     # Port 8002 (health) binds directly on host via network_mode: host
     environment:
       - METRICS_PORT=8002
-      - PSMOVE_PATH=/usr/local/bin/psmove
       - DBUS_SYSTEM_BUS_ADDRESS=unix:path=/var/run/dbus/system_bus_socket
       - OTEL_SERVICE_NAME=pairing-daemon
       - OTEL_SERVICE_NAMESPACE=infrastructure

--- a/lib/psmove_hid.py
+++ b/lib/psmove_hid.py
@@ -7,6 +7,8 @@ replacing the need for psmoveapi C library for basic controller I/O.
 The PS Move uses standard HID over Bluetooth with:
 - 49-byte input reports (buttons, trigger, accelerometer, gyroscope, battery)
 - 9-byte output reports (report 0x06 SetLEDs: LED RGB, rumble)
+- Feature report 0x04 GET (16 bytes): read controller + host BT addresses
+- Feature report 0x05 SET (23 bytes): write new host BT address for pairing
 
 References:
 - https://github.com/nitsch/movern/wiki/Input-report
@@ -26,6 +28,12 @@ ALL_PRODUCT_IDS = (PRODUCT_ID_ZCM1, PRODUCT_ID_ZCM2, PRODUCT_ID_ZCM2E)
 # HID report sizes
 INPUT_REPORT_SIZE = 49
 OUTPUT_REPORT_SIZE = 9  # Output report 0x06 (SetLEDs, works for all models)
+
+# Feature report IDs and sizes (USB pairing)
+FEATURE_REPORT_GET_BTADDR = 0x04
+FEATURE_REPORT_SET_BTADDR = 0x05
+FEATURE_REPORT_GET_SIZE = 16
+FEATURE_REPORT_SET_SIZE = 23
 
 
 class Button(IntFlag):
@@ -216,4 +224,72 @@ def build_output_report(r: int = 0, g: int = 0, b: int = 0, rumble: int = 0) -> 
     # Byte 5: 0x00 (rumble2, reserved)
     report[6] = rumble
     # Bytes 7-8: 0x00 (padding)
+    return bytes(report)
+
+
+# ---------------------------------------------------------------------------
+# Feature report helpers for USB pairing (report 0x04 GET / 0x05 SET)
+# ---------------------------------------------------------------------------
+
+
+def _mac_bytes_to_string(data: bytes) -> str:
+    """Convert 6 LSB-first bytes to 'AA:BB:CC:DD:EE:FF'.
+
+    The PS Move stores MAC addresses in reverse (least-significant byte first),
+    so we reverse before formatting.
+    """
+    return ":".join(f"{b:02X}" for b in reversed(data[:6]))
+
+
+def _mac_string_to_bytes(mac: str) -> bytes:
+    """Convert 'AA:BB:CC:DD:EE:FF' to 6 LSB-first bytes.
+
+    Reverses the octets so the most-significant byte ends up last,
+    matching the PS Move's wire format.
+    """
+    octets = [int(x, 16) for x in mac.split(":")]
+    if len(octets) != 6:
+        raise ValueError(f"Invalid MAC address: {mac}")
+    return bytes(reversed(octets))
+
+
+def parse_btaddr_report(data: bytes) -> tuple[str, str]:
+    """Parse a GET_FEATURE 0x04 report into controller and host MAC addresses.
+
+    Report layout (16 bytes):
+        [0x04, ctrl[0..5], pad(3B), host[0..5]]
+    Bytes 1-6: controller BT address (LSB-first).
+    Bytes 10-15: host BT address (LSB-first).
+
+    Args:
+        data: Raw 16-byte feature report (may include leading report ID).
+
+    Returns:
+        (controller_mac, host_mac) as 'AA:BB:CC:DD:EE:FF' strings.
+
+    Raises:
+        ValueError: If data is too short.
+    """
+    if len(data) < FEATURE_REPORT_GET_SIZE:
+        raise ValueError(f"Feature report too short: {len(data)} bytes (need {FEATURE_REPORT_GET_SIZE})")
+    controller_mac = _mac_bytes_to_string(data[1:7])
+    host_mac = _mac_bytes_to_string(data[10:16])
+    return controller_mac, host_mac
+
+
+def build_set_btaddr_report(host_mac: str) -> bytes:
+    """Build a SET_FEATURE 0x05 report to write a new host BT address.
+
+    Report layout (23 bytes):
+        [0x05, addr[0..5], 0x00 * 16]
+
+    Args:
+        host_mac: Target host address as 'AA:BB:CC:DD:EE:FF'.
+
+    Returns:
+        23-byte feature report ready for send_feature_report().
+    """
+    report = bytearray(FEATURE_REPORT_SET_SIZE)
+    report[0] = FEATURE_REPORT_SET_BTADDR
+    report[1:7] = _mac_string_to_bytes(host_mac)
     return bytes(report)

--- a/lib/tests/test_psmove_hid.py
+++ b/lib/tests/test_psmove_hid.py
@@ -14,13 +14,19 @@ project_root = Path(__file__).parent.parent.parent
 sys.path.insert(0, str(project_root))
 
 from lib.psmove_hid import (
+    FEATURE_REPORT_GET_SIZE,
+    FEATURE_REPORT_SET_SIZE,
     INPUT_REPORT_SIZE,
     OUTPUT_REPORT_SIZE,
     Battery,
     Button,
     Frame,
+    _mac_bytes_to_string,
+    _mac_string_to_bytes,
     battery_to_percent,
     build_output_report,
+    build_set_btaddr_report,
+    parse_btaddr_report,
     parse_input_report,
 )
 
@@ -503,3 +509,121 @@ class TestZCM2GyroscopeParsing:
         assert result["gyro"][0][0] == 256
         assert result["gyro"][0][1] == -256
         assert result["gyro"][0][2] == 0
+
+
+# ---------------------------------------------------------------------------
+# Feature report tests (BT address get/set for USB pairing)
+# ---------------------------------------------------------------------------
+
+
+class TestMacBytesToString:
+    """Test _mac_bytes_to_string() LSB-first → colon string."""
+
+    def test_known_mac(self):
+        # LSB-first: FF EE DD CC BB AA → "AA:BB:CC:DD:EE:FF"
+        assert _mac_bytes_to_string(b"\xff\xee\xdd\xcc\xbb\xaa") == "AA:BB:CC:DD:EE:FF"
+
+    def test_all_zeros(self):
+        assert _mac_bytes_to_string(b"\x00\x00\x00\x00\x00\x00") == "00:00:00:00:00:00"
+
+    def test_broadcast(self):
+        assert _mac_bytes_to_string(b"\xff\xff\xff\xff\xff\xff") == "FF:FF:FF:FF:FF:FF"
+
+    def test_sony_prefix(self):
+        # Sony PS Move prefix 00:06:F7 → LSB bytes: F7 06 00 ...
+        data = b"\xcc\xbb\xaa\xf7\x06\x00"
+        assert _mac_bytes_to_string(data) == "00:06:F7:AA:BB:CC"
+
+
+class TestMacStringToBytes:
+    """Test _mac_string_to_bytes() colon string → LSB-first."""
+
+    def test_known_mac(self):
+        result = _mac_string_to_bytes("AA:BB:CC:DD:EE:FF")
+        assert result == b"\xff\xee\xdd\xcc\xbb\xaa"
+
+    def test_all_zeros(self):
+        result = _mac_string_to_bytes("00:00:00:00:00:00")
+        assert result == b"\x00\x00\x00\x00\x00\x00"
+
+    def test_broadcast(self):
+        result = _mac_string_to_bytes("FF:FF:FF:FF:FF:FF")
+        assert result == b"\xff\xff\xff\xff\xff\xff"
+
+    def test_lowercase_accepted(self):
+        result = _mac_string_to_bytes("aa:bb:cc:dd:ee:ff")
+        assert result == b"\xff\xee\xdd\xcc\xbb\xaa"
+
+    def test_invalid_mac_raises(self):
+        import pytest
+
+        with pytest.raises(ValueError, match="Invalid MAC"):
+            _mac_string_to_bytes("AA:BB:CC")
+
+
+class TestMacRoundtrip:
+    """Test bytes→string→bytes roundtrip."""
+
+    def test_roundtrip(self):
+        original = b"\x11\x22\x33\x44\x55\x66"
+        mac_str = _mac_bytes_to_string(original)
+        assert _mac_string_to_bytes(mac_str) == original
+
+    def test_roundtrip_string(self):
+        original = "DC:A6:32:AA:BB:CC"
+        mac_bytes = _mac_string_to_bytes(original)
+        assert _mac_bytes_to_string(mac_bytes) == original
+
+
+class TestParseBtaddrReport:
+    """Test parse_btaddr_report() for GET_FEATURE 0x04."""
+
+    def test_known_report(self):
+        # Build a 16-byte report:
+        # [0x04, ctrl_lsb(6B), pad(3B), host_lsb(6B)]
+        # Controller: 00:06:F7:AA:BB:CC → LSB: CC BB AA F7 06 00
+        # Host:       DC:A6:32:11:22:33 → LSB: 33 22 11 32 A6 DC
+        report = bytearray(FEATURE_REPORT_GET_SIZE)
+        report[0] = 0x04
+        report[1:7] = b"\xcc\xbb\xaa\xf7\x06\x00"
+        report[7:10] = b"\x00\x00\x00"  # padding
+        report[10:16] = b"\x33\x22\x11\x32\xa6\xdc"
+
+        ctrl, host = parse_btaddr_report(bytes(report))
+        assert ctrl == "00:06:F7:AA:BB:CC"
+        assert host == "DC:A6:32:11:22:33"
+
+    def test_all_zeros(self):
+        report = bytes(FEATURE_REPORT_GET_SIZE)
+        ctrl, host = parse_btaddr_report(report)
+        assert ctrl == "00:00:00:00:00:00"
+        assert host == "00:00:00:00:00:00"
+
+    def test_report_too_short_raises(self):
+        import pytest
+
+        with pytest.raises(ValueError, match="too short"):
+            parse_btaddr_report(b"\x04\x00\x00")
+
+
+class TestBuildSetBtaddrReport:
+    """Test build_set_btaddr_report() for SET_FEATURE 0x05."""
+
+    def test_report_structure(self):
+        report = build_set_btaddr_report("DC:A6:32:11:22:33")
+        assert len(report) == FEATURE_REPORT_SET_SIZE
+        assert report[0] == 0x05
+        # Bytes 1-6: LSB-first MAC
+        assert report[1:7] == b"\x33\x22\x11\x32\xa6\xdc"
+        # Remaining bytes are zero
+        assert report[7:] == b"\x00" * 16
+
+    def test_all_zeros_host(self):
+        report = build_set_btaddr_report("00:00:00:00:00:00")
+        assert report == bytes([0x05] + [0x00] * 22)
+
+    def test_broadcast_host(self):
+        report = build_set_btaddr_report("FF:FF:FF:FF:FF:FF")
+        assert report[0] == 0x05
+        assert report[1:7] == b"\xff\xff\xff\xff\xff\xff"
+        assert report[7:] == b"\x00" * 16

--- a/services/pairing_daemon/Dockerfile
+++ b/services/pairing_daemon/Dockerfile
@@ -1,25 +1,16 @@
 # Multi-stage build for JoustMania Pairing Daemon Service
 #
-# Uses pre-built psmoveapi image for faster builds.
-# Build the images first:
-#   docker build -t ghcr.io/watchmejoustmyflags/joustmania/psmove-builder:latest images/psmove-builder/
+# Build the builder image first:
 #   docker build -t ghcr.io/watchmejoustmyflags/joustmania/builder:latest images/builder/
 #
-# Builder images can be overridden for CI/CD:
+# Builder image can be overridden for CI/CD:
 # --build-arg BUILDER_IMAGE=ghcr.io/watchmejoustmyflags/joustmania/builder:dev-refactor
-# --build-arg PSMOVE_BUILDER_IMAGE=ghcr.io/watchmejoustmyflags/joustmania/psmove-builder:dev-refactor
 
-# Builder images - override with --build-arg for CI/CD
+# Builder image - override with --build-arg for CI/CD
 ARG BUILDER_IMAGE=ghcr.io/watchmejoustmyflags/joustmania/builder:latest
-ARG PSMOVE_BUILDER_IMAGE=ghcr.io/watchmejoustmyflags/joustmania/psmove-builder:latest
 
 # =============================================================================
-# Stage 1: PS Move API - use pre-built image
-# =============================================================================
-FROM ${PSMOVE_BUILDER_IMAGE} AS psmove-builder
-
-# =============================================================================
-# Stage 2: Build Python dependencies
+# Stage 1: Build Python dependencies
 # =============================================================================
 FROM ${BUILDER_IMAGE} AS python-builder
 
@@ -29,7 +20,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libbluetooth-dev \
     libdbus-1-dev \
     libglib2.0-dev \
-    libusb-dev \
     pkg-config \
     && rm -rf /var/lib/apt/lists/*
 
@@ -56,7 +46,7 @@ WORKDIR /app
 RUN uv pip install --system --no-cache-dir -e lib/ -e services/pairing_daemon/
 
 # =============================================================================
-# Stage 3: Runtime image
+# Stage 2: Runtime image
 # =============================================================================
 FROM python:3.11-slim
 
@@ -66,8 +56,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libbluetooth3 \
     libdbus-1-3 \
     libglib2.0-0 \
-    libusb-0.1-4 \
-    libusb-1.0-0 \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
@@ -75,17 +63,6 @@ WORKDIR /app
 # Copy installed packages from python-builder
 COPY --from=python-builder /usr/local/lib/python3.11/site-packages /usr/local/lib/python3.11/site-packages
 COPY --from=python-builder /usr/local/bin /usr/local/bin
-
-# Copy psmove Python bindings from pre-built psmove-builder
-COPY --from=psmove-builder /psmove/psmove.py /usr/local/lib/python3.11/site-packages/
-COPY --from=psmove-builder /psmove/_psmove.so /usr/local/lib/python3.11/site-packages/
-COPY --from=psmove-builder /psmove/libpsmoveapi.so /usr/local/lib/
-
-# Copy psmove CLI tool for calibration
-COPY --from=psmove-builder /psmove/psmove-cli /usr/local/bin/psmove
-
-# Update library cache so _psmove.so can find libpsmoveapi.so
-RUN ldconfig
 
 # Copy application code
 COPY --from=python-builder /app/pyproject.toml /app/
@@ -104,7 +81,6 @@ ENV OTEL_TRACES_EXPORTER=otlp
 ENV OTEL_LOGS_EXPORTER=none
 
 # Pairing daemon config
-ENV PSMOVE_PATH=/usr/local/bin/psmove
 ENV METRICS_PORT=8002
 
 # Expose health check port

--- a/services/pairing_daemon/psmove_pairing/__init__.py
+++ b/services/pairing_daemon/psmove_pairing/__init__.py
@@ -3,6 +3,5 @@
 from lib.telemetry import init_telemetry
 
 from .daemon import PairingDaemon
-from .utils import find_psmove_binary
 
-__all__ = ["PairingDaemon", "init_telemetry", "find_psmove_binary"]
+__all__ = ["PairingDaemon", "init_telemetry"]

--- a/services/pairing_daemon/psmove_pairing/config.py
+++ b/services/pairing_daemon/psmove_pairing/config.py
@@ -2,14 +2,12 @@
 
 import logging
 import os
-import sys
 
 logger = logging.getLogger("psmove-pairing")
 
 # Static configuration from environment
 DEBUG = os.getenv("DEBUG", "0") == "1"
 METRICS_PORT = int(os.getenv("METRICS_PORT", "8002"))
-PSMOVE_PATH = os.getenv("PSMOVE_PATH", "")
 OTEL_ENDPOINT = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")
 
 # Default intervals (used as fallback when flagd is unavailable)
@@ -69,40 +67,6 @@ def get_bt_monitor_interval() -> int:
     except Exception:
         return _DEFAULT_BT_MONITOR_INTERVAL
 
-
-def _find_psmove_bindings() -> str | None:
-    """Find psmove Python bindings.
-
-    In Docker, psmove is installed to site-packages and imports directly.
-    Falls back to PSMOVEAPI_BUILD_PATH env var for development.
-
-    Returns:
-        Path to add to sys.path, or None if psmove is already importable
-    """
-    # Check if psmove is already importable (Docker, or installed to site-packages)
-    try:
-        import psmove  # noqa: F401
-
-        return None  # Already available, no path modification needed
-    except ImportError:
-        pass
-
-    # Check environment variable for development
-    env_path = os.getenv("PSMOVEAPI_BUILD_PATH")
-    if env_path and os.path.isdir(env_path) and os.path.exists(os.path.join(env_path, "psmove.py")):
-        return env_path
-
-    return None
-
-
-# Set up psmove import path
-_psmove_path = _find_psmove_bindings()
-if _psmove_path and _psmove_path not in sys.path:
-    sys.path.insert(0, _psmove_path)
-
-# PS Move USB Vendor/Product IDs
-PSMOVE_USB_IDS = ["054c:03d5", "054c:042f"]  # Motion Controller variants
-PSMOVE_NAV_ID = "054c:03d4"  # Navigation Controller
 
 # PS Move Bluetooth MAC prefix (Sony)
 PSMOVE_BT_PREFIX = "00:06:F7"

--- a/services/pairing_daemon/psmove_pairing/daemon.py
+++ b/services/pairing_daemon/psmove_pairing/daemon.py
@@ -22,10 +22,9 @@ _HEALTH_STALENESS_THRESHOLD = 60.0  # seconds
 class PairingDaemon:
     """PS Move controller pairing daemon with async Bluetooth monitoring."""
 
-    def __init__(self, tracer: trace.Tracer, psmove_path: str):
+    def __init__(self, tracer: trace.Tracer):
         self.tracer = tracer
-        self.psmove = psmove_path
-        self.usb_pairing = USBPairing(tracer, psmove_path)
+        self.usb_pairing = USBPairing(tracer)
         self.bt_monitor = BluetoothMonitor(tracer)
 
         # Health tracking timestamps
@@ -33,7 +32,7 @@ class PairingDaemon:
         self._last_bt_monitor: float = 0.0
         self._startup_time: float = time.time()
 
-        logger.info(f"PairingDaemon initialized with psmove: {self.psmove}")
+        logger.info("PairingDaemon initialized")
 
     async def validate_prerequisites(self) -> bool:
         """Validate that required tools are available.
@@ -41,11 +40,6 @@ class PairingDaemon:
         Returns True if all prerequisites are met, False otherwise.
         """
         errors = []
-
-        # Check psmove binary
-        exit_code, output = await run_command([self.psmove, "list"])
-        if exit_code != 0:
-            errors.append(f"psmove binary failed: {output}")
 
         # Check bluetoothctl
         if not shutil.which("bluetoothctl"):
@@ -145,7 +139,6 @@ class PairingDaemon:
     async def run(self) -> None:
         """Main daemon loop with concurrent USB polling and Bluetooth monitoring."""
         logger.info("PS Move Pairing Daemon started")
-        logger.info(f"  psmove binary: {self.psmove}")
         logger.info(f"  USB poll interval: {get_poll_interval()}s")
         logger.info(f"  Bluetooth monitor interval: {get_bt_monitor_interval()}s")
         logger.info(f"  debug mode: {DEBUG}")

--- a/services/pairing_daemon/psmove_pairing/metrics.py
+++ b/services/pairing_daemon/psmove_pairing/metrics.py
@@ -38,12 +38,6 @@ pairing_duration_seconds = Histogram(
     "Time to complete pairing",
     buckets=[0.5, 1.0, 2.0, 5.0, 10.0, 30.0, 60.0],
 )
-calibration_duration_seconds = Histogram(
-    "psmove_pairing_calibration_duration_seconds",
-    "Time to calibrate controller",
-    buckets=[0.5, 1.0, 2.0, 5.0, 10.0, 30.0],
-)
-
 # Bluetooth monitoring metrics (host-level HCI layer)
 # Note: These are distinct from controller_* metrics in controller-manager
 # which measure the application layer (psmoveapi). These measure the raw

--- a/services/pairing_daemon/psmove_pairing/usb_pairing.py
+++ b/services/pairing_daemon/psmove_pairing/usb_pairing.py
@@ -1,30 +1,28 @@
 """USB controller pairing for PS Move controllers.
 
-Uses the psmove Python bindings (like the original JoustMania) for reliable
-adapter selection via pair_custom().
+Uses hidapi (hidraw backend) for direct HID feature report access,
+replacing the psmoveapi C library and its GIL-blocking pair_custom().
 """
 
 import logging
 import time
 
+import hidraw as hid
 from opentelemetry import trace
 from opentelemetry.trace import Status, StatusCode
 
-# Import config first to set up psmoveapi path
-from .config import DEBUG, get_poll_interval
-
-# Now import psmove (path was set up by config)
-try:
-    import psmove
-except ImportError as e:
-    raise ImportError(
-        "psmove module not found. Ensure PSMOVEAPI_BUILD_PATH is set correctly "
-        "and psmoveapi is built with Python bindings."
-    ) from e
+from lib.psmove_hid import (
+    ALL_PRODUCT_IDS,
+    FEATURE_REPORT_GET_BTADDR,
+    FEATURE_REPORT_GET_SIZE,
+    VENDOR_ID,
+    build_set_btaddr_report,
+    parse_btaddr_report,
+)
 
 from .adapter_manager import AdapterManager, restart_systemd_unit
+from .config import DEBUG, get_poll_interval
 from .metrics import (
-    calibration_duration_seconds,
     pairing_adapter_device_count,
     pairing_adapter_selected_total,
     pairing_attempts_total,
@@ -46,65 +44,71 @@ _ATTR_ADAPTER_ADDRESS = "adapter.address"
 class USBPairing:
     """Handles USB-connected PS Move controller pairing.
 
-    Uses the psmove Python bindings with pair_custom() for reliable
-    adapter selection, matching the original JoustMania approach.
+    Uses hidapi to read/write HID feature reports for BT address
+    management, replacing the psmoveapi C library.
     """
 
-    def __init__(self, tracer: trace.Tracer, psmove_path: str):
+    def __init__(self, tracer: trace.Tracer):
         self.tracer = tracer
-        self.psmove_cli = psmove_path  # Keep for calibration
         self.poll_count = 0
         self.adapter_manager = AdapterManager()
         # Track controllers verified this session to avoid re-processing every poll
         self._verified_serials: set[str] = set()
 
-    def get_usb_controllers_psmove(self) -> list[tuple[int, str]]:
-        """Get list of USB-connected controllers using psmove library.
+    def get_usb_controllers(self) -> list[tuple[bytes, str]]:
+        """Get list of USB-connected controllers using hidapi.
+
+        Enumerates HID devices matching PS Move vendor/product IDs,
+        filters to USB-only (interface_number >= 0), and reads the
+        controller's BT MAC from feature report 0x04.
 
         Returns:
-            List of tuples (index, serial) for USB-connected controllers
+            List of tuples (device_path, serial) for USB-connected controllers.
         """
-        connected = psmove.count_connected()
-        logger.debug(f"psmove.count_connected() = {connected}")
-        pairing_usb_controllers.set(0)  # Will update below
+        pairing_usb_controllers.set(0)
 
-        usb_controllers = []
-        for i in range(connected):
+        usb_controllers: list[tuple[bytes, str]] = []
+        devices = [d for pid in ALL_PRODUCT_IDS for d in hid.enumerate(VENDOR_ID, pid)]
+
+        for dev_info in devices:
+            # BT devices return interface_number == -1; USB returns >= 0
+            if dev_info.get("interface_number", -1) < 0:
+                continue
+
+            path = dev_info["path"]
             try:
-                move = psmove.PSMove(i)
-                if move.connection_type == psmove.Conn_USB:
-                    serial = move.get_serial()
-                    if serial:
-                        usb_controllers.append((i, serial.upper()))
-                        logger.debug(f"USB controller {i}: {serial}")
+                device = hid.device()
+                device.open_path(path)
+                try:
+                    report = device.get_feature_report(FEATURE_REPORT_GET_BTADDR, FEATURE_REPORT_GET_SIZE)
+                    if isinstance(report, list):
+                        report = bytes(report)
+                    serial, _ = parse_btaddr_report(report)
+                    usb_controllers.append((path, serial.upper()))
+                    logger.debug(f"USB controller at {path!r}: {serial}")
+                finally:
+                    device.close()
             except Exception as e:
-                logger.debug(f"Error accessing controller {i}: {e}")
+                logger.debug(f"Error reading controller at {path!r}: {e}")
 
         pairing_usb_controllers.set(len(usb_controllers))
         return usb_controllers
 
-    async def pair_controller_psmove(self, move_index: int, serial: str, adapter_address: str) -> bool:
-        """Pair a controller using psmove Python library's pair_custom().
+    async def pair_controller(self, device_path: bytes, serial: str, adapter_address: str) -> bool:
+        """Pair a controller by writing the host BT address via HID feature report.
 
-        For ZCM2 (PS4-era) controllers, pair_custom() blocks indefinitely in
-        its internal PIN agent (which can't work in Docker because systemctl
-        fails). Since the C code holds the GIL, threading timeouts don't work.
-
-        We run pair_custom() in a subprocess with a timeout. The controller's
-        BT address and BlueZ device files are written before the PIN agent
-        starts, so killing the subprocess after timeout is safe. Our own
-        bluetoothctl agent handles PIN after BlueZ is restarted.
+        Opens the device, reads the current host address, and writes the
+        new adapter address if it differs. Direct HID call (~ms), no
+        subprocess or GIL issues.
 
         Args:
-            move_index: Controller index from psmove.count_connected()
+            device_path: HID device path from enumerate()
             serial: Controller MAC address
             adapter_address: Target Bluetooth adapter address
 
         Returns:
-            True if pairing succeeded (or timed out after address was written)
+            True if pairing succeeded.
         """
-        import asyncio
-
         logger.info(f"Pairing controller {serial} to adapter {adapter_address}...")
 
         with self.tracer.start_as_current_span("pair_controller") as span:
@@ -113,56 +117,35 @@ class USBPairing:
             start_time = time.time()
 
             try:
-                move = psmove.PSMove(move_index)
-                if move.connection_type != psmove.Conn_USB:
-                    logger.warning(f"Controller {serial} not connected via USB")
-                    span.set_status(Status(StatusCode.ERROR, "Not USB connected"))
-                    return False
-                # Release the PSMove handle before subprocess uses it
-                del move
-
-                # Run pair_custom in a subprocess to avoid GIL blocking
-                script = (
-                    "import psmove; "
-                    f"m = psmove.PSMove({move_index}); "
-                    f"r = m.pair_custom('{adapter_address}'); "
-                    "print('OK' if r else 'FAIL')"
-                )
-                proc = await asyncio.create_subprocess_exec(
-                    "python",
-                    "-c",
-                    script,
-                    stdout=asyncio.subprocess.PIPE,
-                    stderr=asyncio.subprocess.PIPE,
-                )
-
+                device = hid.device()
+                device.open_path(device_path)
                 try:
-                    stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=15)
-                    output = stdout.decode().strip()
-                    result = output == "OK"
-                except TimeoutError:
-                    logger.info(
-                        f"pair_custom() timed out for {serial} (ZCM2 PIN agent blocking) "
-                        "- address written, will handle PIN via bluetoothctl agent"
-                    )
-                    proc.kill()
-                    await proc.wait()
-                    # Timeout is expected for ZCM2 — address was already written
-                    result = True
+                    # Read current host address
+                    report = device.get_feature_report(FEATURE_REPORT_GET_BTADDR, FEATURE_REPORT_GET_SIZE)
+                    if isinstance(report, list):
+                        report = bytes(report)
+                    _, current_host = parse_btaddr_report(report)
+                    span.set_attribute("pair.current_host", current_host)
+
+                    if current_host.upper() == adapter_address.upper():
+                        logger.info(f"Controller {serial} already paired to {adapter_address}")
+                        span.set_attribute("pair.already_paired", True)
+                    else:
+                        logger.info(f"Writing host address {adapter_address} (was {current_host})")
+
+                    # Write new host address (idempotent — safe to write even if same)
+                    set_report = build_set_btaddr_report(adapter_address)
+                    device.send_feature_report(set_report)
+                finally:
+                    device.close()
 
                 duration = time.time() - start_time
                 pairing_duration_seconds.observe(duration)
-
-                span.set_attribute("pair.result", result)
+                span.set_attribute("pair.result", True)
                 span.set_attribute("pair.duration_seconds", duration)
-
-                if result:
-                    logger.info(f"pair_custom() succeeded for {serial}")
-                    span.set_status(Status(StatusCode.OK))
-                    return True
-                logger.error(f"pair_custom() returned False for {serial}")
-                span.set_status(Status(StatusCode.ERROR, "pair_custom failed"))
-                return False
+                logger.info(f"Pairing succeeded for {serial}")
+                span.set_status(Status(StatusCode.OK))
+                return True
 
             except Exception as e:
                 duration = time.time() - start_time
@@ -170,30 +153,6 @@ class USBPairing:
                 logger.error(f"Exception during pairing: {e}", exc_info=DEBUG)
                 span.set_status(Status(StatusCode.ERROR, str(e)))
                 return False
-
-    async def calibrate_controller(self, serial: str) -> bool:
-        """Calibrate the controller using CLI tool."""
-        logger.info("Calibrating controller...")
-
-        with self.tracer.start_as_current_span("calibrate_controller") as span:
-            span.set_attribute(_ATTR_CONTROLLER_SERIAL, serial)
-            start_time = time.time()
-
-            exit_code, output = await run_command([self.psmove_cli, "calibrate"])
-            duration = time.time() - start_time
-            calibration_duration_seconds.observe(duration)
-
-            logger.debug(f"Calibrate output: {output}")
-            span.set_attribute("calibrate.exit_code", exit_code)
-            span.set_attribute("calibrate.duration_seconds", duration)
-
-            if exit_code != 0:
-                logger.warning(f"Calibration returned non-zero: {exit_code}")
-                span.set_status(Status(StatusCode.ERROR, "Calibration returned non-zero"))
-            else:
-                span.set_status(Status(StatusCode.OK))
-
-            return exit_code == 0
 
     async def restart_bluetooth_service(self) -> None:
         """Restart the host's BlueZ bluetooth service via D-Bus systemd interface.
@@ -242,7 +201,7 @@ class USBPairing:
         logger.warning(f"bluetoothctl trust failed for {serial}, continuing anyway")
         return False
 
-    async def process_controller(self, move_index: int, serial: str) -> bool:
+    async def process_controller(self, device_path: bytes, serial: str) -> bool:
         """Process a single USB-connected controller with load-balanced adapter selection."""
         with self.tracer.start_as_current_span("process_controller") as span:
             span.set_attribute(_ATTR_CONTROLLER_SERIAL, serial)
@@ -258,11 +217,7 @@ class USBPairing:
 
             already_in_bluez = not self.adapter_manager.check_if_not_paired(serial)
             if already_in_bluez:
-                # BlueZ has a device record, but the controller's internal host
-                # address may point to a different system. Always run pair_custom()
-                # to verify and fix if needed — it's idempotent (only writes if
-                # the host address actually differs).
-                logger.info(f"Controller {serial} in BlueZ device list, verifying host address via pair_custom()")
+                logger.info(f"Controller {serial} in BlueZ device list, verifying host address")
                 span.set_attribute("verify_existing", True)
             else:
                 logger.info(f"Found unpaired USB controller: {serial}")
@@ -288,8 +243,8 @@ class USBPairing:
             pairing_adapter_selected_total.labels(adapter=adapter.address).inc()
             pairing_adapter_device_count.labels(adapter=adapter.address).set(adapter.device_count)
 
-            # Pair controller to selected adapter using Python bindings
-            if not await self.pair_controller_psmove(move_index, serial, adapter.address):
+            # Pair controller to selected adapter via HID feature report
+            if not await self.pair_controller(device_path, serial, adapter.address):
                 logger.error(f"PAIRING FAILED: Controller {serial} could not be paired")
                 pairing_failed_total.inc()
                 span.set_status(Status(StatusCode.ERROR, "Pairing failed"))
@@ -300,9 +255,6 @@ class USBPairing:
 
             # Trust device in BlueZ (for ZCM2, agent handles PIN at connect time)
             await self.bluez_trust_controller(serial)
-
-            # Calibrate
-            await self.calibrate_controller(serial)
 
             # Mark as verified so we don't re-process every poll cycle
             self._verified_serials.add(serial)
@@ -326,8 +278,8 @@ class USBPairing:
         with self.tracer.start_as_current_span("poll_cycle") as span:
             span.set_attribute("poll.count", self.poll_count)
 
-            # Get USB controllers using psmove library
-            controllers = self.get_usb_controllers_psmove()
+            # Get USB controllers using hidapi
+            controllers = self.get_usb_controllers()
             span.set_attribute("controllers.count", len(controllers))
 
             if not controllers:
@@ -335,8 +287,8 @@ class USBPairing:
                 return
 
             # Process each controller
-            for move_index, serial in controllers:
-                await self.process_controller(move_index, serial)
+            for device_path, serial in controllers:
+                await self.process_controller(device_path, serial)
 
     async def run_loop(self) -> None:
         """USB polling loop.
@@ -346,7 +298,6 @@ class USBPairing:
         import asyncio
 
         logger.info(f"Starting USB poll loop (interval: {get_poll_interval()}s)")
-        logger.info(f"Using psmove Python bindings (psmove.Conn_USB={psmove.Conn_USB})")
 
         while True:
             try:

--- a/services/pairing_daemon/psmove_pairing/utils.py
+++ b/services/pairing_daemon/psmove_pairing/utils.py
@@ -3,38 +3,8 @@
 import asyncio
 import logging
 import os
-import shutil
-import sys
-
-from .config import PSMOVE_PATH
 
 logger = logging.getLogger("psmove-pairing")
-
-
-def find_psmove_binary() -> str:
-    """Find the psmove binary, checking various locations."""
-    if PSMOVE_PATH and os.path.isfile(PSMOVE_PATH):
-        return PSMOVE_PATH
-
-    # Check if it's in PATH
-    psmove_in_path = shutil.which("psmove")
-    if psmove_in_path:
-        return psmove_in_path
-
-    # Common installation locations
-    home = os.path.expanduser("~")
-    candidates = [
-        f"{home}/psmoveapi/build/psmove",
-        "/home/joustmania/psmoveapi/build/psmove",
-        "/usr/local/bin/psmove",
-    ]
-
-    for candidate in candidates:
-        if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
-            return candidate
-
-    logger.error("psmove binary not found. Install psmoveapi or set PSMOVE_PATH")
-    sys.exit(1)
 
 
 async def run_command(

--- a/services/pairing_daemon/pyproject.toml
+++ b/services/pairing_daemon/pyproject.toml
@@ -15,8 +15,8 @@ dependencies = [
     # DBus for BlueZ adapter management
     "dbus-fast>=2.0.0; sys_platform == 'linux'",  # Async D-Bus
 
-    # NOTE: psmove/psmoveapi must be built from source (not on PyPI)
-    # See: https://github.com/thp/psmoveapi for build instructions
+    # HID access for USB controller pairing (feature reports)
+    "hidapi>=0.14.0",
 ]
 
 [project.optional-dependencies]

--- a/services/pairing_daemon/server.py
+++ b/services/pairing_daemon/server.py
@@ -2,8 +2,9 @@
 """
 PS Move Controller Pairing Daemon.
 
-Polls for USB-connected PS Move controllers and pairs them automatically.
-Monitors Bluetooth-connected controllers for signal strength and connection status.
+Polls for USB-connected PS Move controllers and pairs them automatically
+using hidapi for direct HID feature report access. Monitors Bluetooth-connected
+controllers for signal strength and connection status.
 Provides OTEL push metrics and OpenTelemetry tracing for observability.
 
 Runs as a Docker container alongside other JoustMania services.
@@ -14,7 +15,6 @@ LED Feedback:
   - Red flash 3x: Error
 
 Environment:
-  PSMOVE_PATH   - path to psmove binary (default: auto-detect)
   DEBUG         - set to 1 for verbose logging
   HEALTH_PORT   - port for health check endpoint (default: 8002)
   OTEL_EXPORTER_OTLP_ENDPOINT - OTLP collector endpoint (default: http://localhost:4317)
@@ -37,7 +37,7 @@ from threading import Thread
 
 from lib.otel_metrics import init_metrics
 from lib.system_metrics import start_system_metrics_collector_thread
-from psmove_pairing import PairingDaemon, find_psmove_binary, init_telemetry, metrics
+from psmove_pairing import PairingDaemon, init_telemetry, metrics
 from psmove_pairing.config import DEBUG, METRICS_PORT, init_performance_flags
 
 # Global daemon reference for health checks
@@ -120,11 +120,8 @@ def main() -> None:
     # Initialize OpenTelemetry tracing
     tracer = init_telemetry()
 
-    # Find psmove binary
-    psmove_path = find_psmove_binary()
-
     # Create and run daemon
-    _daemon = PairingDaemon(tracer, psmove_path)
+    _daemon = PairingDaemon(tracer)
     asyncio.run(_daemon.run())
 
 

--- a/services/pairing_daemon/tests/conftest.py
+++ b/services/pairing_daemon/tests/conftest.py
@@ -1,11 +1,13 @@
 """
 Pytest fixtures for pairing daemon tests.
 
-Mocks psmove module and provides test utilities.
+Mocks hidraw module and provides test utilities.
 """
 
 import os
 import sys
+from types import ModuleType
+from unittest.mock import MagicMock
 
 # Disable OTEL metrics before importing modules that use them
 from lib.otel_metrics import disable_metrics_for_tests
@@ -16,14 +18,11 @@ disable_metrics_for_tests()
 os.environ["OTEL_SDK_DISABLED"] = "true"
 os.environ["OTEL_TRACES_EXPORTER"] = "none"
 
-# Mock psmove module before it gets imported
-from unittest.mock import MagicMock
-
-mock_psmove = MagicMock()
-mock_psmove.Conn_USB = 1
-mock_psmove.Conn_Bluetooth = 2
-mock_psmove.count_connected.return_value = 0
-sys.modules["psmove"] = mock_psmove
+# Mock hidraw module before it gets imported (same pattern as test_hidapi_adapter.py)
+_mock_hid = ModuleType("hidraw")
+_mock_hid.enumerate = MagicMock(return_value=[])
+_mock_hid.device = MagicMock
+sys.modules.setdefault("hidraw", _mock_hid)
 
 import pytest
 
@@ -87,12 +86,6 @@ def mock_tracer():
     span.__exit__ = MagicMock(return_value=False)
     tracer.start_as_current_span.return_value = span
     return tracer
-
-
-@pytest.fixture
-def mock_psmove_module():
-    """Provide a configurable mock psmove module."""
-    return mock_psmove
 
 
 # Sample command outputs for testing

--- a/services/pairing_daemon/tests/test_daemon.py
+++ b/services/pairing_daemon/tests/test_daemon.py
@@ -13,7 +13,7 @@ from .conftest import MockCommandRunner
 @pytest.fixture
 def daemon(mock_tracer):
     """Provide PairingDaemon instance for tests."""
-    return PairingDaemon(mock_tracer, "/usr/bin/psmove")
+    return PairingDaemon(mock_tracer)
 
 
 class TestValidatePrerequisites:
@@ -23,7 +23,6 @@ class TestValidatePrerequisites:
     async def test_all_prerequisites_pass(self, daemon):
         """Test when all prerequisites are available."""
         runner = MockCommandRunner()
-        runner.add_response(["/usr/bin/psmove", "list"], (0, "Controller 0: ..."))
         runner.add_response(["bluetoothctl", "show"], (0, "Controller ..."))
 
         with patch("psmove_pairing.daemon.run_command", runner):
@@ -32,25 +31,28 @@ class TestValidatePrerequisites:
                 assert result is True
 
     @pytest.mark.asyncio
-    async def test_psmove_fails(self, daemon):
-        """Test when psmove binary fails."""
+    async def test_bluetoothctl_not_found(self, daemon):
+        """Test when bluetoothctl is not found."""
         runner = MockCommandRunner()
-        runner.add_response(["/usr/bin/psmove", "list"], (1, "error"))
-        runner.add_response(["bluetoothctl", "show"], (0, "Controller ..."))
+
+        def mock_which(cmd):
+            if cmd == "bluetoothctl":
+                return None
+            return f"/usr/bin/{cmd}"
 
         with patch("psmove_pairing.daemon.run_command", runner):
-            with patch("psmove_pairing.daemon.shutil.which", return_value="/usr/bin/tool"):
+            with patch("psmove_pairing.daemon.shutil.which", side_effect=mock_which):
                 result = await daemon.validate_prerequisites()
                 assert result is False
 
     @pytest.mark.asyncio
-    async def test_bluetoothctl_not_found(self, daemon):
-        """Test when bluetoothctl is not found."""
+    async def test_hciconfig_not_found(self, daemon):
+        """Test when hciconfig is not found."""
         runner = MockCommandRunner()
-        runner.add_response(["/usr/bin/psmove", "list"], (0, "ok"))
+        runner.add_response(["bluetoothctl", "show"], (0, "Controller ..."))
 
         def mock_which(cmd):
-            if cmd == "bluetoothctl":
+            if cmd == "hciconfig":
                 return None
             return f"/usr/bin/{cmd}"
 
@@ -157,7 +159,6 @@ class TestRun:
         daemon._bt_monitor_loop = mock_bt_loop
 
         runner = MockCommandRunner()
-        runner.add_response(["/usr/bin/psmove", "list"], (0, "ok"))
         runner.add_response(["bluetoothctl", "show"], (0, "ok"))
 
         with patch("psmove_pairing.daemon.run_command", runner):

--- a/services/pairing_daemon/tests/test_usb_pairing.py
+++ b/services/pairing_daemon/tests/test_usb_pairing.py
@@ -9,137 +9,182 @@ from psmove_pairing.usb_pairing import USBPairing
 
 from .conftest import MockCommandRunner
 
+# Fake HID device paths (bytes, as returned by hidapi)
+FAKE_PATH_1 = b"/dev/hidraw3"
+FAKE_PATH_2 = b"/dev/hidraw4"
+
+# Feature report 0x04 for controller AA:BB:CC:DD:EE:FF with host 11:22:33:44:55:66
+# Controller MAC LSB-first: FF EE DD CC BB AA
+# Host MAC LSB-first: 66 55 44 33 22 11
+SAMPLE_FEATURE_REPORT = bytes(
+    [0x04, 0xFF, 0xEE, 0xDD, 0xCC, 0xBB, 0xAA, 0x00, 0x00, 0x00, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11]
+)
+
+# Zero host (unpaired)
+SAMPLE_FEATURE_REPORT_UNPAIRED = bytes(
+    [0x04, 0xFF, 0xEE, 0xDD, 0xCC, 0xBB, 0xAA, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]
+)
+
+
+def _make_dev_info(
+    path: bytes = FAKE_PATH_1,
+    vendor_id: int = 0x054C,
+    product_id: int = 0x03D5,
+    interface_number: int = 0,
+) -> dict:
+    """Create a fake hid.enumerate() device info dict."""
+    return {
+        "path": path,
+        "vendor_id": vendor_id,
+        "product_id": product_id,
+        "interface_number": interface_number,
+        "serial_number": "",
+    }
+
 
 @pytest.fixture
 def usb_pairing(mock_tracer):
     """Provide USBPairing instance for tests."""
-    return USBPairing(mock_tracer, "/usr/bin/psmove")
+    return USBPairing(mock_tracer)
 
 
-class TestGetUSBControllersPsmove:
-    """Tests for get_usb_controllers_psmove()."""
+class TestGetUSBControllers:
+    """Tests for get_usb_controllers()."""
 
-    def test_no_controllers_connected(self, usb_pairing, mock_psmove_module):
-        """Test when no controllers are connected."""
-        mock_psmove_module.count_connected.return_value = 0
+    @patch("psmove_pairing.usb_pairing.hid")
+    def test_no_controllers_connected(self, mock_hid, usb_pairing):
+        """Test when no HID devices are found."""
+        mock_hid.enumerate.return_value = []
 
-        controllers = usb_pairing.get_usb_controllers_psmove()
+        controllers = usb_pairing.get_usb_controllers()
         assert controllers == []
 
-    def test_usb_controller_detected(self, usb_pairing, mock_psmove_module):
-        """Test when USB controller is detected."""
-        mock_psmove_module.count_connected.return_value = 1
+    @patch("psmove_pairing.usb_pairing.hid")
+    def test_usb_controller_detected(self, mock_hid, usb_pairing):
+        """Test when a USB controller is detected via feature report."""
+        # enumerate is called once per product ID; return device for first PID only
+        mock_hid.enumerate.side_effect = lambda _v, p: [_make_dev_info()] if p == 0x03D5 else []
 
-        mock_move = MagicMock()
-        mock_move.connection_type = mock_psmove_module.Conn_USB
-        mock_move.get_serial.return_value = "aa:bb:cc:dd:ee:ff"
-        mock_psmove_module.PSMove.return_value = mock_move
+        mock_device = MagicMock()
+        mock_device.get_feature_report.return_value = SAMPLE_FEATURE_REPORT
+        mock_hid.device.return_value = mock_device
 
-        controllers = usb_pairing.get_usb_controllers_psmove()
+        controllers = usb_pairing.get_usb_controllers()
         assert len(controllers) == 1
-        assert controllers[0] == (0, "AA:BB:CC:DD:EE:FF")
+        assert controllers[0] == (FAKE_PATH_1, "AA:BB:CC:DD:EE:FF")
+        mock_device.open_path.assert_called_once_with(FAKE_PATH_1)
+        mock_device.close.assert_called_once()
 
-    def test_bluetooth_controller_excluded(self, usb_pairing, mock_psmove_module):
-        """Test that Bluetooth controllers are excluded."""
-        mock_psmove_module.count_connected.return_value = 1
+    @patch("psmove_pairing.usb_pairing.hid")
+    def test_bluetooth_controller_excluded(self, mock_hid, usb_pairing):
+        """Test that Bluetooth controllers (interface_number == -1) are excluded."""
+        mock_hid.enumerate.side_effect = lambda _v, p: [_make_dev_info(interface_number=-1)] if p == 0x03D5 else []
 
-        mock_move = MagicMock()
-        mock_move.connection_type = mock_psmove_module.Conn_Bluetooth
-        mock_psmove_module.PSMove.return_value = mock_move
-
-        controllers = usb_pairing.get_usb_controllers_psmove()
+        controllers = usb_pairing.get_usb_controllers()
         assert controllers == []
+        # Should not attempt to open BT devices
+        mock_hid.device.assert_not_called()
+
+    @patch("psmove_pairing.usb_pairing.hid")
+    def test_multiple_controllers(self, mock_hid, usb_pairing):
+        """Test multiple USB controllers enumerated with BT filtered out."""
+        # Two controllers for one PID: one USB, one BT (filtered out)
+        mock_hid.enumerate.side_effect = (
+            lambda _v, p: [
+                _make_dev_info(path=FAKE_PATH_1, interface_number=0),
+                _make_dev_info(path=FAKE_PATH_2, interface_number=-1),
+            ]
+            if p == 0x03D5
+            else []
+        )
+
+        mock_device = MagicMock()
+        mock_device.get_feature_report.return_value = SAMPLE_FEATURE_REPORT
+        mock_hid.device.return_value = mock_device
+
+        controllers = usb_pairing.get_usb_controllers()
+        assert len(controllers) == 1  # BT one filtered out
+
+    @patch("psmove_pairing.usb_pairing.hid")
+    def test_hid_error_skips_device(self, mock_hid, usb_pairing):
+        """Test that HID errors during enumeration skip the device gracefully."""
+        mock_hid.enumerate.side_effect = lambda _v, p: [_make_dev_info()] if p == 0x03D5 else []
+
+        mock_device = MagicMock()
+        mock_device.get_feature_report.side_effect = OSError("Device busy")
+        mock_hid.device.return_value = mock_device
+
+        controllers = usb_pairing.get_usb_controllers()
+        assert controllers == []
+        mock_device.close.assert_called_once()
+
+    @patch("psmove_pairing.usb_pairing.hid")
+    def test_feature_report_returned_as_list(self, mock_hid, usb_pairing):
+        """Test that list-type feature report (hidraw quirk) is handled."""
+        mock_hid.enumerate.side_effect = lambda _v, p: [_make_dev_info()] if p == 0x03D5 else []
+
+        mock_device = MagicMock()
+        mock_device.get_feature_report.return_value = list(SAMPLE_FEATURE_REPORT)
+        mock_hid.device.return_value = mock_device
+
+        controllers = usb_pairing.get_usb_controllers()
+        assert len(controllers) == 1
+        assert controllers[0] == (FAKE_PATH_1, "AA:BB:CC:DD:EE:FF")
 
 
-class TestPairControllerPsmove:
-    """Tests for pair_controller_psmove()."""
+class TestPairController:
+    """Tests for pair_controller()."""
 
     @pytest.mark.asyncio
-    async def test_successful_pairing(self, usb_pairing, mock_psmove_module):
-        """Test successful pairing via subprocess."""
-        mock_move = MagicMock()
-        mock_move.connection_type = mock_psmove_module.Conn_USB
-        mock_psmove_module.PSMove.return_value = mock_move
+    @patch("psmove_pairing.usb_pairing.hid")
+    async def test_successful_pairing(self, mock_hid, usb_pairing):
+        """Test successful pairing writes host address."""
+        mock_device = MagicMock()
+        mock_device.get_feature_report.return_value = SAMPLE_FEATURE_REPORT_UNPAIRED
+        mock_hid.device.return_value = mock_device
 
-        mock_proc = AsyncMock()
-        mock_proc.communicate.return_value = (b"OK\n", b"")
-
-        with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
-            result = await usb_pairing.pair_controller_psmove(0, "AA:BB:CC:DD:EE:FF", "11:22:33:44:55:66")
-            assert result is True
-
-    @pytest.mark.asyncio
-    async def test_pairing_failure(self, usb_pairing, mock_psmove_module):
-        """Test pairing failure."""
-        mock_move = MagicMock()
-        mock_move.connection_type = mock_psmove_module.Conn_USB
-        mock_psmove_module.PSMove.return_value = mock_move
-
-        mock_proc = AsyncMock()
-        mock_proc.communicate.return_value = (b"FAIL\n", b"")
-
-        with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
-            result = await usb_pairing.pair_controller_psmove(0, "AA:BB:CC:DD:EE:FF", "11:22:33:44:55:66")
-            assert result is False
+        result = await usb_pairing.pair_controller(FAKE_PATH_1, "AA:BB:CC:DD:EE:FF", "11:22:33:44:55:66")
+        assert result is True
+        mock_device.open_path.assert_called_once_with(FAKE_PATH_1)
+        mock_device.send_feature_report.assert_called_once()
+        mock_device.close.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_not_usb_connected(self, usb_pairing, mock_psmove_module):
-        """Test when controller is not USB connected."""
-        mock_move = MagicMock()
-        mock_move.connection_type = mock_psmove_module.Conn_Bluetooth
-        mock_psmove_module.PSMove.return_value = mock_move
+    @patch("psmove_pairing.usb_pairing.hid")
+    async def test_pairing_already_set(self, mock_hid, usb_pairing):
+        """Test pairing when host address already matches (still succeeds)."""
+        mock_device = MagicMock()
+        mock_device.get_feature_report.return_value = SAMPLE_FEATURE_REPORT
+        mock_hid.device.return_value = mock_device
 
-        result = await usb_pairing.pair_controller_psmove(0, "AA:BB:CC:DD:EE:FF", "11:22:33:44:55:66")
+        result = await usb_pairing.pair_controller(FAKE_PATH_1, "AA:BB:CC:DD:EE:FF", "11:22:33:44:55:66")
+        assert result is True
+        # Still writes (idempotent)
+        mock_device.send_feature_report.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch("psmove_pairing.usb_pairing.hid")
+    async def test_hid_error_returns_false(self, mock_hid, usb_pairing):
+        """Test that HID errors during pairing return False."""
+        mock_device = MagicMock()
+        mock_device.open_path.side_effect = OSError("Device not found")
+        mock_hid.device.return_value = mock_device
+
+        result = await usb_pairing.pair_controller(FAKE_PATH_1, "AA:BB:CC:DD:EE:FF", "11:22:33:44:55:66")
         assert result is False
 
     @pytest.mark.asyncio
-    async def test_timeout_treated_as_success(self, usb_pairing, mock_psmove_module):
-        """Test that timeout (ZCM2 PIN agent blocking) is treated as success."""
-        mock_move = MagicMock()
-        mock_move.connection_type = mock_psmove_module.Conn_USB
-        mock_psmove_module.PSMove.return_value = mock_move
+    @patch("psmove_pairing.usb_pairing.hid")
+    async def test_send_feature_report_error(self, mock_hid, usb_pairing):
+        """Test that send_feature_report errors return False."""
+        mock_device = MagicMock()
+        mock_device.get_feature_report.return_value = SAMPLE_FEATURE_REPORT_UNPAIRED
+        mock_device.send_feature_report.side_effect = OSError("Write failed")
+        mock_hid.device.return_value = mock_device
 
-        mock_proc = AsyncMock()
-        mock_proc.communicate.side_effect = TimeoutError()
-        mock_proc.kill = MagicMock()
-        mock_proc.wait = AsyncMock()
-
-        with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
-            result = await usb_pairing.pair_controller_psmove(0, "AA:BB:CC:DD:EE:FF", "11:22:33:44:55:66")
-            assert result is True
-            mock_proc.kill.assert_called_once()
-
-    @pytest.mark.asyncio
-    async def test_exception_handling(self, usb_pairing, mock_psmove_module):
-        """Test exception handling during pairing."""
-        mock_psmove_module.PSMove.side_effect = RuntimeError("Hardware error")
-
-        result = await usb_pairing.pair_controller_psmove(0, "AA:BB:CC:DD:EE:FF", "11:22:33:44:55:66")
+        result = await usb_pairing.pair_controller(FAKE_PATH_1, "AA:BB:CC:DD:EE:FF", "11:22:33:44:55:66")
         assert result is False
-
-
-class TestCalibrateController:
-    """Tests for calibrate_controller()."""
-
-    @pytest.mark.asyncio
-    async def test_successful_calibration(self, usb_pairing):
-        """Test successful calibration."""
-        runner = MockCommandRunner()
-        runner.add_response(["/usr/bin/psmove", "calibrate"], (0, "Calibration complete"))
-
-        with patch("psmove_pairing.usb_pairing.run_command", runner):
-            result = await usb_pairing.calibrate_controller("00:06:F7:AA:BB:CC")
-            assert result is True
-
-    @pytest.mark.asyncio
-    async def test_calibration_failure(self, usb_pairing):
-        """Test calibration failure (non-critical)."""
-        runner = MockCommandRunner()
-        runner.add_response(["/usr/bin/psmove", "calibrate"], (1, "Calibration failed"))
-
-        with patch("psmove_pairing.usb_pairing.run_command", runner):
-            result = await usb_pairing.calibrate_controller("00:06:F7:AA:BB:CC")
-            assert result is False
+        mock_device.close.assert_called_once()
 
 
 class TestRestartBluetoothService:
@@ -213,24 +258,21 @@ class TestProcessController:
 
     @pytest.mark.asyncio
     async def test_already_in_bluez_runs_full_pairing(self, usb_pairing):
-        """Test that 'already paired' controllers still go through pair_custom() to verify host address."""
+        """Test that 'already paired' controllers still go through pairing to verify host address."""
         usb_pairing.adapter_manager.refresh_adapters = AsyncMock()
         usb_pairing.adapter_manager.check_if_not_paired = MagicMock(return_value=False)
         adapter = AdapterInfo(hci="hci0", address="11:22:33:44:55:66", name="adapter-hci0", device_count=0)
         usb_pairing.adapter_manager.select_least_loaded_adapter = MagicMock(return_value=adapter)
-        usb_pairing.pair_controller_psmove = AsyncMock(return_value=True)
+        usb_pairing.pair_controller = AsyncMock(return_value=True)
         usb_pairing.restart_bluetooth_service = AsyncMock()
         usb_pairing.bluez_trust_controller = AsyncMock(return_value=True)
-        usb_pairing.calibrate_controller = AsyncMock(return_value=True)
 
-        result = await usb_pairing.process_controller(0, "00:06:F7:AA:BB:CC")
+        result = await usb_pairing.process_controller(FAKE_PATH_1, "00:06:F7:AA:BB:CC")
 
         assert result is True
-        # pair_custom is called even though BlueZ thinks it's paired
-        usb_pairing.pair_controller_psmove.assert_called_once_with(0, "00:06:F7:AA:BB:CC", "11:22:33:44:55:66")
+        usb_pairing.pair_controller.assert_called_once_with(FAKE_PATH_1, "00:06:F7:AA:BB:CC", "11:22:33:44:55:66")
         usb_pairing.restart_bluetooth_service.assert_called_once()
         usb_pairing.bluez_trust_controller.assert_called_once()
-        usb_pairing.calibrate_controller.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_verified_serial_skipped_on_subsequent_poll(self, usb_pairing):
@@ -239,20 +281,19 @@ class TestProcessController:
         usb_pairing.adapter_manager.check_if_not_paired = MagicMock(return_value=True)
         adapter = AdapterInfo(hci="hci0", address="11:22:33:44:55:66", name="adapter-hci0", device_count=0)
         usb_pairing.adapter_manager.select_least_loaded_adapter = MagicMock(return_value=adapter)
-        usb_pairing.pair_controller_psmove = AsyncMock(return_value=True)
+        usb_pairing.pair_controller = AsyncMock(return_value=True)
         usb_pairing.restart_bluetooth_service = AsyncMock()
         usb_pairing.bluez_trust_controller = AsyncMock(return_value=True)
-        usb_pairing.calibrate_controller = AsyncMock(return_value=True)
 
         # First call: full pairing
-        result1 = await usb_pairing.process_controller(0, "00:06:F7:AA:BB:CC")
+        result1 = await usb_pairing.process_controller(FAKE_PATH_1, "00:06:F7:AA:BB:CC")
         assert result1 is True
 
         # Second call: should skip
-        result2 = await usb_pairing.process_controller(0, "00:06:F7:AA:BB:CC")
+        result2 = await usb_pairing.process_controller(FAKE_PATH_1, "00:06:F7:AA:BB:CC")
         assert result2 is False
-        # pair_custom only called once (first time)
-        usb_pairing.pair_controller_psmove.assert_called_once()
+        # pair_controller only called once (first time)
+        usb_pairing.pair_controller.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_no_adapters_available(self, usb_pairing):
@@ -261,7 +302,7 @@ class TestProcessController:
         usb_pairing.adapter_manager.check_if_not_paired = MagicMock(return_value=True)
         usb_pairing.adapter_manager.select_least_loaded_adapter = MagicMock(return_value=None)
 
-        result = await usb_pairing.process_controller(0, "00:06:F7:AA:BB:CC")
+        result = await usb_pairing.process_controller(FAKE_PATH_1, "00:06:F7:AA:BB:CC")
         assert result is False
 
 
@@ -269,18 +310,20 @@ class TestPoll:
     """Tests for poll()."""
 
     @pytest.mark.asyncio
-    async def test_poll_increments_count(self, usb_pairing, mock_psmove_module):
+    @patch("psmove_pairing.usb_pairing.hid")
+    async def test_poll_increments_count(self, mock_hid, usb_pairing):
         """Test that poll count is incremented."""
-        mock_psmove_module.count_connected.return_value = 0
+        mock_hid.enumerate.side_effect = lambda _v, _p: []
 
         initial_count = usb_pairing.poll_count
         await usb_pairing.poll()
         assert usb_pairing.poll_count == initial_count + 1
 
     @pytest.mark.asyncio
-    async def test_poll_skips_when_no_controllers(self, usb_pairing, mock_psmove_module):
+    @patch("psmove_pairing.usb_pairing.hid")
+    async def test_poll_skips_when_no_controllers(self, mock_hid, usb_pairing):
         """Test that poll skips processing when no USB controllers found."""
-        mock_psmove_module.count_connected.return_value = 0
+        mock_hid.enumerate.side_effect = lambda _v, _p: []
 
         await usb_pairing.poll()
         # No process_controller calls expected

--- a/services/pairing_daemon/tests/test_utils.py
+++ b/services/pairing_daemon/tests/test_utils.py
@@ -1,12 +1,10 @@
 """Tests for psmove_pairing.utils module."""
 
-import os
-import tempfile
 from unittest.mock import patch
 
 import pytest
 
-from psmove_pairing.utils import find_psmove_binary, run_command
+from psmove_pairing.utils import run_command
 
 
 class TestRunCommand:
@@ -70,38 +68,3 @@ class TestRunCommand:
         exit_code, output = await run_command(["sh", "-c", "echo $TEST_VAR"], env={"TEST_VAR": "hello"})
         assert exit_code == 0
         assert output == "hello"
-
-
-class TestFindPsmoveBinary:
-    """Tests for find_psmove_binary()."""
-
-    def test_env_var_takes_precedence(self):
-        """Test that PSMOVE_PATH environment variable takes precedence."""
-        with tempfile.NamedTemporaryFile(mode="w", suffix="psmove", delete=False) as f:
-            f.write("#!/bin/bash\nexit 0\n")
-            temp_path = f.name
-
-        try:
-            os.chmod(temp_path, 0o755)
-            with patch.dict(os.environ, {"PSMOVE_PATH": temp_path}):
-                with patch("psmove_pairing.utils.PSMOVE_PATH", temp_path):
-                    result = find_psmove_binary()
-                    assert result == temp_path
-        finally:
-            os.unlink(temp_path)
-
-    def test_path_lookup(self):
-        """Test that shutil.which is used for PATH lookup."""
-        with patch("psmove_pairing.utils.PSMOVE_PATH", ""):
-            with patch("psmove_pairing.utils.shutil.which", return_value="/usr/bin/psmove"):
-                result = find_psmove_binary()
-                assert result == "/usr/bin/psmove"
-
-    def test_exits_when_not_found(self):
-        """Test that sys.exit is called when binary not found."""
-        with patch("psmove_pairing.utils.PSMOVE_PATH", ""):
-            with patch("psmove_pairing.utils.shutil.which", return_value=None):
-                with patch("psmove_pairing.utils.os.path.isfile", return_value=False):
-                    with patch("psmove_pairing.utils.sys.exit") as mock_exit:
-                        find_psmove_binary()
-                        mock_exit.assert_called_once_with(1)

--- a/uv.lock
+++ b/uv.lock
@@ -387,7 +387,7 @@ wheels = [
 
 [[package]]
 name = "joustmania"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 
 [package.dev-dependencies]
@@ -673,6 +673,7 @@ version = "1.0.0"
 source = { editable = "services/pairing_daemon" }
 dependencies = [
     { name = "dbus-fast", marker = "sys_platform == 'linux'" },
+    { name = "hidapi" },
     { name = "joustmania-lib" },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp-proto-grpc" },
@@ -689,6 +690,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "dbus-fast", marker = "sys_platform == 'linux'", specifier = ">=2.0.0" },
+    { name = "hidapi", specifier = ">=0.14.0" },
     { name = "joustmania-lib", editable = "lib" },
     { name = "opentelemetry-api", specifier = ">=1.20.0" },
     { name = "opentelemetry-exporter-otlp-proto-grpc", specifier = ">=1.20.0" },


### PR DESCRIPTION
## Summary

- Replace psmoveapi C library with direct hidapi feature report access for USB controller pairing
- Eliminate GIL blocking (no more subprocess workaround with 15s timeout), psmove-builder Docker image dependency, and dual-HID-stack inconsistency
- Add `parse_btaddr_report()` / `build_set_btaddr_report()` to `lib/psmove_hid.py` for HID feature report 0x04/0x05 (BT address read/write)
- Remove `calibrate_controller()` (controller_manager uses raw accel values, never reads psmoveapi calibration data)

Closes #604, closes #605, closes #606, closes #607, closes #608, closes #609

## Changes

| File | What changed |
|------|-------------|
| `lib/psmove_hid.py` | Added feature report constants + 4 functions for BT address get/set |
| `lib/tests/test_psmove_hid.py` | Added 16 tests for MAC conversion and feature report parsing |
| `usb_pairing.py` | Rewrote with `import hidraw as hid` — direct HID feature reports instead of psmoveapi subprocess |
| `config.py` | Removed `PSMOVE_PATH`, `_find_psmove_bindings()`, `sys.path` manipulation, `PSMOVE_USB_IDS` |
| `daemon.py` | Removed `psmove_path` param, psmove binary validation, psmove log line |
| `metrics.py` | Removed `calibration_duration_seconds` histogram |
| `utils.py` | Removed `find_psmove_binary()`, kept `run_command()` |
| `__init__.py` | Removed `find_psmove_binary` export |
| `server.py` | Removed psmove binary lookup, simplified `PairingDaemon(tracer)` |
| `pyproject.toml` | Added `hidapi>=0.14.0`, removed psmoveapi comment |
| `Dockerfile` | Removed psmove-builder stage, psmove COPY lines, libusb deps, `ldconfig` |
| `docker-compose.yml` | Removed `PSMOVE_BUILDER_IMAGE` arg, `PSMOVE_PATH` env, `psmoveapi-data` volume from pairing-daemon |
| `tests/conftest.py` | Replaced psmove mock with hidraw `ModuleType` mock |
| `tests/test_usb_pairing.py` | Rewrote all tests for hidapi API (enumerate, feature reports) |
| `tests/test_daemon.py` | Updated for `PairingDaemon(tracer)` signature, removed psmove prereq tests |
| `tests/test_utils.py` | Removed `find_psmove_binary` tests |

## Test plan

- [x] `cd lib && uv run --extra test pytest tests/test_psmove_hid.py -v` — 75 passed
- [x] `cd services/pairing_daemon && uv run --extra test pytest -v` — 62 passed
- [x] `make lint` — all checks passed
- [ ] `docker compose build pairing-daemon` — verify no psmove-builder dependency
- [ ] Manual: plug PS Move via USB, verify pairing completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)