### PR TITLE
feat: objective-weighted rules engine for agent decisions (#726)

### DIFF
--- a/services/agent/README.md
+++ b/services/agent/README.md
@@ -89,7 +89,7 @@ and the rule set runs at most once per second.
 |------|-----------|---------|--------------|
 | R1/R2 | endurance | session younger than `fitness.endurance.min_session_seconds` while players are eliminated | `adjust_music_tempo` (slow) / `play_audio_cue` |
 | R3 | balanced | skill spread > `fitness.balanced.max_skill_gap` | `adjust_player_sensitivity` → highest-skill outlier |
-| R4 | balanced | weakest player while the field shrinks | `grant_shield` → weakest |
+| R4 | balanced | weakest player while the field shrinks (needs ≥ 2 players with known skill — "weakest" is only meaningful relative to others) | `grant_shield` → weakest |
 | R5 | accelerate | duration > `fitness.accelerate.target_session_seconds` | `adjust_music_tempo` (fast) |
 | R6 | accelerate | duration > 1.5× target, > 2 players | `eliminate_player` → least active |
 | R7 | accelerate | duration > 2× target **and accelerate strictly dominant** (a tie never ends a game) | `end_game` |
@@ -102,9 +102,11 @@ and the rule set runs at most once per second.
   difficulty raises; session-wide demand raises are blocked while *anyone* is
   low; `eliminate_player` of a low-battery player stays available only as the
   accelerate-dominant graceful exit.
-- `movement_variance_window` (10s): variance/chaos candidates are suppressed
-  for one window after any difficulty intervention (the baseline is invalid —
-  players adapt).
+- `movement_variance_window` (10s): ALL chaos candidates (variance-triggered
+  statue nudges and the random R9 nudge alike) are suppressed for one window
+  after any difficulty intervention — the variance baseline is invalid, and a
+  random rumble right after a tempo change would muddy attribution of the
+  difficulty intervention's effect.
 - `max_interventions_per_minute` (2): a **weighted** sliding-window budget per
   the [#722 research §5](../../docs/research/722-intervention-surface.md):
   soft 0.5 (audio cue, controller effect, volume), medium 1 (tempo, player

--- a/services/agent/README.md
+++ b/services/agent/README.md
@@ -67,12 +67,58 @@ Sessions are not carried in every signal, so the Agent synthesizes them:
 After each context update the Agent evaluates `should_evaluate`. When the gate
 opens it invokes the decision hooks:
 
-- **Rules engine** (#726) — evaluates the `GameContext` into intervention intents.
-- **Action sink** (#730) — applies intents via OpenFeature/flagd.
+- **Rules engine** (#726) — `ObjectiveRules`, the objective-weighted decision
+  logic below. Active by default.
+- **Action sink** (#730) — applies intents via OpenFeature/flagd. **Still a
+  no-op**: decisions are traced, nothing is applied yet.
 
-Both are stubs today. See
-[`docs/research/722-intervention-surface.md`](../../docs/research/722-intervention-surface.md)
+See [`docs/research/722-intervention-surface.md`](../../docs/research/722-intervention-surface.md)
 for the intervention-surface design.
+
+## Rules engine (#726)
+
+`ObjectiveRules` is the `rules_decide(context, objectives)` path — the non-LLM
+intelligence and the final link of the inference fallback chain. Each rule
+yields candidates with an urgency (0–1) and the objective they serve; the
+final score is `urgency × weight[objective]`. Candidates below a minimum score
+(0.10) are dropped, the rest are admitted best-first (ties: cheaper first, then
+name) while the weighted budget allows — at most 2 decisions per evaluation,
+and the rule set runs at most once per second.
+
+| Rule | Objective | Trigger | Intervention |
+|------|-----------|---------|--------------|
+| R1/R2 | endurance | session younger than `fitness.endurance.min_session_seconds` while players are eliminated | `adjust_music_tempo` (slow) / `play_audio_cue` |
+| R3 | balanced | skill spread > `fitness.balanced.max_skill_gap` | `adjust_player_sensitivity` → highest-skill outlier |
+| R4 | balanced | weakest player while the field shrinks | `grant_shield` → weakest |
+| R5 | accelerate | duration > `fitness.accelerate.target_session_seconds` | `adjust_music_tempo` (fast) |
+| R6 | accelerate | duration > 1.5× target, > 2 players | `eliminate_player` → least active |
+| R7 | accelerate | duration > 2× target **and accelerate strictly dominant** (a tie never ends a game) | `end_game` |
+| R8 | chaos | movement variance ≈ 0 ("statue") — dormant until producers ship the variance metric | `send_controller_effect` |
+| R9 | chaos | periodic random nudge (injectable rng) | `send_controller_effect` |
+
+**Policy constraints** (`policy.*` flags):
+
+- `battery_threshold` (20): players below it lose controller effects and
+  difficulty raises; session-wide demand raises are blocked while *anyone* is
+  low; `eliminate_player` of a low-battery player stays available only as the
+  accelerate-dominant graceful exit.
+- `movement_variance_window` (10s): variance/chaos candidates are suppressed
+  for one window after any difficulty intervention (the baseline is invalid —
+  players adapt).
+- `max_interventions_per_minute` (2): a **weighted** sliding-window budget per
+  the [#722 research §5](../../docs/research/722-intervention-surface.md):
+  soft 0.5 (audio cue, controller effect, volume), medium 1 (tempo, player
+  sensitivity, shield), hard 2 (global sensitivity, eliminate, revive,
+  end_game). The engine charges every decision it **emits**, including ones
+  the permission layer later blocks — it cannot see permissions (layering),
+  and the game coordinator's flag-application layer (#730) is the
+  authoritative backstop.
+
+**Configuration seam (#727):** objectives, policy, and fitness thresholds come
+from the `ObjectivesSource` / `PolicySource` / `FitnessSource` interfaces
+(`decision/config.go`). Until #727 wires OpenFeature, `DefaultStaticConfig()`
+supplies the flagd-schema defaults with objectives `{endurance: 1.0}` (the
+flag's own `balanced_focused` default surfaces once the flag is actually read).
 
 ## Span schema (#724) — the trace is the audit log
 

--- a/services/agent/decision/config.go
+++ b/services/agent/decision/config.go
@@ -1,0 +1,110 @@
+package decision
+
+import "time"
+
+// Config source interfaces for the rules engine. These are the seam where
+// issue #727 plugs in OpenFeature/flagd-backed implementations; until then the
+// engine runs on StaticConfig defaults that mirror services/flagd/agent.json.
+// Sources are re-read on every evaluation so a live-flag implementation takes
+// effect without restarting the engine.
+
+// ObjectivesSource provides the objective weights being pursued
+// (agent `objectives` flag). Keys: endurance, balanced, accelerate, chaos.
+// An empty or nil map means "no value provided" — the engine falls back to
+// DefaultObjectiveWeights.
+type ObjectivesSource interface {
+	Objectives() map[string]float64
+}
+
+// PolicySource provides the policy constraints (agent `policy.*` flags).
+type PolicySource interface {
+	Policy() Policy
+}
+
+// FitnessSource provides the fitness thresholds (agent `fitness.*` flags).
+type FitnessSource interface {
+	Fitness() FitnessThresholds
+}
+
+// Policy holds the policy constraints the engine enforces.
+type Policy struct {
+	// BatteryThreshold (pct, 0-100): players below it are protected from
+	// battery-draining or difficulty-raising interventions
+	// (policy.battery_threshold, default 20).
+	BatteryThreshold float64
+	// MovementVarianceWindow gates variance-triggered rules and sets the
+	// cooldown after difficulty interventions
+	// (policy.movement_variance_window, default 10s).
+	MovementVarianceWindow time.Duration
+	// MaxInterventionsPerMinute is the weighted intervention budget per
+	// sliding 60s window (policy.max_interventions_per_minute, default 2).
+	MaxInterventionsPerMinute float64
+}
+
+// FitnessThresholds holds the per-objective fitness targets the rules
+// evaluate against.
+type FitnessThresholds struct {
+	// EnduranceMinSessionSeconds: sessions ending earlier fail endurance
+	// (fitness.endurance.min_session_seconds, default 120).
+	EnduranceMinSessionSeconds float64
+	// BalancedMaxSkillGap: larger skill spreads fail balance
+	// (fitness.balanced.max_skill_gap, default 0.4).
+	BalancedMaxSkillGap float64
+	// BalancedSpikeSurvivalThreshold (fitness.balanced.spike_survival_threshold,
+	// default 0.8). Reserved for #731; not used by the scaffold rules.
+	BalancedSpikeSurvivalThreshold float64
+	// AccelerateTargetSessionSeconds: sessions running longer trigger
+	// accelerate rules (fitness.accelerate.target_session_seconds, default 60).
+	AccelerateTargetSessionSeconds float64
+}
+
+// Objective names (keys of the objectives weight map).
+const (
+	ObjectiveEndurance  = "endurance"
+	ObjectiveBalanced   = "balanced"
+	ObjectiveAccelerate = "accelerate"
+	ObjectiveChaos      = "chaos"
+)
+
+// DefaultObjectiveWeights is the engine fallback when no objectives source is
+// wired or the source provides no value (#726 acceptance criterion). The flagd
+// flag's own default (balanced_focused) surfaces once #727 wires the flag.
+func DefaultObjectiveWeights() map[string]float64 {
+	return map[string]float64{ObjectiveEndurance: 1.0}
+}
+
+// StaticConfig implements all three sources with fixed values.
+type StaticConfig struct {
+	ObjectiveWeights  map[string]float64
+	PolicyValues      Policy
+	FitnessThresholds FitnessThresholds
+}
+
+// Objectives implements ObjectivesSource.
+func (c StaticConfig) Objectives() map[string]float64 { return c.ObjectiveWeights }
+
+// Policy implements PolicySource.
+func (c StaticConfig) Policy() Policy { return c.PolicyValues }
+
+// Fitness implements FitnessSource.
+func (c StaticConfig) Fitness() FitnessThresholds { return c.FitnessThresholds }
+
+// DefaultStaticConfig returns the defaults from the flagd agent schema
+// (services/flagd/agent.json defaultVariants), with the engine's no-flag
+// objective fallback.
+func DefaultStaticConfig() StaticConfig {
+	return StaticConfig{
+		ObjectiveWeights: DefaultObjectiveWeights(),
+		PolicyValues: Policy{
+			BatteryThreshold:          20,
+			MovementVarianceWindow:    10 * time.Second,
+			MaxInterventionsPerMinute: 2,
+		},
+		FitnessThresholds: FitnessThresholds{
+			EnduranceMinSessionSeconds:     120,
+			BalancedMaxSkillGap:            0.4,
+			BalancedSpikeSurvivalThreshold: 0.8,
+			AccelerateTargetSessionSeconds: 60,
+		},
+	}
+}

--- a/services/agent/decision/config_test.go
+++ b/services/agent/decision/config_test.go
@@ -1,0 +1,52 @@
+package decision
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDefaultStaticConfig_MatchesFlagdSchema(t *testing.T) {
+	cfg := DefaultStaticConfig()
+
+	if w := cfg.ObjectiveWeights; len(w) != 1 || w[ObjectiveEndurance] != 1.0 {
+		t.Errorf("objectives = %v, want {endurance: 1.0} (engine no-flag default)", w)
+	}
+	pol := cfg.PolicyValues
+	if pol.BatteryThreshold != 20 {
+		t.Errorf("battery threshold = %v, want 20", pol.BatteryThreshold)
+	}
+	if pol.MovementVarianceWindow != 10*time.Second {
+		t.Errorf("variance window = %v, want 10s", pol.MovementVarianceWindow)
+	}
+	if pol.MaxInterventionsPerMinute != 2 {
+		t.Errorf("max interventions/min = %v, want 2", pol.MaxInterventionsPerMinute)
+	}
+	fit := cfg.FitnessThresholds
+	if fit.EnduranceMinSessionSeconds != 120 || fit.BalancedMaxSkillGap != 0.4 ||
+		fit.BalancedSpikeSurvivalThreshold != 0.8 || fit.AccelerateTargetSessionSeconds != 60 {
+		t.Errorf("fitness thresholds = %+v, want flagd schema defaults 120/0.4/0.8/60", fit)
+	}
+}
+
+func TestNewObjectiveRules_NilConfigUsesDefaults(t *testing.T) {
+	r := NewObjectiveRules(nil)
+	if w := r.objectives.Objectives(); len(w) != 1 || w[ObjectiveEndurance] != 1.0 {
+		t.Errorf("nil config objectives = %v, want {endurance: 1.0}", w)
+	}
+	if r.policy.Policy().MaxInterventionsPerMinute != 2 {
+		t.Error("nil config must fall back to default policy")
+	}
+}
+
+func TestNormalizedWeights_EmptyFallsBack(t *testing.T) {
+	if w := normalizedWeights(nil); w[ObjectiveEndurance] != 1.0 {
+		t.Errorf("nil weights = %v, want endurance fallback", w)
+	}
+	if w := normalizedWeights(map[string]float64{}); w[ObjectiveEndurance] != 1.0 {
+		t.Errorf("empty weights = %v, want endurance fallback", w)
+	}
+	custom := map[string]float64{ObjectiveChaos: 0.9}
+	if w := normalizedWeights(custom); w[ObjectiveChaos] != 0.9 {
+		t.Errorf("custom weights = %v, want passthrough", w)
+	}
+}

--- a/services/agent/decision/decision.go
+++ b/services/agent/decision/decision.go
@@ -2,12 +2,15 @@
 // turns a GameContext snapshot into interventions via a pluggable rules engine
 // and action sink, and emits the agent.span_received -> agent.decision ->
 // agent.action audit trace for every evaluation that produces decisions
-// (issue #724). The concrete rules and actions are stubbed in this scaffold.
+// (issue #724). ObjectiveRules (#726) is the objective-weighted rules engine;
+// the action sink stays a no-op until the intervention API (#730).
 package decision
 
 import (
 	"context"
 	"log/slog"
+	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -31,9 +34,17 @@ type Decision struct {
 	// Reason is a human-readable explanation, recorded as decision.reason.
 	Reason string
 	// ObjectiveServed names the session objective this decision serves
-	// (endurance/balanced/accelerate/chaos); empty until objectives exist
-	// (#725/#731), recorded as decision.objective_served.
+	// (endurance/balanced/accelerate/chaos), recorded as
+	// decision.objective_served.
 	ObjectiveServed string
+	// Fitness holds the fitness values the rule evaluated to reach this
+	// decision (e.g. session_duration, target_session_seconds), recorded as
+	// fitness.evaluated.
+	Fitness map[string]float64
+	// Objectives holds the active objective weights used to score this
+	// decision, recorded as agent.objectives. Nil/empty (the Noop/Probe/stub
+	// engines) renders the "unset" placeholder.
+	Objectives map[string]float64
 }
 
 // RulesEngine turns a context snapshot into zero or more Decisions. The
@@ -241,7 +252,7 @@ func decisionAttributes(d Decision, blocked bool, allowed []string) []attribute.
 	return []attribute.KeyValue{
 		semconv.GenAIAgentName(AgentName),
 		attribute.String(AttrMode, DefaultMode),
-		attribute.String(AttrObjectives, DefaultObjectives),
+		attribute.String(AttrObjectives, summarizeObjectives(d.Objectives)),
 		attribute.String(AttrInterventionsAllowed, allowedSummary(allowed)),
 		attribute.String(AttrInferenceConfigured, DefaultInference),
 		attribute.String(AttrInferenceUsed, DefaultInference),
@@ -250,8 +261,35 @@ func decisionAttributes(d Decision, blocked bool, allowed []string) []attribute.
 		attribute.String(AttrDecisionReason, d.Reason),
 		attribute.String(AttrDecisionObjective, objective),
 		attribute.Bool(AttrDecisionBlocked, blocked),
-		attribute.StringSlice(AttrFitnessEvaluated, []string{}),
+		attribute.StringSlice(AttrFitnessEvaluated, renderFitness(d.Fitness)),
 	}
+}
+
+// summarizeObjectives renders the objective weights as a stable sorted "k=v"
+// summary (e.g. "balanced=0.3,endurance=0.7"); nil/empty keeps the "unset"
+// placeholder for engines that carry no weights.
+func summarizeObjectives(weights map[string]float64) string {
+	if len(weights) == 0 {
+		return DefaultObjectives
+	}
+	parts := make([]string, 0, len(weights))
+	for k, v := range weights {
+		parts = append(parts, k+"="+strconv.FormatFloat(v, 'g', -1, 64))
+	}
+	sort.Strings(parts)
+	return strings.Join(parts, ",")
+}
+
+// renderFitness renders the evaluated fitness values as sorted "k=v" strings
+// for the fitness.evaluated attribute; an empty map renders the empty slice
+// (the schema attribute is always present).
+func renderFitness(fitness map[string]float64) []string {
+	out := make([]string, 0, len(fitness))
+	for k, v := range fitness {
+		out = append(out, k+"="+strconv.FormatFloat(v, 'g', -1, 64))
+	}
+	sort.Strings(out)
+	return out
 }
 
 // permits reports whether the intervention is allowed. A nil list means no

--- a/services/agent/decision/limiter.go
+++ b/services/agent/decision/limiter.go
@@ -1,0 +1,94 @@
+package decision
+
+import (
+	"sync"
+	"time"
+)
+
+// Intervention identifiers — exactly the interventions_allowed vocabulary from
+// the flagd agent schema (services/flagd/agent.json) and the #722 research §6.
+const (
+	InterventionPlayAudioCue            = "play_audio_cue"
+	InterventionSendControllerEffect    = "send_controller_effect"
+	InterventionAdjustVolume            = "adjust_volume"
+	InterventionAdjustMusicTempo        = "adjust_music_tempo"
+	InterventionAdjustPlayerSensitivity = "adjust_player_sensitivity"
+	InterventionGrantShield             = "grant_shield"
+	InterventionAdjustGlobalSensitivity = "adjust_global_sensitivity"
+	InterventionEliminatePlayer         = "eliminate_player"
+	InterventionRevivePlayer            = "revive_player"
+	InterventionEndGame                 = "end_game"
+)
+
+// interventionCost weights the per-minute budget per the #722 research §5:
+// a physical party game tolerates ambient nudges far better than visible
+// state changes, so soft actions cost 0.5, reversible tunables 1, and hard
+// state changes 2. Unknown interventions default to the hard cost (fail safe).
+var interventionCost = map[string]float64{
+	InterventionPlayAudioCue:            0.5,
+	InterventionSendControllerEffect:    0.5,
+	InterventionAdjustVolume:            0.5,
+	InterventionAdjustMusicTempo:        1,
+	InterventionAdjustPlayerSensitivity: 1,
+	InterventionGrantShield:             1,
+	InterventionAdjustGlobalSensitivity: 2,
+	InterventionEliminatePlayer:         2,
+	InterventionRevivePlayer:            2,
+	InterventionEndGame:                 2,
+}
+
+// costOf returns the budget cost for an intervention, defaulting to the hard
+// cost for unknown identifiers.
+func costOf(intervention string) float64 {
+	if c, ok := interventionCost[intervention]; ok {
+		return c
+	}
+	return 2
+}
+
+// rateWindow is the sliding window over which the weighted budget applies.
+const rateWindow = time.Minute
+
+// windowLimiter enforces the weighted interventions-per-minute budget
+// (policy.max_interventions_per_minute) over a sliding window. Safe for
+// concurrent use.
+//
+// Budget semantics: the engine charges for every decision it EMITS, including
+// decisions the Loop's Permissions layer later blocks. The engine cannot see
+// permissions (that seam lives in the Loop, after Evaluate returns), the §5
+// model rate-limits attempts, and the game coordinator's flag-application
+// layer (#730) is the authoritative backstop — charging attempts keeps
+// emission bounded even under a misconfigured allowed-list.
+type windowLimiter struct {
+	mu      sync.Mutex
+	entries []limiterEntry
+}
+
+type limiterEntry struct {
+	at   time.Time
+	cost float64
+}
+
+// admit reports whether a decision of the given cost fits the budget at time
+// now, charging it when admitted.
+func (l *windowLimiter) admit(now time.Time, cost, budget float64) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	cutoff := now.Add(-rateWindow)
+	kept := l.entries[:0]
+	spent := 0.0
+	for _, e := range l.entries {
+		if e.at.After(cutoff) {
+			kept = append(kept, e)
+			spent += e.cost
+		}
+	}
+	l.entries = kept
+
+	if spent+cost > budget {
+		return false
+	}
+	l.entries = append(l.entries, limiterEntry{at: now, cost: cost})
+	return true
+}

--- a/services/agent/decision/limiter_test.go
+++ b/services/agent/decision/limiter_test.go
@@ -1,0 +1,94 @@
+package decision
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestWindowLimiter_WeightedBudget(t *testing.T) {
+	now := time.Unix(1000, 0)
+	var l windowLimiter
+
+	t.Run("two medium fit, third denied", func(t *testing.T) {
+		l = windowLimiter{}
+		if !l.admit(now, 1, 2) || !l.admit(now, 1, 2) {
+			t.Fatal("two medium-cost decisions must fit budget 2")
+		}
+		if l.admit(now, 1, 2) {
+			t.Fatal("third medium-cost decision must be denied")
+		}
+	})
+
+	t.Run("four soft fit", func(t *testing.T) {
+		l = windowLimiter{}
+		for i := 0; i < 4; i++ {
+			if !l.admit(now, 0.5, 2) {
+				t.Fatalf("soft decision %d must fit budget 2", i+1)
+			}
+		}
+		if l.admit(now, 0.5, 2) {
+			t.Fatal("fifth soft decision must be denied")
+		}
+	})
+
+	t.Run("one hard exhausts the budget", func(t *testing.T) {
+		l = windowLimiter{}
+		if !l.admit(now, 2, 2) {
+			t.Fatal("hard decision must fit a fresh budget")
+		}
+		if l.admit(now, 0.5, 2) {
+			t.Fatal("nothing fits after a hard decision")
+		}
+	})
+}
+
+func TestWindowLimiter_WindowExpiry(t *testing.T) {
+	now := time.Unix(1000, 0)
+	var l windowLimiter
+	if !l.admit(now, 2, 2) {
+		t.Fatal("hard decision must fit")
+	}
+	if l.admit(now.Add(30*time.Second), 1, 2) {
+		t.Fatal("budget must still be exhausted inside the window")
+	}
+	if !l.admit(now.Add(61*time.Second), 2, 2) {
+		t.Fatal("budget must recover after the window expires")
+	}
+}
+
+func TestWindowLimiter_Concurrent(t *testing.T) {
+	now := time.Unix(1000, 0)
+	var l windowLimiter
+	var admitted atomic.Int32
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if l.admit(now, 0.5, 2) {
+				admitted.Add(1)
+			}
+		}()
+	}
+	wg.Wait()
+	if got := admitted.Load(); got != 4 {
+		t.Fatalf("admitted = %d, want exactly 4 (0.5 cost x budget 2) under concurrency", got)
+	}
+}
+
+func TestCostOf(t *testing.T) {
+	cases := map[string]float64{
+		InterventionPlayAudioCue:            0.5,
+		InterventionAdjustMusicTempo:        1,
+		InterventionEndGame:                 2,
+		"unknown_future_intervention":       2, // fail safe: unknown = hard
+		InterventionAdjustPlayerSensitivity: 1,
+	}
+	for intervention, want := range cases {
+		if got := costOf(intervention); got != want {
+			t.Errorf("costOf(%s) = %v, want %v", intervention, got, want)
+		}
+	}
+}

--- a/services/agent/decision/loop_test.go
+++ b/services/agent/decision/loop_test.go
@@ -282,3 +282,34 @@ func TestOnEvaluate_ConcurrentExportHandlers(t *testing.T) {
 		t.Fatalf("root spans = %d, want 50", got)
 	}
 }
+
+func TestOnEvaluate_RendersFitnessAndObjectives(t *testing.T) {
+	l, sr := newTestLoop(t)
+	l.Rules = fakeRules{out: []Decision{{
+		Intervention:    "adjust_music_tempo",
+		Reason:          "test",
+		ObjectiveServed: "accelerate",
+		Fitness:         map[string]float64{"session_duration": 95, "target_session_seconds": 60},
+		Objectives:      map[string]float64{"endurance": 0.7, "balanced": 0.3},
+	}}}
+	l.Actions = &fakeSink{}
+
+	l.OnEvaluate(context.Background(), gamecontext.GameContext{}, testTrigger())
+
+	dec := spansByName(sr.Ended(), SpanDecision)[0]
+	if v, ok := attrValue(dec, AttrObjectives); !ok || v.AsString() != "balanced=0.3,endurance=0.7" {
+		t.Errorf("agent.objectives = %q, want sorted weight summary", v.AsString())
+	}
+	if v, ok := attrValue(dec, AttrDecisionObjective); !ok || v.AsString() != "accelerate" {
+		t.Errorf("decision.objective_served = %q, want accelerate", v.AsString())
+	}
+	v, ok := attrValue(dec, AttrFitnessEvaluated)
+	if !ok {
+		t.Fatal("fitness.evaluated missing")
+	}
+	got := v.AsStringSlice()
+	want := []string{"session_duration=95", "target_session_seconds=60"}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Errorf("fitness.evaluated = %v, want %v", got, want)
+	}
+}

--- a/services/agent/decision/rules.go
+++ b/services/agent/decision/rules.go
@@ -1,0 +1,241 @@
+package decision
+
+import (
+	"context"
+	"math/rand/v2"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/joustmania/agent/gamecontext"
+)
+
+// Engine tuning constants.
+const (
+	// evalInterval bounds how often the rule set actually runs: Evaluate is
+	// invoked ~10x/s from the Export handlers during games, but rules only
+	// need ~1 Hz; the weighted budget further caps emissions.
+	evalInterval = time.Second
+	// minScore drops candidates whose urgency x objective-weight is too weak
+	// to act on (also drops everything for objectives with ~zero weight).
+	minScore = 0.10
+	// maxDecisionsPerEval caps emissions per evaluation so one pass cannot
+	// spend the whole per-minute budget at once.
+	maxDecisionsPerEval = 2
+)
+
+// ObjectiveRules is the rules engine of #726: deterministic, objective-weighted
+// decision logic — the rules_decide(context, objectives) path of the decision
+// loop and the final link of the inference fallback chain. Each rule yields
+// candidates with an urgency and the objective they serve; candidates are
+// scored urgency x weight[objective], filtered by policy (battery, variance
+// cooldown), and admitted best-first while the weighted per-minute budget
+// allows. Safe for concurrent use (Evaluate is called from concurrent Export
+// handler goroutines).
+type ObjectiveRules struct {
+	objectives ObjectivesSource
+	policy     PolicySource
+	fitness    FitnessSource
+
+	mu               sync.Mutex
+	now              func() time.Time
+	rng              *rand.Rand
+	lastEval         time.Time
+	lastDifficultyAt time.Time
+	limiter          windowLimiter
+}
+
+// NewObjectiveRules builds the engine. cfg may be nil, in which case
+// DefaultStaticConfig (flagd-schema defaults, objectives {endurance:1.0}) is
+// used; #727 passes OpenFeature-backed sources instead.
+func NewObjectiveRules(cfg *StaticConfig) *ObjectiveRules {
+	c := DefaultStaticConfig()
+	if cfg != nil {
+		c = *cfg
+	}
+	return newObjectiveRules(c, c, c, nil, nil)
+}
+
+// newObjectiveRules is the fully-injectable constructor used by tests.
+// now nil -> time.Now; rng nil -> time-seeded.
+func newObjectiveRules(obj ObjectivesSource, pol PolicySource, fit FitnessSource, now func() time.Time, rng *rand.Rand) *ObjectiveRules {
+	if now == nil {
+		now = time.Now
+	}
+	if rng == nil {
+		n := time.Now()
+		rng = rand.New(rand.NewPCG(uint64(n.UnixNano()), uint64(n.UnixNano()>>32))) // #nosec G404 -- non-cryptographic: chaos-rule jitter only
+	}
+	return &ObjectiveRules{
+		objectives: obj,
+		policy:     pol,
+		fitness:    fit,
+		now:        now,
+		rng:        rng,
+	}
+}
+
+// Evaluate implements RulesEngine: run the rule set (at most once per
+// evalInterval), score candidates by the objective weights, apply policy
+// filters, and emit the best decisions the weighted budget allows.
+func (r *ObjectiveRules) Evaluate(_ context.Context, c gamecontext.GameContext) []Decision {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	now := r.now()
+	if now.Sub(r.lastEval) < evalInterval {
+		return nil
+	}
+	r.lastEval = now
+
+	weights := normalizedWeights(r.objectives.Objectives())
+	pol := r.policy.Policy()
+	fit := r.fitness.Fitness()
+
+	// R9's randomness is drawn here so the rule functions stay pure.
+	roll, rollTarget := r.chaosRoll(c)
+
+	cands := enduranceCandidates(c, fit)
+	cands = append(cands, balancedCandidates(c, fit)...)
+	cands = append(cands, accelerateCandidates(c, fit, weights)...)
+	cands = append(cands, chaosCandidates(c, pol, roll, rollTarget)...)
+
+	cands = applyBatteryPolicy(cands, c, pol, weights)
+	cands = r.applyVarianceCooldown(cands, now, pol)
+	cands = scoreAndSort(cands, weights)
+
+	var out []Decision
+	for _, cd := range cands {
+		if len(out) == maxDecisionsPerEval {
+			break
+		}
+		if !r.limiter.admit(now, cd.cost, pol.MaxInterventionsPerMinute) {
+			continue
+		}
+		d := cd.decision
+		d.Objectives = weights
+		out = append(out, d)
+		if cd.difficulty {
+			// Difficulty interventions invalidate the movement-variance
+			// baseline: players change behavior in response (#722 §5).
+			r.lastDifficultyAt = now
+		}
+	}
+	return out
+}
+
+// chaosRoll draws R9's randomness: a roll in [0,1) and a random active player.
+// Caller holds r.mu (rand.Rand is not goroutine-safe).
+func (r *ObjectiveRules) chaosRoll(c gamecontext.GameContext) (float64, string) {
+	active := activePlayers(c)
+	if len(active) == 0 {
+		return 0, ""
+	}
+	return r.rng.Float64(), active[r.rng.IntN(len(active))].Serial
+}
+
+// normalizedWeights returns the active objective weights, falling back to
+// DefaultObjectiveWeights when the source provides none (#726 acceptance:
+// works with {endurance: 1.0} when no flag value is provided).
+func normalizedWeights(w map[string]float64) map[string]float64 {
+	if len(w) == 0 {
+		return DefaultObjectiveWeights()
+	}
+	return w
+}
+
+// applyBatteryPolicy enforces policy.battery_threshold (#722 §5): players
+// below the threshold are protected from the dominant battery drains
+// (controller effects) and from difficulty-raising demand; eliminate_player
+// stays available only as the graceful-exit path when accelerate dominates.
+// Session-scoped difficulty raises are dropped when ANY active player is below
+// the threshold. Kept low-battery eliminations record the battery fitness.
+func applyBatteryPolicy(cands []candidate, c gamecontext.GameContext, pol Policy, weights map[string]float64) []candidate {
+	if pol.BatteryThreshold <= 0 {
+		return cands // policy off
+	}
+	low := func(p *gamecontext.PlayerSignals) bool {
+		return p != nil && p.BatteryPct != nil && *p.BatteryPct < pol.BatteryThreshold
+	}
+	anyActiveLow := false
+	for _, p := range activePlayers(c) {
+		if low(p) {
+			anyActiveLow = true
+			break
+		}
+	}
+
+	kept := cands[:0]
+	for _, cd := range cands {
+		target := c.Players[cd.decision.TargetSerial]
+		switch {
+		case cd.decision.Intervention == InterventionSendControllerEffect && low(target):
+			continue // rumble/LED on a dying battery — blocked
+		case cd.difficulty && cd.decision.TargetSerial != "" && low(target):
+			continue // more demand on a dying battery — blocked
+		case cd.difficulty && cd.decision.TargetSerial == "" && anyActiveLow:
+			continue // session-wide demand raise while someone is low — blocked
+		case cd.decision.Intervention == InterventionEliminatePlayer && low(target):
+			if !accelerateDominant(weights) {
+				continue // graceful exit is an accelerate move only
+			}
+			cd.decision.Fitness["battery_pct"] = *target.BatteryPct
+			cd.decision.Fitness["battery_threshold"] = pol.BatteryThreshold
+		}
+		kept = append(kept, cd)
+	}
+	return kept
+}
+
+// applyVarianceCooldown enforces policy.movement_variance_window: after any
+// difficulty intervention the variance baseline is invalid (players adapt),
+// so variance-triggered chaos candidates are suppressed for one full window.
+// Caller holds r.mu.
+func (r *ObjectiveRules) applyVarianceCooldown(cands []candidate, now time.Time, pol Policy) []candidate {
+	if r.lastDifficultyAt.IsZero() || now.Sub(r.lastDifficultyAt) >= pol.MovementVarianceWindow {
+		return cands
+	}
+	kept := cands[:0]
+	for _, cd := range cands {
+		if cd.objective == ObjectiveChaos {
+			continue
+		}
+		kept = append(kept, cd)
+	}
+	return kept
+}
+
+// scoreAndSort scores candidates (urgency x weight[objective]), drops those
+// below minScore, and orders them deterministically: higher score first, then
+// cheaper/safer, then lexicographic intervention and target.
+func scoreAndSort(cands []candidate, weights map[string]float64) []candidate {
+	type scored struct {
+		candidate
+		score float64
+	}
+	kept := make([]scored, 0, len(cands))
+	for _, cd := range cands {
+		s := clamp01(cd.urgency) * weights[cd.objective]
+		if s < minScore {
+			continue
+		}
+		kept = append(kept, scored{cd, s})
+	}
+	sort.SliceStable(kept, func(i, j int) bool {
+		if kept[i].score != kept[j].score {
+			return kept[i].score > kept[j].score
+		}
+		if kept[i].cost != kept[j].cost {
+			return kept[i].cost < kept[j].cost
+		}
+		if kept[i].decision.Intervention != kept[j].decision.Intervention {
+			return kept[i].decision.Intervention < kept[j].decision.Intervention
+		}
+		return kept[i].decision.TargetSerial < kept[j].decision.TargetSerial
+	})
+	out := make([]candidate, len(kept))
+	for i, s := range kept {
+		out[i] = s.candidate
+	}
+	return out
+}

--- a/services/agent/decision/rules.go
+++ b/services/agent/decision/rules.go
@@ -134,14 +134,21 @@ func (r *ObjectiveRules) chaosRoll(c gamecontext.GameContext) (float64, string) 
 	return r.rng.Float64(), active[r.rng.IntN(len(active))].Serial
 }
 
-// normalizedWeights returns the active objective weights, falling back to
-// DefaultObjectiveWeights when the source provides none (#726 acceptance:
-// works with {endurance: 1.0} when no flag value is provided).
+// normalizedWeights returns a COPY of the active objective weights, falling
+// back to DefaultObjectiveWeights when the source provides none (#726
+// acceptance: works with {endurance: 1.0} when no flag value is provided).
+// The copy matters: the weights are handed out on every emitted Decision and
+// read later on other goroutines (span rendering); a live map from a future
+// OpenFeature-backed source (#727) must not be shared unprotected.
 func normalizedWeights(w map[string]float64) map[string]float64 {
 	if len(w) == 0 {
 		return DefaultObjectiveWeights()
 	}
-	return w
+	cp := make(map[string]float64, len(w))
+	for k, v := range w {
+		cp[k] = v
+	}
+	return cp
 }
 
 // applyBatteryPolicy enforces policy.battery_threshold (#722 §5): players
@@ -179,6 +186,9 @@ func applyBatteryPolicy(cands []candidate, c gamecontext.GameContext, pol Policy
 			if !accelerateDominant(weights) {
 				continue // graceful exit is an accelerate move only
 			}
+			if cd.decision.Fitness == nil {
+				cd.decision.Fitness = map[string]float64{}
+			}
 			cd.decision.Fitness["battery_pct"] = *target.BatteryPct
 			cd.decision.Fitness["battery_threshold"] = pol.BatteryThreshold
 		}
@@ -188,9 +198,11 @@ func applyBatteryPolicy(cands []candidate, c gamecontext.GameContext, pol Policy
 }
 
 // applyVarianceCooldown enforces policy.movement_variance_window: after any
-// difficulty intervention the variance baseline is invalid (players adapt),
-// so variance-triggered chaos candidates are suppressed for one full window.
-// Caller holds r.mu.
+// difficulty intervention the variance baseline is invalid and players are
+// still adapting, so ALL chaos candidates — variance-triggered (R8) and the
+// random nudge (R9) alike — are suppressed for one full window. Suppressing
+// R9 too is deliberate: a random rumble right after a tempo/sensitivity change
+// muddies attribution of the difficulty intervention's effect. Caller holds r.mu.
 func (r *ObjectiveRules) applyVarianceCooldown(cands []candidate, now time.Time, pol Policy) []candidate {
 	if r.lastDifficultyAt.IsZero() || now.Sub(r.lastDifficultyAt) >= pol.MovementVarianceWindow {
 		return cands

--- a/services/agent/decision/rules_test.go
+++ b/services/agent/decision/rules_test.go
@@ -6,6 +6,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/joustmania/agent/gamecontext"
 )
 
 // newTestEngine builds an ObjectiveRules with injected clock, fixed-seed rng,
@@ -210,4 +212,58 @@ func TestObjectiveRules_ConcurrentEvaluate(t *testing.T) {
 		}()
 	}
 	wg.Wait() // -race validates the engine's locking
+}
+
+func TestObjectiveRules_EmptyContext(t *testing.T) {
+	cfg := DefaultStaticConfig()
+	clock := time.Unix(10_000, 0)
+	r := newTestEngine(cfg, &clock)
+	if out := r.Evaluate(context.Background(), gamecontext.GameContext{}); out != nil {
+		t.Fatalf("decisions = %v, want nil on an empty context", out)
+	}
+}
+
+func TestObjectiveRules_ZeroThresholdsSafe(t *testing.T) {
+	// A misbehaving flag source could deliver zero thresholds — the engine
+	// must not divide by zero or emit garbage.
+	cfg := DefaultStaticConfig()
+	cfg.ObjectiveWeights = map[string]float64{
+		ObjectiveEndurance: 1, ObjectiveBalanced: 1, ObjectiveAccelerate: 1, ObjectiveChaos: 1,
+	}
+	cfg.FitnessThresholds = FitnessThresholds{} // all zero
+	cfg.PolicyValues = Policy{}                 // all zero (battery policy off, budget zero)
+	clock := time.Unix(10_000, 0)
+	r := newTestEngine(cfg, &clock)
+
+	c := gameCtx(100, []string{"GONE"}, map[string]testPlayer{
+		"A": {skill: fptr(0.2), intensity: fptr(0.3), active: true},
+		"B": {skill: fptr(0.9), intensity: fptr(1.5), active: true},
+	})
+	out := r.Evaluate(context.Background(), c) // must not panic
+	// Budget 0 admits nothing regardless of candidates.
+	if len(out) != 0 {
+		t.Fatalf("decisions = %v, want none with a zero budget", out)
+	}
+}
+
+func TestObjectiveRules_WeightsMapIsCopied(t *testing.T) {
+	// A live map from a future OpenFeature source (#727) must not be shared
+	// with emitted decisions: the engine hands out a copy.
+	live := map[string]float64{ObjectiveEndurance: 1.0}
+	cfg := DefaultStaticConfig()
+	cfg.ObjectiveWeights = live
+	clock := time.Unix(10_000, 0)
+	r := newTestEngine(cfg, &clock)
+
+	c := gameCtx(20, []string{"GONE"}, map[string]testPlayer{
+		"A": {active: true}, "B": {active: true},
+	})
+	out := r.Evaluate(context.Background(), c)
+	if len(out) == 0 {
+		t.Fatal("expected decisions")
+	}
+	live[ObjectiveEndurance] = 0.123 // source mutates its map afterwards
+	if out[0].Objectives[ObjectiveEndurance] != 1.0 {
+		t.Fatalf("decision weights = %v, want a snapshot unaffected by source mutation", out[0].Objectives)
+	}
 }

--- a/services/agent/decision/rules_test.go
+++ b/services/agent/decision/rules_test.go
@@ -1,0 +1,213 @@
+package decision
+
+import (
+	"context"
+	"math/rand/v2"
+	"sync"
+	"testing"
+	"time"
+)
+
+// newTestEngine builds an ObjectiveRules with injected clock, fixed-seed rng,
+// and the given config.
+func newTestEngine(cfg StaticConfig, clock *time.Time) *ObjectiveRules {
+	now := func() time.Time { return *clock }
+	rng := rand.New(rand.NewPCG(1, 2))
+	return newObjectiveRules(cfg, cfg, cfg, now, rng)
+}
+
+func advance(clock *time.Time, d time.Duration) { *clock = clock.Add(d) }
+
+func TestObjectiveRules_ConflictResolutionByWeights(t *testing.T) {
+	// Acceptance scenario: weights {endurance:0.7, balanced:0.3}.
+	// Context fires BOTH an endurance rule (young session, eliminations) and a
+	// balanced rule (large skill gap) — the weights resolve the conflict.
+	cfg := DefaultStaticConfig()
+	cfg.ObjectiveWeights = map[string]float64{ObjectiveEndurance: 0.7, ObjectiveBalanced: 0.3}
+	clock := time.Unix(10_000, 0)
+	r := newTestEngine(cfg, &clock)
+
+	c := gameCtx(20, []string{"GONE"}, map[string]testPlayer{
+		"WEAK":   {skill: fptr(0.2), active: true},
+		"STRONG": {skill: fptr(0.9), active: true}, // gap 0.7 > 0.4
+	})
+
+	out := r.Evaluate(context.Background(), c)
+	if len(out) == 0 {
+		t.Fatal("expected decisions")
+	}
+	if out[0].ObjectiveServed != ObjectiveEndurance {
+		t.Fatalf("top decision serves %q, want endurance (0.7 weight wins)", out[0].ObjectiveServed)
+	}
+	for _, d := range out {
+		if len(d.Objectives) != 2 || d.Objectives[ObjectiveEndurance] != 0.7 {
+			t.Errorf("decision must carry the active weights, got %v", d.Objectives)
+		}
+		if len(d.Fitness) == 0 {
+			t.Errorf("decision %s must carry evaluated fitness values", d.Intervention)
+		}
+	}
+}
+
+func TestObjectiveRules_DefaultObjectivesWhenSourceEmpty(t *testing.T) {
+	// Acceptance: works with {endurance: 1.0} when no flag value is provided.
+	cfg := DefaultStaticConfig()
+	cfg.ObjectiveWeights = nil // "no flag value"
+	clock := time.Unix(10_000, 0)
+	r := newTestEngine(cfg, &clock)
+
+	// Long session with a big skill gap: accelerate + balanced rules fire, but
+	// with endurance-only weights they all score 0 and must be dropped.
+	c := gameCtx(200, nil, map[string]testPlayer{
+		"WEAK":   {skill: fptr(0.2), intensity: fptr(0.3), active: true},
+		"MID":    {skill: fptr(0.5), intensity: fptr(0.8), active: true},
+		"STRONG": {skill: fptr(0.9), intensity: fptr(1.5), active: true},
+	})
+	if out := r.Evaluate(context.Background(), c); len(out) != 0 {
+		t.Fatalf("decisions = %v, want none (non-endurance candidates must score 0)", out)
+	}
+
+	// An endurance-relevant context still decides.
+	advance(&clock, 2*time.Second)
+	c2 := gameCtx(20, []string{"GONE"}, map[string]testPlayer{
+		"A": {active: true}, "B": {active: true},
+	})
+	out := r.Evaluate(context.Background(), c2)
+	if len(out) == 0 || out[0].ObjectiveServed != ObjectiveEndurance {
+		t.Fatalf("decisions = %v, want endurance decision under default weights", out)
+	}
+	if got := out[0].Objectives[ObjectiveEndurance]; got != 1.0 {
+		t.Errorf("objectives = %v, want default {endurance:1.0}", out[0].Objectives)
+	}
+}
+
+func TestObjectiveRules_CadenceGate(t *testing.T) {
+	cfg := DefaultStaticConfig()
+	clock := time.Unix(10_000, 0)
+	r := newTestEngine(cfg, &clock)
+	c := gameCtx(20, []string{"GONE"}, map[string]testPlayer{
+		"A": {active: true}, "B": {active: true},
+	})
+
+	if out := r.Evaluate(context.Background(), c); len(out) == 0 {
+		t.Fatal("first evaluation must decide")
+	}
+	advance(&clock, 200*time.Millisecond)
+	if out := r.Evaluate(context.Background(), c); out != nil {
+		t.Fatalf("decisions = %v, want nil within the 1s cadence gate", out)
+	}
+	advance(&clock, time.Second)
+	// Past the gate the engine runs again (budget may or may not admit).
+	r.Evaluate(context.Background(), c) // must not panic; gate reopened
+}
+
+func TestObjectiveRules_MaxTwoDecisionsAndBudget(t *testing.T) {
+	cfg := DefaultStaticConfig()
+	cfg.ObjectiveWeights = map[string]float64{ObjectiveEndurance: 1.0, ObjectiveBalanced: 1.0}
+	clock := time.Unix(10_000, 0)
+	r := newTestEngine(cfg, &clock)
+
+	// Young dying session with skill gap: endurance tempo (1) + cue (0.5) +
+	// balanced sensitivity (1) + shield (1) candidates available.
+	c := gameCtx(20, []string{"GONE"}, map[string]testPlayer{
+		"WEAK":   {skill: fptr(0.1), active: true},
+		"STRONG": {skill: fptr(0.9), active: true},
+	})
+
+	out := r.Evaluate(context.Background(), c)
+	if len(out) != maxDecisionsPerEval {
+		t.Fatalf("decisions = %d, want capped at %d", len(out), maxDecisionsPerEval)
+	}
+
+	// Budget 2 is now spent (top candidates cost 1+1) — the next evaluation
+	// admits nothing.
+	advance(&clock, 2*time.Second)
+	if out := r.Evaluate(context.Background(), c); len(out) != 0 {
+		t.Fatalf("decisions = %v, want none with the minute budget spent", out)
+	}
+
+	// After the window expires the budget recovers.
+	advance(&clock, time.Minute)
+	if out := r.Evaluate(context.Background(), c); len(out) == 0 {
+		t.Fatal("budget must recover after the sliding window")
+	}
+}
+
+func TestObjectiveRules_DeterministicOrdering(t *testing.T) {
+	cfg := DefaultStaticConfig()
+	cfg.ObjectiveWeights = map[string]float64{ObjectiveEndurance: 0.7, ObjectiveBalanced: 0.3}
+	c := gameCtx(20, []string{"GONE"}, map[string]testPlayer{
+		"WEAK":   {skill: fptr(0.2), active: true},
+		"STRONG": {skill: fptr(0.9), active: true},
+	})
+
+	var first []Decision
+	for i := 0; i < 5; i++ {
+		clock := time.Unix(10_000, 0)
+		r := newTestEngine(cfg, &clock)
+		out := r.Evaluate(context.Background(), c)
+		if i == 0 {
+			first = out
+			continue
+		}
+		if len(out) != len(first) {
+			t.Fatalf("run %d: %d decisions, first run had %d", i, len(out), len(first))
+		}
+		for j := range out {
+			if out[j].Intervention != first[j].Intervention || out[j].TargetSerial != first[j].TargetSerial {
+				t.Fatalf("run %d decision %d = %+v, first run had %+v (must be deterministic)",
+					i, j, out[j], first[j])
+			}
+		}
+	}
+}
+
+func TestObjectiveRules_VarianceCooldownAfterDifficulty(t *testing.T) {
+	cfg := DefaultStaticConfig()
+	cfg.ObjectiveWeights = map[string]float64{ObjectiveEndurance: 0.5, ObjectiveChaos: 0.5}
+	clock := time.Unix(10_000, 0)
+	r := newTestEngine(cfg, &clock)
+
+	// First evaluation: young dying session -> endurance tempo (difficulty)
+	// admitted, which starts the variance cooldown.
+	c := gameCtx(20, []string{"GONE"}, map[string]testPlayer{
+		"A": {variance: fptr(0.01), active: true},
+		"B": {active: true},
+	})
+	out := r.Evaluate(context.Background(), c)
+	emittedTempo := false
+	for _, d := range out {
+		if d.Intervention == InterventionAdjustMusicTempo {
+			emittedTempo = true
+		}
+	}
+	if !emittedTempo {
+		t.Fatalf("decisions = %v, want the tempo difficulty decision emitted (starts the cooldown)", out)
+	}
+
+	// Inside the cooldown window chaos/variance candidates are suppressed.
+	advance(&clock, 2*time.Second)
+	for _, d := range r.Evaluate(context.Background(), c) {
+		if d.ObjectiveServed == ObjectiveChaos {
+			t.Fatalf("chaos decision %v emitted inside the variance cooldown", d.Intervention)
+		}
+	}
+}
+
+func TestObjectiveRules_ConcurrentEvaluate(t *testing.T) {
+	cfg := DefaultStaticConfig()
+	r := NewObjectiveRules(&cfg) // real clock + rng
+	c := gameCtx(20, []string{"GONE"}, map[string]testPlayer{
+		"A": {active: true}, "B": {active: true},
+	})
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			r.Evaluate(context.Background(), c)
+		}()
+	}
+	wg.Wait() // -race validates the engine's locking
+}

--- a/services/agent/decision/ruleset.go
+++ b/services/agent/decision/ruleset.go
@@ -1,0 +1,341 @@
+package decision
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/joustmania/agent/gamecontext"
+)
+
+// candidate is a potential decision produced by a rule, before objective
+// weighting, policy filtering, and budget admission.
+type candidate struct {
+	decision  Decision
+	objective string
+	urgency   float64 // 0-1, how strongly the rule's signal fires
+	cost      float64 // weighted budget cost (limiter.go)
+	// difficulty marks interventions that change difficulty / movement demand
+	// (tempo, sensitivity): they trigger the variance-baseline cooldown and
+	// are blocked for low-battery players by the battery policy.
+	difficulty bool
+}
+
+// statueVarianceEpsilon is the movement-variance level below which a player is
+// considered to be gaming the EMA by holding still (R8).
+const statueVarianceEpsilon = 0.05
+
+// clamp01 clamps v to [0, 1].
+func clamp01(v float64) float64 {
+	switch {
+	case v < 0:
+		return 0
+	case v > 1:
+		return 1
+	default:
+		return v
+	}
+}
+
+// activePlayers returns the players marked Active, sorted by serial for
+// deterministic iteration.
+func activePlayers(c gamecontext.GameContext) []*gamecontext.PlayerSignals {
+	out := make([]*gamecontext.PlayerSignals, 0, len(c.Players))
+	for _, p := range c.Players {
+		if p.Active != nil && *p.Active {
+			out = append(out, p)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Serial < out[j].Serial })
+	return out
+}
+
+// sessionDuration returns the session duration or -1 when unknown.
+func sessionDuration(c gamecontext.GameContext) float64 {
+	if c.Session.DurationSeconds == nil {
+		return -1
+	}
+	return *c.Session.DurationSeconds
+}
+
+// elimFraction is the fraction of known players already eliminated, used to
+// gate "players are dying fast" rules. Returns 0 when nothing is known.
+func elimFraction(c gamecontext.GameContext, active int) float64 {
+	elims := len(c.Session.EliminationSequence)
+	if elims == 0 || elims+active == 0 {
+		return 0
+	}
+	return float64(elims) / float64(elims+active)
+}
+
+// enduranceCandidates implements R1 (slow the music while the session is young
+// and players are dying fast) and R2 (a calming audio cue, same window, lower
+// urgency).
+func enduranceCandidates(c gamecontext.GameContext, fit FitnessThresholds) []candidate {
+	dur := sessionDuration(c)
+	if dur < 0 || dur >= fit.EnduranceMinSessionSeconds {
+		return nil
+	}
+	active := activePlayers(c)
+	ef := elimFraction(c, len(active))
+	if ef == 0 {
+		return nil // nobody eliminated yet — the session is not at risk
+	}
+	timeURgency := clamp01((fit.EnduranceMinSessionSeconds - dur) / fit.EnduranceMinSessionSeconds)
+	urgency := clamp01(timeURgency * 2 * ef)
+	if urgency == 0 {
+		return nil
+	}
+	fitness := map[string]float64{
+		"session_duration":    dur,
+		"min_session_seconds": fit.EnduranceMinSessionSeconds,
+		"eliminations":        float64(len(c.Session.EliminationSequence)),
+	}
+	return []candidate{
+		{
+			decision: Decision{
+				Intervention:    InterventionAdjustMusicTempo,
+				Reason:          fmt.Sprintf("session at %.0fs of %.0fs endurance target with %d eliminations: slow the tempo", dur, fit.EnduranceMinSessionSeconds, len(c.Session.EliminationSequence)),
+				ObjectiveServed: ObjectiveEndurance,
+				Fitness:         fitness,
+			},
+			objective:  ObjectiveEndurance,
+			urgency:    urgency,
+			cost:       costOf(InterventionAdjustMusicTempo),
+			difficulty: true,
+		},
+		{
+			decision: Decision{
+				Intervention:    InterventionPlayAudioCue,
+				Reason:          "calming cue while the field shrinks early in the session",
+				ObjectiveServed: ObjectiveEndurance,
+				Fitness: map[string]float64{
+					"session_duration":    dur,
+					"min_session_seconds": fit.EnduranceMinSessionSeconds,
+				},
+			},
+			objective: ObjectiveEndurance,
+			urgency:   clamp01(urgency * 0.5),
+			cost:      costOf(InterventionPlayAudioCue),
+		},
+	}
+}
+
+// balancedCandidates implements R3 (handicap the skill outlier when the spread
+// exceeds the fitness gap) and R4 (shield the weakest player while the field
+// shrinks).
+func balancedCandidates(c gamecontext.GameContext, fit FitnessThresholds) []candidate {
+	active := activePlayers(c)
+	var out []candidate
+
+	// R3: skill gap.
+	skilled := make([]*gamecontext.PlayerSignals, 0, len(active))
+	for _, p := range active {
+		if p.SkillLevel != nil {
+			skilled = append(skilled, p)
+		}
+	}
+	if len(skilled) >= 2 {
+		minP, maxP := skilled[0], skilled[0]
+		for _, p := range skilled[1:] {
+			if *p.SkillLevel < *minP.SkillLevel {
+				minP = p
+			}
+			if *p.SkillLevel > *maxP.SkillLevel {
+				maxP = p
+			}
+		}
+		gap := *maxP.SkillLevel - *minP.SkillLevel
+		if gap > fit.BalancedMaxSkillGap {
+			out = append(out, candidate{
+				decision: Decision{
+					Intervention:    InterventionAdjustPlayerSensitivity,
+					TargetSerial:    maxP.Serial,
+					Reason:          fmt.Sprintf("skill gap %.2f exceeds %.2f: handicap the outlier", gap, fit.BalancedMaxSkillGap),
+					ObjectiveServed: ObjectiveBalanced,
+					Fitness: map[string]float64{
+						"skill_gap":     gap,
+						"max_skill_gap": fit.BalancedMaxSkillGap,
+						"outlier_skill": *maxP.SkillLevel,
+					},
+				},
+				objective:  ObjectiveBalanced,
+				urgency:    clamp01((gap - fit.BalancedMaxSkillGap) / (1 - fit.BalancedMaxSkillGap)),
+				cost:       costOf(InterventionAdjustPlayerSensitivity),
+				difficulty: true,
+			})
+		}
+	}
+
+	// R4: shield the weakest while the field shrinks.
+	if len(skilled) >= 2 {
+		if ef := elimFraction(c, len(active)); ef > 0 {
+			weakest := skilled[0]
+			for _, p := range skilled[1:] {
+				if *p.SkillLevel < *weakest.SkillLevel {
+					weakest = p
+				}
+			}
+			urgency := clamp01((1 - *weakest.SkillLevel) * 2 * ef)
+			if urgency > 0 {
+				out = append(out, candidate{
+					decision: Decision{
+						Intervention:    InterventionGrantShield,
+						TargetSerial:    weakest.Serial,
+						Reason:          fmt.Sprintf("shield the weakest player (skill %.2f) while the field shrinks", *weakest.SkillLevel),
+						ObjectiveServed: ObjectiveBalanced,
+						Fitness: map[string]float64{
+							"weakest_skill":  *weakest.SkillLevel,
+							"active_players": float64(len(active)),
+						},
+					},
+					objective: ObjectiveBalanced,
+					urgency:   urgency,
+					cost:      costOf(InterventionGrantShield),
+				})
+			}
+		}
+	}
+	return out
+}
+
+// accelerateCandidates implements R5 (speed up past the target duration),
+// R6 (eliminate the least-moving player when far past target), and R7
+// (end the game when way past target — only when accelerate strictly
+// dominates the weights; ties never end a game).
+func accelerateCandidates(c gamecontext.GameContext, fit FitnessThresholds, weights map[string]float64) []candidate {
+	dur := sessionDuration(c)
+	target := fit.AccelerateTargetSessionSeconds
+	if dur < 0 || target <= 0 || dur <= target {
+		return nil
+	}
+	active := activePlayers(c)
+	durFit := map[string]float64{
+		"session_duration":       dur,
+		"target_session_seconds": target,
+	}
+	out := []candidate{{
+		decision: Decision{
+			Intervention:    InterventionAdjustMusicTempo,
+			Reason:          fmt.Sprintf("session at %.0fs past the %.0fs accelerate target: speed up", dur, target),
+			ObjectiveServed: ObjectiveAccelerate,
+			Fitness:         durFit,
+		},
+		objective:  ObjectiveAccelerate,
+		urgency:    clamp01((dur - target) / target),
+		cost:       costOf(InterventionAdjustMusicTempo),
+		difficulty: true,
+	}}
+
+	// R6: eliminate the least-moving player.
+	if dur > 1.5*target && len(active) > 2 {
+		var lowest *gamecontext.PlayerSignals
+		for _, p := range active {
+			if p.MovementIntensity == nil {
+				continue
+			}
+			if lowest == nil || *p.MovementIntensity < *lowest.MovementIntensity {
+				lowest = p
+			}
+		}
+		if lowest != nil {
+			fitness := map[string]float64{
+				"session_duration":       dur,
+				"target_session_seconds": target,
+				"lowest_intensity":       *lowest.MovementIntensity,
+			}
+			out = append(out, candidate{
+				decision: Decision{
+					Intervention:    InterventionEliminatePlayer,
+					TargetSerial:    lowest.Serial,
+					Reason:          fmt.Sprintf("session 1.5x past target: eliminate the least active player (%.2fg)", *lowest.MovementIntensity),
+					ObjectiveServed: ObjectiveAccelerate,
+					Fitness:         fitness,
+				},
+				objective: ObjectiveAccelerate,
+				urgency:   clamp01((dur - 1.5*target) / target),
+				cost:      costOf(InterventionEliminatePlayer),
+			})
+		}
+	}
+
+	// R7: end the game — terminal, only when accelerate strictly dominates.
+	if dur > 2*target && accelerateDominant(weights) {
+		out = append(out, candidate{
+			decision: Decision{
+				Intervention:    InterventionEndGame,
+				Reason:          fmt.Sprintf("session 2x past the %.0fs target with accelerate dominant: end the game", target),
+				ObjectiveServed: ObjectiveAccelerate,
+				Fitness:         durFit,
+			},
+			objective: ObjectiveAccelerate,
+			urgency:   clamp01((dur - 2*target) / target),
+			cost:      costOf(InterventionEndGame),
+		})
+	}
+	return out
+}
+
+// accelerateDominant reports whether accelerate is the strict argmax of the
+// weights. A tie is NOT dominance — a tie must never silently end a game.
+func accelerateDominant(weights map[string]float64) bool {
+	acc, ok := weights[ObjectiveAccelerate]
+	if !ok {
+		return false
+	}
+	for name, w := range weights {
+		if name != ObjectiveAccelerate && w >= acc {
+			return false
+		}
+	}
+	return true
+}
+
+// chaosCandidates implements R8 (rumble a "statue" player whose movement
+// variance shows them gaming the EMA — no-ops until producers ship the
+// variance metric) and R9 (a periodic random controller effect, driven by the
+// engine's rng roll and pre-picked target).
+func chaosCandidates(c gamecontext.GameContext, pol Policy, roll float64, rollTarget string) []candidate {
+	var out []candidate
+	dur := sessionDuration(c)
+
+	// R8: statue detection — requires the variance window to be filled.
+	if dur >= pol.MovementVarianceWindow.Seconds() {
+		for _, p := range activePlayers(c) {
+			if p.MovementVariance == nil || *p.MovementVariance >= statueVarianceEpsilon {
+				continue
+			}
+			out = append(out, candidate{
+				decision: Decision{
+					Intervention:    InterventionSendControllerEffect,
+					TargetSerial:    p.Serial,
+					Reason:          fmt.Sprintf("near-zero movement variance (%.3f): nudge the statue", *p.MovementVariance),
+					ObjectiveServed: ObjectiveChaos,
+					Fitness: map[string]float64{
+						"movement_variance": *p.MovementVariance,
+						"variance_epsilon":  statueVarianceEpsilon,
+					},
+				},
+				objective: ObjectiveChaos,
+				urgency:   clamp01(1 - *p.MovementVariance/statueVarianceEpsilon),
+				cost:      costOf(InterventionSendControllerEffect),
+			})
+		}
+	}
+
+	// R9: periodic random effect.
+	if rollTarget != "" {
+		out = append(out, candidate{
+			decision: Decision{
+				Intervention:    InterventionSendControllerEffect,
+				TargetSerial:    rollTarget,
+				Reason:          "chaos: random controller effect",
+				ObjectiveServed: ObjectiveChaos,
+				Fitness:         map[string]float64{"chaos_roll": roll},
+			},
+			objective: ObjectiveChaos,
+			urgency:   clamp01(0.6 * roll),
+			cost:      costOf(InterventionSendControllerEffect),
+		})
+	}
+	return out
+}

