### PR TITLE
feat: difficulty interventions — tempo, sensitivity, per-player factor (#730)

### DIFF
--- a/services/game_coordinator/difficulty_handlers.py
+++ b/services/game_coordinator/difficulty_handlers.py
@@ -1,0 +1,141 @@
+"""
+Difficulty intervention handlers for JoustMania (#730, PR C).
+
+Registers the real effect handlers for the three *difficulty* state-shaped
+intervention flags against the InterventionManager registry built in PR A:
+
+- ``music_tempo_override``        — N6: the music loop adopts the override tempo
+  and suspends its own speed-up/slow-down schedule (resolves the E1 tempo race
+  in docs/research/722-intervention-surface.md §3.1); reverting to none (0)
+  resumes the natural schedule from the current state.
+- ``global_sensitivity_override`` — N2: live update of ``game.sensitivity``,
+  consumed next frame by ``_compute_effective_thresholds``; reverting to none
+  (-1) restores the sensitivity the game started with.
+- ``player_sensitivity_factor``   — N1: per-serial ``targeting_key`` evaluation
+  sets each active player's ``sensitivity_factor`` (clamped 0.5-2.0); serials
+  with no targeting match get the neutral default (1.0).
+
+Handler contract (PR A): handlers are ``async def handler(ctx) -> None``, called
+only after the enforcement chain passes (they do NOT re-check policy), and the
+manager records the metric + publishes the EventBus event around the call. The
+handlers below mutate live game state; they are defensive (no live game / no
+audio client → no-op) because exceptions are swallowed by the manager as a
+``handler_error`` blocked outcome.
+
+PR C does not edit ``INTERVENTION_SPECS`` — it only attaches handlers via
+``register_handler`` (one line per flag), so the parallel ambience PR (E) does
+not conflict structurally.
+"""
+
+import logging
+
+from lib.types import Sensitivity
+
+from .interventions import InterventionContext, InterventionManager
+
+logger = logging.getLogger(__name__)
+
+# Per-player sensitivity factor clamp (mirrors base.py _compute_effective_thresholds).
+SENSITIVITY_FACTOR_MIN = 0.5
+SENSITIVITY_FACTOR_MAX = 2.0
+SENSITIVITY_FACTOR_DEFAULT = 1.0
+
+
+async def handle_music_tempo_override(ctx: InterventionContext) -> None:
+    """Apply / clear the agent music-tempo override on the live game.
+
+    A value > 0 sets ``game.tempo_override`` so the music loop adopts the
+    override tempo and suspends its own schedule. A value of 0 (none) clears the
+    override so the natural speed-up/slow-down schedule resumes from the current
+    music state. The override is applied by the game's own music loop via
+    ``_apply_tempo_change`` (single tempo owner — no race with the schedule).
+    """
+    game = ctx.game
+    if game is None:
+        logger.debug("music_tempo_override: no live game, ignoring")
+        return
+
+    tempo = float(ctx.value)
+    if tempo > 0.0:
+        game.tempo_override = tempo
+        logger.info(f"music_tempo_override: override active at {tempo:.2f}x (schedule suspended)")
+    else:
+        game.tempo_override = None
+        logger.info("music_tempo_override: override cleared, natural schedule resumes")
+
+
+async def handle_global_sensitivity_override(ctx: InterventionContext) -> None:
+    """Apply / clear the agent global-sensitivity override on the live game.
+
+    A value >= 0 sets ``game.sensitivity`` to the matching ``Sensitivity`` index;
+    the change is picked up next frame by ``_compute_effective_thresholds``. A
+    value of -1 (none) restores the sensitivity the game was configured with at
+    start (``game.configured_sensitivity``).
+    """
+    game = ctx.game
+    if game is None:
+        logger.debug("global_sensitivity_override: no live game, ignoring")
+        return
+
+    idx = int(ctx.value)
+    if idx < 0:
+        restored = getattr(game, "configured_sensitivity", game.sensitivity)
+        game.sensitivity = restored
+        logger.info(f"global_sensitivity_override: cleared, restored to {restored.name}")
+        return
+
+    try:
+        game.sensitivity = Sensitivity(idx)
+    except ValueError:
+        logger.warning(f"global_sensitivity_override: invalid sensitivity index {idx}, ignoring")
+        return
+    logger.info(f"global_sensitivity_override: live sensitivity -> {game.sensitivity.name}")
+
+
+async def handle_player_sensitivity_factor(ctx: InterventionContext, manager: InterventionManager) -> None:
+    """Apply per-player sensitivity factors via per-serial targeting resolution.
+
+    Uses the manager's reusable ``resolve_player_targets`` helper to evaluate the
+    flag once per active serial with ``EvaluationContext(targeting_key=serial)``.
+    Each resolved factor is clamped to [0.5, 2.0] and written to the player's
+    ``sensitivity_factor`` (consumed next frame by ``_compute_effective_thresholds``).
+    Players without a targeting match get the neutral default (1.0); battery-gated
+    serials are skipped by the helper.
+    """
+    game = ctx.game
+    if game is None:
+        logger.debug("player_sensitivity_factor: no live game, ignoring")
+        return
+
+    factors = manager.resolve_player_targets(
+        flag_key=ctx.spec.flag_key,
+        default=SENSITIVITY_FACTOR_DEFAULT,
+        game=game,
+        value_kind="float",
+        battery_gate=True,
+    )
+
+    players = getattr(game, "players", {})
+    for serial, factor in factors.items():
+        player = players.get(serial)
+        if player is None:
+            continue
+        clamped = max(SENSITIVITY_FACTOR_MIN, min(SENSITIVITY_FACTOR_MAX, factor))
+        player.sensitivity_factor = clamped
+        logger.info(f"player_sensitivity_factor: {serial} -> {clamped:.2f}")
+
+
+def register_difficulty_handlers(manager: InterventionManager) -> None:
+    """Wire the difficulty handlers onto the manager (one line per flag).
+
+    Called from the servicer after the manager is constructed. Kept one-line-
+    per-flag so the parallel ambience PR (E) appends rather than conflicts.
+    """
+    manager.register_handler("music_tempo_override", handle_music_tempo_override)
+    manager.register_handler("global_sensitivity_override", handle_global_sensitivity_override)
+    # player_sensitivity_factor needs the manager (for the reusable targeting
+    # helper), so bind it via a small closure.
+    manager.register_handler(
+        "player_sensitivity_factor",
+        lambda ctx: handle_player_sensitivity_factor(ctx, manager),
+    )

--- a/services/game_coordinator/games/base.py
+++ b/services/game_coordinator/games/base.py
@@ -248,6 +248,15 @@ class BaseGameMode(ABC):
         self.speed_up = True  # True = next change will speed up, False = slow down
         self.change_time = 0.0  # Time of next tempo change
         self.music_loop_task = None
+        # Agent tempo override (#730 PR C). When set to a float (1.0-1.3), the
+        # music loop adopts this tempo and SUSPENDS its own speed-up/slow-down
+        # schedule (resolves the E1 race in 722-intervention-surface §3.1).
+        # None = no override; the natural schedule runs. Set/cleared by the
+        # music_tempo_override intervention handler; consumed in _check_music_speed.
+        self.tempo_override: float | None = None
+        # Configured sensitivity captured at game start so a reverted
+        # global_sensitivity_override (#730 PR C) restores the original level.
+        self.configured_sensitivity = self.sensitivity
         self.dead_count = 0  # Track deaths for tempo timing
         # Elimination ordering for game_player_elimination_order metric (#730).
         # Incremented on each kill; the value at kill time is the player's order
@@ -1819,6 +1828,19 @@ class BaseGameMode(ABC):
         between slow and fast tempos.
         """
         if not self.audio_client or not self.music_track_id:
+            return
+
+        # Agent tempo override (#730 PR C): while an override is active the music
+        # loop adopts that tempo and suspends its own schedule. Apply once when
+        # the override differs from the current speed, then hold — no scheduled
+        # transitions fire (self.change_time is left untouched so the natural
+        # schedule resumes from the current state when the override clears).
+        if self.tempo_override is not None:
+            if abs(self.music_speed - self.tempo_override) > 1e-9:
+                try:
+                    await self._apply_tempo_change(self.tempo_override)
+                except Exception as e:
+                    logger.warning(f"Failed to apply tempo override: {e}")
             return
 
         if time.time() >= self.change_time:

--- a/services/game_coordinator/interventions.py
+++ b/services/game_coordinator/interventions.py
@@ -785,10 +785,78 @@ class InterventionManager:
         return client.get_string_value(spec.flag_key, "", ctx)
 
     def _state_target_serial(self, _spec: InterventionSpec) -> str | None:
-        """Per-player state flags target via flagd targeting (serial), which is
-        not resolvable from a global read in PR A. Returns None (no battery gate)
-        until per-serial evaluation lands in PR D."""
+        """Player-targeted state flags fan out across all active serials via
+        flagd targeting (keyed on ``targeting_key = serial``); there is no single
+        chain-level target. The battery guard is therefore applied per serial
+        inside :meth:`resolve_player_targets`, not here, so this returns None
+        (the chain's single-target battery check is a no-op for fan-out flags).
+        """
         return None
+
+    # ------------------------------------------------------------------ #
+    # Per-player targeting resolution (reusable; PR D shield_seconds uses it)
+    # ------------------------------------------------------------------ #
+    def resolve_player_targets(
+        self,
+        flag_key: str,
+        default: float,
+        game: object,
+        *,
+        value_kind: str = "float",
+        battery_gate: bool = True,
+    ) -> dict[str, float]:
+        """Evaluate a per-player targeted flag for every active player serial.
+
+        For each active serial in ``game.players`` the flag is evaluated with an
+        ``EvaluationContext(targeting_key=serial)`` so flagd's per-serial
+        targeting rules resolve. Serials with no targeting match receive
+        ``default``. When ``battery_gate`` is True, any serial whose battery pct
+        is below ``policy.battery_threshold`` is dropped from the result (the
+        per-serial equivalent of the chain's battery guard — closes the
+        player-targeted-state-flag battery-guard gap documented in PR A's
+        ``_state_target_serial``).
+
+        Reusable across player-targeted state interventions: PR C uses it for
+        ``player_sensitivity_factor``; PR D uses it for ``shield_seconds``.
+
+        Args:
+            flag_key: Flag to evaluate in the ``interventions`` domain.
+            default: Neutral value returned for serials with no targeting match
+                (e.g. 1.0 for sensitivity factor, 0 for shield seconds).
+            game: Live game whose ``players`` dict supplies the active serials.
+            value_kind: ``"float"`` or ``"int"`` (flag value type).
+            battery_gate: If True, drop serials below the battery threshold.
+
+        Returns:
+            ``{serial: value}`` for every active serial that should be acted on.
+            Battery-gated serials are omitted entirely.
+        """
+        result: dict[str, float] = {}
+        client = self._interventions_client
+        serials = _active_player_serials(game)
+        threshold = self._battery_threshold() if battery_gate else None
+
+        for serial in serials:
+            if threshold is not None:
+                pct = self._battery_pct(serial)
+                if pct is not None and pct < threshold:
+                    continue  # battery guard: skip low-battery controllers
+
+            if client is None:
+                value: float = default
+            else:
+                ctx = EvaluationContext(targeting_key=serial)
+                try:
+                    if value_kind == "int":
+                        value = float(client.get_integer_value(flag_key, int(default), ctx))
+                    else:
+                        value = float(client.get_float_value(flag_key, float(default), ctx))
+                except Exception as e:  # one bad serial must not drop the rest
+                    logger.debug(f"InterventionManager: per-serial read failed for {serial}: {e}")
+                    value = default
+            result[serial] = value
+
+        return result
 
     def _allowed_types(self) -> set[str]:
         if self._agent_client is None:
@@ -889,6 +957,25 @@ def _spec_default(spec: InterventionSpec) -> object:
     if spec.value_kind in ("int", "float"):
         return spec.none_value
     return ""
+
+
+def _active_player_serials(game: object) -> list[str]:
+    """Best-effort list of active (alive) player serials from a live game.
+
+    Returns serials of players that are still alive; falls back to all serials
+    if aliveness can't be read. Empty list when there is no game / no players.
+    """
+    if game is None:
+        return []
+    players = getattr(game, "players", None)
+    if not isinstance(players, dict):
+        return []
+    serials: list[str] = []
+    for serial, player in players.items():
+        alive = getattr(player, "alive", True)
+        if alive:
+            serials.append(serial)
+    return serials
 
 
 def _game_mode_name(game: object) -> str:

--- a/services/game_coordinator/servicer.py
+++ b/services/game_coordinator/servicer.py
@@ -19,6 +19,7 @@ from lib.telemetry import get_tracer
 from lib.types import GameEvent, get_game_display_name
 from proto import game_coordinator_pb2, game_coordinator_pb2_grpc
 from services.game_coordinator import metrics
+from services.game_coordinator.difficulty_handlers import register_difficulty_handlers
 from services.game_coordinator.event_bus import EventBus
 from services.game_coordinator.game_factory import GameFactory
 from services.game_coordinator.grpc_clients import GrpcClientManager
@@ -79,8 +80,11 @@ class GameCoordinatorServicer(game_coordinator_pb2_grpc.GameCoordinatorServiceSe
             end_game_fn=self._force_end_current_game,
         )
         # PR E: register the ambient/session handlers (audio cue, volume,
-        # controller effect, end game). PR C registers difficulty handlers.
+        # controller effect, end game).
         self.intervention_manager.register_ambient_handlers()
+        # Register difficulty intervention handlers (#730 PR C): music tempo
+        # override, global sensitivity override, per-player sensitivity factor.
+        register_difficulty_handlers(self.intervention_manager)
         self.intervention_manager.start()
 
         logger.info("GameCoordinator initialized")

--- a/services/game_coordinator/tests/test_difficulty_interventions.py
+++ b/services/game_coordinator/tests/test_difficulty_interventions.py
@@ -1,0 +1,425 @@
+"""
+Unit tests for the difficulty intervention handlers (#730, PR C).
+
+Covers the three difficulty state-shaped interventions and the reusable
+per-player targeting helper they introduce:
+
+- music_tempo_override: override beats/suspends the music loop's schedule; revert
+  resumes the natural schedule from the current state; mid-game sensitivity swap
+  during an in-flight tempo LERP.
+- global_sensitivity_override: live swap changes effective thresholds on the next
+  computation; revert restores the game's configured sensitivity.
+- player_sensitivity_factor: per-serial targeting (targeted player changed,
+  others default), clamping, and battery-gated skip.
+- resolve_player_targets: reusable targeting helper, unit-tested directly
+  (PR D consumes it for shield_seconds).
+
+Telemetry is disabled via conftest; the intervention metric is patched per the
+repo metric-testing convention (.claude/rules/development.md).
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+# Setup paths for imports
+test_dir = Path(__file__).parent
+service_dir = test_dir.parent
+project_root = service_dir.parent.parent
+sys.path.insert(0, str(project_root))
+sys.path.insert(0, str(test_dir))
+
+from conftest import MockControllerManagerService, async_noop
+
+from lib.types import GameEvent, Sensitivity
+from services.game_coordinator.difficulty_handlers import (
+    handle_global_sensitivity_override,
+    handle_music_tempo_override,
+    handle_player_sensitivity_factor,
+    register_difficulty_handlers,
+)
+from services.game_coordinator.games.base import (
+    FAST_MUSIC_SPEED,
+    SLOW_MUSIC_SPEED,
+    Player,
+)
+from services.game_coordinator.games.ffa import FFAGame
+from services.game_coordinator.interventions import (
+    InterventionContext,
+    InterventionManager,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures / fakes
+# --------------------------------------------------------------------------- #
+def make_game(sensitivity=2, num_players=2):
+    """Build a real FFAGame (for live _compute_effective_thresholds) with audio."""
+    mock_cm = MockControllerManagerService(num_controllers=num_players)
+    mock_audio = AsyncMock()
+    game = FFAGame(
+        controller_manager_client=mock_cm,
+        event_publisher=async_noop,
+        audio_client=mock_audio,
+        game_id="test_difficulty",
+        sensitivity=sensitivity,
+    )
+    game.music_track_id = "track_123"
+    game.music_speed = SLOW_MUSIC_SPEED
+    game.speed_up = True
+    game.gameplay_span = None
+    game.gameplay_span_context = None
+    for i in range(num_players):
+        s = f"p{i + 1}"
+        game.players[s] = Player(serial=s, alive=True, color=(255, 0, 0))
+    return game
+
+
+class TargetingFlagClient:
+    """Flag client that resolves per-serial via EvaluationContext.targeting_key.
+
+    ``per_serial`` maps serial -> value; serials not present fall back to
+    ``default`` (mimicking flagd targeting rules with a default variant).
+    """
+
+    def __init__(self, default, per_serial=None):
+        self.default = default
+        self.per_serial = per_serial or {}
+
+    def _resolve(self, ctx, default):
+        key = getattr(ctx, "targeting_key", None) if ctx is not None else None
+        if key in self.per_serial:
+            return self.per_serial[key]
+        return self.default if self.default is not None else default
+
+    def get_float_value(self, _key, default, ctx=None):
+        return float(self._resolve(ctx, default))
+
+    def get_integer_value(self, _key, default, ctx=None):
+        return int(self._resolve(ctx, default))
+
+
+def make_manager(game=None, battery=None, threshold=20):
+    """Manager bypassing start(); records published events."""
+    events = []
+
+    async def publisher(event_type, data):
+        events.append((event_type, data))
+
+    mgr = InterventionManager(
+        event_publisher=publisher,
+        get_game=lambda: game,
+        battery_provider=(lambda s: battery.get(s)) if battery is not None else None,
+    )
+    # Minimal agent client: only battery threshold is consulted by the helper.
+    mgr._agent_client = _AgentStub(threshold)
+    return mgr, events
+
+
+class _AgentStub:
+    def __init__(self, threshold):
+        self._threshold = threshold
+
+    def get_integer_value(self, key, default, _ctx=None):
+        if key == "policy.battery_threshold":
+            return self._threshold
+        return default
+
+    def get_object_value(self, _key, default, _ctx=None):
+        return default
+
+
+def _spec(flag_key):
+    from services.game_coordinator.interventions import INTERVENTION_SPECS
+
+    return next(s for s in INTERVENTION_SPECS if s.flag_key == flag_key)
+
+
+def make_ctx(flag_key, value, game, *, payload="", target=None):
+    return InterventionContext(
+        spec=_spec(flag_key),
+        value=value,
+        payload=payload,
+        target_serial=target,
+        game=game,
+        objective="balanced",
+    )
+
+
+# --------------------------------------------------------------------------- #
+# music_tempo_override
+# --------------------------------------------------------------------------- #
+class TestMusicTempoOverride:
+    @pytest.mark.asyncio
+    async def test_override_sets_attribute(self):
+        game = make_game()
+        await handle_music_tempo_override(make_ctx("music_tempo_override", 1.3, game))
+        assert game.tempo_override == pytest.approx(1.3)
+
+    @pytest.mark.asyncio
+    async def test_override_beats_and_suspends_schedule(self):
+        """While override holds, the music loop adopts it and skips its schedule."""
+        game = make_game()
+        # Make the natural schedule "due" so without an override it would fire.
+        game.change_time = 0.0
+        game.tempo_override = 1.15
+        await game._check_music_speed()
+        # Override tempo applied via _apply_tempo_change path.
+        assert game.music_speed == pytest.approx(1.15)
+        # A second check holds the override (no further transition since already at tempo).
+        game.audio_client.ChangeTempo.reset_mock()
+        await game._check_music_speed()
+        game.audio_client.ChangeTempo.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_revert_resumes_schedule(self):
+        """Clearing the override (value 0) lets the natural schedule run again."""
+        game = make_game()
+        game.tempo_override = 1.3
+        await game._check_music_speed()
+        assert game.music_speed == pytest.approx(1.3)
+
+        # Revert via handler.
+        await handle_music_tempo_override(make_ctx("music_tempo_override", 0, game))
+        assert game.tempo_override is None
+
+        # Now the schedule resumes: force it due and confirm a scheduled change fires.
+        game.audio_client.ChangeTempo.reset_mock()
+        game.change_time = 0.0
+        await game._check_music_speed()
+        game.audio_client.ChangeTempo.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_no_live_game_is_noop(self):
+        await handle_music_tempo_override(make_ctx("music_tempo_override", 1.3, None))  # no raise
+
+    @pytest.mark.asyncio
+    async def test_mid_game_sensitivity_swap_during_tempo_lerp(self):
+        """Swapping sensitivity while a tempo override LERP is in flight is safe:
+        thresholds are recomputed per frame from the live sensitivity and speed.
+        """
+        game = make_game(sensitivity=2)
+        player = game.players["p1"]
+
+        # Override drives music to fast; thresholds at MEDIUM/fast.
+        game.tempo_override = FAST_MUSIC_SPEED
+        await game._check_music_speed()
+        warn_before, death_before = game._compute_effective_thresholds(player)
+
+        # Mid-LERP global sensitivity swap to a harder level.
+        await handle_global_sensitivity_override(make_ctx("global_sensitivity_override", 4, game))
+        warn_after, death_after = game._compute_effective_thresholds(player)
+
+        # Harder sensitivity (index 4) raises the death threshold; computation
+        # stays well-defined despite the active override.
+        assert death_after != death_before
+        assert game.sensitivity == Sensitivity.ULTRA_FAST
+
+
+# --------------------------------------------------------------------------- #
+# global_sensitivity_override
+# --------------------------------------------------------------------------- #
+class TestGlobalSensitivityOverride:
+    @pytest.mark.asyncio
+    async def test_live_swap_changes_effective_thresholds(self):
+        game = make_game(sensitivity=0)  # ULTRA_SLOW
+        player = game.players["p1"]
+        _, death_before = game._compute_effective_thresholds(player)
+
+        await handle_global_sensitivity_override(make_ctx("global_sensitivity_override", 4, game))
+        assert game.sensitivity == Sensitivity.ULTRA_FAST
+        _, death_after = game._compute_effective_thresholds(player)
+        # Different sensitivity index -> different effective death threshold.
+        assert death_after != death_before
+
+    @pytest.mark.asyncio
+    async def test_revert_restores_configured_sensitivity(self):
+        game = make_game(sensitivity=1)  # configured SLOW
+        assert game.configured_sensitivity == Sensitivity.SLOW
+
+        await handle_global_sensitivity_override(make_ctx("global_sensitivity_override", 3, game))
+        assert game.sensitivity == Sensitivity.FAST
+
+        # Revert with -1 restores the original configured level.
+        await handle_global_sensitivity_override(make_ctx("global_sensitivity_override", -1, game))
+        assert game.sensitivity == Sensitivity.SLOW
+
+    @pytest.mark.asyncio
+    async def test_invalid_index_ignored(self):
+        game = make_game(sensitivity=2)
+        await handle_global_sensitivity_override(make_ctx("global_sensitivity_override", 99, game))
+        assert game.sensitivity == Sensitivity.MEDIUM  # unchanged
+
+    @pytest.mark.asyncio
+    async def test_no_live_game_is_noop(self):
+        await handle_global_sensitivity_override(make_ctx("global_sensitivity_override", 3, None))
+
+
+# --------------------------------------------------------------------------- #
+# player_sensitivity_factor + targeting
+# --------------------------------------------------------------------------- #
+class TestPlayerSensitivityFactor:
+    @pytest.mark.asyncio
+    async def test_targeted_player_changed_others_default(self):
+        game = make_game(num_players=3)
+        mgr, _ = make_manager(game=game)
+        mgr._interventions_client = TargetingFlagClient(default=1.0, per_serial={"p2": 1.5})
+
+        await handle_player_sensitivity_factor(make_ctx("player_sensitivity_factor", 1.5, game), mgr)
+
+        assert game.players["p1"].sensitivity_factor == pytest.approx(1.0)
+        assert game.players["p2"].sensitivity_factor == pytest.approx(1.5)
+        assert game.players["p3"].sensitivity_factor == pytest.approx(1.0)
+
+    @pytest.mark.asyncio
+    async def test_factor_is_clamped(self):
+        game = make_game(num_players=2)
+        mgr, _ = make_manager(game=game)
+        # Out-of-range factors are clamped to [0.5, 2.0].
+        mgr._interventions_client = TargetingFlagClient(default=1.0, per_serial={"p1": 5.0, "p2": 0.1})
+
+        await handle_player_sensitivity_factor(make_ctx("player_sensitivity_factor", 0, game), mgr)
+
+        assert game.players["p1"].sensitivity_factor == pytest.approx(2.0)
+        assert game.players["p2"].sensitivity_factor == pytest.approx(0.5)
+
+    @pytest.mark.asyncio
+    async def test_changed_factor_changes_effective_threshold(self):
+        game = make_game(num_players=2)
+        player = game.players["p1"]
+        _, death_default = game._compute_effective_thresholds(player)
+
+        mgr, _ = make_manager(game=game)
+        mgr._interventions_client = TargetingFlagClient(default=1.0, per_serial={"p1": 1.5})
+        await handle_player_sensitivity_factor(make_ctx("player_sensitivity_factor", 1.5, game), mgr)
+
+        _, death_after = game._compute_effective_thresholds(player)
+        # Higher factor -> lower (easier) death threshold.
+        assert death_after < death_default
+
+    @pytest.mark.asyncio
+    async def test_no_live_game_is_noop(self):
+        mgr, _ = make_manager(game=None)
+        mgr._interventions_client = TargetingFlagClient(default=1.0)
+        await handle_player_sensitivity_factor(make_ctx("player_sensitivity_factor", 1.5, None), mgr)
+
+
+# --------------------------------------------------------------------------- #
+# resolve_player_targets (reusable helper) — PR D consumes this
+# --------------------------------------------------------------------------- #
+class TestResolvePlayerTargets:
+    def test_resolves_per_serial_with_default(self):
+        game = make_game(num_players=3)
+        mgr, _ = make_manager(game=game)
+        mgr._interventions_client = TargetingFlagClient(default=1.0, per_serial={"p2": 1.5})
+
+        result = mgr.resolve_player_targets("player_sensitivity_factor", 1.0, game)
+        assert result == {"p1": 1.0, "p2": 1.5, "p3": 1.0}
+
+    def test_battery_gate_drops_low_battery_serial(self):
+        game = make_game(num_players=3)
+        mgr, _ = make_manager(game=game, battery={"p1": 50.0, "p2": 5.0, "p3": 80.0}, threshold=20)
+        mgr._interventions_client = TargetingFlagClient(default=1.0, per_serial={"p2": 1.5})
+
+        result = mgr.resolve_player_targets("player_sensitivity_factor", 1.0, game)
+        # p2 is below the 20% threshold -> excluded from the result entirely.
+        assert "p2" not in result
+        assert set(result) == {"p1", "p3"}
+
+    def test_battery_gate_disabled_keeps_all(self):
+        game = make_game(num_players=2)
+        mgr, _ = make_manager(game=game, battery={"p1": 5.0, "p2": 5.0}, threshold=20)
+        mgr._interventions_client = TargetingFlagClient(default=1.0)
+
+        result = mgr.resolve_player_targets("player_sensitivity_factor", 1.0, game, battery_gate=False)
+        assert set(result) == {"p1", "p2"}
+
+    def test_only_alive_players_resolved(self):
+        game = make_game(num_players=3)
+        game.players["p2"].alive = False
+        mgr, _ = make_manager(game=game)
+        mgr._interventions_client = TargetingFlagClient(default=1.0)
+
+        result = mgr.resolve_player_targets("player_sensitivity_factor", 1.0, game)
+        assert set(result) == {"p1", "p3"}
+
+    def test_int_value_kind(self):
+        game = make_game(num_players=1)
+        mgr, _ = make_manager(game=game)
+        mgr._interventions_client = TargetingFlagClient(default=0, per_serial={"p1": 5})
+
+        result = mgr.resolve_player_targets("shield_seconds", 0, game, value_kind="int")
+        assert result == {"p1": 5.0}
+
+    def test_no_game_returns_empty(self):
+        mgr, _ = make_manager(game=None)
+        mgr._interventions_client = TargetingFlagClient(default=1.0)
+        assert mgr.resolve_player_targets("player_sensitivity_factor", 1.0, None) == {}
+
+
+# --------------------------------------------------------------------------- #
+# Registration / end-to-end dispatch through the manager
+# --------------------------------------------------------------------------- #
+class TestRegistration:
+    def test_register_difficulty_handlers_wires_all_three(self):
+        mgr, _ = make_manager(game=None)
+        register_difficulty_handlers(mgr)
+        assert mgr._handlers["music_tempo_override"] is handle_music_tempo_override
+        assert mgr._handlers["global_sensitivity_override"] is handle_global_sensitivity_override
+        # player_sensitivity_factor is bound via closure (not identity-equal).
+        assert callable(mgr._handlers["player_sensitivity_factor"])
+
+    @pytest.mark.asyncio
+    @patch("services.game_coordinator.metrics.interventions_total")
+    async def test_dispatch_applies_tempo_override_via_chain(self, _metric):
+        """End-to-end: a tempo-override flag change flows through the enforcement
+        chain and the real handler sets game.tempo_override."""
+        game = make_game()
+        events = []
+
+        async def publisher(event_type, data):
+            events.append((event_type, data))
+
+        mgr = InterventionManager(event_publisher=publisher, get_game=lambda: game)
+        mgr._interventions_client = _ScalarFlagClient({"music_tempo_override": 0})
+        mgr._agent_client = _AllowAllAgent()
+        register_difficulty_handlers(mgr)
+        # Baseline: override currently none (so the later change is detected).
+        mgr._prime_baseline()
+
+        # Now the agent sets the override; evaluate the single flag.
+        mgr._interventions_client.values["music_tempo_override"] = 1.15
+        await mgr._evaluate_one(_spec("music_tempo_override"))
+
+        assert game.tempo_override == pytest.approx(1.15)
+        assert any(e[0] == GameEvent.AGENT_INTERVENTION and e[1]["blocked"] == "false" for e in events)
+
+
+class _ScalarFlagClient:
+    def __init__(self, values):
+        self.values = values
+
+    def get_float_value(self, key, default, _ctx=None):
+        return float(self.values.get(key, default))
+
+    def get_integer_value(self, key, default, _ctx=None):
+        return int(self.values.get(key, default))
+
+    def get_string_value(self, key, default, _ctx=None):
+        return str(self.values.get(key, default))
+
+
+class _AllowAllAgent:
+    def get_object_value(self, key, default, _ctx=None):
+        if key == "interventions_allowed":
+            return ["adjust_music_tempo", "adjust_global_sensitivity", "adjust_player_sensitivity"]
+        return default
+
+    def get_integer_value(self, key, default, _ctx=None):
+        if key == "policy.max_interventions_per_minute":
+            return 100
+        if key == "policy.battery_threshold":
+            return 20
+        return default


### PR DESCRIPTION
## Summary

**PR C** of the stacked #730 plan — the **difficulty interventions**: real handlers for the three difficulty state-shaped flags. **Stacked on #755** (PR A, InterventionManager core); this PR targets `feat/730-intervention-manager-core`, **not** `main`.

Implements the N1/N2/N6 difficulty levers from [722-intervention-surface](docs/research/722-intervention-surface.md) §2/§3/§8 by attaching handlers to PR A's registry — no edits to `INTERVENTION_SPECS`, no enforcement-chain changes.

## What this adds

- **`games/base.py`** (additive hooks only):
  - `tempo_override: float | None` — when set, `_check_music_speed` adopts the override tempo via `_apply_tempo_change` and **suspends** its own speed-up/slow-down schedule (resolves the **E1 tempo race**, §3.1). Clearing it resumes the natural schedule from the current state — the music loop stays the single tempo owner.
  - `configured_sensitivity` — sensitivity captured at game start so a reverted `global_sensitivity_override` restores the original level. `_compute_effective_thresholds` already reads `self.sensitivity` / `player.sensitivity_factor` per frame, so live changes apply next frame with no further wiring.

- **`interventions.py`** (additive):
  - **`InterventionManager.resolve_player_targets()`** — the reusable per-serial targeting resolver the core PR stubbed in `_state_target_serial`. Evaluates a player-targeted flag once per active serial with `EvaluationContext(targeting_key=serial)`, defaults serials with no match, and **battery-gates per serial** (closes the player-targeted-state-flag battery-guard gap PR A documented). Flag/mode agnostic — **PR D reuses it for `shield_seconds`**.

- **`difficulty_handlers.py`** (new) + servicer wiring:
  - `music_tempo_override` → set/clear `game.tempo_override`.
  - `global_sensitivity_override` → live `game.sensitivity` swap; `-1` restores `configured_sensitivity`.
  - `player_sensitivity_factor` → per-serial factors via `resolve_player_targets`, clamped to `[0.5, 2.0]`.
  - `register_difficulty_handlers(manager)` — one `register_handler` line per flag (so the parallel ambience PR E appends without structural conflict). Handlers follow PR A's contract: no policy re-checks; defensive on no live game.

## Reusable targeting helper (PR D consumes this)

```python
def resolve_player_targets(
    self,
    flag_key: str,
    default: float,
    game: object,
    *,
    value_kind: str = "float",   # "float" | "int"
    battery_gate: bool = True,
) -> dict[str, float]:
    """{serial: value} for every active serial; serials with no targeting match
    get `default`; battery-gated serials (pct < policy.battery_threshold) are
    omitted entirely. Evaluates per serial with EvaluationContext(targeting_key=serial)."""
```

## Test plan

- New `tests/test_difficulty_interventions.py` — **21 tests**: tempo override beats/suspends schedule + resumes on revert; live + per-player sensitivity swaps change effective thresholds next computation; revert restores configured sensitivity; per-serial factor targeting (targeted changed, others default, clamping); battery-gated skip; alive-only resolution; **mid-game sensitivity swap during a tempo LERP**; registration + end-to-end dispatch through the enforcement chain.
- `cd services/game_coordinator && uv run pytest` → **722 passed** (701 base + 21).
- `make lint` → **clean**.

Part of #730.

🤖 Generated with [Claude Code](https://claude.com/claude-code)