### PR TITLE
feat: observability control flags and fork-compatible CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,6 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  # Repository name in lowercase for GHCR
-  IMAGE_PREFIX: ghcr.io/watchmejoustmyflags/joustmania
   # Main branch - used for :latest Docker tag
   MAIN_BRANCH: main
 
@@ -241,6 +239,8 @@ jobs:
     name: SonarCloud Analysis
     runs-on: ubuntu-latest
     needs: [service-checks, lib-tests]
+    # Skip on forks that don't have SONAR_TOKEN configured
+    if: ${{ github.repository == 'WatchMeJoustMyFlags/JoustMania' || vars.ENABLE_SONARCLOUD == 'true' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -328,6 +328,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set image prefix
+        run: echo "IMAGE_PREFIX=ghcr.io/${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
+
       - name: Set up QEMU
         if: needs.detect-builder-changes.outputs.builder == 'true'
         uses: docker/setup-qemu-action@v3
@@ -361,10 +364,24 @@ jobs:
       # Re-tag stable image when unchanged (much faster)
       - name: Reuse stable image (unchanged)
         if: needs.detect-builder-changes.outputs.builder != 'true'
+        id: reuse
+        continue-on-error: true
         run: |
           docker buildx imagetools create \
             --tag ${{ env.IMAGE_PREFIX }}/builder:${{ github.sha }} \
             ${{ env.IMAGE_PREFIX }}/builder:main
+
+      # Fallback: full build if reuse failed (e.g., first run on a fork)
+      - name: Build builder (fallback)
+        if: needs.detect-builder-changes.outputs.builder != 'true' && steps.reuse.outcome != 'success'
+        uses: docker/build-push-action@v5
+        with:
+          context: images/builder
+          platforms: linux/amd64
+          push: true
+          tags: ${{ env.IMAGE_PREFIX }}/builder:${{ github.sha }}
+          cache-from: type=gha,scope=builder
+          cache-to: type=gha,mode=max,scope=builder
 
   docker-build:
     name: Build ${{ matrix.service }}
@@ -384,6 +401,9 @@ jobs:
           - pairing_daemon
     steps:
       - uses: actions/checkout@v4
+
+      - name: Set image prefix
+        run: echo "IMAGE_PREFIX=ghcr.io/${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -454,6 +474,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set image prefix
+        run: echo "IMAGE_PREFIX=ghcr.io/${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
@@ -488,6 +511,9 @@ jobs:
     needs: [build-builder]
     steps:
       - uses: actions/checkout@v4
+
+      - name: Set image prefix
+        run: echo "IMAGE_PREFIX=ghcr.io/${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
 
       - uses: dorny/paths-filter@v3
         id: changes

--- a/services/flagd/performance.ci.json
+++ b/services/flagd/performance.ci.json
@@ -163,6 +163,47 @@
       },
       "defaultVariant": "none",
       "targeting": {}
+    },
+    "trace_sampling_rate": {
+      "state": "ENABLED",
+      "variants": {
+        "off": 0.0,
+        "low": 0.1,
+        "half": 0.5,
+        "full": 1.0
+      },
+      "defaultVariant": "full",
+      "targeting": {}
+    },
+    "verbose_logging": {
+      "state": "ENABLED",
+      "variants": {
+        "on": true,
+        "off": false
+      },
+      "defaultVariant": "off",
+      "targeting": {}
+    },
+    "span_enrichment_config": {
+      "state": "ENABLED",
+      "variants": {
+        "off": { "enabled": false, "attribute_sets": [] },
+        "basic": { "enabled": true, "attribute_sets": ["service_identity"] },
+        "flags": { "enabled": true, "attribute_sets": ["service_identity", "flag_values"] },
+        "full": { "enabled": true, "attribute_sets": ["service_identity", "flag_values", "runtime", "system"] }
+      },
+      "defaultVariant": "off",
+      "targeting": {}
+    },
+    "metrics_filter_pattern": {
+      "state": "ENABLED",
+      "variants": {
+        "none": "",
+        "poll_only": "controller_poll_*",
+        "process_only": "process_*"
+      },
+      "defaultVariant": "none",
+      "targeting": {}
     }
   }
 }

--- a/services/flagd/performance.json
+++ b/services/flagd/performance.json
@@ -178,6 +178,47 @@
       },
       "defaultVariant": "none",
       "targeting": {}
+    },
+    "trace_sampling_rate": {
+      "state": "ENABLED",
+      "variants": {
+        "off": 0.0,
+        "low": 0.1,
+        "half": 0.5,
+        "full": 1.0
+      },
+      "defaultVariant": "full",
+      "targeting": {}
+    },
+    "verbose_logging": {
+      "state": "ENABLED",
+      "variants": {
+        "on": true,
+        "off": false
+      },
+      "defaultVariant": "off",
+      "targeting": {}
+    },
+    "span_enrichment_config": {
+      "state": "ENABLED",
+      "variants": {
+        "off": { "enabled": false, "attribute_sets": [] },
+        "basic": { "enabled": true, "attribute_sets": ["service_identity"] },
+        "flags": { "enabled": true, "attribute_sets": ["service_identity", "flag_values"] },
+        "full": { "enabled": true, "attribute_sets": ["service_identity", "flag_values", "runtime", "system"] }
+      },
+      "defaultVariant": "off",
+      "targeting": {}
+    },
+    "metrics_filter_pattern": {
+      "state": "ENABLED",
+      "variants": {
+        "none": "",
+        "poll_only": "controller_poll_*",
+        "process_only": "process_*"
+      },
+      "defaultVariant": "none",
+      "targeting": {}
     }
   }
 }


### PR DESCRIPTION
## Summary

- Add observability control flags to flagd (trace sampling, verbose logging, span enrichment, metrics filter)
- Make CI pipeline work for forks (dynamic IMAGE_PREFIX, builder fallback, SonarCloud skip)

## Stack

This is the base of a stacked PR series for dynamic observability control:

1. **This PR** — flagd flags + CI fix
2. feat/opamp-bridge — OpAMP bridge for collector-level control
3. feat/python-otel-control — Python SDK dynamic OTel control
4. feat/rust-otel-control — Rust SDK dynamic OTel control
5. feat/go-otel-control — Go SDK dynamic OTel control
6. feat/obs-routes — HTTP routes for observability control
7. feat/otel-pipeline-dashboard — Grafana dashboard

## Test plan

- [x] CI passes on fork
- [x] Unit tests pass
- [x] Flagd config validates

🤖 Generated with [Claude Code](https://claude.com/claude-code)