### PR TITLE
feat: dynamic OTel SDK control for Python services

### DIFF
--- a/lib/flagd_log_processor.py
+++ b/lib/flagd_log_processor.py
@@ -44,4 +44,5 @@ class FlagdLogLevelFilter(LogRecordProcessor):
             client = get_flag_client("performance")
             return client.get_boolean_value("verbose_logging", False)
         except Exception:
+            logger.debug("Failed to read verbose_logging from flagd, defaulting to False", exc_info=True)
             return False

--- a/lib/flagd_log_processor.py
+++ b/lib/flagd_log_processor.py
@@ -4,13 +4,19 @@ FlagdLogLevelFilter — Dynamic log verbosity via OpenFeature/flagd.
 Wraps a delegate ``LogRecordProcessor`` and drops log records below
 INFO severity when the ``verbose_logging`` flag is *off*. When toggled
 *on*, all records (including DEBUG) pass through to the exporter.
+
+Flag values are cached for 2 seconds to avoid per-record flagd calls
+and prevent a feedback loop when verbose mode increases log volume.
 """
 
 import logging
+import time
 
 from opentelemetry.sdk._logs import LogRecordProcessor, ReadableLogRecord
 
 logger = logging.getLogger(__name__)
+
+_CACHE_TTL = 2.0  # seconds
 
 
 class FlagdLogLevelFilter(LogRecordProcessor):
@@ -18,6 +24,8 @@ class FlagdLogLevelFilter(LogRecordProcessor):
 
     def __init__(self, delegate: LogRecordProcessor) -> None:
         self._delegate = delegate
+        self._cached_verbose: bool = False
+        self._last_fetch: float = 0.0
 
     def on_emit(self, log_data: ReadableLogRecord) -> None:
         if not self._is_verbose():
@@ -35,13 +43,17 @@ class FlagdLogLevelFilter(LogRecordProcessor):
 
     # ------------------------------------------------------------------
 
-    @staticmethod
-    def _is_verbose() -> bool:
+    def _is_verbose(self) -> bool:
+        now = time.monotonic()
+        if now - self._last_fetch < _CACHE_TTL:
+            return self._cached_verbose
+
         try:
             from lib.feature_flags import get_flag_client
 
             client = get_flag_client("performance")
-            return client.get_boolean_value("verbose_logging", False)
+            self._cached_verbose = client.get_boolean_value("verbose_logging", False)
+            self._last_fetch = now
         except Exception:
-            logger.debug("Failed to read verbose_logging from flagd, defaulting to False", exc_info=True)
-            return False
+            logger.debug("Failed to read verbose_logging from flagd, using cached value", exc_info=True)
+        return self._cached_verbose

--- a/lib/flagd_log_processor.py
+++ b/lib/flagd_log_processor.py
@@ -1,0 +1,47 @@
+"""
+FlagdLogLevelFilter — Dynamic log verbosity via OpenFeature/flagd.
+
+Wraps a delegate ``LogRecordProcessor`` and drops log records below
+INFO severity when the ``verbose_logging`` flag is *off*. When toggled
+*on*, all records (including DEBUG) pass through to the exporter.
+"""
+
+import logging
+
+from opentelemetry.context import Context
+from opentelemetry.sdk._logs import LogRecordProcessor, ReadableLogRecord
+
+logger = logging.getLogger(__name__)
+
+
+class FlagdLogLevelFilter(LogRecordProcessor):
+    """Filters log records based on the flagd verbose_logging flag."""
+
+    def __init__(self, delegate: LogRecordProcessor) -> None:
+        self._delegate = delegate
+
+    def on_emit(self, log_data: ReadableLogRecord, context: Context | None = None) -> None:
+        if not self._is_verbose():
+            severity = log_data.severity_number
+            # OTel severity: TRACE=1-4, DEBUG=5-8, INFO=9-12
+            if severity is not None and severity.value < 9:
+                return  # Drop DEBUG/TRACE when not verbose
+        self._delegate.on_emit(log_data, context)
+
+    def shutdown(self) -> None:
+        self._delegate.shutdown()
+
+    def force_flush(self, timeout_millis: int = 30000) -> bool:
+        return self._delegate.force_flush(timeout_millis)
+
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _is_verbose() -> bool:
+        try:
+            from lib.feature_flags import get_flag_client
+
+            client = get_flag_client("performance")
+            return client.get_boolean_value("verbose_logging", False)
+        except Exception:
+            return False

--- a/lib/flagd_log_processor.py
+++ b/lib/flagd_log_processor.py
@@ -8,7 +8,6 @@ INFO severity when the ``verbose_logging`` flag is *off*. When toggled
 
 import logging
 
-from opentelemetry.context import Context
 from opentelemetry.sdk._logs import LogRecordProcessor, ReadableLogRecord
 
 logger = logging.getLogger(__name__)
@@ -20,13 +19,13 @@ class FlagdLogLevelFilter(LogRecordProcessor):
     def __init__(self, delegate: LogRecordProcessor) -> None:
         self._delegate = delegate
 
-    def on_emit(self, log_data: ReadableLogRecord, context: Context | None = None) -> None:
+    def on_emit(self, log_data: ReadableLogRecord) -> None:
         if not self._is_verbose():
             severity = log_data.severity_number
             # OTel severity: TRACE=1-4, DEBUG=5-8, INFO=9-12
             if severity is not None and severity.value < 9:
                 return  # Drop DEBUG/TRACE when not verbose
-        self._delegate.on_emit(log_data, context)
+        self._delegate.on_emit(log_data)
 
     def shutdown(self) -> None:
         self._delegate.shutdown()

--- a/lib/flagd_log_processor.py
+++ b/lib/flagd_log_processor.py
@@ -58,5 +58,9 @@ class FlagdLogLevelFilter(LogRecordProcessor):
             self._cached_verbose = client.get_boolean_value("verbose_logging", False)
             self._last_fetch = now
         except Exception:
+            # Advance _last_fetch on failure to honor TTL as backoff,
+            # preventing per-record retries and potential recursion when
+            # this filter's own debug log flows through the same pipeline.
+            self._last_fetch = now
             logger.debug("Failed to read verbose_logging from flagd, using cached value", exc_info=True)
         return self._cached_verbose

--- a/lib/flagd_log_processor.py
+++ b/lib/flagd_log_processor.py
@@ -29,7 +29,10 @@ class FlagdLogLevelFilter(LogRecordProcessor):
 
     def on_emit(self, log_data: ReadableLogRecord) -> None:
         if not self._is_verbose():
-            severity = log_data.severity_number
+            # OTEL SDK 1.39+ wraps log records in ReadWriteLogRecord;
+            # severity_number lives on the inner log_record object.
+            inner = getattr(log_data, "log_record", log_data)
+            severity = getattr(inner, "severity_number", None)
             # OTel severity: TRACE=1-4, DEBUG=5-8, INFO=9-12
             if severity is not None and severity.value < 9:
                 return  # Drop DEBUG/TRACE when not verbose

--- a/lib/flagd_sampler.py
+++ b/lib/flagd_sampler.py
@@ -1,0 +1,61 @@
+"""
+FlagdSampler — Dynamic trace sampling via OpenFeature/flagd.
+
+Reads the ``trace_sampling_rate`` flag (float 0.0–1.0) from the flagd
+``performance`` domain on every sampling decision. Because the flagd
+in-process provider syncs flag state to local memory, each evaluation
+is a cheap local read — safe even at 1 000 Hz.
+"""
+
+import logging
+import random
+
+from opentelemetry.context import Context
+from opentelemetry.sdk.trace.sampling import Decision, Sampler, SamplingResult
+from opentelemetry.trace import Link, SpanKind
+from opentelemetry.util.types import Attributes
+
+logger = logging.getLogger(__name__)
+
+
+class FlagdSampler(Sampler):
+    """Sampler that reads trace_sampling_rate from flagd."""
+
+    def should_sample(  # noqa: ARG002
+        self,
+        parent_context: Context | None,
+        trace_id: int,
+        name: str,
+        kind: SpanKind | None = None,
+        attributes: Attributes | None = None,
+        links: list[Link] | None = None,
+    ) -> SamplingResult:
+        rate = self._get_rate(attributes)
+        if rate >= 1.0 or random.random() < rate:
+            return SamplingResult(Decision.RECORD_AND_SAMPLE, attributes or {})
+        return SamplingResult(Decision.DROP)
+
+    def get_description(self) -> str:
+        return "FlagdSampler"
+
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _get_rate(attributes: Attributes | None) -> float:
+        try:
+            from lib.feature_flags import get_flag_client
+
+            client = get_flag_client("performance")
+
+            # Build per-evaluation context from span attributes
+            eval_ctx = None
+            if attributes:
+                serial = dict(attributes).get("controller.serial")
+                if serial:
+                    from openfeature.evaluation_context import EvaluationContext
+
+                    eval_ctx = EvaluationContext(attributes={"controller_serial": str(serial)})
+
+            return client.get_float_value("trace_sampling_rate", 1.0, eval_ctx)
+        except Exception:
+            return 1.0

--- a/lib/flagd_sampler.py
+++ b/lib/flagd_sampler.py
@@ -69,5 +69,8 @@ class FlagdSampler(Sampler):
             self._cached_rate = client.get_float_value("trace_sampling_rate", 1.0, eval_ctx)
             self._last_fetch = now
         except Exception:
+            # Advance _last_fetch on failure to honor TTL as backoff,
+            # preventing per-decision retries when flagd is down.
+            self._last_fetch = now
             logger.debug("Failed to read trace_sampling_rate from flagd, using cached value", exc_info=True)
         return self._cached_rate

--- a/lib/flagd_sampler.py
+++ b/lib/flagd_sampler.py
@@ -8,7 +8,6 @@ is a cheap local read — safe even at 1 000 Hz.
 """
 
 import logging
