### PR TITLE
feat: Claude Code devcontainer for AI-assisted development

### DIFF
--- a/.devcontainer/claude-code/Dockerfile
+++ b/.devcontainer/claude-code/Dockerfile
@@ -1,0 +1,84 @@
+FROM python:3.12-slim
+
+ARG GO_VERSION=1.25.1
+ARG RUST_VERSION=1.88.0
+ARG NODE_MAJOR=22
+
+# Avoid interactive prompts
+ENV DEBIAN_FRONTEND=noninteractive
+
+# ── System packages ──────────────────────────────────────────────────
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    ca-certificates \
+    curl \
+    g++ \
+    gcc \
+    git \
+    gnupg \
+    libasound2-dev \
+    libbluetooth-dev \
+    libdbus-1-dev \
+    libglib2.0-dev \
+    libhidapi-dev \
+    libhidapi-hidraw0 \
+    libudev-dev \
+    make \
+    pkg-config \
+    protobuf-compiler \
+    sudo \
+    unzip \
+    wget \
+    && rm -rf /var/lib/apt/lists/*
+
+# ── Node.js 22 ───────────────────────────────────────────────────────
+RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_MAJOR}.x | bash - \
+    && apt-get install -y nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+# ── Go ───────────────────────────────────────────────────────────────
+RUN curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-$(dpkg --print-architecture).tar.gz" \
+    | tar -C /usr/local -xzf - \
+    && ln -s /usr/local/go/bin/go /usr/local/bin/go \
+    && ln -s /usr/local/go/bin/gofmt /usr/local/bin/gofmt
+
+# ── Rust (via rustup, non-root) ──────────────────────────────────────
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH="/usr/local/cargo/bin:$PATH"
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+    | sh -s -- -y --default-toolchain ${RUST_VERSION} --component clippy \
+    && chmod -R a+rwx $RUSTUP_HOME $CARGO_HOME
+
+# ── uv (Python package manager) ─────────────────────────────────────
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh \
+    && mv /root/.local/bin/uv /usr/local/bin/uv \
+    && mv /root/.local/bin/uvx /usr/local/bin/uvx
+
+# ── buf CLI (protobuf) ──────────────────────────────────────────────
+RUN BUF_ARCH=$(dpkg --print-architecture | sed 's/amd64/x86_64/' | sed 's/arm64/aarch64/') \
+    && curl -fsSL "https://github.com/bufbuild/buf/releases/latest/download/buf-Linux-${BUF_ARCH}" \
+       -o /usr/local/bin/buf \
+    && chmod +x /usr/local/bin/buf
+
+# ── GitHub CLI ───────────────────────────────────────────────────────
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+       -o /usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+       > /etc/apt/sources.list.d/github-cli.list \
+    && apt-get update && apt-get install -y gh \
+    && rm -rf /var/lib/apt/lists/*
+
+# ── Claude Code CLI ─────────────────────────────────────────────────
+RUN npm install -g @anthropic-ai/claude-code
+
+# ── Non-root user ───────────────────────────────────────────────────
+RUN groupadd --gid 1000 claude \
+    && useradd --uid 1000 --gid claude --shell /bin/bash --create-home claude \
+    && echo "claude ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/claude
+
+# ── Global git config ───────────────────────────────────────────────
+RUN git config --system --add safe.directory '*'
+
+USER claude
+WORKDIR /workspace

--- a/.devcontainer/claude-code/devcontainer.json
+++ b/.devcontainer/claude-code/devcontainer.json
@@ -1,0 +1,36 @@
+{
+  "name": "Claude Code Agent",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "workspaceFolder": "/workspace",
+
+  "containerEnv": {
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+  },
+
+  "secrets": {
+    "ANTHROPIC_API_KEY": {
+      "description": "Anthropic API key for Claude Code"
+    },
+    "GH_TOKEN": {
+      "description": "GitHub fine-grained PAT (contents:read, pull_requests:write, issues:write)"
+    }
+  },
+
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {}
+  },
+
+  "postCreateCommand": "git config --global url.\"https://${GH_TOKEN}@github.com/\".insteadOf \"git@github.com:\" && uv sync --all-packages 2>/dev/null; true",
+
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "anthropics.claude-code"
+      ]
+    }
+  },
+
+  "remoteUser": "claude"
+}


### PR DESCRIPTION
## Summary

- Full-stack devcontainer at `.devcontainer/claude-code/` for running Claude Code agents
- Includes all languages in the repo: Python 3.12 + uv, Go 1.25, Rust 1.88 + clippy, Node.js 22
- Tooling: protoc, buf CLI, gh CLI, Claude Code CLI, Docker-in-Docker
- Agent teams enabled via `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`
- No SSH keys — git operations use HTTPS rewrite via `GH_TOKEN` (fine-grained PAT controls push access)

## Usage

**VS Code (Windows/Mac/Linux):**
1. Install Docker Desktop + Dev Containers extension
2. F1 → "Dev Containers: Reopen in Container" → select "Claude Code Agent"
3. Set `ANTHROPIC_API_KEY` and `GH_TOKEN` secrets when prompted
4. Terminal: `claude --dangerously-skip-permissions`

**Docker CLI:**
```bash
docker build -t claude-code-dev .devcontainer/claude-code/
docker run -it -e ANTHROPIC_API_KEY -e GH_TOKEN \
  -e CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1 \
  -v "$(pwd)":/workspace claude-code-dev \
  claude --dangerously-skip-permissions
```

## Test plan

- [ ] `docker build` succeeds
- [ ] All tools available: `python3`, `go`, `rustc`, `node`, `claude`, `gh`, `uv`, `buf`, `protoc`
- [ ] `make lint` works inside container
- [ ] `cd services/connect-proxy && go build ./...` works
- [ ] `cd services/rust-hid && cargo check` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)