--- a/services/agent/decision/ruleset.go
+++ b/services/agent/decision/ruleset.go
@@ -61,7 +61,7 @@ func sessionDuration(c gamecontext.GameContext) float64 {
 // gate "players are dying fast" rules. Returns 0 when nothing is known.
 func elimFraction(c gamecontext.GameContext, active int) float64 {
 	elims := len(c.Session.EliminationSequence)
-	if elims == 0 || elims+active == 0 {
+	if elims == 0 {
 		return 0
 	}
 	return float64(elims) / float64(elims+active)
@@ -80,8 +80,8 @@ func enduranceCandidates(c gamecontext.GameContext, fit FitnessThresholds) []can
 	if ef == 0 {
 		return nil // nobody eliminated yet — the session is not at risk
 	}
-	timeURgency := clamp01((fit.EnduranceMinSessionSeconds - dur) / fit.EnduranceMinSessionSeconds)
-	urgency := clamp01(timeURgency * 2 * ef)
+	timeUrgency := clamp01((fit.EnduranceMinSessionSeconds - dur) / fit.EnduranceMinSessionSeconds)
+	urgency := clamp01(timeUrgency * 2 * ef)
 	if urgency == 0 {
 		return nil
 	}

--- a/services/agent/decision/ruleset_test.go
+++ b/services/agent/decision/ruleset_test.go
@@ -1,0 +1,331 @@
+package decision
+
+import (
+	"testing"
+
+	"github.com/joustmania/agent/gamecontext"
+)
+
+func fptr(v float64) *float64 { return &v }
+func bptr(v bool) *bool       { return &v }
+
+// gameCtx builds a GameContext with active players defined as
+// serial -> {skill, intensity, battery} (nil pointer = unset).
+type testPlayer struct {
+	skill, intensity, battery *float64
+	variance                  *float64
+	active                    bool
+}
+
+func gameCtx(duration float64, elims []string, players map[string]testPlayer) gamecontext.GameContext {
+	c := gamecontext.GameContext{
+		SessionID: "s-1",
+		Players:   map[string]*gamecontext.PlayerSignals{},
+	}
+	c.Session.GameActive = bptr(true)
+	c.Session.DurationSeconds = fptr(duration)
+	c.Session.EliminationSequence = elims
+	for serial, tp := range players {
+		c.Players[serial] = &gamecontext.PlayerSignals{
+			Serial:            serial,
+			SkillLevel:        tp.skill,
+			MovementIntensity: tp.intensity,
+			BatteryPct:        tp.battery,
+			MovementVariance:  tp.variance,
+			Active:            bptr(tp.active),
+		}
+	}
+	return c
+}
+
+func defaultFit() FitnessThresholds { return DefaultStaticConfig().FitnessThresholds }
+func defaultPol() Policy            { return DefaultStaticConfig().PolicyValues }
+
+func interventionsOf(cands []candidate) []string {
+	out := make([]string, len(cands))
+	for i, cd := range cands {
+		out[i] = cd.decision.Intervention
+	}
+	return out
+}
+
+func TestEnduranceCandidates(t *testing.T) {
+	players := map[string]testPlayer{
+		"A": {active: true}, "B": {active: true},
+	}
+
+	t.Run("fires when young session loses players", func(t *testing.T) {
+		cands := enduranceCandidates(gameCtx(30, []string{"C"}, players), defaultFit())
+		if len(cands) != 2 {
+			t.Fatalf("candidates = %d, want 2 (tempo + cue)", len(cands))
+		}
+		tempo, cue := cands[0], cands[1]
+		if tempo.decision.Intervention != InterventionAdjustMusicTempo || !tempo.difficulty {
+			t.Errorf("first candidate = %+v, want difficulty tempo adjust", tempo.decision.Intervention)
+		}
+		if cue.decision.Intervention != InterventionPlayAudioCue {
+			t.Errorf("second candidate = %v, want audio cue", cue.decision.Intervention)
+		}
+		if cue.urgency >= tempo.urgency {
+			t.Errorf("cue urgency %v must be below tempo urgency %v", cue.urgency, tempo.urgency)
+		}
+		for _, k := range []string{"session_duration", "min_session_seconds", "eliminations"} {
+			if _, ok := tempo.decision.Fitness[k]; !ok {
+				t.Errorf("tempo fitness missing %s", k)
+			}
+		}
+	})
+
+	t.Run("silent without eliminations", func(t *testing.T) {
+		if cands := enduranceCandidates(gameCtx(30, nil, players), defaultFit()); cands != nil {
+			t.Fatalf("candidates = %v, want none", interventionsOf(cands))
+		}
+	})
+
+	t.Run("silent past the endurance target", func(t *testing.T) {
+		if cands := enduranceCandidates(gameCtx(150, []string{"C"}, players), defaultFit()); cands != nil {
+			t.Fatalf("candidates = %v, want none (session no longer young)", interventionsOf(cands))
+		}
+	})
+}
+
+func TestBalancedCandidates(t *testing.T) {
+	t.Run("skill gap above threshold handicaps the outlier", func(t *testing.T) {
+		c := gameCtx(30, nil, map[string]testPlayer{
+			"LOW":  {skill: fptr(0.2), active: true},
+			"HIGH": {skill: fptr(0.9), active: true},
+		})
+		cands := balancedCandidates(c, defaultFit())
+		if len(cands) != 1 {
+			t.Fatalf("candidates = %v, want only the gap rule", interventionsOf(cands))
+		}
+		if cands[0].decision.Intervention != InterventionAdjustPlayerSensitivity ||
+			cands[0].decision.TargetSerial != "HIGH" {
+			t.Fatalf("candidate = %+v, want sensitivity on HIGH", cands[0].decision)
+		}
+		if got := cands[0].decision.Fitness["skill_gap"]; got < 0.69 || got > 0.71 {
+			t.Errorf("skill_gap fitness = %v, want 0.7", got)
+		}
+	})
+
+	t.Run("gap at threshold is silent", func(t *testing.T) {
+		c := gameCtx(30, nil, map[string]testPlayer{
+			"A": {skill: fptr(0.3), active: true},
+			"B": {skill: fptr(0.7), active: true}, // gap exactly 0.4
+		})
+		if cands := balancedCandidates(c, defaultFit()); len(cands) != 0 {
+			t.Fatalf("candidates = %v, want none at exact threshold", interventionsOf(cands))
+		}
+	})
+
+	t.Run("shields the weakest while the field shrinks", func(t *testing.T) {
+		c := gameCtx(30, []string{"GONE"}, map[string]testPlayer{
+			"WEAK":   {skill: fptr(0.1), active: true},
+			"STRONG": {skill: fptr(0.4), active: true},
+		})
+		cands := balancedCandidates(c, defaultFit())
+		var shield *candidate
+		for i := range cands {
+			if cands[i].decision.Intervention == InterventionGrantShield {
+				shield = &cands[i]
+			}
+		}
+		if shield == nil || shield.decision.TargetSerial != "WEAK" {
+			t.Fatalf("candidates = %v, want grant_shield on WEAK", interventionsOf(cands))
+		}
+	})
+}
+
+func TestAccelerateCandidates(t *testing.T) {
+	accelDominant := map[string]float64{ObjectiveAccelerate: 0.7, ObjectiveEndurance: 0.3}
+	players := map[string]testPlayer{
+		"A": {intensity: fptr(1.5), active: true},
+		"B": {intensity: fptr(0.4), active: true},
+		"C": {intensity: fptr(0.9), active: true},
+	}
+
+	t.Run("silent at or below target", func(t *testing.T) {
+		if cands := accelerateCandidates(gameCtx(60, nil, players), defaultFit(), accelDominant); cands != nil {
+			t.Fatalf("candidates = %v, want none at target", interventionsOf(cands))
+		}
+	})
+
+	t.Run("past target speeds up only", func(t *testing.T) {
+		cands := accelerateCandidates(gameCtx(80, nil, players), defaultFit(), accelDominant)
+		if len(cands) != 1 || cands[0].decision.Intervention != InterventionAdjustMusicTempo {
+			t.Fatalf("candidates = %v, want only tempo", interventionsOf(cands))
+		}
+	})
+
+	t.Run("1.5x past target eliminates the least active", func(t *testing.T) {
+		cands := accelerateCandidates(gameCtx(100, nil, players), defaultFit(), accelDominant)
+		var elim *candidate
+		for i := range cands {
+			if cands[i].decision.Intervention == InterventionEliminatePlayer {
+				elim = &cands[i]
+			}
+		}
+		if elim == nil || elim.decision.TargetSerial != "B" {
+			t.Fatalf("candidates = %v, want eliminate_player on B (lowest intensity)", interventionsOf(cands))
+		}
+	})
+
+	t.Run("2x past target ends the game only when accelerate dominant", func(t *testing.T) {
+		c := gameCtx(130, nil, players)
+		withDominant := interventionsOf(accelerateCandidates(c, defaultFit(), accelDominant))
+		if !contains(withDominant, InterventionEndGame) {
+			t.Fatalf("candidates = %v, want end_game with accelerate dominant", withDominant)
+		}
+		tie := map[string]float64{ObjectiveAccelerate: 0.5, ObjectiveEndurance: 0.5}
+		withTie := interventionsOf(accelerateCandidates(c, defaultFit(), tie))
+		if contains(withTie, InterventionEndGame) {
+			t.Fatalf("candidates = %v: a weight TIE must never end a game", withTie)
+		}
+	})
+}
+
+func TestChaosCandidates(t *testing.T) {
+	t.Run("statue rule no-ops while variance is nil", func(t *testing.T) {
+		c := gameCtx(30, nil, map[string]testPlayer{"A": {active: true}})
+		cands := chaosCandidates(c, defaultPol(), 0, "")
+		if len(cands) != 0 {
+			t.Fatalf("candidates = %v, want none with nil variance and no roll", interventionsOf(cands))
+		}
+	})
+
+	t.Run("statue rule fires on near-zero variance after the window", func(t *testing.T) {
+		c := gameCtx(30, nil, map[string]testPlayer{"A": {variance: fptr(0.01), active: true}})
+		cands := chaosCandidates(c, defaultPol(), 0, "")
+		if len(cands) != 1 || cands[0].decision.TargetSerial != "A" {
+			t.Fatalf("candidates = %v, want statue nudge on A", interventionsOf(cands))
+		}
+		if cands[0].urgency < 0.7 {
+			t.Errorf("urgency = %v, want high for near-zero variance", cands[0].urgency)
+		}
+	})
+
+	t.Run("statue rule respects the variance window", func(t *testing.T) {
+		c := gameCtx(5, nil, map[string]testPlayer{"A": {variance: fptr(0.01), active: true}}) // 5s < 10s window
+		if cands := chaosCandidates(c, defaultPol(), 0, ""); len(cands) != 0 {
+			t.Fatalf("candidates = %v, want none before the variance window fills", interventionsOf(cands))
+		}
+	})
+
+	t.Run("periodic roll targets the picked player", func(t *testing.T) {
+		c := gameCtx(30, nil, map[string]testPlayer{"A": {active: true}})
+		cands := chaosCandidates(c, defaultPol(), 0.9, "A")
+		if len(cands) != 1 || cands[0].decision.Fitness["chaos_roll"] != 0.9 {
+			t.Fatalf("candidates = %+v, want one roll candidate with chaos_roll fitness", cands)
+		}
+	})
+}
+
+func TestBatteryPolicy(t *testing.T) {
+	accelDominant := map[string]float64{ObjectiveAccelerate: 1.0}
+	enduranceOnly := DefaultObjectiveWeights()
+	pol := defaultPol() // threshold 20
+
+	lowBattery := map[string]testPlayer{
+		"LOW": {battery: fptr(10), intensity: fptr(0.2), skill: fptr(0.1), active: true},
+		"OK":  {battery: fptr(90), intensity: fptr(1.0), skill: fptr(0.9), active: true},
+	}
+
+	mk := func(intervention, target string, difficulty bool) candidate {
+		return candidate{
+			decision:   Decision{Intervention: intervention, TargetSerial: target, Fitness: map[string]float64{}},
+			objective:  ObjectiveBalanced,
+			urgency:    1,
+			cost:       costOf(intervention),
+			difficulty: difficulty,
+		}
+	}
+	c := gameCtx(30, nil, lowBattery)
+
+	t.Run("controller effect on low-battery player dropped", func(t *testing.T) {
+		got := applyBatteryPolicy([]candidate{mk(InterventionSendControllerEffect, "LOW", false)}, c, pol, enduranceOnly)
+		if len(got) != 0 {
+			t.Fatal("effect on low-battery player must be dropped")
+		}
+	})
+
+	t.Run("controller effect on healthy player kept", func(t *testing.T) {
+		got := applyBatteryPolicy([]candidate{mk(InterventionSendControllerEffect, "OK", false)}, c, pol, enduranceOnly)
+		if len(got) != 1 {
+			t.Fatal("effect on healthy player must be kept")
+		}
+	})
+
+	t.Run("targeted difficulty raise on low-battery player dropped", func(t *testing.T) {
+		got := applyBatteryPolicy([]candidate{mk(InterventionAdjustPlayerSensitivity, "LOW", true)}, c, pol, enduranceOnly)
+		if len(got) != 0 {
+			t.Fatal("difficulty on low-battery player must be dropped")
+		}
+	})
+
+	t.Run("session difficulty raise dropped while anyone is low", func(t *testing.T) {
+		got := applyBatteryPolicy([]candidate{mk(InterventionAdjustMusicTempo, "", true)}, c, pol, enduranceOnly)
+		if len(got) != 0 {
+			t.Fatal("session-wide demand raise must be dropped while a player is low")
+		}
+	})
+
+	t.Run("shield and audio kept for low-battery player", func(t *testing.T) {
+		got := applyBatteryPolicy([]candidate{
+			mk(InterventionGrantShield, "LOW", false),
+			mk(InterventionPlayAudioCue, "", false),
+		}, c, pol, enduranceOnly)
+		if len(got) != 2 {
+			t.Fatalf("kept = %v, want shield + audio kept", interventionsOf(got))
+		}
+	})
+
+	t.Run("eliminate low-battery player is accelerate-only graceful exit", func(t *testing.T) {
+		cand := []candidate{mk(InterventionEliminatePlayer, "LOW", false)}
+		if got := applyBatteryPolicy(cand, c, pol, enduranceOnly); len(got) != 0 {
+			t.Fatal("low-battery eliminate must be dropped without accelerate dominance")
+		}
+		got := applyBatteryPolicy(cand, c, pol, accelDominant)
+		if len(got) != 1 {
+			t.Fatal("low-battery eliminate must be kept under accelerate dominance")
+		}
+		if got[0].decision.Fitness["battery_pct"] != 10 || got[0].decision.Fitness["battery_threshold"] != 20 {
+			t.Errorf("graceful-exit fitness = %v, want battery values recorded", got[0].decision.Fitness)
+		}
+	})
+
+	t.Run("threshold 0 disables the policy", func(t *testing.T) {
+		off := pol
+		off.BatteryThreshold = 0
+		got := applyBatteryPolicy([]candidate{mk(InterventionSendControllerEffect, "LOW", false)}, c, off, enduranceOnly)
+		if len(got) != 1 {
+			t.Fatal("policy off must keep all candidates")
+		}
+	})
+}
+
+func TestAccelerateDominant(t *testing.T) {
+	cases := []struct {
+		name    string
+		weights map[string]float64
+		want    bool
+	}{
+		{"strictly dominant", map[string]float64{ObjectiveAccelerate: 0.7, ObjectiveEndurance: 0.3}, true},
+		{"tie is not dominance", map[string]float64{ObjectiveAccelerate: 0.5, ObjectiveChaos: 0.5}, false},
+		{"absent", map[string]float64{ObjectiveEndurance: 1.0}, false},
+		{"sole weight", map[string]float64{ObjectiveAccelerate: 1.0}, true},
+	}
+	for _, tc := range cases {
+		if got := accelerateDominant(tc.weights); got != tc.want {
+			t.Errorf("%s: accelerateDominant = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func contains(list []string, v string) bool {
+	for _, s := range list {
+		if s == v {
+			return true
+		}
+	}
+	return false
+}

--- a/services/agent/main.go
+++ b/services/agent/main.go
@@ -4,8 +4,9 @@
 // an OTLP gRPC receiver that ingests both spans and metrics emitted by the game
 // services, accumulates them into a denormalized GameContext, gates on whether a
 // game is live with fresh player data, and on each gated update runs a decision
-// loop. The rules engine and action sink are stubbed in this scaffold; later
-// issues replace them with real interventions written to a flagd domain.
+// loop. The objective-weighted rules engine (#726) produces decisions; the
+// action sink is stubbed until the intervention API (#730) writes them to a
+// flagd domain.
 //
 // Self-observability (exporting the agent's own telemetry) follows the house
 // pattern in otel.go and is a no-op until OTEL_EXPORTER_OTLP_ENDPOINT is set.
@@ -93,9 +94,16 @@ func main() {
 	store.SetOwnService(resolveServiceName())
 
 	loop := decision.NewLoop(logger)
+	// The objective-weighted rules engine (#726) is the active default:
+	// decisions are traced through the audit spans, but the action sink is
+	// still a no-op until the intervention API (#730), so nothing is applied.
+	// Objectives/policy run on flagd-schema defaults until #727 wires the
+	// OpenFeature sources.
+	loop.Rules = decision.NewObjectiveRules(nil)
 	if strings.EqualFold(getEnv("AGENT_PROBE_DECISIONS", ""), "true") {
 		// Demo/verification mode: emit a synthetic noop decision (and thus the
-		// full audit trace, #724) at most once per probe interval.
+		// full audit trace, #724) at most once per probe interval. Overrides
+		// the rules engine.
 		loop.Rules = decision.NewProbeRules(probeInterval, nil)
 		slog.Warn("Probe decisions enabled (demo/verification mode)",
 			"interval", probeInterval)


### PR DESCRIPTION
> **Stacked PR** on #750 (`feat/issue-724-agent-span-schema`). Will be retargeted to `main` once #750 merges. Only the last commit is new.

## Summary

Implements #726: `ObjectiveRules`, the `rules_decide(context, objectives)` path of the decision loop — the non-LLM intelligence and the final link of the inference fallback chain. **Active by default**: decisions flow through the #724 audit spans (real `fitness.evaluated`, `agent.objectives`, `decision.objective_served` values now), but the ActionSink stays a no-op until the intervention API (#730), so nothing is applied to the game.

### Design

**Scoring:** each rule yields candidates with an urgency (0–1) and the objective served; final score = `urgency × weight[objective]`; min score 0.10 (this is what resolves objective conflicts — the acceptance example `{endurance:0.7, balanced:0.3}` is a dedicated test); deterministic tie-breaks (cheaper first, then name); ≤2 decisions per evaluation; the rule set runs at most 1/s (Evaluate is called ~10×/s from concurrent Export handlers — engine is mutex-guarded, with a concurrent test under `-race`).

**Rules** (9, grounded in the #722 research §4; identifiers exactly match the merged `interventions_allowed` vocabulary):
endurance (slow tempo / calm cue while a young session loses players), balanced (handicap the skill outlier past `max_skill_gap`; shield the weakest while the field shrinks), accelerate (speed up past `target_session_seconds`; eliminate the least-active at 1.5×; `end_game` at 2× **only when accelerate is the strict argmax — a weight tie never ends a game**), chaos (statue detection, dormant until the movement-variance metric ships; periodic rng nudge).

**Policy constraints** (defaults from the merged `services/flagd/agent.json`):
- `policy.battery_threshold` (20): low-battery players lose controller effects + difficulty raises; session-wide demand raises blocked while anyone is low; eliminating a low-battery player is allowed only as the accelerate-dominant graceful exit (recorded in fitness)
- `policy.movement_variance_window` (10s): chaos/variance candidates suppressed for one window after any difficulty intervention (baseline invalidation per research §5)
- `policy.max_interventions_per_minute` (2): **weighted** sliding-window budget — soft 0.5 (audio cue, controller effect, volume), medium 1 (tempo, player sensitivity, shield), hard 2 (global sensitivity, eliminate, revive, end_game). **Documented choice:** the budget charges every *emitted* decision, including ones the permission layer later blocks — the engine can't see Permissions (layering), §5 rate-limits attempts, and the game coordinator's flag-application layer (#730) is the authoritative backstop.

**Config seam for #727:** `ObjectivesSource`/`PolicySource`/`FitnessSource` interfaces with `DefaultStaticConfig()` mirroring the flagd schema defaults; engine fallback objectives are `{endurance: 1.0}` per the acceptance criteria (the flag's `balanced_focused` default surfaces once #727 actually reads the flag). Sources are re-read every evaluation, so live flag changes take effect without restart.

## Acceptance criteria (#726)

- [x] Rules engine produces decisions from game context + objective weights
- [x] Conflicting objectives resolved via configured weights (`{endurance:0.7, balanced:0.3}` test)
- [x] Every decision carries action type, reason, objective, and evaluated fitness for span attribution
- [x] Policy constraints enforced, including the (weighted) interventions-per-minute rate limit
- [x] Works with default objectives `{endurance: 1.0}` when no flag value is provided

## Test plan

- [x] 30+ new unit tests: per-rule trigger boundaries + fitness keys, nil-variance no-op, battery-filter matrix, end_game dominance/tie, weighted budget admit/deny + window expiry + concurrent admits, cadence gate, max-2 cap, deterministic ordering across runs, variance cooldown, concurrent Evaluate under `-race`, default-config = flagd schema, span rendering of fitness/objectives (existing #724 placeholder tests untouched and green)
- [x] `go build`, `go test -race ./...`, `go vet`, `gofmt` clean; `make lint`
- [x] **Live E2E** (probe OFF — real engine): synthetic young-session-with-elimination metrics → Jaeger shows `agent.decision` spans with `decision.action=adjust_music_tempo`/`play_audio_cue`, `decision.objective_served=endurance`, `agent.objectives=endurance=1`, `fitness.evaluated=["eliminations=1","min_session_seconds=120","session_duration=12.5"]` — and exactly 2 traces despite continuous evaluations (weighted budget 1+0.5+0.5=2.0 capped emission precisely)

Closes #726

🤖 Generated with [Claude Code](https://claude.com/claude-code)