### PR TITLE
fix: align PS Move button parsing with psmoveapi byte layout

### DIFF
--- a/lib/psmove_hid.py
+++ b/lib/psmove_hid.py
@@ -39,8 +39,12 @@ FEATURE_REPORT_SET_SIZE = 23
 class Button(IntFlag):
     """PS Move button bitmask values.
 
-    Buttons are encoded as a 3-byte little-endian bitmask in the input report
-    (bytes 1-3), extended with byte 4 for the PS and Move buttons.
+    Matches psmoveapi's PSMove_Button enum. The 32-bit button mask is
+    constructed from four raw bytes (buttons1-4) using psmoveapi's formula:
+        buttons2 | (buttons1 << 8) | ((buttons3 & 0x01) << 16)
+                                   | ((buttons4 & 0xF0) << 13)
+
+    See PSMove_Data_Input_Common in psmoveapi/src/psmove.c.
     """
 
     TRIANGLE = 0x0010
@@ -98,9 +102,30 @@ class Frame(IntEnum):
 def parse_input_report(data: bytes, zcm2: bool = False) -> dict:
     """Parse a PS Move HID input report into structured data.
 
+    The 49-byte report includes the report ID (0x01) as byte 0, matching
+    psmoveapi's PSMove_Data_Input_Common struct layout:
+
+        Byte 0:     Report ID (0x01)
+        Byte 1:     buttons1 (Select, Start — dpad bits unused on PS Move)
+        Byte 2:     buttons2 (Triangle, Circle, Cross, Square)
+        Byte 3:     buttons3 (PS button at bit 0)
+        Byte 4:     buttons4 (Move at bit 6, T at bit 7; low nibble = seq)
+        Byte 5:     trigger analog (frame 1)
+        Byte 6:     trigger analog (frame 2)
+        Bytes 7-11: unknown / timestamp
+        Byte 12:    battery
+        Bytes 13-18: accelerometer frame 1 (3× uint16 LE)
+        Bytes 19-24: accelerometer frame 2
+        Bytes 25-30: gyroscope frame 1
+        Bytes 31-36: gyroscope frame 2
+        Bytes 37-38: temperature (12-bit)
+
+    If some HID libraries prepend a redundant report ID byte (50 bytes total),
+    the extra leading 0x01 is stripped before parsing.
+
     Args:
         data: Raw HID input report bytes (49 bytes).
-              May include a leading report ID byte (0x01) which is stripped.
+              May include a redundant leading report ID byte (50 bytes).
         zcm2: If True, decode accelerometer/gyroscope as signed 16-bit
               two's complement (ZCM2/PS4-era). If False (default), decode as
               unsigned 16-bit offset by 0x8000 (ZCM1/PS3-era).
@@ -120,27 +145,29 @@ def parse_input_report(data: bytes, zcm2: bool = False) -> dict:
     Raises:
         ValueError: If data is too short to parse.
     """
-    # Strip leading report ID byte (0x01) if present
+    # Strip redundant leading report ID byte if the HID library prepended one
     if len(data) > INPUT_REPORT_SIZE and data[0] == 0x01:
         data = data[1:]
 
     if len(data) < INPUT_REPORT_SIZE:
         raise ValueError(f"Input report too short: {len(data)} bytes (need {INPUT_REPORT_SIZE})")
 
-    # Buttons: bytes 1-3 as little-endian, plus byte 4 shifted up
-    # Byte 0 is typically 0x00 or sequence
-    # Bytes 1-2: main buttons (little-endian 16-bit)
-    # Byte 3: extended buttons
-    btn_lo = data[1] | (data[2] << 8)
-    btn_hi = data[3]
-    buttons = btn_lo | (btn_hi << 16)
+    # Buttons: psmoveapi formula (PSMove_Data_Input_Common bytes 1-4)
+    #   buttons2 | (buttons1 << 8) | ((buttons3 & 0x01) << 16)
+    #                               | ((buttons4 & 0xF0) << 13)
+    buttons = (
+        data[2]  # buttons2: face buttons (Triangle, Circle, Cross, Square)
+        | (data[1] << 8)  # buttons1: Select, Start
+        | ((data[3] & 0x01) << 16)  # buttons3 bit 0: PS
+        | ((data[4] & 0xF0) << 13)  # buttons4 bits 4-7: Move (bit 6), T (bit 7)
+    )
 
-    # Sequence number: byte 4
-    sequence = data[4]
+    # Sequence number: buttons4 low nibble
+    sequence = data[4] & 0x0F
 
