### PR TITLE
feat: dynamic OTel SDK control for Rust (rust-hid)

### DIFF
--- a/services/rust-hid/Cargo.toml
+++ b/services/rust-hid/Cargo.toml
@@ -38,6 +38,8 @@ open-feature-flagd = { version = "0.1", default-features = false, features = ["r
 tower = "0.5"
 # HTTP types (Request, Response, HeaderMap) used by tower tracing layer
 http = "1"
+# JSON for structured flag values
+serde_json = "1"
 
 [profile.release]
 strip = true

--- a/services/rust-hid/Cargo.toml
+++ b/services/rust-hid/Cargo.toml
@@ -38,8 +38,6 @@ open-feature-flagd = { version = "0.1", default-features = false, features = ["r
 tower = "0.5"
 # HTTP types (Request, Response, HeaderMap) used by tower tracing layer
 http = "1"
-# JSON for structured flag values
-serde_json = "1"
 
 [profile.release]
 strip = true

--- a/services/rust-hid/src/feature_flags.rs
+++ b/services/rust-hid/src/feature_flags.rs
@@ -56,22 +56,19 @@ fn build_eval_context() -> EvaluationContext {
     ctx.add_custom_field(
         "service_name",
         std::env::var("OTEL_SERVICE_NAME")
-            .unwrap_or_else(|_| "rust-hid".into())
-            .into(),
+            .unwrap_or_else(|_| "rust-hid".into()),
     );
-    ctx.add_custom_field("language", "rust".into());
+    ctx.add_custom_field("language", String::from("rust"));
     ctx.add_custom_field(
         "service_namespace",
         std::env::var("OTEL_SERVICE_NAMESPACE")
-            .unwrap_or_else(|_| "infrastructure".into())
-            .into(),
+            .unwrap_or_else(|_| "infrastructure".into()),
     );
     ctx.add_custom_field(
         "hostname",
         gethostname::gethostname()
             .into_string()
-            .unwrap_or_else(|_| "unknown".into())
-            .into(),
+            .unwrap_or_else(|_| "unknown".into()),
     );
     ctx
 }

--- a/services/rust-hid/src/feature_flags.rs
+++ b/services/rust-hid/src/feature_flags.rs
@@ -89,14 +89,3 @@ pub async fn grpc_rpc_spans_enabled() -> bool {
         .await
         .unwrap_or(false)
 }
-
-/// Check if `verbose_logging` flag is enabled.
-pub async fn is_verbose_logging() -> bool {
-    let of = OpenFeature::singleton().await;
-    let client = of.create_client();
-    let ctx = build_eval_context();
-    client
-        .get_bool_value("verbose_logging", Some(&ctx), None)
-        .await
-        .unwrap_or(false)
-}

--- a/services/rust-hid/src/feature_flags.rs
+++ b/services/rust-hid/src/feature_flags.rs
@@ -53,7 +53,7 @@ pub async fn init_flagd() {
 /// Resolve host.name from OTEL_RESOURCE_ATTRIBUTES if set, falling back to
 /// gethostname(). Inside Docker, gethostname() returns the container ID;
 /// OTEL_RESOURCE_ATTRIBUTES provides the real host name.
-fn resolve_host_name() -> String {
+pub fn resolve_host_name() -> String {
     if let Ok(attrs) = std::env::var("OTEL_RESOURCE_ATTRIBUTES") {
         for pair in attrs.split(',') {
             if let Some((key, value)) = pair.split_once('=')

--- a/services/rust-hid/src/feature_flags.rs
+++ b/services/rust-hid/src/feature_flags.rs
@@ -50,6 +50,24 @@ pub async fn init_flagd() {
     }
 }
 
+/// Resolve host.name from OTEL_RESOURCE_ATTRIBUTES if set, falling back to
+/// gethostname(). Inside Docker, gethostname() returns the container ID;
+/// OTEL_RESOURCE_ATTRIBUTES provides the real host name.
+fn resolve_host_name() -> String {
+    if let Ok(attrs) = std::env::var("OTEL_RESOURCE_ATTRIBUTES") {
+        for pair in attrs.split(',') {
+            if let Some((key, value)) = pair.split_once('=')
+                && key.trim() == "host.name"
+            {
+                return value.trim().to_string();
+            }
+        }
+    }
+    gethostname::gethostname()
+        .into_string()
+        .unwrap_or_else(|_| "unknown".into())
+}
+
 /// Build evaluation context with service identity for flag targeting.
 fn build_eval_context() -> EvaluationContext {
     let mut ctx = EvaluationContext::default();
@@ -64,12 +82,7 @@ fn build_eval_context() -> EvaluationContext {
         std::env::var("OTEL_SERVICE_NAMESPACE")
             .unwrap_or_else(|_| "infrastructure".into()),
     );
-    ctx.add_custom_field(
-        "hostname",
-        gethostname::gethostname()
-            .into_string()
-            .unwrap_or_else(|_| "unknown".into()),
-    );
+    ctx.add_custom_field("hostname", resolve_host_name());
     ctx
 }
 

--- a/services/rust-hid/src/feature_flags.rs
+++ b/services/rust-hid/src/feature_flags.rs
@@ -50,6 +50,32 @@ pub async fn init_flagd() {
     }
 }
 
+/// Build evaluation context with service identity for flag targeting.
+fn build_eval_context() -> EvaluationContext {
+    let mut ctx = EvaluationContext::default();
+    ctx.add_custom_field(
+        "service_name",
+        std::env::var("OTEL_SERVICE_NAME")
+            .unwrap_or_else(|_| "rust-hid".into())
+            .into(),
+    );
+    ctx.add_custom_field("language", "rust".into());
+    ctx.add_custom_field(
+        "service_namespace",
+        std::env::var("OTEL_SERVICE_NAMESPACE")
+            .unwrap_or_else(|_| "infrastructure".into())
+            .into(),
+    );
+    ctx.add_custom_field(
+        "hostname",
+        gethostname::gethostname()
+            .into_string()
+            .unwrap_or_else(|_| "unknown".into())
+            .into(),
+    );
+    ctx
+}
+
 /// Check if the `grpc_rpc_spans` feature flag is enabled.
 ///
 /// Returns false if flagd is unavailable or the flag is not defined.
@@ -57,9 +83,20 @@ pub async fn init_flagd() {
 pub async fn grpc_rpc_spans_enabled() -> bool {
     let of = OpenFeature::singleton().await;
     let client = of.create_client();
-    let ctx = EvaluationContext::default();
+    let ctx = build_eval_context();
     client
         .get_bool_value("grpc_rpc_spans", Some(&ctx), None)
+        .await
+        .unwrap_or(false)
+}
+
+/// Check if `verbose_logging` flag is enabled.
+pub async fn is_verbose_logging() -> bool {
+    let of = OpenFeature::singleton().await;
+    let client = of.create_client();
+    let ctx = build_eval_context();
+    client
+        .get_bool_value("verbose_logging", Some(&ctx), None)
         .await
         .unwrap_or(false)
 }

--- a/services/rust-hid/src/flagd_sampler.rs
+++ b/services/rust-hid/src/flagd_sampler.rs
@@ -1,8 +1,8 @@
 //! FlagdSampler — Dynamic trace sampling via OpenFeature/flagd.
 //!
 //! Reads the `trace_sampling_rate` flag (float 0.0–1.0) from flagd
-//! on every sampling decision. Falls back to 1.0 (sample all) if
-//! flagd is unavailable.
+//! via a background task that refreshes the cached rate every 2 seconds.
+//! Falls back to 1.0 (sample all) if flagd is unavailable.
 
 use opentelemetry::trace::{Link, SamplingDecision, SamplingResult, SpanKind, TraceId, TraceState};
 use opentelemetry_sdk::trace::ShouldSample;
@@ -11,7 +11,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 /// Shared cached sampling rate between the reader and background updater.
 /// Initialized to f64::to_bits(1.0) so we sample all spans until the updater sets the real value.
-static CACHED_RATE: AtomicU64 = AtomicU64::new(0x3FF0_0000_0000_0000);
+static CACHED_RATE: AtomicU64 = AtomicU64::new({ 1.0f64.to_bits() });
 
 /// Sampler that reads trace_sampling_rate from flagd.
 #[derive(Debug, Clone, Default)]

--- a/services/rust-hid/src/flagd_sampler.rs
+++ b/services/rust-hid/src/flagd_sampler.rs
@@ -1,0 +1,114 @@
+//! FlagdSampler — Dynamic trace sampling via OpenFeature/flagd.
+//!
+//! Reads the `trace_sampling_rate` flag (float 0.0–1.0) from flagd
+//! on every sampling decision. Falls back to 1.0 (sample all) if
+//! flagd is unavailable.
+
+use opentelemetry::trace::{Link, SpanKind, TraceId, TraceState};
+use opentelemetry_sdk::trace::{ShouldSample, SamplingDecision, SamplingResult};
+use opentelemetry::KeyValue;
+use std::borrow::Cow;
+
+/// Sampler that reads trace_sampling_rate from flagd.
+#[derive(Debug, Clone)]
+pub struct FlagdSampler;
+
+impl FlagdSampler {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl ShouldSample for FlagdSampler {
+    fn should_sample(
+        &self,
+        _parent_context: Option<&opentelemetry::Context>,
+        trace_id: TraceId,
+        _name: &str,
+        _span_kind: &SpanKind,
+        _attributes: &[KeyValue],
+        _links: &[Link],
+    ) -> SamplingResult {
+        let rate = get_sampling_rate_sync();
+
+        if rate >= 1.0 {
+            return SamplingResult {
+                decision: SamplingDecision::RecordAndSample,
+                attributes: Vec::new(),
+                trace_state: TraceState::default(),
+            };
+        }
+
+        if rate <= 0.0 {
+            return SamplingResult {
+                decision: SamplingDecision::Drop,
+                attributes: Vec::new(),
+                trace_state: TraceState::default(),
+            };
+        }
+
+        // Deterministic sampling based on trace ID for consistency
+        let trace_id_bytes = trace_id.to_bytes();
+        let hash = u64::from_be_bytes(trace_id_bytes[8..16].try_into().unwrap_or([0; 8]));
+        let threshold = (rate * u64::MAX as f64) as u64;
+
+        let decision = if hash < threshold {
+            SamplingDecision::RecordAndSample
+        } else {
+            SamplingDecision::Drop
+        };
+
+        SamplingResult {
+            decision,
+            attributes: Vec::new(),
+            trace_state: TraceState::default(),
+        }
+    }
+}
+
+/// Synchronous wrapper to get sampling rate from flagd.
+/// Uses tokio::Runtime::block_on since ShouldSample is sync.
+fn get_sampling_rate_sync() -> f64 {
+    // Try to get the current tokio handle — if we're in an async context
+    // we can't block_on. Use a cached value or default instead.
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static CACHED_RATE: AtomicU64 = AtomicU64::new(u64::MAX); // sentinel for "not set"
+
+    let cached = CACHED_RATE.load(Ordering::Relaxed);
+    if cached != u64::MAX {
+        return f64::from_bits(cached);
+    }
+
+    // Default to 1.0 (sample all) — the async updater will set the real value
+    1.0
+}
+
+/// Spawn a background task that periodically updates the cached sampling rate.
+/// Call this once during initialization.
+pub fn spawn_rate_updater() {
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    // Share the same static as get_sampling_rate_sync
+    static CACHED_RATE: AtomicU64 = AtomicU64::new(u64::MAX);
+
+    tokio::spawn(async move {
+        loop {
+            let rate = get_sampling_rate_async().await;
+            CACHED_RATE.store(rate.to_bits(), Ordering::Relaxed);
+            tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+        }
+    });
+}
+
+async fn get_sampling_rate_async() -> f64 {
+    use open_feature::{EvaluationContext, OpenFeature};
+
+    let of = OpenFeature::singleton().await;
+    let client = of.create_client();
+    let ctx = EvaluationContext::default();
+    client
+        .get_float_value("trace_sampling_rate", Some(&ctx), None)
+        .await
+        .unwrap_or(1.0)
+}

--- a/services/rust-hid/src/flagd_sampler.rs
+++ b/services/rust-hid/src/flagd_sampler.rs
@@ -4,8 +4,8 @@
 //! on every sampling decision. Falls back to 1.0 (sample all) if
 //! flagd is unavailable.
 
-use opentelemetry::trace::{Link, SpanKind, TraceId, TraceState};
-use opentelemetry_sdk::trace::{ShouldSample, SamplingDecision, SamplingResult};
+use opentelemetry::trace::{Link, SamplingDecision, SamplingResult, SpanKind, TraceId, TraceState};
+use opentelemetry_sdk::trace::ShouldSample;
 use opentelemetry::KeyValue;
 use std::sync::atomic::{AtomicU64, Ordering};
 

--- a/services/rust-hid/src/flagd_sampler.rs
+++ b/services/rust-hid/src/flagd_sampler.rs
@@ -10,7 +10,8 @@ use opentelemetry::KeyValue;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 /// Shared cached sampling rate between the reader and background updater.
-static CACHED_RATE: AtomicU64 = AtomicU64::new(u64::MAX); // sentinel for "not set"
+/// Initialized to f64::to_bits(1.0) so we sample all spans until the updater sets the real value.
+static CACHED_RATE: AtomicU64 = AtomicU64::new(0x3FF0_0000_0000_0000);
 
 /// Sampler that reads trace_sampling_rate from flagd.
 #[derive(Debug, Clone, Default)]
@@ -69,16 +70,10 @@ impl ShouldSample for FlagdSampler {
     }
 }
 
-/// Synchronous wrapper to get sampling rate from flagd.
-/// Uses tokio::Runtime::block_on since ShouldSample is sync.
+/// Return the cached sampling rate.
+/// Always valid — initialized to 1.0, updated by background task.
 fn get_sampling_rate_sync() -> f64 {
-    let cached = CACHED_RATE.load(Ordering::Relaxed);
-    if cached != u64::MAX {
-        return f64::from_bits(cached);
-    }
-
-    // Default to 1.0 (sample all) — the async updater will set the real value
-    1.0
+    f64::from_bits(CACHED_RATE.load(Ordering::Relaxed))
 }
 
 /// Spawn a background task that periodically updates the cached sampling rate.

--- a/services/rust-hid/src/flagd_sampler.rs
+++ b/services/rust-hid/src/flagd_sampler.rs
@@ -7,10 +7,13 @@
 use opentelemetry::trace::{Link, SpanKind, TraceId, TraceState};
 use opentelemetry_sdk::trace::{ShouldSample, SamplingDecision, SamplingResult};
 use opentelemetry::KeyValue;
-use std::borrow::Cow;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Shared cached sampling rate between the reader and background updater.
+static CACHED_RATE: AtomicU64 = AtomicU64::new(u64::MAX); // sentinel for "not set"
 
 /// Sampler that reads trace_sampling_rate from flagd.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct FlagdSampler;
 
 impl FlagdSampler {
@@ -69,12 +72,6 @@ impl ShouldSample for FlagdSampler {
 /// Synchronous wrapper to get sampling rate from flagd.
 /// Uses tokio::Runtime::block_on since ShouldSample is sync.
 fn get_sampling_rate_sync() -> f64 {
-    // Try to get the current tokio handle — if we're in an async context
-    // we can't block_on. Use a cached value or default instead.
-    use std::sync::atomic::{AtomicU64, Ordering};
-
-    static CACHED_RATE: AtomicU64 = AtomicU64::new(u64::MAX); // sentinel for "not set"
-
     let cached = CACHED_RATE.load(Ordering::Relaxed);
     if cached != u64::MAX {
         return f64::from_bits(cached);
@@ -87,11 +84,6 @@ fn get_sampling_rate_sync() -> f64 {
 /// Spawn a background task that periodically updates the cached sampling rate.
 /// Call this once during initialization.
 pub fn spawn_rate_updater() {
-    use std::sync::atomic::{AtomicU64, Ordering};
-
-    // Share the same static as get_sampling_rate_sync
-    static CACHED_RATE: AtomicU64 = AtomicU64::new(u64::MAX);
-
     tokio::spawn(async move {
         loop {
             let rate = get_sampling_rate_async().await;

--- a/services/rust-hid/src/main.rs
+++ b/services/rust-hid/src/main.rs
@@ -77,24 +77,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-/// Resolve host.name from OTEL_RESOURCE_ATTRIBUTES if set, falling back to
-/// gethostname(). Inside Docker, gethostname() returns the container ID;
-/// OTEL_RESOURCE_ATTRIBUTES provides the real host name.
-fn resolve_host_name() -> String {
-    if let Ok(attrs) = std::env::var("OTEL_RESOURCE_ATTRIBUTES") {
-        for pair in attrs.split(',') {
-            if let Some((key, value)) = pair.split_once('=')
-                && key.trim() == "host.name"
-            {
-                return value.trim().to_string();
-            }
-        }
-    }
-    gethostname::gethostname()
-        .into_string()
-        .unwrap_or_else(|_| "unknown".into())
-}
-
 /// Build a shared OTEL resource with standard + Dynatrace-relevant attributes.
 fn build_otel_resource() -> opentelemetry_sdk::Resource {
     use opentelemetry::KeyValue;
@@ -105,7 +87,7 @@ fn build_otel_resource() -> opentelemetry_sdk::Resource {
         std::env::var("OTEL_SERVICE_NAMESPACE").unwrap_or_else(|_| "infrastructure".into());
     let version =
         std::env::var("SERVICE_VERSION").unwrap_or_else(|_| "0.0.0-dev".into());
-    let hostname = resolve_host_name();
+    let hostname = feature_flags::resolve_host_name();
     let instance_id =
         std::env::var("HOSTNAME").unwrap_or_else(|_| hostname.clone());
     let environment =

--- a/services/rust-hid/src/main.rs
+++ b/services/rust-hid/src/main.rs
@@ -6,9 +6,11 @@
 mod controller_io_service;
 mod device_manager;
 mod feature_flags;
+mod flagd_sampler;
 mod grpc_tracing;
 mod hid;
 mod service;
+mod span_enrichment;
 
 use controller_io_service::ControllerIoServiceImpl;
 use service::proto::controller_io_service_server::ControllerIoServiceServer;
@@ -190,6 +192,7 @@ fn init_tracing(
 
         let provider = opentelemetry_sdk::trace::TracerProvider::builder()
             .with_batch_exporter(exporter, opentelemetry_sdk::runtime::Tokio)
+            .with_sampler(flagd_sampler::FlagdSampler::new())
             .with_resource(resource)
             .build();
 
@@ -203,7 +206,12 @@ fn init_tracing(
             .with(fmt_layer)
             .with(otel_layer)
             .with(logs_layer)
+            .with(span_enrichment::FlagdSpanEnrichmentLayer)
             .init();
+
+        // Spawn background tasks for dynamic flag updates
+        flagd_sampler::spawn_rate_updater();
+        span_enrichment::spawn_enrichment_updater();
 
         Some(provider)
     } else {

--- a/services/rust-hid/src/span_enrichment.rs
+++ b/services/rust-hid/src/span_enrichment.rs
@@ -137,11 +137,16 @@ async fn update_enrichment_config() {
     let client = of.create_client();
     let ctx = EvaluationContext::default();
 
-    // get_object_value returns a serde_json::Value
-    let config = client
-        .get_struct_value::<serde_json::Value>("span_enrichment_config", Some(&ctx), None)
+    // Fetch the config as a string and parse as JSON.
+    // get_struct_value requires TryFrom<StructValue> which serde_json::Value doesn't implement,
+    // so we use get_string_value and parse manually.
+    let config: serde_json::Value = match client
+        .get_string_value("span_enrichment_config", Some(&ctx), None)
         .await
-        .unwrap_or_default();
+    {
+        Ok(s) => serde_json::from_str(&s).unwrap_or_default(),
+        Err(_) => serde_json::Value::default(),
+    };
 
     let enabled = config
         .get("enabled")

--- a/services/rust-hid/src/span_enrichment.rs
+++ b/services/rust-hid/src/span_enrichment.rs
@@ -80,6 +80,16 @@ where
                     ));
                 }
 
+                if sets & SET_FLAG_VALUES != 0 {
+                    // TODO: read actual flag values from the OpenFeature client
+                    // (requires async access or a second cache layer). For now,
+                    // emit a marker so dashboards can detect the set is active.
+                    attrs.push(opentelemetry::KeyValue::new(
+                        "demo.flag.enrichment_active",
+                        true,
+                    ));
+                }
+
                 if sets & SET_RUNTIME != 0 {
                     attrs.push(opentelemetry::KeyValue::new(
                         "demo.runtime.version",
@@ -89,14 +99,16 @@ where
                         "demo.runtime.pid",
                         std::process::id() as i64,
                     ));
+                    // Thread count: use available parallelism as a proxy since
+                    // tokio runtime metrics require the tokio_unstable cfg flag.
+                    attrs.push(opentelemetry::KeyValue::new(
+                        "demo.runtime.threads",
+                        num_cpus() as i64,
+                    ));
                 }
 
                 if sets & SET_SYSTEM != 0 {
-                    let hostname = HOSTNAME.get_or_init(|| {
-                        gethostname::gethostname()
-                            .into_string()
-                            .unwrap_or_else(|_| "unknown".into())
-                    });
+                    let hostname = HOSTNAME.get_or_init(resolve_host_name);
                     attrs.push(opentelemetry::KeyValue::new(
                         "demo.system.hostname",
                         hostname.clone(),
@@ -104,6 +116,10 @@ where
                     attrs.push(opentelemetry::KeyValue::new(
                         "demo.system.cpu_count",
                         num_cpus() as i64,
+                    ));
+                    attrs.push(opentelemetry::KeyValue::new(
+                        "demo.system.os_type",
+                        std::env::consts::OS,
                     ));
                 }
 
@@ -114,6 +130,24 @@ where
             }
         }
     }
+}
+
+/// Resolve host.name from OTEL_RESOURCE_ATTRIBUTES if set, falling back to
+/// gethostname(). Inside Docker, gethostname() returns the container ID;
+/// OTEL_RESOURCE_ATTRIBUTES provides the real host name.
+fn resolve_host_name() -> String {
+    if let Ok(attrs) = std::env::var("OTEL_RESOURCE_ATTRIBUTES") {
+        for pair in attrs.split(',') {
+            if let Some((key, value)) = pair.split_once('=')
+                && key.trim() == "host.name"
+            {
+                return value.trim().to_string();
+            }
+        }
+    }
+    gethostname::gethostname()
+        .into_string()
+        .unwrap_or_else(|_| "unknown".into())
 }
 
 fn num_cpus() -> usize {
@@ -132,41 +166,37 @@ pub fn spawn_enrichment_updater() {
     });
 }
 
+/// Map a flagd variant name to (enabled, attribute_sets) config.
+/// These mirror the variants defined in `services/flagd/performance.json`.
+fn variant_to_config(variant: &str) -> (bool, u8) {
+    match variant {
+        "basic" => (true, SET_SERVICE_IDENTITY),
+        "flags" => (true, SET_SERVICE_IDENTITY | SET_FLAG_VALUES),
+        "full" => (
+            true,
+            SET_SERVICE_IDENTITY | SET_FLAG_VALUES | SET_RUNTIME | SET_SYSTEM,
+        ),
+        // "off" and any unknown variant
+        _ => (false, 0),
+    }
+}
+
 async fn update_enrichment_config() {
     let of = OpenFeature::singleton().await;
     let client = of.create_client();
     let ctx = EvaluationContext::default();
 
-    // Fetch the config as a string and parse as JSON.
-    // get_struct_value requires TryFrom<StructValue> which serde_json::Value doesn't implement,
-    // so we use get_string_value and parse manually.
-    let config: serde_json::Value = match client
+    // span_enrichment_config is an object-typed flag in flagd. The Rust
+    // OpenFeature SDK's get_struct_value requires TryFrom<StructValue>,
+    // which serde_json::Value doesn't implement. Instead we fetch the
+    // resolved variant name via get_string_value and map it locally to
+    // the known (enabled, attribute_sets) configuration.
+    let variant = client
         .get_string_value("span_enrichment_config", Some(&ctx), None)
         .await
-    {
-        Ok(s) => serde_json::from_str(&s).unwrap_or_default(),
-        Err(_) => serde_json::Value::default(),
-    };
+        .unwrap_or_else(|_| "off".into());
 
-    let enabled = config
-        .get("enabled")
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false);
+    let (enabled, sets) = variant_to_config(&variant);
     ENRICHMENT_ENABLED.store(enabled, Ordering::Relaxed);
-
-    let mut sets: u8 = 0;
-    if let Some(arr) = config.get("attribute_sets").and_then(|v| v.as_array()) {
-        for item in arr {
-            if let Some(s) = item.as_str() {
-                match s {
-                    "service_identity" => sets |= SET_SERVICE_IDENTITY,
-                    "flag_values" => sets |= SET_FLAG_VALUES,
-                    "runtime" => sets |= SET_RUNTIME,
-                    "system" => sets |= SET_SYSTEM,
-                    _ => {}
-                }
-            }
-        }
-    }
     ATTR_SETS.store(sets, Ordering::Relaxed);
 }

--- a/services/rust-hid/src/span_enrichment.rs
+++ b/services/rust-hid/src/span_enrichment.rs
@@ -6,7 +6,7 @@
 
 use open_feature::{EvaluationContext, OpenFeature};
 use std::sync::atomic::{AtomicBool, Ordering};
-use tracing::Span;
+use std::sync::OnceLock;
 use tracing_subscriber::layer::Context;
 use tracing_subscriber::Layer;
 
@@ -20,6 +20,11 @@ const SET_SERVICE_IDENTITY: u8 = 1;
 const SET_FLAG_VALUES: u8 = 2;
 const SET_RUNTIME: u8 = 4;
 const SET_SYSTEM: u8 = 8;
+
+// Cached values for hot-path span enrichment (immutable after first read)
+static HOSTNAME: OnceLock<String> = OnceLock::new();
+static SERVICE_NAME: OnceLock<String> = OnceLock::new();
+static SERVICE_NS: OnceLock<String> = OnceLock::new();
 
 /// A tracing Layer that adds enrichment attributes to spans.
 pub struct FlagdSpanEnrichmentLayer;
@@ -57,15 +62,21 @@ where
                 let mut attrs = Vec::new();
 
                 if sets & SET_SERVICE_IDENTITY != 0 {
+                    let svc = SERVICE_NAME.get_or_init(|| {
+                        std::env::var("OTEL_SERVICE_NAME").unwrap_or_else(|_| "unknown".into())
+                    });
+                    let ns = SERVICE_NS.get_or_init(|| {
+                        std::env::var("OTEL_SERVICE_NAMESPACE").unwrap_or_else(|_| "unknown".into())
+                    });
                     attrs.push(opentelemetry::KeyValue::new("demo.enriched", true));
                     attrs.push(opentelemetry::KeyValue::new("demo.language", "rust"));
                     attrs.push(opentelemetry::KeyValue::new(
                         "demo.service",
-                        std::env::var("OTEL_SERVICE_NAME").unwrap_or_else(|_| "unknown".into()),
+                        svc.clone(),
                     ));
                     attrs.push(opentelemetry::KeyValue::new(
                         "demo.namespace",
-                        std::env::var("OTEL_SERVICE_NAMESPACE").unwrap_or_else(|_| "unknown".into()),
+                        ns.clone(),
                     ));
                 }
 
@@ -81,11 +92,14 @@ where
                 }
 
                 if sets & SET_SYSTEM != 0 {
-                    attrs.push(opentelemetry::KeyValue::new(
-                        "demo.system.hostname",
+                    let hostname = HOSTNAME.get_or_init(|| {
                         gethostname::gethostname()
                             .into_string()
-                            .unwrap_or_else(|_| "unknown".into()),
+                            .unwrap_or_else(|_| "unknown".into())
+                    });
+                    attrs.push(opentelemetry::KeyValue::new(
+                        "demo.system.hostname",
+                        hostname.clone(),
                     ));
                     attrs.push(opentelemetry::KeyValue::new(
                         "demo.system.cpu_count",

--- a/services/rust-hid/src/span_enrichment.rs
+++ b/services/rust-hid/src/span_enrichment.rs
@@ -1,0 +1,153 @@
+//! FlagdSpanEnrichmentLayer — Configurable span attribute enrichment.
+//!
+//! Reads the `span_enrichment_config` structured flag from flagd and adds
+//! diagnostic attributes to spans. Uses the same attribute sets as the
+//! Python and Go implementations for cross-language consistency.
+
+use open_feature::{EvaluationContext, OpenFeature};
+use std::sync::atomic::{AtomicBool, Ordering};
+use tracing::Span;
+use tracing_subscriber::layer::Context;
+use tracing_subscriber::Layer;
+
+/// Cached enrichment state (updated by background task).
+static ENRICHMENT_ENABLED: AtomicBool = AtomicBool::new(false);
+
+// Which attribute sets are active (stored as bitflags for simplicity)
+static ATTR_SETS: std::sync::atomic::AtomicU8 = std::sync::atomic::AtomicU8::new(0);
+
+const SET_SERVICE_IDENTITY: u8 = 1;
+const SET_FLAG_VALUES: u8 = 2;
+const SET_RUNTIME: u8 = 4;
+const SET_SYSTEM: u8 = 8;
+
+/// A tracing Layer that adds enrichment attributes to spans.
+pub struct FlagdSpanEnrichmentLayer;
+
+impl<S> Layer<S> for FlagdSpanEnrichmentLayer
+where
+    S: tracing::Subscriber + for<'span> tracing_subscriber::registry::LookupSpan<'span>,
+{
+    fn on_new_span(
+        &self,
+        _attrs: &tracing::span::Attributes<'_>,
+        id: &tracing::span::Id,
+        ctx: Context<'_, S>,
+    ) {
+        if !ENRICHMENT_ENABLED.load(Ordering::Relaxed) {
+            return;
+        }
+
+        let sets = ATTR_SETS.load(Ordering::Relaxed);
+        if sets == 0 {
+            return;
+        }
+
+        let span = ctx.span(id);
+        if let Some(span) = span {
+            let mut extensions = span.extensions_mut();
+
+            // We use OtelData if available, otherwise skip
+            // The attributes will be added when the span is exported
+            if let Some(otel_data) = extensions
+                .get_mut::<tracing_opentelemetry::OtelData>()
+            {
+                let builder = &mut otel_data.builder;
+
+                let mut attrs = Vec::new();
+
+                if sets & SET_SERVICE_IDENTITY != 0 {
+                    attrs.push(opentelemetry::KeyValue::new("demo.enriched", true));
+                    attrs.push(opentelemetry::KeyValue::new("demo.language", "rust"));
+                    attrs.push(opentelemetry::KeyValue::new(
+                        "demo.service",
+                        std::env::var("OTEL_SERVICE_NAME").unwrap_or_else(|_| "unknown".into()),
+                    ));
+                    attrs.push(opentelemetry::KeyValue::new(
+                        "demo.namespace",
+                        std::env::var("OTEL_SERVICE_NAMESPACE").unwrap_or_else(|_| "unknown".into()),
+                    ));
+                }
+
+                if sets & SET_RUNTIME != 0 {
+                    attrs.push(opentelemetry::KeyValue::new(
+                        "demo.runtime.version",
+                        env!("CARGO_PKG_VERSION"),
+                    ));
+                    attrs.push(opentelemetry::KeyValue::new(
+                        "demo.runtime.pid",
+                        std::process::id() as i64,
+                    ));
+                }
+
+                if sets & SET_SYSTEM != 0 {
+                    attrs.push(opentelemetry::KeyValue::new(
+                        "demo.system.hostname",
+                        gethostname::gethostname()
+                            .into_string()
+                            .unwrap_or_else(|_| "unknown".into()),
+                    ));
+                    attrs.push(opentelemetry::KeyValue::new(
+                        "demo.system.cpu_count",
+                        num_cpus() as i64,
+                    ));
+                }
+
+                if !attrs.is_empty() {
+                    let existing = builder.attributes.get_or_insert_with(Vec::new);
+                    existing.extend(attrs);
+                }
+            }
+        }
+    }
+}
+
+fn num_cpus() -> usize {
+    std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(1)
+}
+
+/// Spawn a background task that periodically updates enrichment config from flagd.
+pub fn spawn_enrichment_updater() {
+    tokio::spawn(async move {
+        loop {
+            update_enrichment_config().await;
+            tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+        }
+    });
+}
+
+async fn update_enrichment_config() {
+    let of = OpenFeature::singleton().await;
+    let client = of.create_client();
+    let ctx = EvaluationContext::default();
+
+    // get_object_value returns a serde_json::Value
+    let config = client
+        .get_struct_value::<serde_json::Value>("span_enrichment_config", Some(&ctx), None)
+        .await
+        .unwrap_or_default();
+
+    let enabled = config
+        .get("enabled")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    ENRICHMENT_ENABLED.store(enabled, Ordering::Relaxed);
+
+    let mut sets: u8 = 0;
+    if let Some(arr) = config.get("attribute_sets").and_then(|v| v.as_array()) {
+        for item in arr {
+            if let Some(s) = item.as_str() {
+                match s {
+                    "service_identity" => sets |= SET_SERVICE_IDENTITY,
+                    "flag_values" => sets |= SET_FLAG_VALUES,
+                    "runtime" => sets |= SET_RUNTIME,
+                    "system" => sets |= SET_SYSTEM,
+                    _ => {}
+                }
+            }
+        }
+    }
+    ATTR_SETS.store(sets, Ordering::Relaxed);
+}

--- a/services/rust-hid/src/span_enrichment.rs
+++ b/services/rust-hid/src/span_enrichment.rs
@@ -4,6 +4,7 @@
 //! diagnostic attributes to spans. Uses the same attribute sets as the
 //! Python and Go implementations for cross-language consistency.
 
+use crate::feature_flags::resolve_host_name;
 use open_feature::{EvaluationContext, OpenFeature};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::OnceLock;
@@ -130,24 +131,6 @@ where
             }
         }
     }
-}
-
-/// Resolve host.name from OTEL_RESOURCE_ATTRIBUTES if set, falling back to
-/// gethostname(). Inside Docker, gethostname() returns the container ID;
-/// OTEL_RESOURCE_ATTRIBUTES provides the real host name.
-fn resolve_host_name() -> String {
-    if let Ok(attrs) = std::env::var("OTEL_RESOURCE_ATTRIBUTES") {
-        for pair in attrs.split(',') {
-            if let Some((key, value)) = pair.split_once('=')
-                && key.trim() == "host.name"
-            {
-                return value.trim().to_string();
-            }
-        }
-    }
-    gethostname::gethostname()
-        .into_string()
-        .unwrap_or_else(|_| "unknown".into())
 }
 
 fn num_cpus() -> usize {


### PR DESCRIPTION
## Summary

- FlagdSampler with shared atomic CACHED_RATE and background updater
- Span enrichment with OnceLock-cached hostname/env vars
- Safe f64 bit initialization (no NaN sentinel)

**Stack**: #714 ← opamp-bridge ← python-otel ← **this PR** ← next

## Test plan

- [x] Rust checks pass (cargo test + clippy)
- [x] Integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)