### PR TITLE
feat: intervention observability metrics (#730)

### DIFF
--- a/lib/types.py
+++ b/lib/types.py
@@ -383,6 +383,12 @@ class GameEvent(StrEnum):
     TEAM_FORMATION_END = "team_formation_end"
     TEAM_ELIMINATED = "team_eliminated"
 
+    # Agent intervention audit event (#730, #722 §8 enforcement step 5).
+    # Published by the flag-application layer in a later PR for every applied or
+    # blocked agent intervention, alongside the game.intervention span and the
+    # game_interventions_total counter. Defined here so later PRs can publish it.
+    AGENT_INTERVENTION = "agent_intervention"
+
     @classmethod
     def is_game_starting(cls, event_type: str) -> bool:
         """Check if event indicates game is starting (any start phase)."""

--- a/services/controller_manager/discovery_loop.py
+++ b/services/controller_manager/discovery_loop.py
@@ -675,6 +675,7 @@ class DiscoveryLoop:
             metrics.active_controllers.inc()
             metrics.controller_connected.labels(serial=serial).set(1)
             metrics.controller_battery_level.labels(serial=serial).set(battery)
+            metrics.controller_battery_pct.labels(serial=serial).set(metrics.battery_to_pct(battery))
             # Controller info metric with human-readable name (Issue #74)
             # Use actual name from name_manager, fallback to serial suffix
             if name:

--- a/services/controller_manager/metrics.py
+++ b/services/controller_manager/metrics.py
@@ -12,6 +12,32 @@ from lib.otel_metrics import Counter, Gauge, Histogram
 # Controller health metrics
 controller_battery_level = Gauge("controller_battery_level", "Controller battery level (0-5)", ["serial"])
 
+# Normalized battery percentage (#730, #722 §7). The 0-5 scale above is kept for
+# compatibility; this exposes 0-100 so policy.battery_threshold (expressed in
+# percent) is enforceable and the agent reads one consistent unit.
+controller_battery_pct = Gauge("controller_battery_pct", "Controller battery level (0-100)", ["serial"])
+
+
+def battery_to_pct(battery: float) -> float:
+    """
+    Normalize a controller battery reading to a 0-100 percentage (#730).
+
+    Two sources feed battery values:
+    - The psmoveapi path reports a 0-5 charge level -> multiply by 20.
+    - The Rust HID path (proto/psmove_hid.proto) already reports 0-100 -> pass
+      through unchanged.
+
+    Heuristic: values in the 0-5 range are treated as the coarse scale; anything
+    above 5 is assumed to already be a percentage. Result is clamped to [0, 100].
+
+    Note: charging/unknown sentinel values from psmoveapi (e.g. 0xEE/0xEF, well
+    above 100) clamp to 100, matching the "full if unknown" default used by
+    callers.
+    """
+    pct = battery * 20.0 if battery <= 5 else float(battery)
+    return max(0.0, min(100.0, pct))
+
+
 controller_connected = Gauge(
     "controller_connected", "Controller connection status (0=disconnected, 1=connected)", ["serial"]
 )

--- a/services/controller_manager/monitoring.py
+++ b/services/controller_manager/monitoring.py
@@ -48,6 +48,8 @@ class ControllerMonitoring:
 
                 # Update battery metric (Phase 38)
                 metrics.controller_battery_level.labels(serial=serial).set(battery)
+                # Normalized 0-100 percentage (#730)
+                metrics.controller_battery_pct.labels(serial=serial).set(metrics.battery_to_pct(battery))
 
             except Exception as e:
                 logger.error(f"Error checking battery for {serial}: {e}")

--- a/services/controller_manager/tests/test_battery_pct.py
+++ b/services/controller_manager/tests/test_battery_pct.py
@@ -1,0 +1,54 @@
+"""
+Tests for battery percentage normalization added in #730 / #722 §7.
+
+controller_battery_pct exposes a 0-100 value derived from either the 0-5
+psmoveapi scale (x20) or the Rust HID 0-100 path (passthrough). The 0-5
+controller_battery_level metric is unchanged for compatibility.
+"""
+
+import pytest
+
+from services.controller_manager.metrics import battery_to_pct
+
+
+class TestBatteryToPct:
+    @pytest.mark.parametrize(
+        ("level", "expected"),
+        [
+            (0, 0.0),
+            (1, 20.0),
+            (2, 40.0),
+            (3, 60.0),
+            (4, 80.0),
+            (5, 100.0),
+        ],
+    )
+    def test_scale_0_5_maps_to_percent(self, level, expected):
+        assert battery_to_pct(level) == expected
+
+    @pytest.mark.parametrize(
+        ("hid_value", "expected"),
+        [
+            (10, 10.0),
+            (42, 42.0),
+            (75, 75.0),
+            (100, 100.0),
+        ],
+    )
+    def test_hid_0_100_passthrough(self, hid_value, expected):
+        # Values above the 0-5 range are assumed to already be percentages
+        assert battery_to_pct(hid_value) == expected
+
+    def test_clamped_to_100(self):
+        # psmoveapi charging/unknown sentinels (e.g. 0xEE) clamp to full
+        assert battery_to_pct(238) == 100.0
+
+    def test_clamped_to_zero(self):
+        assert battery_to_pct(-1) == 0.0
+
+    def test_boundary_five_is_full_not_five_percent(self):
+        # 5 is the top of the coarse scale, not 5% on the HID scale
+        assert battery_to_pct(5) == 100.0
+
+    def test_fractional_level(self):
+        assert battery_to_pct(2.5) == 50.0

--- a/services/game_coordinator/games/analytics.py
+++ b/services/game_coordinator/games/analytics.py
@@ -20,9 +20,16 @@ import json
 import logging
 import math
 import time
+from collections import deque
 from dataclasses import dataclass, field
 from enum import IntEnum
 from typing import TYPE_CHECKING
+
+# Rolling-window size for windowed movement variance (#730 / #722 §7).
+# Fixed for now; a policy flag (policy.movement_variance_window) will configure
+# this later. At ~60Hz this is roughly the last ~1s of motion, enough to
+# distinguish steady jostling from someone gaming the EMA by holding still.
+MOVEMENT_VARIANCE_WINDOW = 64
 
 if TYPE_CHECKING:
     from services.game_coordinator.runtime_config import AnalyticsConfig
@@ -111,6 +118,11 @@ class PlayerAnalytics:
     _mean: float = 0.0
     _m2: float = 0.0  # Sum of squared differences from mean
 
+    # Rolling window of recent accel magnitudes for windowed variance (#730).
+    # Kept separate from the cumulative Welford stats above: the cumulative
+    # variance is a whole-game summary, while this reflects only recent motion.
+    _accel_window: deque[float] = field(default_factory=lambda: deque(maxlen=MOVEMENT_VARIANCE_WINDOW))
+
     # Replay buffer (if enabled)
     replay_samples: list[ReplaySample] = field(default_factory=list)
 
@@ -159,6 +171,9 @@ class PlayerAnalytics:
         self._mean += delta / self.sample_count
         delta2 = raw_accel_mag - self._mean
         self._m2 += delta * delta2
+
+        # Rolling window for windowed variance (deque auto-evicts oldest sample)
+        self._accel_window.append(raw_accel_mag)
 
         # Gyro tracking (optional)
         if config.track_gyro:
@@ -233,6 +248,24 @@ class PlayerAnalytics:
         return math.sqrt(self._m2 / (self.sample_count - 1))
 
     @property
+    def windowed_variance(self) -> float:
+        """
+        Sample variance of accel magnitude over the rolling window (#730).
+
+        Unlike ``std_deviation`` (cumulative over the whole game via Welford),
+        this reflects only the most recent ``MOVEMENT_VARIANCE_WINDOW`` samples,
+        so it tracks current behavior — e.g. it drops toward zero when a player
+        games the EMA by holding the controller perfectly still.
+
+        Returns 0.0 until at least two samples are present.
+        """
+        n = len(self._accel_window)
+        if n < 2:
+            return 0.0
+        mean = sum(self._accel_window) / n
+        return sum((x - mean) ** 2 for x in self._accel_window) / (n - 1)
+
+    @property
     def total_time_ms(self) -> int:
         """Total tracked time in milliseconds."""
         return self.time_still_ms + self.time_active_ms + self.time_warning_ms + self.time_danger_ms
@@ -271,6 +304,46 @@ class PlayerAnalytics:
             return Playstyle.BALANCED
         return Playstyle.ACTIVE
 
+    def get_skill_level(self) -> float:
+        """
+        Derive a normalized skill level in [0.0, 1.0] from existing signals (#730).
+
+        The game has no virtual health or kills, so "skill" is the ability to
+        survive — i.e. to move enough to stay engaged while keeping motion under
+        the death threshold. We blend two existing, cheap signals:
+
+        - **playstyle control** (60%): the existing ``get_playstyle`` proxy. A
+          balanced/active player who avoids the danger zone is more skilled than
+          one who is either frozen (CALM) or reckless (AGGRESSIVE). Mapped so the
+          middle styles score highest:
+          CALM=0.4, BALANCED=1.0, ACTIVE=0.7, AGGRESSIVE=0.2.
+        - **motion smoothness** (40%): low rolling-window variance means steady,
+          deliberate control rather than erratic jerks. Mapped from
+          ``windowed_variance`` through a soft falloff so 0 variance → 1.0 and
+          high variance → 0.0.
+
+        Returns 0.0 before any samples are recorded (no signal yet). The blend
+        is intentionally simple and fully bounded; a richer model (survival
+        percentile across players, warnings-survived ratio) can replace it later
+        without changing the metric contract.
+        """
+        if self.sample_count == 0:
+            return 0.0
+
+        playstyle_skill = {
+            Playstyle.CALM: 0.4,
+            Playstyle.BALANCED: 1.0,
+            Playstyle.ACTIVE: 0.7,
+            Playstyle.AGGRESSIVE: 0.2,
+        }[self.get_playstyle()]
+
+        # Soft falloff: variance of ~0.25 g² (a fairly jerky player) halves the
+        # smoothness score; clamps keep the result in [0, 1].
+        smoothness = 1.0 / (1.0 + self.windowed_variance * 4.0)
+
+        skill = 0.6 * playstyle_skill + 0.4 * smoothness
+        return max(0.0, min(1.0, skill))
+
     def get_summary(self) -> dict:
         """
         Get complete analytics summary for this player.
@@ -304,6 +377,7 @@ class PlayerAnalytics:
             # Classification
             "playstyle": playstyle.name.lower(),
             "playstyle_value": playstyle.value,
+            "skill_level": round(self.get_skill_level(), 3),
         }
 
     def export_replay_json(self) -> str:

--- a/services/game_coordinator/games/base.py
+++ b/services/game_coordinator/games/base.py
@@ -249,6 +249,10 @@ class BaseGameMode(ABC):
         self.change_time = 0.0  # Time of next tempo change
         self.music_loop_task = None
         self.dead_count = 0  # Track deaths for tempo timing
+        # Elimination ordering for game_player_elimination_order metric (#730).
+        # Incremented on each kill; the value at kill time is the player's order
+        # index (1 = first eliminated). In respawn modes this counts each death.
+        self._elimination_count = 0
         self.gameplay_span: trace.Span | None = None  # Reference for span events
         self.gameplay_span_context = None  # Context for child spans in background tasks
         self._players_span: trace.Span | None = None  # Parent span grouping all player lifecycles
@@ -933,6 +937,9 @@ class BaseGameMode(ABC):
             metrics.player_movement_zone.labels(serial=serial).set(zone.value)
             metrics.player_peak_accel.labels(serial=serial, game_id=self.game_id).set(player.analytics.peak_accel)
             metrics.player_playstyle.labels(serial=serial).set(player.analytics.get_playstyle().value)
+            # Intervention observability signals (#730 / #722 §7)
+            metrics.player_movement_variance.labels(serial=serial).set(player.analytics.windowed_variance)
+            metrics.player_skill_level.labels(serial=serial).set(player.analytics.get_skill_level())
 
         # Record to histogram for distribution analysis
         metrics.accel_distribution.labels(game_mode=self.get_game_name()).observe(accel_mag)
@@ -1161,6 +1168,11 @@ class BaseGameMode(ABC):
         metrics.player_alive.labels(serial=serial).set(0)
         alive_count = len([p for p in self.players.values() if p.alive])
         metrics.players_alive.set(alive_count)
+
+        # Record elimination order (1 = first out) for #730 / #722 §7.
+        # Makes session.elimination_sequence queryable per game.
+        self._elimination_count += 1
+        metrics.player_elimination_order.labels(serial=serial, game_id=self.game_id).set(self._elimination_count)
 
         # Extract trace context BEFORE _kill_player_impl() which may close the span.
         # This ensures the death effect and sound are parented to the player_lifecycle

--- a/services/game_coordinator/metrics.py
+++ b/services/game_coordinator/metrics.py
@@ -192,6 +192,30 @@ player_alive = Gauge(
     ["serial"],
 )
 
+# Intervention observability metrics (#730, closes gaps from #722 §7).
+# Continuous per-player signals the intervention rules engine (#726) and the
+# agent fitness functions (#731) read as PromQL instant queries.
+player_movement_variance = Gauge(
+    "game_player_movement_variance",
+    "Rolling-window variance of acceleration magnitude (g^2). "
+    "Near zero indicates a player gaming the EMA by holding still.",
+    ["serial"],
+)
+
+player_skill_level = Gauge(
+    "game_player_skill_level",
+    "Derived player skill level in [0.0, 1.0] (blend of playstyle control and "
+    "motion smoothness). Complements game_player_playstyle.",
+    ["serial"],
+)
+
+player_elimination_order = Gauge(
+    "game_player_elimination_order",
+    "Order in which a player was eliminated (1=first out). Set on elimination; "
+    "makes session.elimination_sequence queryable per game.",
+    ["serial", "game_id"],
+)
+
 # Counters (incremented on events)
 near_death_events_total = Counter(
     "game_near_death_events_total",
@@ -247,12 +271,21 @@ def clear_player_analytics(serial: str, game_id: str = "") -> None:
         player_playstyle.remove(serial)
 
     with suppress(KeyError, ValueError):
+        player_movement_variance.remove(serial)
+
+    with suppress(KeyError, ValueError):
+        player_skill_level.remove(serial)
+
+    with suppress(KeyError, ValueError):
         player_alive.remove(serial)
 
-    # peak_accel has both serial and game_id labels
+    # peak_accel and elimination_order have both serial and game_id labels
     if game_id:
         with suppress(KeyError, ValueError):
             player_peak_accel.remove(serial, game_id)
+
+        with suppress(KeyError, ValueError):
+            player_elimination_order.remove(serial, game_id)
 
 
 def clear_all_player_analytics() -> None:
@@ -270,8 +303,14 @@ def clear_all_player_analytics() -> None:
     player_movement_zone._values.clear()
     player_playstyle._metrics.clear()
     player_playstyle._values.clear()
+    player_movement_variance._metrics.clear()
+    player_movement_variance._values.clear()
+    player_skill_level._metrics.clear()
+    player_skill_level._values.clear()
     player_peak_accel._metrics.clear()
     player_peak_accel._values.clear()
+    player_elimination_order._metrics.clear()
+    player_elimination_order._values.clear()
     player_alive._metrics.clear()
     player_alive._values.clear()
     # Reset game state gauges to 0 to indicate no game running
@@ -280,6 +319,20 @@ def clear_all_player_analytics() -> None:
     effective_warning_threshold.set(0)
     effective_death_threshold.set(0)
 
+
+# Agent intervention audit metric (#730, #722 §7).
+# Incremented by the flag-application layer in a later PR (PR C) for every agent
+# intervention attempt — applied or blocked. Also feeds the weighted rate limiter
+# (#722 §5) and the #731 fitness functions. Defined here now so the metric name
+# exists in the registry; zero usages in this PR is intentional.
+#   type:      intervention identifier (e.g. 'adjust_player_sensitivity', 'grant_shield')
+#   objective: active session objective ('endurance'/'balanced'/'accelerate'/'chaos')
+#   blocked:   'true' if rejected by policy/permission enforcement, else 'false'
+interventions_total = Counter(
+    "game_interventions_total",
+    "Total agent intervention attempts (applied or blocked by policy)",
+    ["type", "objective", "blocked"],
+)
 
 # EventBus stream health metrics (Issue #337)
 event_bus_publish_drops_total = Counter(

--- a/services/game_coordinator/tests/test_analytics_intervention_signals.py
+++ b/services/game_coordinator/tests/test_analytics_intervention_signals.py
@@ -1,0 +1,141 @@
+"""
+Tests for intervention observability signals added in #730 / #722 §7:
+- windowed (rolling) movement variance
+- derived skill level (bounds + empty input)
+
+These exercise PlayerAnalytics directly (no game loop) so the computations are
+verified against known sequences independently of metric emission.
+"""
+
+import math
+
+from services.game_coordinator.games.analytics import (
+    MOVEMENT_VARIANCE_WINDOW,
+    PlayerAnalytics,
+    Playstyle,
+)
+from services.game_coordinator.runtime_config import AnalyticsConfig
+
+
+def _make_analytics() -> PlayerAnalytics:
+    return PlayerAnalytics(serial="TEST01", game_start_time=0.0)
+
+
+def _config() -> AnalyticsConfig:
+    return AnalyticsConfig()
+
+
+def _feed(analytics: PlayerAnalytics, magnitudes: list[float], config: AnalyticsConfig) -> None:
+    """Record a sequence of accel magnitudes (decomposed onto the x-axis)."""
+    for mag in magnitudes:
+        analytics.record_sample(
+            accel_x=mag,
+            accel_y=0.0,
+            accel_z=0.0,
+            raw_accel_mag=mag,
+            smoothed_accel=mag,
+            death_threshold=10.0,  # high so nothing counts as near-death
+            config=config,
+        )
+
+
+def _sample_variance(values: list[float]) -> float:
+    n = len(values)
+    mean = sum(values) / n
+    return sum((v - mean) ** 2 for v in values) / (n - 1)
+
+
+class TestWindowedVariance:
+    def test_empty_returns_zero(self):
+        assert _make_analytics().windowed_variance == 0.0
+
+    def test_single_sample_returns_zero(self):
+        analytics = _make_analytics()
+        _feed(analytics, [1.0], _config())
+        assert analytics.windowed_variance == 0.0
+
+    def test_known_sequence_matches_sample_variance(self):
+        analytics = _make_analytics()
+        seq = [1.0, 2.0, 3.0, 4.0, 5.0]
+        _feed(analytics, seq, _config())
+        # Sample variance of 1..5 = 2.5
+        assert math.isclose(analytics.windowed_variance, 2.5, rel_tol=1e-9)
+        assert math.isclose(analytics.windowed_variance, _sample_variance(seq), rel_tol=1e-9)
+
+    def test_constant_sequence_zero_variance(self):
+        analytics = _make_analytics()
+        _feed(analytics, [1.2] * 20, _config())
+        assert math.isclose(analytics.windowed_variance, 0.0, abs_tol=1e-12)
+
+    def test_window_only_keeps_recent_samples(self):
+        analytics = _make_analytics()
+        # Fill window with a calm baseline, then push a single window's worth
+        # of a different constant. Old samples must be evicted.
+        _feed(analytics, [3.0] * MOVEMENT_VARIANCE_WINDOW, _config())
+        assert math.isclose(analytics.windowed_variance, 0.0, abs_tol=1e-12)
+        _feed(analytics, [1.0] * MOVEMENT_VARIANCE_WINDOW, _config())
+        # Window now contains only the 1.0 samples -> variance back to zero
+        assert math.isclose(analytics.windowed_variance, 0.0, abs_tol=1e-12)
+
+    def test_window_independent_of_cumulative_welford(self):
+        analytics = _make_analytics()
+        # A long calm run then a recent jittery burst: cumulative std stays
+        # influenced by the whole history, windowed variance reflects only recent.
+        _feed(analytics, [1.0] * 200, _config())
+        _feed(analytics, [0.5, 2.5] * (MOVEMENT_VARIANCE_WINDOW // 2), _config())
+        assert analytics.windowed_variance > 0.5
+        # Cumulative std exists but is a separate quantity (sanity: both defined)
+        assert analytics.std_deviation >= 0.0
+
+
+class TestSkillLevel:
+    def test_empty_input_returns_zero(self):
+        assert _make_analytics().get_skill_level() == 0.0
+
+    def test_always_within_bounds(self):
+        config = _config()
+        # A spread of behaviors should never escape [0, 1]
+        for seq in (
+            [1.0] * 50,  # calm
+            [1.3] * 50,  # active
+            [3.0] * 50,  # aggressive/danger
+            [0.5, 5.0] * 25,  # erratic
+            [1.2, 1.6, 2.1, 0.9, 1.8] * 10,  # mixed
+        ):
+            analytics = _make_analytics()
+            _feed(analytics, seq, config)
+            skill = analytics.get_skill_level()
+            assert 0.0 <= skill <= 1.0, f"skill {skill} out of bounds for {seq[:3]}..."
+
+    def test_balanced_player_scores_above_aggressive(self):
+        config = _config()
+        balanced = _make_analytics()
+        # Mostly active zone, low warning/danger -> BALANCED/ACTIVE playstyle
+        _feed(balanced, [1.2] * 100, config)
+
+        aggressive = _make_analytics()
+        # Mostly danger zone -> AGGRESSIVE playstyle
+        _feed(aggressive, [3.0] * 100, config)
+
+        assert aggressive.get_playstyle() == Playstyle.AGGRESSIVE
+        assert balanced.get_skill_level() > aggressive.get_skill_level()
+
+    def test_steady_motion_scores_above_erratic_same_playstyle(self):
+        config = _config()
+        steady = _make_analytics()
+        _feed(steady, [1.2] * 100, config)
+
+        erratic = _make_analytics()
+        # Same active-ish average but high variance
+        _feed(erratic, [0.6, 1.8] * 50, config)
+
+        # Steady has lower windowed variance -> higher smoothness component
+        assert steady.windowed_variance < erratic.windowed_variance
+        assert steady.get_skill_level() >= erratic.get_skill_level()
+
+    def test_appears_in_summary(self):
+        analytics = _make_analytics()
+        _feed(analytics, [1.2] * 20, _config())
+        summary = analytics.get_summary()
+        assert "skill_level" in summary
+        assert 0.0 <= summary["skill_level"] <= 1.0

--- a/services/game_coordinator/tests/test_elimination_order.py
+++ b/services/game_coordinator/tests/test_elimination_order.py
@@ -1,0 +1,88 @@
+"""
+Tests for the game_player_elimination_order metric added in #730 / #722 §7.
+
+Verifies that _kill_player assigns ascending elimination indices (1 = first out)
+keyed on (serial, game_id), driven by the game's internal _elimination_count.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import pytest_asyncio
+
+# Setup paths for imports
+test_dir = Path(__file__).parent
+service_dir = test_dir.parent
+project_root = service_dir.parent.parent
+sys.path.insert(0, str(project_root))
+sys.path.insert(0, str(test_dir))
+
+from conftest import EventCollector, MockControllerManagerService
+
+from services.game_coordinator.games.ffa import FFAGame
+
+
+class MockGameplayStream:
+    """Minimal mock for gameplay stream writes."""
+
+    async def write(self, message):
+        pass
+
+
+@pytest_asyncio.fixture
+async def ffa_game():
+    """FFA game with 4 initialized players and a mock gameplay stream."""
+    mock_cm = MockControllerManagerService(num_controllers=4, death_schedule={}, max_duration=10.0)
+    collector = EventCollector()
+    game = FFAGame(
+        controller_manager_client=mock_cm,
+        event_publisher=collector.publish,
+        audio_client=None,
+        game_id="test_elim_001",
+    )
+    await game._initialize_players_impl(mock_cm.controllers)
+    game.gameplay_stream = MockGameplayStream()
+    return game
+
+
+@pytest.mark.asyncio
+async def test_first_death_is_order_one(ffa_game):
+    game = ffa_game
+    serials = list(game.players.keys())
+
+    with patch("services.game_coordinator.metrics.player_elimination_order") as mock_metric:
+        await game._kill_player(serials[0], accel_mag=5.0)
+
+    mock_metric.labels.assert_called_with(serial=serials[0], game_id="test_elim_001")
+    mock_metric.labels.return_value.set.assert_called_with(1)
+    assert game._elimination_count == 1
+
+
+@pytest.mark.asyncio
+async def test_elimination_order_increments(ffa_game):
+    game = ffa_game
+    serials = list(game.players.keys())
+
+    set_values = []
+    with patch("services.game_coordinator.metrics.player_elimination_order") as mock_metric:
+        mock_metric.labels.return_value.set.side_effect = lambda v: set_values.append(v)
+        for serial in serials[:3]:
+            await game._kill_player(serial, accel_mag=5.0)
+
+    assert set_values == [1, 2, 3]
+    assert game._elimination_count == 3
+
+
+@pytest.mark.asyncio
+async def test_already_dead_player_not_recounted(ffa_game):
+    game = ffa_game
+    serials = list(game.players.keys())
+
+    with patch("services.game_coordinator.metrics.player_elimination_order"):
+        await game._kill_player(serials[0], accel_mag=5.0)
+        # Killing the same (now-dead) player again is a no-op
+        await game._kill_player(serials[0], accel_mag=5.0)
+
+    assert game._elimination_count == 1


### PR DESCRIPTION
## Summary

PR **B** of the stacked #730 plan. Adds the OBSERVE-layer metrics that the intervention system (#730) and the agent fitness functions (#731) need. This is the metrics layer from the [#722 intervention-surface research](docs/research/722-intervention-surface.md) §7 — it closes the signal gaps in §1. **Additive only; no behavior changes and no interventions implemented.**

## What this adds

| Metric / type | Where |
|---|---|
| `game_player_movement_variance{serial}` gauge — rolling-window variance of accel magnitude (deque-based; window constant for now, a policy flag will configure it later). Existing cumulative Welford stats left intact. | `games/analytics.py`, exported in `games/base.py` next to the other per-player accel gauges |
| `game_player_skill_level{serial}` gauge (0.0–1.0) — documented blend of playstyle control + motion smoothness, fully bounded | `games/analytics.py` |
| `controller_battery_pct{serial}` gauge (0–100) — `battery_to_pct()` maps 0–5 → percent and passes HID 0–100 through; existing 0–5 `controller_battery_level` untouched | `controller_manager/metrics.py`, wired in `monitoring.py` + `discovery_loop.py` |
| `game_player_elimination_order{serial, game_id}` gauge — set in `_kill_player` (1 = first out) | `games/base.py`, `metrics.py` |
| `game_interventions_total{type, objective, blocked}` counter — defined now, incremented by later PRs (zero usages) | `game_coordinator/metrics.py` |
| `GameEvent.AGENT_INTERVENTION` EventBus event type — definition only, for later PRs to publish | `lib/types.py` |

The Go agent (`services/agent/gamecontext/extract_metrics.go`) already recognizes all four metric names; they light up automatically once produced. Not touched.

Cardinality stays bounded: only `serial` / `game_id` labels, matching existing exposure.

## Test plan

- New unit tests:
  - rolling variance correctness (known sequence → sample variance, window eviction, independence from cumulative Welford)
  - skill-level bounds (always 0–1, empty input → 0.0, balanced > aggressive, steady > erratic)
  - battery normalization (0–5 → pct, 0–100 passthrough, clamping)
  - elimination-order assignment (first death = 1, increments, dead player not recounted)
- `cd services/game_coordinator && uv run pytest` → **670 passed**
- `cd services/controller_manager && uv run pytest` → **560 passed**
- `make lint` (ruff check + format) → **clean**

Part of #730. Closes signal gaps from #722 §1/§7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)