-    # Trigger analog: byte 6 (frame 1), byte 7 (frame 2)
-    trigger1 = data[6]
-    trigger2 = data[7]
+    # Trigger analog: byte 5 (frame 1), byte 6 (frame 2)
+    trigger1 = data[5]
+    trigger2 = data[6]
 
     # Battery: byte 12
     battery = data[12]

--- a/lib/tests/test_psmove_hid.py
+++ b/lib/tests/test_psmove_hid.py
@@ -32,8 +32,7 @@ from lib.psmove_hid import (
 
 
 def _build_test_report(
-    buttons_lo=0,
-    buttons_hi=0,
+    buttons=0,
     sequence=0,
     trigger1=0,
     trigger2=0,
@@ -52,20 +51,39 @@ def _build_test_report(
     gz2=0x8000,
     temperature=0,
 ) -> bytes:
-    """Build a synthetic 49-byte HID input report for testing."""
+    """Build a synthetic 49-byte HID input report for testing.
+
+    Uses psmoveapi's PSMove_Data_Input_Common byte layout:
+        Byte 0: Report ID (0x01)
+        Byte 1: buttons1 (bits 8-15 of button mask)
+        Byte 2: buttons2 (bits 0-7 of button mask)
+        Byte 3: buttons3 (PS = bit 0)
+        Byte 4: buttons4 (Move/T in high nibble, sequence in low nibble)
+        Byte 5: trigger frame 1
+        Byte 6: trigger frame 2
+        Byte 12: battery
+        ...
+
+    The `buttons` parameter takes a combined bitmask (e.g. Button.TRIANGLE | Button.PS)
+    and encodes it into the raw bytes by reversing the psmoveapi formula:
+        result = buttons2 | (buttons1 << 8) | ((buttons3 & 0x01) << 16)
+                                             | ((buttons4 & 0xF0) << 13)
+    """
     data = bytearray(INPUT_REPORT_SIZE)
 
-    # Buttons: bytes 1-2 (little-endian 16-bit), byte 3 (extended)
-    data[1] = buttons_lo & 0xFF
-    data[2] = (buttons_lo >> 8) & 0xFF
-    data[3] = buttons_hi & 0xFF
+    # Report ID
+    data[0] = 0x01
 
-    # Sequence: byte 4
-    data[4] = sequence
+    # Reverse the psmoveapi formula to encode buttons into raw bytes
+    data[1] = (buttons >> 8) & 0xFF  # buttons1
+    data[2] = buttons & 0xFF  # buttons2
+    data[3] = (buttons >> 16) & 0x01  # buttons3 (PS bit)
+    data[4] = (buttons >> 13) & 0xF0  # buttons4 high nibble (Move, T)
+    data[4] |= sequence & 0x0F  # buttons4 low nibble (sequence)
 
-    # Trigger: byte 6 (frame1), byte 7 (frame2)
-    data[6] = trigger1
-    data[7] = trigger2
+    # Trigger: byte 5 (frame1), byte 6 (frame2)
+    data[5] = trigger1
+    data[6] = trigger2
 
     # Battery: byte 12
     data[12] = battery
@@ -101,61 +119,100 @@ class TestButtonParsing:
         assert result["buttons"] & Button.PS == 0
 
     def test_triangle_button(self):
-        data = _build_test_report(buttons_lo=Button.TRIANGLE)
+        data = _build_test_report(buttons=Button.TRIANGLE)
         result = parse_input_report(data)
         assert result["buttons"] & Button.TRIANGLE
 
     def test_circle_button(self):
-        data = _build_test_report(buttons_lo=Button.CIRCLE)
+        data = _build_test_report(buttons=Button.CIRCLE)
         result = parse_input_report(data)
         assert result["buttons"] & Button.CIRCLE
 
     def test_cross_button(self):
-        data = _build_test_report(buttons_lo=Button.CROSS)
+        data = _build_test_report(buttons=Button.CROSS)
         result = parse_input_report(data)
         assert result["buttons"] & Button.CROSS
 
     def test_square_button(self):
-        data = _build_test_report(buttons_lo=Button.SQUARE)
+        data = _build_test_report(buttons=Button.SQUARE)
         result = parse_input_report(data)
         assert result["buttons"] & Button.SQUARE
 
     def test_select_button(self):
-        data = _build_test_report(buttons_lo=Button.SELECT)
+        data = _build_test_report(buttons=Button.SELECT)
         result = parse_input_report(data)
         assert result["buttons"] & Button.SELECT
 
     def test_start_button(self):
-        data = _build_test_report(buttons_lo=Button.START)
+        data = _build_test_report(buttons=Button.START)
         result = parse_input_report(data)
         assert result["buttons"] & Button.START
 
     def test_ps_button(self):
-        """PS button is in the extended byte (byte 3)."""
-        data = _build_test_report(buttons_hi=(Button.PS >> 16))
+        """PS button is in buttons3 byte (byte 3), bit 0."""
+        data = _build_test_report(buttons=Button.PS)
         result = parse_input_report(data)
         assert result["buttons"] & Button.PS
 
     def test_move_button(self):
-        """Move button is in the extended byte (byte 3)."""
-        data = _build_test_report(buttons_hi=(Button.MOVE >> 16))
+        """Move button is in buttons4 byte (byte 4), bit 6."""
+        data = _build_test_report(buttons=Button.MOVE)
         result = parse_input_report(data)
         assert result["buttons"] & Button.MOVE
 
     def test_trigger_digital(self):
-        """T (trigger digital) button in extended byte."""
-        data = _build_test_report(buttons_hi=(Button.T >> 16))
+        """T (trigger digital) button in buttons4 byte (byte 4), bit 7."""
+        data = _build_test_report(buttons=Button.T)
         result = parse_input_report(data)
         assert result["buttons"] & Button.T
 
     def test_multiple_buttons(self):
         """Multiple buttons pressed simultaneously."""
-        lo = Button.TRIANGLE | Button.CROSS
-        data = _build_test_report(buttons_lo=lo)
+        data = _build_test_report(buttons=Button.TRIANGLE | Button.CROSS)
         result = parse_input_report(data)
         assert result["buttons"] & Button.TRIANGLE
         assert result["buttons"] & Button.CROSS
         assert not (result["buttons"] & Button.CIRCLE)
+
+    def test_all_buttons(self):
+        """All 9 buttons pressed simultaneously."""
+        all_buttons = (
+            Button.TRIANGLE
+            | Button.CIRCLE
+            | Button.CROSS
+            | Button.SQUARE
+            | Button.SELECT
+            | Button.START
+            | Button.PS
+            | Button.MOVE
+            | Button.T
+        )
+        data = _build_test_report(buttons=all_buttons)
+        result = parse_input_report(data)
+        assert result["buttons"] & Button.TRIANGLE
+        assert result["buttons"] & Button.CIRCLE
+        assert result["buttons"] & Button.CROSS
+        assert result["buttons"] & Button.SQUARE
+        assert result["buttons"] & Button.SELECT
+        assert result["buttons"] & Button.START
+        assert result["buttons"] & Button.PS
+        assert result["buttons"] & Button.MOVE
+        assert result["buttons"] & Button.T
+
+    def test_face_buttons_isolated_from_extended(self):
+        """Face buttons don't trigger PS/Move/T and vice versa."""
+        face = _build_test_report(buttons=Button.TRIANGLE | Button.CIRCLE | Button.CROSS | Button.SQUARE)
+        result = parse_input_report(face)
+        assert not (result["buttons"] & Button.PS)
+        assert not (result["buttons"] & Button.MOVE)
+        assert not (result["buttons"] & Button.T)
+
+        extended = _build_test_report(buttons=Button.PS | Button.MOVE | Button.T)
+        result = parse_input_report(extended)
+        assert not (result["buttons"] & Button.TRIANGLE)
+        assert not (result["buttons"] & Button.CIRCLE)
+        assert not (result["buttons"] & Button.CROSS)
+        assert not (result["buttons"] & Button.SQUARE)
 
 
 class TestTriggerParsing:
@@ -299,12 +356,18 @@ class TestTemperatureParsing:
 
 
 class TestSequenceParsing:
-    """Test sequence number parsing."""
+    """Test sequence number parsing (from buttons4 low nibble)."""
 
     def test_sequence_number(self):
-        data = _build_test_report(sequence=42)
+        data = _build_test_report(sequence=7)
         result = parse_input_report(data)
-        assert result["sequence"] == 42
+        assert result["sequence"] == 7
+
+    def test_sequence_max_nibble(self):
+        """Sequence is only 4 bits (0-15)."""
+        data = _build_test_report(sequence=15)
+        result = parse_input_report(data)
+        assert result["sequence"] == 15
 
 
 class TestInputReportEdgeCases:
@@ -317,10 +380,11 @@ class TestInputReportEdgeCases:
         with pytest.raises(ValueError, match="too short"):
             parse_input_report(b"\x00" * 10)
 
-    def test_strips_leading_report_id(self):
-        """Leading 0x01 report ID byte should be stripped."""
+    def test_strips_redundant_report_id(self):
+        """Redundant leading 0x01 byte (50 bytes) should be stripped."""
         inner = _build_test_report(trigger2=42)
         data = b"\x01" + inner
+        assert len(data) == 50
         result = parse_input_report(data)
         assert result["trigger"][1] == 42
 
@@ -424,8 +488,7 @@ class TestFrameEnum:
 
 
 def _build_zcm2_test_report(
-    buttons_lo=0,
-    buttons_hi=0,
+    buttons=0,
     sequence=0,
     trigger1=0,
     trigger2=0,
@@ -447,12 +510,14 @@ def _build_zcm2_test_report(
     """Build a synthetic 49-byte HID input report with ZCM2-style signed sensor values."""
     data = bytearray(INPUT_REPORT_SIZE)
 
-    data[1] = buttons_lo & 0xFF
-    data[2] = (buttons_lo >> 8) & 0xFF
-    data[3] = buttons_hi & 0xFF
-    data[4] = sequence
-    data[6] = trigger1
-    data[7] = trigger2
+    # psmoveapi byte layout (same as _build_test_report)
+    data[0] = 0x01  # Report ID
+    data[1] = (buttons >> 8) & 0xFF  # buttons1
+    data[2] = buttons & 0xFF  # buttons2
+    data[3] = (buttons >> 16) & 0x01  # buttons3
+    data[4] = ((buttons >> 13) & 0xF0) | (sequence & 0x0F)  # buttons4
+    data[5] = trigger1
+    data[6] = trigger2
     data[12] = battery
 
     # Pack as signed int16 (same raw bytes a ZCM2 controller would produce)

--- a/services/python_hid/device_manager.py
+++ b/services/python_hid/device_manager.py
@@ -437,6 +437,10 @@ class DeviceManager:
             if data is None:
                 return None
 
+            # Diagnostic hex dump: log raw bytes when any button is pressed
+            if any(b != 0 for b in data[1:5]):
+                logger.debug(f"HID raw [{len(data)}B]: {data[:8].hex(' ')}")
+
             is_zcm2 = self._product_ids.get(serial) in (PRODUCT_ID_ZCM2, PRODUCT_ID_ZCM2E)
             parsed = parse_input_report(data, zcm2=is_zcm2)
 

--- a/services/rust-hid/src/hid.rs
+++ b/services/rust-hid/src/hid.rs
@@ -278,14 +278,18 @@ pub fn battery_to_percent(raw: u8) -> i32 {
 
 /// Parse a 49-byte PS Move HID input report.
 ///
-/// Matches Python `parse_input_report()`. Uses second frame of sensor data
-/// (bytes 19-24 for accel, 31-36 for gyro) and second trigger value (byte 7),
-/// matching the HidapiAdapter convention.
+/// Matches Python `parse_input_report()` and psmoveapi's PSMove_Data_Input_Common.
+/// Uses second frame of sensor data (bytes 19-24 for accel, 31-36 for gyro)
+/// and second trigger value (byte 6), matching the HidapiAdapter convention.
+///
+/// The 49-byte report includes the report ID (0x01) at byte 0. Button bytes
+/// are at offsets 1-4 and are combined using psmoveapi's formula:
+///   buttons2 | (buttons1 << 8) | ((buttons3 & 0x01) << 16) | ((buttons4 & 0xF0) << 13)
 ///
 /// `zcm2`: If true, decode accel/gyro as signed 16-bit two's complement
 /// (ZCM2/PS4-era). If false, decode as unsigned 16-bit offset by 0x8000.
 pub fn parse_input_report(data: &[u8], zcm2: bool) -> Result<ParsedInputReport, String> {
-    // Strip leading report ID byte (0x01) if present
+    // Strip redundant leading report ID byte if the HID library prepended one
     let data = if data.len() > INPUT_REPORT_SIZE && data[0] == 0x01 {
         &data[1..]
     } else {
@@ -299,13 +303,15 @@ pub fn parse_input_report(data: &[u8], zcm2: bool) -> Result<ParsedInputReport, 
         ));
     }
 
-    // Buttons: bytes 1-3 as little-endian, plus byte 3 shifted up
-    let btn_lo = (data[1] as u32) | ((data[2] as u32) << 8);
-    let btn_hi = data[3] as u32;
-    let buttons = btn_lo | (btn_hi << 16);
+    // Buttons: psmoveapi formula (PSMove_Data_Input_Common bytes 1-4)
+    //   buttons2 | (buttons1 << 8) | ((buttons3 & 0x01) << 16) | ((buttons4 & 0xF0) << 13)
+    let buttons = (data[2] as u32)                          // buttons2: face buttons
+        | ((data[1] as u32) << 8)                           // buttons1: Select, Start
+        | (((data[3] & 0x01) as u32) << 16)                 // buttons3 bit 0: PS
+        | (((data[4] & 0xF0) as u32) << 13);                // buttons4 bits 4-7: Move, T
 
-    // Trigger analog: byte 7 (frame 2)
-    let trigger = data[7];
+    // Trigger analog: byte 6 (frame 2)
+    let trigger = data[6];
 
     // Battery: byte 12
     let battery = battery_to_percent(data[12]);
@@ -669,6 +675,14 @@ mod tests {
 
     // --- Input report parsing tests ---
 
+    /// Build a test input report with the psmoveapi byte layout.
+    ///
+    /// Encodes buttons using psmoveapi's PSMove_Data_Input_Common format:
+    ///   Byte 0: report ID (0x01)
+    ///   Byte 1: buttons1 (bits 8-15 of button mask)
+    ///   Byte 2: buttons2 (bits 0-7 of button mask)
+    ///   Byte 3: buttons3 (PS = bit 0)
+    ///   Byte 4: buttons4 (Move/T in high nibble, seq in low nibble)
     fn make_input_report(
         buttons: u32,
         trigger2: u8,
@@ -678,12 +692,18 @@ mod tests {
         temperature: u16,
     ) -> [u8; INPUT_REPORT_SIZE] {
         let mut data = [0u8; INPUT_REPORT_SIZE];
-        // Buttons: bytes 1-3
-        data[1] = (buttons & 0xFF) as u8;
-        data[2] = ((buttons >> 8) & 0xFF) as u8;
-        data[3] = ((buttons >> 16) & 0xFF) as u8;
-        // Trigger frame 2: byte 7
-        data[7] = trigger2;
+        data[0] = 0x01; // Report ID
+        // Reverse the psmoveapi formula to encode buttons into raw bytes:
+        //   result = buttons2 | (buttons1 << 8) | ((buttons3 & 0x01) << 16) | ((buttons4 & 0xF0) << 13)
+        // So: buttons2 = result & 0xFF, buttons1 = (result >> 8) & 0xFF
+        //     buttons3 bit 0 = (result >> 16) & 0x01
+        //     buttons4 high nibble = (result >> 13) & 0xF0
+        data[1] = ((buttons >> 8) & 0xFF) as u8;        // buttons1
+        data[2] = (buttons & 0xFF) as u8;                // buttons2
+        data[3] = ((buttons >> 16) & 0x01) as u8;        // buttons3
+        data[4] = ((buttons >> 13) & 0xF0) as u8;        // buttons4 high nibble
+        // Trigger frame 2: byte 6
+        data[6] = trigger2;
         // Battery: byte 12
         data[12] = battery;
         // Accel frame 2: bytes 19-24 (little-endian u16)


### PR DESCRIPTION
## Summary

- Fix button parsing to match psmoveapi's `PSMove_Data_Input_Common` struct layout — bytes 1-2 were swapped (buttons1/buttons2), byte 4 (Move/T) was missing, and trigger offsets were off by one
- Apply psmoveapi's proven formula: `buttons2 | (buttons1 << 8) | ((buttons3 & 0x01) << 16) | ((buttons4 & 0xF0) << 13)`
- Add diagnostic hex dump logging in `device_manager.py` for verifying byte layout on hardware

Fixes face buttons (triangle, circle, cross, square) not being detected. The previous fix attempt (#694, reverted in #707) addressed report ID stripping but the actual bug was in the button byte ordering and formula.

## Test plan

- [ ] Verify all 9 buttons detected via hex dump logs (MOVE, T, PS, triangle, circle, cross, square, select, start)
- [ ] Confirm face buttons work for admin mode
- [ ] Confirm trigger starts game, MOVE deselects in menu
- [ ] Verify no ghost button presses
- [ ] Unit tests pass: Python (78/78), Rust (36/36)
- [ ] `make lint` + `cargo clippy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)