-import random
 
 from opentelemetry.context import Context
 from opentelemetry.sdk.trace.sampling import Decision, Sampler, SamplingResult
@@ -31,7 +30,9 @@ class FlagdSampler(Sampler):
         links: list[Link] | None = None,
     ) -> SamplingResult:
         rate = self._get_rate(attributes)
-        if rate >= 1.0 or random.random() < rate:
+        # Use trace_id for deterministic sampling (consistent across parent/child spans)
+        hash_value = (trace_id & 0xFFFFFFFFFFFFFFFF) / (1 << 64)
+        if rate >= 1.0 or hash_value < rate:
             return SamplingResult(Decision.RECORD_AND_SAMPLE, attributes or {})
         return SamplingResult(Decision.DROP)
 
@@ -58,4 +59,5 @@ class FlagdSampler(Sampler):
 
             return client.get_float_value("trace_sampling_rate", 1.0, eval_ctx)
         except Exception:
+            logger.debug("Failed to read trace_sampling_rate from flagd, defaulting to 1.0", exc_info=True)
             return 1.0

--- a/lib/flagd_sampler.py
+++ b/lib/flagd_sampler.py
@@ -33,7 +33,7 @@ class FlagdSampler(Sampler):
         # Use trace_id for deterministic sampling (consistent across parent/child spans)
         hash_value = (trace_id & 0xFFFFFFFFFFFFFFFF) / (1 << 64)
         if rate >= 1.0 or hash_value < rate:
