### PR TITLE
fix: dashboard not loading controllers (wrong content type)

### DIFF
--- a/services/dashboard/src/client.ts
+++ b/services/dashboard/src/client.ts
@@ -30,7 +30,7 @@ async function unaryCall<Req, Res>(
   const response = await fetch(url, {
     method: "POST",
     headers: {
-      "Content-Type": "application/connect+json",
+      "Content-Type": "application/json",
     },
     body: JSON.stringify(request),
   });
@@ -52,8 +52,8 @@ async function* serverStream<Req, Res>(
   const response = await fetch(url, {
     method: "POST",
     headers: {
-      "Content-Type": "application/connect+json",
-      Accept: "application/connect+json",
+      "Content-Type": "application/json",
+      Accept: "application/json",
     },
     body: JSON.stringify(request),
   });


### PR DESCRIPTION
## Summary

Fix `application/connect+json` → `application/json` in the dashboard's fetch client. Connect-Go rejects `application/connect+json` as an unknown content type, returning 415 for unary RPCs and 505 for streaming RPCs. This broke all dashboard functionality (controller list, game status, metrics).

## Test plan

- [ ] Open dashboard in browser, verify controllers appear
- [ ] Start a game, verify game status updates in real-time
- [ ] Rebuild dashboard Docker image (`docker compose build dashboard`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)