### PR TITLE
feat: OTel Pipeline Control Grafana dashboard

### DIFF
--- a/services/grafana/dashboards/otel-pipeline-control.json
+++ b/services/grafana/dashboards/otel-pipeline-control.json
@@ -12,6 +12,7 @@
       }
     ]
   },
+  "description": "Real-time monitoring of OTel pipeline control: trace sampling, log verbosity, span enrichment, and collector throughput.",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
@@ -100,7 +101,7 @@
       "type": "timeseries",
       "targets": [
         {
-          "expr": "sum by(level) (rate({job=~\".+\"} |= \"\" [$__interval]))",
+          "expr": "sum by(level) (rate({job=~\".+\"} [$__interval]))",
           "legendFormat": "{{level}}",
           "refId": "A",
           "datasource": { "type": "loki", "uid": "loki" }
@@ -130,7 +131,7 @@
       "type": "stat",
       "targets": [
         {
-          "expr": "sum(rate({level=\"debug\"} |= \"\" [$__interval])) / sum(rate({job=~\".+\"} |= \"\" [$__interval])) * 100",
+          "expr": "(sum(rate({level=\"debug\"} [$__interval])) / sum(rate({job=~\".+\"} [$__interval])) * 100) or vector(0)",
           "legendFormat": "Debug %",
           "refId": "A",
           "datasource": { "type": "loki", "uid": "loki" }
@@ -225,7 +226,7 @@
       "type": "stat",
       "targets": [
         {
-          "expr": "count({__name__=~\".+\"})",
+          "expr": "sum(scrape_series_added)",
           "legendFormat": "Series",
           "refId": "A"
         }

--- a/services/grafana/dashboards/otel-pipeline-control.json
+++ b/services/grafana/dashboards/otel-pipeline-control.json
@@ -101,7 +101,7 @@
       "type": "timeseries",
       "targets": [
         {
-          "expr": "sum by(level) (rate({job=~\".+\"} [$__interval]))",
+          "expr": "sum by(level) (rate({job=~\".+\"} | logfmt | level != \"\" [1m]))",
           "legendFormat": "{{level}}",
           "refId": "A",
           "datasource": { "type": "loki", "uid": "loki" }
@@ -114,6 +114,7 @@
         "defaults": {
           "color": { "mode": "thresholds" },
           "thresholds": {
+            "mode": "absolute",
             "steps": [
               { "color": "green", "value": null },
               { "color": "yellow", "value": 10 },
@@ -131,7 +132,7 @@
       "type": "stat",
       "targets": [
         {
-          "expr": "(sum(rate({level=\"debug\"} [$__interval])) / sum(rate({job=~\".+\"} [$__interval])) * 100) or vector(0)",
+          "expr": "(sum(rate({job=~\".+\"} | logfmt | level=\"debug\" [1m])) / sum(rate({job=~\".+\"} | logfmt | level != \"\" [1m])) * 100) or vector(0)",
           "legendFormat": "Debug %",
           "refId": "A",
           "datasource": { "type": "loki", "uid": "loki" }
@@ -151,6 +152,7 @@
         "defaults": {
           "color": { "mode": "thresholds" },
           "thresholds": {
+            "mode": "absolute",
             "steps": [
               { "color": "gray", "value": null },
               { "color": "green", "value": 1 }
@@ -209,6 +211,7 @@
         "defaults": {
           "color": { "mode": "thresholds" },
           "thresholds": {
+            "mode": "absolute",
             "steps": [
               { "color": "green", "value": null },
               { "color": "yellow", "value": 500 },
@@ -226,7 +229,7 @@
       "type": "stat",
       "targets": [
         {
-          "expr": "sum(scrape_series_added)",
+          "expr": "sum(prometheus_tsdb_head_series)",
           "legendFormat": "Series",
           "refId": "A"
         }

--- a/services/grafana/dashboards/otel-pipeline-control.json
+++ b/services/grafana/dashboards/otel-pipeline-control.json
@@ -1,0 +1,279 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "id": 100,
+      "title": "Trace Sampling",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "fillOpacity": 10, "lineWidth": 2 },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 1 },
+      "id": 1,
+      "options": { "legend": { "displayMode": "list" }, "tooltip": { "mode": "multi" } },
+      "title": "Traces / Second",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "sum(rate(traces_spanmetrics_calls_total[1m])) or vector(0)",
+          "legendFormat": "Total traces/s",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "fillOpacity": 20 },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 1 },
+      "id": 2,
+      "options": { "legend": { "displayMode": "list" }, "tooltip": { "mode": "multi" } },
+      "title": "Traces by Service",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "sum by(service_name) (rate(traces_spanmetrics_calls_total[1m]))",
+          "legendFormat": "{{service_name}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 9 },
+      "id": 101,
+      "title": "Log Verbosity",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "loki", "uid": "loki" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "fillOpacity": 30, "stacking": { "mode": "normal" } },
+          "unit": "ops"
+        },
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "error" }, "properties": [{ "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }] },
+          { "matcher": { "id": "byName", "options": "warn" }, "properties": [{ "id": "color", "value": { "fixedColor": "orange", "mode": "fixed" } }] },
+          { "matcher": { "id": "byName", "options": "info" }, "properties": [{ "id": "color", "value": { "fixedColor": "green", "mode": "fixed" } }] },
+          { "matcher": { "id": "byName", "options": "debug" }, "properties": [{ "id": "color", "value": { "fixedColor": "blue", "mode": "fixed" } }] }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 10 },
+      "id": 3,
+      "options": { "legend": { "displayMode": "list" }, "tooltip": { "mode": "multi" } },
+      "title": "Logs / Second by Severity",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "sum by(level) (rate({job=~\".+\"} |= \"\" [$__interval]))",
+          "legendFormat": "{{level}}",
+          "refId": "A",
+          "datasource": { "type": "loki", "uid": "loki" }
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "loki", "uid": "loki" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 10 },
+              { "color": "red", "value": 50 }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 10 },
+      "id": 4,
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "title": "DEBUG Log Ratio",
+      "type": "stat",
+      "targets": [
+        {
+          "expr": "sum(rate({level=\"debug\"} |= \"\" [$__interval])) / sum(rate({job=~\".+\"} |= \"\" [$__interval])) * 100",
+          "legendFormat": "Debug %",
+          "refId": "A",
+          "datasource": { "type": "loki", "uid": "loki" }
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 18 },
+      "id": 102,
+      "title": "Span Enrichment",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "steps": [
+              { "color": "gray", "value": null },
+              { "color": "green", "value": 1 }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 19 },
+      "id": 5,
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "title": "Enriched Span Ratio",
+      "type": "stat",
+      "targets": [
+        {
+          "expr": "sum(rate(traces_spanmetrics_calls_total{span_attr_demo_enriched=\"true\"}[5m])) / sum(rate(traces_spanmetrics_calls_total[5m])) * 100 or vector(0)",
+          "legendFormat": "Enriched %",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "fillOpacity": 15 },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 16, "x": 8, "y": 19 },
+      "id": 6,
+      "options": { "legend": { "displayMode": "list" }, "tooltip": { "mode": "multi" } },
+      "title": "Enriched Spans by Language",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "sum by(span_attr_demo_language) (rate(traces_spanmetrics_calls_total{span_attr_demo_enriched=\"true\"}[1m]))",
+          "legendFormat": "{{span_attr_demo_language}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 27 },
+      "id": 103,
+      "title": "Metrics Pipeline",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 500 },
+              { "color": "red", "value": 1000 }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 28 },
+      "id": 7,
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "title": "Active Metric Series",
+      "type": "stat",
+      "targets": [
+        {
+          "expr": "count({__name__=~\".+\"})",
+          "legendFormat": "Series",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "fillOpacity": 10, "lineWidth": 2 },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 16, "x": 8, "y": 28 },
+      "id": 8,
+      "options": { "legend": { "displayMode": "list" }, "tooltip": { "mode": "multi" } },
+      "title": "Collector Pipeline Throughput",
+      "type": "timeseries",
+      "targets": [
+        {
+          "expr": "sum(rate(otelcol_exporter_sent_spans_total[1m]))",
+          "legendFormat": "Spans exported/s",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(otelcol_exporter_sent_metric_points_total[1m]))",
+          "legendFormat": "Metrics exported/s",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(rate(otelcol_exporter_sent_log_records_total[1m]))",
+          "legendFormat": "Logs exported/s",
+          "refId": "C"
+        }
+      ]
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 39,
+  "tags": ["observability", "otel", "demo"],
+  "templating": { "list": [] },
+  "time": { "from": "now-15m", "to": "now" },
+  "timepicker": {},
+  "timezone": "",
+  "title": "OTel Pipeline Control",
+  "uid": "otel-pipeline-control",
+  "version": 1,
+  "weekStart": ""
+}


### PR DESCRIPTION
## Summary

- Grafana dashboard for monitoring OTel pipeline control
- Panels: trace sampling, log severity, span enrichment, collector throughput
- Correct Loki queries with logfmt parser
- prometheus_tsdb_head_series for active metric series

**Stack**: #714 ← opamp-bridge ← python-otel ← rust-otel ← go-otel ← obs-routes ← **this PR** (top)

## Test plan

- [x] JSON validates
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)