-            return SamplingResult(Decision.RECORD_AND_SAMPLE, attributes or {})
+            return SamplingResult(Decision.RECORD_AND_SAMPLE)
         return SamplingResult(Decision.DROP)
 
     def get_description(self) -> str:

--- a/lib/flagd_sampler.py
+++ b/lib/flagd_sampler.py
@@ -2,12 +2,12 @@
 FlagdSampler — Dynamic trace sampling via OpenFeature/flagd.
 
 Reads the ``trace_sampling_rate`` flag (float 0.0–1.0) from the flagd
-``performance`` domain on every sampling decision. Because the flagd
-in-process provider syncs flag state to local memory, each evaluation
-is a cheap local read — safe even at 1 000 Hz.
+``performance`` domain. Flag values are cached for 2 seconds to avoid
+per-decision flagd calls at high sampling rates (up to 1 000 Hz).
 """
 
 import logging
+import time
 
 from opentelemetry.context import Context
 from opentelemetry.sdk.trace.sampling import Decision, Sampler, SamplingResult
@@ -16,9 +16,15 @@ from opentelemetry.util.types import Attributes
 
 logger = logging.getLogger(__name__)
 
+_CACHE_TTL = 2.0  # seconds
+
 
 class FlagdSampler(Sampler):
     """Sampler that reads trace_sampling_rate from flagd."""
+
+    def __init__(self) -> None:
+        self._cached_rate: float = 1.0
+        self._last_fetch: float = 0.0
 
     def should_sample(  # noqa: ARG002
         self,
@@ -41,8 +47,11 @@ class FlagdSampler(Sampler):
 
     # ------------------------------------------------------------------
 
-    @staticmethod
-    def _get_rate(attributes: Attributes | None) -> float:
+    def _get_rate(self, attributes: Attributes | None) -> float:
+        now = time.monotonic()
+        if now - self._last_fetch < _CACHE_TTL:
+            return self._cached_rate
+
         try:
             from lib.feature_flags import get_flag_client
 
@@ -57,7 +66,8 @@ class FlagdSampler(Sampler):
 
                     eval_ctx = EvaluationContext(attributes={"controller_serial": str(serial)})
 
-            return client.get_float_value("trace_sampling_rate", 1.0, eval_ctx)
+            self._cached_rate = client.get_float_value("trace_sampling_rate", 1.0, eval_ctx)
+            self._last_fetch = now
         except Exception:
-            logger.debug("Failed to read trace_sampling_rate from flagd, defaulting to 1.0", exc_info=True)
-            return 1.0
+            logger.debug("Failed to read trace_sampling_rate from flagd, using cached value", exc_info=True)
+        return self._cached_rate

--- a/lib/flagd_sampler.py
+++ b/lib/flagd_sampler.py
@@ -12,6 +12,7 @@ import time
 from opentelemetry.context import Context
 from opentelemetry.sdk.trace.sampling import Decision, Sampler, SamplingResult
 from opentelemetry.trace import Link, SpanKind
+from opentelemetry.trace.span import TraceState
 from opentelemetry.util.types import Attributes
 
 logger = logging.getLogger(__name__)
@@ -34,6 +35,7 @@ class FlagdSampler(Sampler):
         kind: SpanKind | None = None,
         attributes: Attributes | None = None,
         links: list[Link] | None = None,
+        trace_state: TraceState | None = None,
     ) -> SamplingResult:
         rate = self._get_rate(attributes)
         # Use trace_id for deterministic sampling (consistent across parent/child spans)

--- a/lib/flagd_span_processor.py
+++ b/lib/flagd_span_processor.py
@@ -78,6 +78,9 @@ class FlagdSpanEnrichmentProcessor(SpanProcessor):
             self._cached_config = result if isinstance(result, dict) else dict(_DEFAULT_CONFIG)
             self._last_fetch = now
         except Exception:
+            # Advance _last_fetch on failure to honor TTL as backoff,
+            # preventing per-span retries when flagd is down.
+            self._last_fetch = now
             logger.debug("Failed to read span_enrichment_config from flagd, using cached value", exc_info=True)
         return self._cached_config
 

--- a/lib/flagd_span_processor.py
+++ b/lib/flagd_span_processor.py
@@ -15,7 +15,9 @@ Attribute sets (same across Python, Rust, and Go):
 import logging
 import os
 import platform
+import sys
 import threading
+from collections.abc import Callable
 
 from opentelemetry.context import Context
 from opentelemetry.sdk.trace import ReadableSpan, Span, SpanProcessor
@@ -61,6 +63,7 @@ class FlagdSpanEnrichmentProcessor(SpanProcessor):
             )
             return result if isinstance(result, dict) else {}
         except Exception:
+            logger.debug("Failed to read span_enrichment_config from flagd", exc_info=True)
             return {"enabled": False, "attribute_sets": []}
 
 
@@ -87,6 +90,7 @@ def _flag_values_attrs() -> dict[str, float | bool]:
             "demo.flag.grpc_rpc_spans": client.get_boolean_value("grpc_rpc_spans", False),
         }
     except Exception:
+        logger.debug("Failed to read flag values from flagd", exc_info=True)
         return {}
 
 
@@ -103,9 +107,13 @@ def _system_attrs() -> dict[str, str | int]:
     try:
         import resource
 
-        mem_bytes = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss * 1024
+        if sys.platform == "darwin":
+            mem_bytes = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss  # already bytes on macOS
+        else:
+            mem_bytes = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss * 1024  # KB on Linux
         mem_mb = mem_bytes // (1024 * 1024)
     except Exception:
+        logger.debug("Failed to read system memory usage", exc_info=True)
         mem_mb = 0
     return {
         "demo.system.hostname": platform.node(),
@@ -114,7 +122,7 @@ def _system_attrs() -> dict[str, str | int]:
     }
 
 
-_ATTRIBUTE_BUILDERS: dict[str, callable] = {
+_ATTRIBUTE_BUILDERS: dict[str, Callable[[], dict]] = {
     "service_identity": _service_identity_attrs,
     "flag_values": _flag_values_attrs,
     "runtime": _runtime_attrs,

--- a/lib/flagd_span_processor.py
+++ b/lib/flagd_span_processor.py
@@ -5,6 +5,8 @@ Reads the ``span_enrichment_config`` structured flag from flagd and adds
 diagnostic attributes to every span. The flag controls *which* attribute
 sets are added, enabling progressive enrichment during live demos.
 
+Flag values are cached for 2 seconds to avoid per-span flagd calls.
+
 Attribute sets (same across Python, Rust, and Go):
   service_identity  — demo.enriched, demo.language, demo.service, demo.namespace
   flag_values       — demo.flag.trace_sampling_rate, demo.flag.verbose_logging, …
@@ -17,6 +19,7 @@ import os
 import platform
 import sys
 import threading
+import time
 from collections.abc import Callable
 
 from opentelemetry.context import Context
@@ -24,9 +27,17 @@ from opentelemetry.sdk.trace import ReadableSpan, Span, SpanProcessor
 
 logger = logging.getLogger(__name__)
 
+_CACHE_TTL = 2.0  # seconds
+
+_DEFAULT_CONFIG: dict = {"enabled": False, "attribute_sets": []}
+
 
 class FlagdSpanEnrichmentProcessor(SpanProcessor):
     """Adds diagnostic attributes to spans based on flagd config."""
+
+    def __init__(self) -> None:
+        self._cached_config: dict = dict(_DEFAULT_CONFIG)
+        self._last_fetch: float = 0.0
 
     def on_start(self, span: Span, parent_context: Context | None = None) -> None:
         config = self._get_config()
@@ -51,20 +62,24 @@ class FlagdSpanEnrichmentProcessor(SpanProcessor):
 
     # ------------------------------------------------------------------
 
-    @staticmethod
-    def _get_config() -> dict:
+    def _get_config(self) -> dict:
+        now = time.monotonic()
+        if now - self._last_fetch < _CACHE_TTL:
+            return self._cached_config
+
         try:
             from lib.feature_flags import get_flag_client
 
             client = get_flag_client("performance")
             result = client.get_object_value(
                 "span_enrichment_config",
-                {"enabled": False, "attribute_sets": []},
+                dict(_DEFAULT_CONFIG),
             )
-            return result if isinstance(result, dict) else {}
+            self._cached_config = result if isinstance(result, dict) else dict(_DEFAULT_CONFIG)
+            self._last_fetch = now
         except Exception:
-            logger.debug("Failed to read span_enrichment_config from flagd", exc_info=True)
-            return {"enabled": False, "attribute_sets": []}
+            logger.debug("Failed to read span_enrichment_config from flagd, using cached value", exc_info=True)
+        return self._cached_config
 
 
 # ── Attribute set builders ───────────────────────────────────────────

--- a/lib/flagd_span_processor.py
+++ b/lib/flagd_span_processor.py
@@ -97,19 +97,32 @@ def _service_identity_attrs() -> dict[str, str | bool]:
     }
 
 
+_flag_values_cache: dict[str, float | bool] = {}
+_flag_values_last_fetch: float = 0.0
+
+
 def _flag_values_attrs() -> dict[str, float | bool]:
+    global _flag_values_cache, _flag_values_last_fetch
+
+    now = time.monotonic()
+    if now - _flag_values_last_fetch < _CACHE_TTL:
+        return _flag_values_cache
+
     try:
         from lib.feature_flags import get_flag_client
 
         client = get_flag_client("performance")
-        return {
+        _flag_values_cache = {
             "demo.flag.trace_sampling_rate": client.get_float_value("trace_sampling_rate", 1.0),
             "demo.flag.verbose_logging": client.get_boolean_value("verbose_logging", False),
             "demo.flag.grpc_rpc_spans": client.get_boolean_value("grpc_rpc_spans", False),
         }
+        _flag_values_last_fetch = now
     except Exception:
+        # Advance on failure to honor TTL as backoff
+        _flag_values_last_fetch = now
         logger.debug("Failed to read flag values from flagd", exc_info=True)
-        return {}
+    return _flag_values_cache
 
 
 def _runtime_attrs() -> dict[str, str | int]:

--- a/lib/flagd_span_processor.py
+++ b/lib/flagd_span_processor.py
@@ -1,0 +1,122 @@
+"""
+FlagdSpanEnrichmentProcessor — Configurable span attribute enrichment.
+
+Reads the ``span_enrichment_config`` structured flag from flagd and adds
+diagnostic attributes to every span. The flag controls *which* attribute
+sets are added, enabling progressive enrichment during live demos.
+
+Attribute sets (same across Python, Rust, and Go):
+  service_identity  — demo.enriched, demo.language, demo.service, demo.namespace
+  flag_values       — demo.flag.trace_sampling_rate, demo.flag.verbose_logging, …
+  runtime           — demo.runtime.version, demo.runtime.pid, demo.runtime.threads
+  system            — demo.system.hostname, demo.system.cpu_count, demo.system.memory_mb
+"""
+
+import logging
+import os
+import platform
+import threading
+
+from opentelemetry.context import Context
+from opentelemetry.sdk.trace import ReadableSpan, Span, SpanProcessor
+
+logger = logging.getLogger(__name__)
+
+
+class FlagdSpanEnrichmentProcessor(SpanProcessor):
+    """Adds diagnostic attributes to spans based on flagd config."""
+
+    def on_start(self, span: Span, parent_context: Context | None = None) -> None:
+        config = self._get_config()
+        if not config.get("enabled", False):
+            return
+
+        attribute_sets = config.get("attribute_sets", [])
+        for attr_set in attribute_sets:
+            attrs = _ATTRIBUTE_BUILDERS.get(attr_set)
+            if attrs:
+                for key, value in attrs().items():
+                    span.set_attribute(key, value)
+
+    def on_end(self, span: ReadableSpan) -> None:  # noqa: ARG002
+        pass
+
+    def shutdown(self) -> None:
+        pass
+
+    def force_flush(self, timeout_millis: int = 30000) -> bool:  # noqa: ARG002
+        return True
+
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _get_config() -> dict:
+        try:
+            from lib.feature_flags import get_flag_client
+
+            client = get_flag_client("performance")
+            result = client.get_object_value(
+                "span_enrichment_config",
+                {"enabled": False, "attribute_sets": []},
+            )
+            return result if isinstance(result, dict) else {}
+        except Exception:
+            return {"enabled": False, "attribute_sets": []}
+
+
+# ── Attribute set builders ───────────────────────────────────────────
+
+
+def _service_identity_attrs() -> dict[str, str | bool]:
+    return {
+        "demo.enriched": True,
+        "demo.language": "python",
+        "demo.service": os.getenv("OTEL_SERVICE_NAME", "unknown"),
+        "demo.namespace": os.getenv("OTEL_SERVICE_NAMESPACE", "unknown"),
+    }
+
+
+def _flag_values_attrs() -> dict[str, float | bool]:
+    try:
+        from lib.feature_flags import get_flag_client
+
+        client = get_flag_client("performance")
+        return {
+            "demo.flag.trace_sampling_rate": client.get_float_value("trace_sampling_rate", 1.0),
+            "demo.flag.verbose_logging": client.get_boolean_value("verbose_logging", False),
+            "demo.flag.grpc_rpc_spans": client.get_boolean_value("grpc_rpc_spans", False),
+        }
+    except Exception:
+        return {}
+
+
+def _runtime_attrs() -> dict[str, str | int]:
+    return {
+        "demo.runtime.version": platform.python_version(),
+        "demo.runtime.pid": os.getpid(),
+        "demo.runtime.threads": threading.active_count(),
+    }
+
+
+def _system_attrs() -> dict[str, str | int]:
+    cpu_count = os.cpu_count() or 0
+    try:
+        import resource
+
+        mem_bytes = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss * 1024
+        mem_mb = mem_bytes // (1024 * 1024)
+    except Exception:
+        mem_mb = 0
+    return {
+        "demo.system.hostname": platform.node(),
+        "demo.system.cpu_count": cpu_count,
+        "demo.system.memory_mb": mem_mb,
+    }
+
+
+_ATTRIBUTE_BUILDERS: dict[str, callable] = {
+    "service_identity": _service_identity_attrs,
+    "flag_values": _flag_values_attrs,
+    "runtime": _runtime_attrs,
+    "system": _system_attrs,
+}

--- a/lib/otel_logging.py
+++ b/lib/otel_logging.py
@@ -86,7 +86,12 @@ def init_logging() -> None:
 
         exporter = OTLPLogExporter(endpoint=otlp_endpoint, insecure=True)
         provider = LoggerProvider(resource=resource)
+        from lib.feature_flags import init_flag_domain
         from lib.flagd_log_processor import FlagdLogLevelFilter
+
+        # Ensure the performance flag domain is initialized before creating
+        # flag-driven components so they don't evaluate against a no-op provider.
+        init_flag_domain("performance")
 
         provider.add_log_record_processor(FlagdLogLevelFilter(BatchLogRecordProcessor(exporter)))
 

--- a/lib/otel_logging.py
+++ b/lib/otel_logging.py
@@ -86,7 +86,9 @@ def init_logging() -> None:
 
         exporter = OTLPLogExporter(endpoint=otlp_endpoint, insecure=True)
         provider = LoggerProvider(resource=resource)
-        provider.add_log_record_processor(BatchLogRecordProcessor(exporter))
+        from lib.flagd_log_processor import FlagdLogLevelFilter
+
+        provider.add_log_record_processor(FlagdLogLevelFilter(BatchLogRecordProcessor(exporter)))
 
         # Attach OTEL handler to root logger so all existing loggers flow through OTLP
         log_level_str = os.getenv("LOG_LEVEL", "INFO").upper()

--- a/lib/pyproject.toml
+++ b/lib/pyproject.toml
@@ -57,6 +57,8 @@ ignore = ["ANN"]
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]
 "tests/*.py" = ["ARG002", "E402"]
+"flagd_sampler.py" = ["ARG002"]  # OTel Sampler interface has unused params
+"flagd_span_processor.py" = ["ARG002"]  # OTel SpanProcessor interface has unused params
 
 [tool.ruff.lint.isort]
 known-first-party = ["lib"]

--- a/lib/telemetry.py
+++ b/lib/telemetry.py
@@ -92,8 +92,13 @@ def _do_init() -> None:
 
     resource = get_otel_resource()
 
+    from lib.feature_flags import init_flag_domain
     from lib.flagd_sampler import FlagdSampler
     from lib.flagd_span_processor import FlagdSpanEnrichmentProcessor
+
+    # Ensure the performance flag domain is initialized before creating
+    # flag-driven components so they don't evaluate against a no-op provider.
+    init_flag_domain("performance")
 
     provider = TracerProvider(resource=resource, sampler=FlagdSampler())
     otlp_exporter = OTLPSpanExporter(endpoint=otlp_endpoint, insecure=True)

--- a/lib/telemetry.py
+++ b/lib/telemetry.py
@@ -92,9 +92,13 @@ def _do_init() -> None:
 
     resource = get_otel_resource()
 
-    provider = TracerProvider(resource=resource)
+    from lib.flagd_sampler import FlagdSampler
+    from lib.flagd_span_processor import FlagdSpanEnrichmentProcessor
+
+    provider = TracerProvider(resource=resource, sampler=FlagdSampler())
     otlp_exporter = OTLPSpanExporter(endpoint=otlp_endpoint, insecure=True)
     provider.add_span_processor(BatchSpanProcessor(otlp_exporter))
+    provider.add_span_processor(FlagdSpanEnrichmentProcessor())
 
     # Trace-profile correlation: link Pyroscope CPU profiles to trace spans
     from lib.profiling import _is_profiling_enabled

--- a/lib/tests/test_flagd_log_processor.py
+++ b/lib/tests/test_flagd_log_processor.py
@@ -1,0 +1,66 @@
+"""Tests for FlagdLogLevelFilter."""
+
+from unittest.mock import MagicMock, patch
+
+from lib.flagd_log_processor import FlagdLogLevelFilter
+
+PATCH_TARGET = "lib.feature_flags.get_flag_client"
+
+
+def _make_log_record(severity_number_value: int) -> MagicMock:
+    """Create a mock ReadableLogRecord with the given severity number."""
+    record = MagicMock()
+    severity = MagicMock()
+    severity.value = severity_number_value
+    record.severity_number = severity
+    return record
+
+
+class TestFlagdLogLevelFilter:
+    def setup_method(self):
+        self.delegate = MagicMock()
+        self.filter = FlagdLogLevelFilter(self.delegate)
+
+    @patch(PATCH_TARGET)
+    def test_passes_info_when_not_verbose(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_client.get_boolean_value.return_value = False
+        mock_get_client.return_value = mock_client
+
+        record = _make_log_record(9)  # INFO
+        self.filter.on_emit(record)
+        self.delegate.on_emit.assert_called_once()
+
+    @patch(PATCH_TARGET)
+    def test_drops_debug_when_not_verbose(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_client.get_boolean_value.return_value = False
+        mock_get_client.return_value = mock_client
+
+        record = _make_log_record(5)  # DEBUG
+        self.filter.on_emit(record)
+        self.delegate.on_emit.assert_not_called()
+
+    @patch(PATCH_TARGET)
+    def test_passes_debug_when_verbose(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_client.get_boolean_value.return_value = True
+        mock_get_client.return_value = mock_client
+
+        record = _make_log_record(5)  # DEBUG
+        self.filter.on_emit(record)
+        self.delegate.on_emit.assert_called_once()
+
+    @patch(PATCH_TARGET, side_effect=Exception("flagd down"))
+    def test_drops_debug_when_flagd_unavailable(self, _mock):
+        record = _make_log_record(5)  # DEBUG
+        self.filter.on_emit(record)
+        self.delegate.on_emit.assert_not_called()
+
+    def test_delegates_shutdown(self):
+        self.filter.shutdown()
+        self.delegate.shutdown.assert_called_once()
+
+    def test_delegates_force_flush(self):
+        self.filter.force_flush(5000)
+        self.delegate.force_flush.assert_called_once_with(5000)

--- a/lib/tests/test_flagd_log_processor.py
+++ b/lib/tests/test_flagd_log_processor.py
@@ -8,18 +8,29 @@ PATCH_TARGET = "lib.feature_flags.get_flag_client"
 
 
 def _make_log_record(severity_number_value: int) -> MagicMock:
-    """Create a mock ReadableLogRecord with the given severity number."""
-    record = MagicMock()
+    """Create a mock ReadWriteLogRecord (OTEL SDK 1.39+) with the given severity number.
+
+    In OTEL SDK 1.39+, ReadWriteLogRecord wraps a LogRecord via the
+    ``log_record`` attribute.  severity_number lives on the inner object.
+    """
     severity = MagicMock()
     severity.value = severity_number_value
-    record.severity_number = severity
+
+    inner = MagicMock()
+    inner.severity_number = severity
+
+    record = MagicMock()
+    record.log_record = inner
     return record
 
 
 def _make_log_record_no_severity() -> MagicMock:
-    """Create a mock ReadableLogRecord with severity_number=None."""
+    """Create a mock ReadWriteLogRecord with severity_number=None on the inner log_record."""
+    inner = MagicMock()
+    inner.severity_number = None
+
     record = MagicMock()
-    record.severity_number = None
+    record.log_record = inner
     return record
 
 

--- a/lib/tests/test_flagd_log_processor.py
+++ b/lib/tests/test_flagd_log_processor.py
@@ -16,6 +16,13 @@ def _make_log_record(severity_number_value: int) -> MagicMock:
     return record
 
 
+def _make_log_record_no_severity() -> MagicMock:
+    """Create a mock ReadableLogRecord with severity_number=None."""
+    record = MagicMock()
+    record.severity_number = None
+    return record
+
+
 class TestFlagdLogLevelFilter:
     def setup_method(self):
         self.delegate = MagicMock()
@@ -56,6 +63,17 @@ class TestFlagdLogLevelFilter:
         record = _make_log_record(5)  # DEBUG
         self.filter.on_emit(record)
         self.delegate.on_emit.assert_not_called()
+
+    @patch(PATCH_TARGET)
+    def test_passes_through_when_severity_number_is_none(self, mock_get_client):
+        """Records with no severity_number set should always pass through."""
+        mock_client = MagicMock()
+        mock_client.get_boolean_value.return_value = False
+        mock_get_client.return_value = mock_client
+
+        record = _make_log_record_no_severity()
+        self.filter.on_emit(record)
+        self.delegate.on_emit.assert_called_once()
 
     def test_delegates_shutdown(self):
         self.filter.shutdown()

--- a/lib/tests/test_flagd_sampler.py
+++ b/lib/tests/test_flagd_sampler.py
@@ -1,0 +1,63 @@
+"""Tests for FlagdSampler."""
+
+from unittest.mock import MagicMock, patch
+
+from opentelemetry.sdk.trace.sampling import Decision
+
+from lib.flagd_sampler import FlagdSampler
+
+PATCH_TARGET = "lib.feature_flags.get_flag_client"
+
+
+class TestFlagdSampler:
+    def setup_method(self):
+        self.sampler = FlagdSampler()
+
+    @patch(PATCH_TARGET)
+    def test_samples_all_when_rate_is_1(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_client.get_float_value.return_value = 1.0
+        mock_get_client.return_value = mock_client
+
+        result = self.sampler.should_sample(None, 12345, "test-span")
+        assert result.decision == Decision.RECORD_AND_SAMPLE
+
+    @patch(PATCH_TARGET)
+    def test_drops_all_when_rate_is_0(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_client.get_float_value.return_value = 0.0
+        mock_get_client.return_value = mock_client
+
+        result = self.sampler.should_sample(None, 12345, "test-span")
+        assert result.decision == Decision.DROP
+
+    @patch(PATCH_TARGET)
+    def test_probabilistic_sampling(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_client.get_float_value.return_value = 0.5
+        mock_get_client.return_value = mock_client
+
+        decisions = [self.sampler.should_sample(None, i, "test-span").decision for i in range(1000)]
+        sampled = sum(1 for d in decisions if d == Decision.RECORD_AND_SAMPLE)
+        assert 300 < sampled < 700
+
+    @patch(PATCH_TARGET, side_effect=Exception("flagd unavailable"))
+    def test_defaults_to_sample_all_when_flagd_unavailable(self, _mock):
+        result = self.sampler.should_sample(None, 12345, "test-span")
+        assert result.decision == Decision.RECORD_AND_SAMPLE
+
+    @patch(PATCH_TARGET)
+    def test_passes_controller_serial_as_context(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_client.get_float_value.return_value = 1.0
+        mock_get_client.return_value = mock_client
+
+        self.sampler.should_sample(None, 12345, "test-span", attributes={"controller.serial": "AA:BB:CC"})
+
+        call_args = mock_client.get_float_value.call_args
+        eval_ctx = call_args[0][2] if len(call_args[0]) > 2 else None
+        assert eval_ctx is not None
+        assert eval_ctx.attributes["controller_serial"] == "AA:BB:CC"
+
+    def test_get_description(self):
+        assert self.sampler.get_description() == "FlagdSampler"

--- a/lib/tests/test_flagd_sampler.py
+++ b/lib/tests/test_flagd_sampler.py
@@ -32,12 +32,27 @@ class TestFlagdSampler:
         assert result.decision == Decision.DROP
 
     @patch(PATCH_TARGET)
-    def test_probabilistic_sampling(self, mock_get_client):
+    def test_deterministic_sampling_same_trace_id(self, mock_get_client):
+        """Same trace_id always produces the same sampling decision."""
         mock_client = MagicMock()
         mock_client.get_float_value.return_value = 0.5
         mock_get_client.return_value = mock_client
 
-        decisions = [self.sampler.should_sample(None, i, "test-span").decision for i in range(1000)]
+        trace_id = 0xABCDEF1234567890
+        decisions = [self.sampler.should_sample(None, trace_id, "test-span").decision for _ in range(10)]
+        assert len(set(decisions)) == 1, "Same trace_id should always yield the same decision"
+
+    @patch(PATCH_TARGET)
+    def test_probabilistic_sampling_distribution(self, mock_get_client):
+        """Deterministic trace-ID-based sampling produces roughly expected distribution."""
+        mock_client = MagicMock()
+        mock_client.get_float_value.return_value = 0.5
+        mock_get_client.return_value = mock_client
+
+        # Use trace IDs spread across the full 64-bit space for realistic distribution
+        step = (1 << 64) // 1000
+        trace_ids = [i * step for i in range(1000)]
+        decisions = [self.sampler.should_sample(None, tid, "test-span").decision for tid in trace_ids]
         sampled = sum(1 for d in decisions if d == Decision.RECORD_AND_SAMPLE)
         assert 300 < sampled < 700
 

--- a/lib/tests/test_flagd_span_processor.py
+++ b/lib/tests/test_flagd_span_processor.py
@@ -1,0 +1,77 @@
+"""Tests for FlagdSpanEnrichmentProcessor."""
+
+from unittest.mock import MagicMock, patch
+
+from lib.flagd_span_processor import FlagdSpanEnrichmentProcessor
+
+PATCH_TARGET = "lib.feature_flags.get_flag_client"
+
+
+class TestFlagdSpanEnrichmentProcessor:
+    def setup_method(self):
+        self.processor = FlagdSpanEnrichmentProcessor()
+
+    @patch(PATCH_TARGET)
+    def test_no_attributes_when_disabled(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_client.get_object_value.return_value = {
+            "enabled": False,
+            "attribute_sets": [],
+        }
+        mock_get_client.return_value = mock_client
+
+        span = MagicMock()
+        self.processor.on_start(span)
+        span.set_attribute.assert_not_called()
+
+    @patch(PATCH_TARGET)
+    def test_service_identity_attributes(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_client.get_object_value.return_value = {
+            "enabled": True,
+            "attribute_sets": ["service_identity"],
+        }
+        mock_get_client.return_value = mock_client
+
+        span = MagicMock()
+        self.processor.on_start(span)
+
+        attr_calls = {call[0][0]: call[0][1] for call in span.set_attribute.call_args_list}
+        assert attr_calls["demo.enriched"] is True
+        assert attr_calls["demo.language"] == "python"
+        assert "demo.service" in attr_calls
+        assert "demo.namespace" in attr_calls
+
+    @patch(PATCH_TARGET)
+    def test_full_enrichment_adds_all_sets(self, mock_get_client):
+        mock_client = MagicMock()
+        mock_client.get_object_value.return_value = {
+            "enabled": True,
+            "attribute_sets": [
+                "service_identity",
+                "flag_values",
+                "runtime",
+                "system",
+            ],
+        }
+        mock_client.get_float_value.return_value = 1.0
+        mock_client.get_boolean_value.return_value = False
+        mock_get_client.return_value = mock_client
+
+        span = MagicMock()
+        self.processor.on_start(span)
+
+        attr_names = {call[0][0] for call in span.set_attribute.call_args_list}
+        assert "demo.enriched" in attr_names
+        assert "demo.flag.trace_sampling_rate" in attr_names
+        assert "demo.runtime.pid" in attr_names
+        assert "demo.system.hostname" in attr_names
+
+    @patch(PATCH_TARGET, side_effect=Exception("flagd down"))
+    def test_graceful_when_flagd_unavailable(self, _mock):
+        span = MagicMock()
+        self.processor.on_start(span)
+        span.set_attribute.assert_not_called()
+
+    def test_force_flush_returns_true(self):
+        assert self.processor.force_flush() is True

--- a/lib/tests/test_flagd_span_processor.py
+++ b/lib/tests/test_flagd_span_processor.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import MagicMock, patch
 
+import lib.flagd_span_processor as span_proc_module
 from lib.flagd_span_processor import FlagdSpanEnrichmentProcessor
 
 PATCH_TARGET = "lib.feature_flags.get_flag_client"
@@ -10,6 +11,9 @@ PATCH_TARGET = "lib.feature_flags.get_flag_client"
 class TestFlagdSpanEnrichmentProcessor:
     def setup_method(self):
         self.processor = FlagdSpanEnrichmentProcessor()
+        # Reset module-level flag_values cache so tests are independent
+        span_proc_module._flag_values_cache = {}
+        span_proc_module._flag_values_last_fetch = 0.0
 
     @patch(PATCH_TARGET)
     def test_no_attributes_when_disabled(self, mock_get_client):


### PR DESCRIPTION
## Summary

- FlagdSampler: dynamic trace sampling via OpenFeature
- FlagdSpanEnrichmentProcessor: configurable span attributes
- FlagdLogLevelFilter: verbose logging toggle
- 2s TTL caching on all flag reads to match Rust/Go pattern

**Stack**: #714 ← opamp-bridge ← **this PR** ← next

## Test plan

- [x] Unit tests pass (19 tests)
- [x] Integration tests pass
- [x] Menu service starts healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)