### PR TITLE
feat: ambient interventions — audio cue, volume, controller effect, end game (#730)

### DIFF
--- a/services/game_coordinator/interventions.py
+++ b/services/game_coordinator/interventions.py
@@ -317,6 +317,7 @@ class InterventionManager:
         get_game: Callable[[], object | None],
         battery_provider: Callable[[str], float | None] | None = None,
         time_fn: Callable[[], float] = time.monotonic,
+        end_game_fn: Callable[[str], Awaitable[tuple[bool, str]]] | None = None,
     ):
         """
         Args:
@@ -327,11 +328,15 @@ class InterventionManager:
                 testability (the real source is the controller manager's
                 ``controller_battery_pct`` metric).
             time_fn: Monotonic clock (injectable for tests).
+            end_game_fn: Async ``end_game(reason) -> (success, error)`` used by
+                the ``end_game`` intervention handler to share the servicer's
+                force-end path (#730, PR E). None disables the handler's effect.
         """
         self._publish = event_publisher
         self._get_game = get_game
         self._battery_provider = battery_provider
         self._time_fn = time_fn
+        self._end_game_fn = end_game_fn
 
         self._interventions_client = None  # interventions domain
         self._agent_client = None  # agent domain (backstop reads)
@@ -346,6 +351,10 @@ class InterventionManager:
         # Handler registry: flag_key -> Handler. Defaults to the no-op stub for
         # every spec. PRs C/D/E replace entries via register_handler().
         self._handlers: dict[str, Handler] = {spec.flag_key: self._noop_handler for spec in INTERVENTION_SPECS}
+        # Optional per-flag handlers run when a state-shaped flag reverts to its
+        # neutral value (e.g. volume_override -> default game volume). Additive;
+        # absence means "do nothing on revert" (the default for all flags).
+        self._revert_handlers: dict[str, Handler] = {}
 
         self._lock = threading.RLock()
         self._started = False
@@ -380,6 +389,135 @@ class InterventionManager:
             f"(flag={ctx.spec.flag_key}, target={ctx.target_serial}, "
             f"value={ctx.value!r}, payload={ctx.payload!r}) — no-op (PR A)"
         )
+
+    # ------------------------------------------------------------------ #
+    # Ambient + session intervention handlers (#730, PR E)
+    #
+    # These reuse the exact audio/effect paths the games already use; they do
+    # NOT touch the audio/controller services. Registered via
+    # register_ambient_handlers(); the enforcement chain has already passed when
+    # they run, so they only do the effect (defensively).
+    # ------------------------------------------------------------------ #
+    def register_ambient_handlers(self) -> None:
+        """Register the PR E ambient/session handlers (one line per flag).
+
+        Additive: PR C registers its own difficulty handlers separately. Call
+        once after construction (the servicer does this on startup).
+        """
+        self.register_handler("audio_cue", self._handle_audio_cue)
+        self.register_handler("volume_override", self._handle_volume_override)
+        self.register_handler("controller_effect", self._handle_controller_effect)
+        self.register_handler("end_game", self._handle_end_game)
+        # volume_override restores the configured game volume when reverted.
+        self._revert_handlers["volume_override"] = self._handle_volume_revert
+
+    async def _handle_audio_cue(self, ctx: InterventionContext) -> None:
+        """Play ``ctx.payload`` as a sound id through the live game's audio path.
+
+        Unknown/empty sound id or no running game -> log and return.
+        """
+        sound_id = ctx.payload.strip()
+        if not sound_id:
+            logger.info("audio_cue: empty sound id, skipping")
+            return
+        game = ctx.game
+        play = getattr(game, "_play_sound", None) if game is not None else None
+        if not callable(play):
+            logger.info(f"audio_cue: no live game audio path for sound '{sound_id}', skipping")
+            return
+        # _play_sound already swallows unknown-sound / audio errors defensively.
+        await play(sound_id, priority=2)
+        logger.info(f"audio_cue: played sound '{sound_id}'")
+
+    async def _handle_volume_override(self, ctx: InterventionContext) -> None:
+        """Set the audio volume via the game's audio client.
+
+        State-shaped: ``ctx.value`` is the float volume. ``none_value`` (-1)
+        never reaches here (the manager skips reverts-to-neutral), so reverting
+        to the configured game volume is handled in ``_handle_volume_revert``,
+        invoked by the manager's neutral-revert path.
+        """
+        volume = _coerce_float(ctx.value)
+        if volume is None or volume < 0:
+            logger.info(f"volume_override: non-applicable value {ctx.value!r}, skipping")
+            return
+        await self._set_volume(ctx.game, volume)
+        logger.info(f"volume_override: set volume to {volume}")
+
+    async def _handle_volume_revert(self, ctx: InterventionContext) -> None:
+        """Restore the configured game volume when the override reverts to none.
+
+        Dispatched by the manager when ``volume_override`` returns to its
+        ``none_value`` (-1). Restores exactly ``games.base.GAME_VOLUME``.
+        """
+        from services.game_coordinator.games.base import GAME_VOLUME
+
+        await self._set_volume(ctx.game, GAME_VOLUME)
+        logger.info(f"volume_override: reverted volume to game default {GAME_VOLUME}")
+
+    async def _set_volume(self, game: object, volume: float) -> None:
+        """Send a SetVolume RPC via the live game's audio client (no-op if
+        there is no running game / audio client)."""
+        audio_client = getattr(game, "audio_client", None) if game is not None else None
+        if audio_client is None:
+            logger.info("volume_override: no live game audio client, skipping")
+            return
+        from proto import audio_pb2
+
+        await audio_client.SetVolume(audio_pb2.SetVolumeRequest(volume=float(volume)))
+
+    async def _handle_controller_effect(self, ctx: InterventionContext) -> None:
+        """Send a controller effect via the live game's gameplay stream.
+
+        Payload is ``"<serial>:<effect>"``; an empty serial broadcasts the
+        effect to all active (alive) players. Effect names are validated against
+        the supported set; unknown effects / malformed payloads -> log + return.
+        """
+        serial, effect_name = _parse_effect_payload(ctx.payload)
+        if effect_name is None:
+            logger.info(f"controller_effect: malformed payload {ctx.payload!r}, skipping")
+            return
+        effect_enum = _resolve_effect(effect_name)
+        if effect_enum is None:
+            logger.info(f"controller_effect: unknown effect '{effect_name}', skipping")
+            return
+
+        game = ctx.game
+        stream = getattr(game, "gameplay_stream", None) if game is not None else None
+        if stream is None:
+            logger.info("controller_effect: no live gameplay stream, skipping")
+            return
+
+        targets = _effect_targets(game, serial)
+        if not targets:
+            logger.info(f"controller_effect: no active target for serial '{serial}', skipping")
+            return
+
+        from proto import controller_manager_pb2
+
+        for target_serial in targets:
+            cmd = controller_manager_pb2.GameplayStreamControl(
+                game_effect=controller_manager_pb2.GameEffectCommand(
+                    serial=target_serial,
+                    effect=effect_enum,
+                )
+            )
+            await stream.write(cmd)
+        logger.info(f"controller_effect: sent '{effect_name}' to {len(targets)} controller(s)")
+
+    async def _handle_end_game(self, _ctx: InterventionContext) -> None:
+        """End the running game via the servicer's shared force-end path.
+
+        No-ops safely when no game is running or no end_game_fn is wired.
+        """
+        if self._end_game_fn is None:
+            logger.info("end_game: no end_game_fn wired, skipping")
+            return
+        success, error = await self._end_game_fn("agent_intervention")
+        if success:
+            logger.info("end_game: game force-ended via agent intervention")
+        else:
+            logger.info(f"end_game: no-op ({error})")
 
     # ------------------------------------------------------------------ #
     # Lifecycle
@@ -510,7 +648,30 @@ class InterventionManager:
             if not changed:
                 return
             if _is_none_value(spec, raw):
-                return  # reverting to neutral is not an intervention to dispatch
+                # Reverting to neutral is not an enforced intervention, but some
+                # state flags need to actively restore a default on revert (e.g.
+                # volume_override -> configured game volume, #730 PR E). Such
+                # flags register a revert handler; it runs without enforcement
+                # (restoring a default is always safe / not rate-limited).
+                # Only fire when the PREVIOUS value was a real (non-none)
+                # intervention — a fresh none-to-none transition (unknown prior
+                # baseline) must not spuriously restore.
+                was_active = last is not None and not _is_none_value(spec, last)
+                revert = self._revert_handlers.get(spec.flag_key)
+                if was_active and revert is not None:
+                    ctx = InterventionContext(
+                        spec=spec,
+                        value=raw,
+                        payload="",
+                        target_serial=None,
+                        game=self._get_game(),
+                        objective=self._dominant_objective(),
+                    )
+                    try:
+                        await revert(ctx)
+                    except Exception as e:
+                        logger.error(f"InterventionManager: revert handler for {spec.flag_key} raised: {e}")
+                return
             payload = ""
             target = self._state_target_serial(spec)
             value = raw
@@ -739,3 +900,72 @@ def _game_mode_name(game: object) -> str:
         except Exception:
             return ""
     return ""
+
+
+# --- PR E ambient/session helpers -------------------------------------- #
+
+# Effect names the agent may request -> controller_manager GameEffectType enum
+# value name. Only the agent-safe subset (signalling / ambient feedback) is
+# exposed; per-player lifecycle effects (warning/death/respawn/countdown) and
+# admin effects are intentionally NOT addressable via this intervention. The
+# mode-capability matrix already blocks send_controller_effect in hidden-role
+# modes (LED leak), so this map does not re-encode that policy.
+_CONTROLLER_EFFECT_NAMES: dict[str, str] = {
+    "rumble": "GAME_EFFECT_RUMBLE",
+    "pulse": "GAME_EFFECT_PULSE",
+    "flash": "GAME_EFFECT_FLASH",
+    "show_battery": "GAME_EFFECT_SHOW_BATTERY",
+}
+
+
+def _coerce_float(value: object) -> float | None:
+    """Best-effort float coercion; returns None on failure."""
+    try:
+        return float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+
+
+def _parse_effect_payload(payload: str) -> tuple[str, str | None]:
+    """Split a controller_effect payload ``"<serial>:<effect>"``.
+
+    Returns ``(serial, effect_name)``. ``serial`` may be empty (broadcast).
+    A payload with no ``:`` or an empty effect is malformed -> effect_name None.
+    """
+    if ":" not in payload:
+        return "", None
+    serial, effect = payload.split(":", 1)
+    serial = serial.strip()
+    effect = effect.strip().lower()
+    if not effect:
+        return serial, None
+    return serial, effect
+
+
+def _resolve_effect(effect_name: str) -> int | None:
+    """Map a validated effect name to its GameEffectType enum value, or None."""
+    enum_name = _CONTROLLER_EFFECT_NAMES.get(effect_name)
+    if enum_name is None:
+        return None
+    try:
+        from proto import controller_manager_pb2
+
+        return getattr(controller_manager_pb2, enum_name)
+    except Exception:
+        return None
+
+
+def _effect_targets(game: object, serial: str) -> list[str]:
+    """Resolve controller serials for an effect.
+
+    Empty ``serial`` broadcasts to all alive players; a specific serial routes
+    to that one player when present and alive. Unknown / dead serials -> [].
+    """
+    players = getattr(game, "players", None) if game is not None else None
+    if not isinstance(players, dict):
+        # No player map (e.g. test stub): honor an explicit serial, else nothing.
+        return [serial] if serial else []
+    if serial:
+        player = players.get(serial)
+        return [serial] if player is not None and getattr(player, "alive", False) else []
+    return [s for s, p in players.items() if getattr(p, "alive", False)]

--- a/services/game_coordinator/servicer.py
+++ b/services/game_coordinator/servicer.py
@@ -76,7 +76,11 @@ class GameCoordinatorServicer(game_coordinator_pb2_grpc.GameCoordinatorServiceSe
         self.intervention_manager = InterventionManager(
             event_publisher=self.event_bus.publish,
             get_game=self.get_live_game,
+            end_game_fn=self._force_end_current_game,
         )
+        # PR E: register the ambient/session handlers (audio cue, volume,
+        # controller effect, end game). PR C registers difficulty handlers.
+        self.intervention_manager.register_ambient_handlers()
         self.intervention_manager.start()
 
         logger.info("GameCoordinator initialized")
@@ -280,46 +284,57 @@ class GameCoordinatorServicer(game_coordinator_pb2_grpc.GameCoordinatorServiceSe
                 await self.clients.close()
                 logger.info("Closed gRPC channels")
 
+    async def _force_end_current_game(self, reason: str) -> tuple[bool, str]:
+        """Force end the running game (shared by ForceEndGame RPC and the
+        ``end_game`` agent intervention, #730).
+
+        Stops the game loop, calls ``force_end()`` on the live game, joins the
+        game thread, transitions to ENDED, and publishes ``game_force_ended``.
+        No-ops safely (returns ``(False, ...)``) when no game is in progress.
+
+        Returns ``(success, error)``.
+        """
+        # Thread-safe state check and update
+        with self._state_lock:
+            if self.game_state not in [
+                game_coordinator_pb2.GameState.STARTING,
+                game_coordinator_pb2.GameState.RUNNING,
+            ]:
+                return False, "No game in progress"
+
+            # Stop game loop
+            self.game_running = False
+            current_game = self.current_game
+            game_thread = self.game_thread
+            game_id = self.game_id
+
+        # Call force_end on current game if it exists
+        if current_game and hasattr(current_game, "force_end"):
+            current_game.force_end()
+
+        # Wait for thread in executor to avoid blocking gRPC server
+        if game_thread and game_thread.is_alive():
+            loop = asyncio.get_running_loop()
+            await loop.run_in_executor(None, lambda: game_thread.join(timeout=2.0))
+
+        # Thread-safe state transition
+        with self._state_lock:
+            self.game_state = game_coordinator_pb2.GameState.ENDED
+
+        # Publish event
+        await self.event_bus.publish(
+            "game_force_ended",
+            {"reason": reason, "game_id": game_id or "unknown"},
+        )
+
+        logger.info(f"Force ended game: {reason}")
+        return True, ""
+
     async def ForceEndGame(self, request, _context):
         """Force end the current game."""
         try:
-            # Thread-safe state check and update
-            with self._state_lock:
-                if self.game_state not in [
-                    game_coordinator_pb2.GameState.STARTING,
-                    game_coordinator_pb2.GameState.RUNNING,
-                ]:
-                    return game_coordinator_pb2.ForceEndGameResponse(success=False, error="No game in progress")
-
-                # Stop game loop
-                self.game_running = False
-                current_game = self.current_game
-                game_thread = self.game_thread
-                game_id = self.game_id
-
-            # Call force_end on current game if it exists
-            if current_game and hasattr(current_game, "force_end"):
-                current_game.force_end()
-
-            # Wait for thread in executor to avoid blocking gRPC server
-            if game_thread and game_thread.is_alive():
-                loop = asyncio.get_running_loop()
-                await loop.run_in_executor(None, lambda: game_thread.join(timeout=2.0))
-
-            # Thread-safe state transition
-            with self._state_lock:
-                self.game_state = game_coordinator_pb2.GameState.ENDED
-
-            # Publish event
-            await self.event_bus.publish(
-                "game_force_ended",
-                {"reason": request.reason, "game_id": game_id or "unknown"},
-            )
-
-            logger.info(f"Force ended game: {request.reason}")
-
-            return game_coordinator_pb2.ForceEndGameResponse(success=True, error="")
-
+            success, error = await self._force_end_current_game(request.reason)
+            return game_coordinator_pb2.ForceEndGameResponse(success=success, error=error)
         except Exception as e:
             logger.error(f"ForceEndGame error: {e}", exc_info=True)
             return game_coordinator_pb2.ForceEndGameResponse(success=False, error=str(e))

--- a/services/game_coordinator/tests/test_intervention_handlers.py
+++ b/services/game_coordinator/tests/test_intervention_handlers.py
@@ -1,0 +1,358 @@
+"""
+Unit tests for the ambient + session intervention handlers (#730, PR E).
+
+Covers the real handlers wired by ``register_ambient_handlers``:
+``audio_cue``, ``volume_override`` (apply + exact revert), ``controller_effect``
+(broadcast vs per-serial routing, effect validation) and ``end_game`` (delegates
+to the shared force-end path, no-ops without a game). Telemetry is disabled via
+conftest; the intervention metric is patched per the repo convention.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from lib.types import GameEvent
+from proto import controller_manager_pb2
+from services.game_coordinator.games.base import GAME_VOLUME
+from services.game_coordinator.interventions import (
+    INTERVENTION_SPECS,
+    InterventionContext,
+    InterventionManager,
+    _parse_effect_payload,
+    _resolve_effect,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Fakes
+# --------------------------------------------------------------------------- #
+class FakeFlagClient:
+    def __init__(self, values=None):
+        self.values = values or {}
+
+    def set(self, key, value):
+        self.values[key] = value
+
+    def get_string_value(self, key, default, _ctx=None):
+        return str(self.values.get(key, default))
+
+    def get_integer_value(self, key, default, _ctx=None):
+        return int(self.values.get(key, default))
+
+    def get_float_value(self, key, default, _ctx=None):
+        return float(self.values.get(key, default))
+
+    def get_object_value(self, key, default, _ctx=None):
+        return self.values.get(key, default)
+
+
+class FakePlayer:
+    def __init__(self, serial, alive=True):
+        self.serial = serial
+        self.alive = alive
+
+
+class FakeGame:
+    """Stand-in for a live BaseGameMode with an audio client + gameplay stream."""
+
+    def __init__(self, name="Nonstop Joust", players=None, with_audio=True, with_stream=True):
+        self._name = name
+        self.players = players or {}
+        self.audio_client = AsyncMock() if with_audio else None
+        self.gameplay_stream = AsyncMock() if with_stream else None
+        self.played_sounds = []
+
+    def get_game_name(self):
+        return self._name
+
+    async def _play_sound(self, sound, priority=2, parent_context=None):
+        self.played_sounds.append((sound, priority))
+
+
+ALL_TYPES = {
+    "play_audio_cue",
+    "adjust_volume",
+    "send_controller_effect",
+    "end_game",
+    "adjust_music_tempo",
+    "adjust_global_sensitivity",
+    "adjust_player_sensitivity",
+    "grant_shield",
+    "eliminate_player",
+    "revive_player",
+}
+
+
+def make_manager(*, interventions=None, game=None, end_game_fn=None, budget=20):
+    events = []
+
+    async def publisher(event_type, data):
+        events.append((event_type, data))
+
+    agent_values = {
+        "interventions_allowed": list(ALL_TYPES),
+        "policy.max_interventions_per_minute": budget,
+        "policy.battery_threshold": 20,
+    }
+    mgr = InterventionManager(
+        event_publisher=publisher,
+        get_game=lambda: game,
+        end_game_fn=end_game_fn,
+    )
+    mgr._interventions_client = FakeFlagClient(interventions or {})
+    mgr._agent_client = FakeFlagClient(agent_values)
+    mgr._rate_limiter.set_budget(float(budget))
+    mgr.register_ambient_handlers()
+    return mgr, events
+
+
+# --------------------------------------------------------------------------- #
+# Pure helpers
+# --------------------------------------------------------------------------- #
+def test_parse_effect_payload():
+    assert _parse_effect_payload("ctrl_a:pulse") == ("ctrl_a", "pulse")
+    assert _parse_effect_payload(":rumble") == ("", "rumble")
+    assert _parse_effect_payload("ctrl_a:PULSE") == ("ctrl_a", "pulse")  # case-insensitive
+    assert _parse_effect_payload("ctrl_a:") == ("ctrl_a", None)  # empty effect
+    assert _parse_effect_payload("noeffect") == ("", None)  # no separator
+
+
+def test_resolve_effect():
+    assert _resolve_effect("rumble") == controller_manager_pb2.GAME_EFFECT_RUMBLE
+    assert _resolve_effect("pulse") == controller_manager_pb2.GAME_EFFECT_PULSE
+    assert _resolve_effect("flash") == controller_manager_pb2.GAME_EFFECT_FLASH
+    assert _resolve_effect("show_battery") == controller_manager_pb2.GAME_EFFECT_SHOW_BATTERY
+    assert _resolve_effect("player_death") is None  # not agent-addressable
+    assert _resolve_effect("bogus") is None
+
+
+# --------------------------------------------------------------------------- #
+# audio_cue
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_audio_cue_plays_sound_via_game():
+    game = FakeGame()
+    mgr, _ = make_manager(interventions={"audio_cue": "1:wolfdown"}, game=game)
+    with patch("services.game_coordinator.metrics.interventions_total"):
+        await mgr.evaluate_all()
+    assert game.played_sounds == [("wolfdown", 2)]
+
+
+@pytest.mark.asyncio
+async def test_audio_cue_applies_once_per_nonce():
+    game = FakeGame()
+    mgr, _ = make_manager(interventions={"audio_cue": "1:wolfdown"}, game=game)
+    with patch("services.game_coordinator.metrics.interventions_total"):
+        await mgr.evaluate_all()
+        await mgr.evaluate_all()  # same nonce -> no replay
+    assert len(game.played_sounds) == 1
+    with patch("services.game_coordinator.metrics.interventions_total"):
+        mgr._interventions_client.set("audio_cue", "2:wolfdown")
+        await mgr.evaluate_all()  # new nonce -> replay
+    assert len(game.played_sounds) == 2
+
+
+@pytest.mark.asyncio
+async def test_audio_cue_empty_sound_is_defensive_noop():
+    game = FakeGame()
+    mgr, _ = make_manager(interventions={"audio_cue": "1: "}, game=game)
+    with patch("services.game_coordinator.metrics.interventions_total"):
+        await mgr.evaluate_all()
+    assert game.played_sounds == []
+
+
+@pytest.mark.asyncio
+async def test_audio_cue_no_game_is_noop():
+    mgr, events = make_manager(interventions={"audio_cue": "1:wolfdown"}, game=None)
+    with patch("services.game_coordinator.metrics.interventions_total"):
+        await mgr.evaluate_all()
+    # Still dispatched (not blocked) — handler defensively returns.
+    cue = [d for et, d in events if et == GameEvent.AGENT_INTERVENTION and d["type"] == "play_audio_cue"]
+    assert cue and cue[0]["blocked"] == "false"
+
+
+# --------------------------------------------------------------------------- #
+# volume_override
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_volume_override_applies_value():
+    from proto import audio_pb2
+
+    game = FakeGame()
+    mgr, _ = make_manager(interventions={"volume_override": -1}, game=game)
+    with patch("services.game_coordinator.metrics.interventions_total"):
+        await mgr.evaluate_all()  # prime baseline (none)
+        mgr._interventions_client.set("volume_override", 0.3)
+        await mgr.evaluate_all()
+    game.audio_client.SetVolume.assert_awaited_once()
+    req = game.audio_client.SetVolume.await_args.args[0]
+    assert isinstance(req, audio_pb2.SetVolumeRequest)
+    assert abs(req.volume - 0.3) < 1e-6
+
+
+@pytest.mark.asyncio
+async def test_volume_override_restores_game_volume_on_revert():
+    game = FakeGame()
+    mgr, _ = make_manager(interventions={"volume_override": 0.3}, game=game)
+    with patch("services.game_coordinator.metrics.interventions_total"):
+        await mgr.evaluate_all()  # 0.3 applied
+        mgr._interventions_client.set("volume_override", -1)
+        await mgr.evaluate_all()  # revert -> restore GAME_VOLUME
+    # First call set 0.3, second restored exactly GAME_VOLUME.
+    calls = game.audio_client.SetVolume.await_args_list
+    assert len(calls) == 2
+    assert abs(calls[1].args[0].volume - GAME_VOLUME) < 1e-6
+
+
+@pytest.mark.asyncio
+async def test_volume_override_no_audio_client_is_noop():
+    game = FakeGame(with_audio=False)
+    mgr, _ = make_manager(interventions={"volume_override": -1}, game=game)
+    with patch("services.game_coordinator.metrics.interventions_total"):
+        await mgr.evaluate_all()
+        mgr._interventions_client.set("volume_override", 0.3)
+        await mgr.evaluate_all()  # no client -> defensive no-op (no crash)
+
+
+# --------------------------------------------------------------------------- #
+# controller_effect
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_controller_effect_per_serial_routing():
+    players = {"ctrl_a": FakePlayer("ctrl_a"), "ctrl_b": FakePlayer("ctrl_b")}
+    game = FakeGame(players=players)
+    mgr, _ = make_manager(interventions={"controller_effect": "1:ctrl_a:pulse"}, game=game)
+    with patch("services.game_coordinator.metrics.interventions_total"):
+        await mgr.evaluate_all()
+    game.gameplay_stream.write.assert_awaited_once()
+    cmd = game.gameplay_stream.write.await_args.args[0]
+    assert cmd.game_effect.serial == "ctrl_a"
+    assert cmd.game_effect.effect == controller_manager_pb2.GAME_EFFECT_PULSE
+
+
+@pytest.mark.asyncio
+async def test_controller_effect_broadcast_to_alive_players():
+    players = {
+        "ctrl_a": FakePlayer("ctrl_a", alive=True),
+        "ctrl_b": FakePlayer("ctrl_b", alive=True),
+        "ctrl_c": FakePlayer("ctrl_c", alive=False),  # dead -> excluded
+    }
+    game = FakeGame(players=players)
+    mgr, _ = make_manager(interventions={"controller_effect": "1::flash"}, game=game)
+    with patch("services.game_coordinator.metrics.interventions_total"):
+        await mgr.evaluate_all()
+    sent = [c.args[0].game_effect.serial for c in game.gameplay_stream.write.await_args_list]
+    assert set(sent) == {"ctrl_a", "ctrl_b"}
+
+
+@pytest.mark.asyncio
+async def test_controller_effect_unknown_effect_is_noop():
+    players = {"ctrl_a": FakePlayer("ctrl_a")}
+    game = FakeGame(players=players)
+    mgr, _ = make_manager(interventions={"controller_effect": "1:ctrl_a:disco"}, game=game)
+    with patch("services.game_coordinator.metrics.interventions_total"):
+        await mgr.evaluate_all()
+    game.gameplay_stream.write.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_controller_effect_malformed_payload_is_noop():
+    players = {"ctrl_a": FakePlayer("ctrl_a")}
+    game = FakeGame(players=players)
+    mgr, _ = make_manager(interventions={"controller_effect": "1:ctrl_a"}, game=game)  # no effect
+    with patch("services.game_coordinator.metrics.interventions_total"):
+        await mgr.evaluate_all()
+    game.gameplay_stream.write.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_controller_effect_no_stream_is_noop():
+    players = {"ctrl_a": FakePlayer("ctrl_a")}
+    game = FakeGame(players=players, with_stream=False)
+    mgr, _ = make_manager(interventions={"controller_effect": "1:ctrl_a:pulse"}, game=game)
+    with patch("services.game_coordinator.metrics.interventions_total"):
+        await mgr.evaluate_all()  # no stream -> defensive no-op (no crash)
+
+
+# --------------------------------------------------------------------------- #
+# end_game
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_end_game_delegates_to_force_end():
+    end = AsyncMock(return_value=(True, ""))
+    game = FakeGame()
+    mgr, _ = make_manager(interventions={"end_game": "1"}, game=game, end_game_fn=end)
+    with patch("services.game_coordinator.metrics.interventions_total"):
+        await mgr.evaluate_all()
+    end.assert_awaited_once_with("agent_intervention")
+
+
+@pytest.mark.asyncio
+async def test_end_game_applies_once_per_nonce():
+    end = AsyncMock(return_value=(True, ""))
+    game = FakeGame()
+    mgr, _ = make_manager(interventions={"end_game": "1"}, game=game, end_game_fn=end)
+    with patch("services.game_coordinator.metrics.interventions_total"):
+        await mgr.evaluate_all()
+        await mgr.evaluate_all()  # same nonce -> not re-ended
+    end.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_end_game_no_game_is_safe_noop():
+    # end_game_fn reports "no game in progress"; handler must not raise.
+    end = AsyncMock(return_value=(False, "No game in progress"))
+    mgr, events = make_manager(interventions={"end_game": "1"}, game=None, end_game_fn=end)
+    with patch("services.game_coordinator.metrics.interventions_total"):
+        await mgr.evaluate_all()
+    end.assert_awaited_once()
+    eg = [d for et, d in events if et == GameEvent.AGENT_INTERVENTION and d["type"] == "end_game"]
+    assert eg and eg[0]["blocked"] == "false"  # dispatched; no-op handled internally
+
+
+@pytest.mark.asyncio
+async def test_end_game_no_fn_wired_is_noop():
+    mgr, _ = make_manager(interventions={"end_game": "1"}, game=FakeGame(), end_game_fn=None)
+    with patch("services.game_coordinator.metrics.interventions_total"):
+        await mgr.evaluate_all()  # no end_game_fn -> defensive no-op (no crash)
+
+
+# --------------------------------------------------------------------------- #
+# Revert handler bypasses enforcement (always safe to restore default)
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_volume_revert_runs_even_when_not_allowed():
+    """Restoring the default volume on revert is not gated by the allow-list."""
+    game = FakeGame()
+    mgr, _ = make_manager(interventions={"volume_override": 0.3}, game=game)
+    with patch("services.game_coordinator.metrics.interventions_total"):
+        await mgr.evaluate_all()  # apply 0.3
+    # Now disallow everything; revert should still restore.
+    mgr._agent_client.set("interventions_allowed", [])
+    with patch("services.game_coordinator.metrics.interventions_total"):
+        mgr._interventions_client.set("volume_override", -1)
+        await mgr.evaluate_all()
+    calls = game.audio_client.SetVolume.await_args_list
+    assert abs(calls[-1].args[0].volume - GAME_VOLUME) < 1e-6
+
+
+def test_register_ambient_handlers_wires_all_four():
+    mgr, _ = make_manager()
+    assert mgr._handlers["audio_cue"] == mgr._handle_audio_cue
+    assert mgr._handlers["volume_override"] == mgr._handle_volume_override
+    assert mgr._handlers["controller_effect"] == mgr._handle_controller_effect
+    assert mgr._handlers["end_game"] == mgr._handle_end_game
+    assert mgr._revert_handlers["volume_override"] == mgr._handle_volume_revert
+
+
+@pytest.mark.asyncio
+async def test_handle_volume_revert_direct():
+    """Direct unit test of the revert handler restoring GAME_VOLUME."""
+    game = FakeGame()
+    mgr, _ = make_manager(game=game)
+    spec = next(s for s in INTERVENTION_SPECS if s.flag_key == "volume_override")
+    ctx = InterventionContext(spec=spec, value=-1, payload="", target_serial=None, game=game, objective="balanced")
+    await mgr._handle_volume_revert(ctx)
+    req = game.audio_client.SetVolume.await_args.args[0]
+    assert abs(req.volume - GAME_VOLUME) < 1e-6


### PR DESCRIPTION
## Summary

**PR E** of the stacked #730 plan — real handlers for the **ambient + session interventions**, registered against the InterventionManager core. **Stacked on #755** (PR A, intervention manager core); this PR targets `feat/730-intervention-manager-core`, not `main`.

The core PR landed no-op handler stubs and the enforcement chain. This PR attaches real effects for four flags, reusing the exact audio/effect paths the games already use — **no changes to the audio or controller services**.

## What this adds

- **`audio_cue`** (edge, soft): plays `ctx.payload` as a sound id through the live game's `_play_sound` path. Empty sound id / no running game → defensive log + return.
- **`volume_override`** (state, soft): applies the float volume via the live game's audio client `SetVolume`. Reverting to none (`-1`) restores **exactly** `games.base.GAME_VOLUME` via a new additive per-flag *revert handler* — it runs **without** the enforcement chain (restoring a default is always safe and must not be rate-limited or allow-list-gated), and only fires when the previous value was a real (non-none) intervention.
- **`controller_effect`** (edge, soft): parses `"<serial>:<effect>"`, validates the effect against an agent-safe subset (`rumble`, `pulse`, `flash`, `show_battery`), and writes a `GameEffectCommand` to the game's `gameplay_stream`. Empty serial broadcasts to all **alive** players; unknown effect / malformed payload / no stream → defensive no-op. (The hidden-role LED-leak restriction is already enforced by the core manager's mode-capability matrix, not re-encoded here.)
- **`end_game`** (edge, nonce-only, hard): delegates to the servicer's force-end path. `ForceEndGame` was refactored to extract `_force_end_current_game(reason)` so the RPC and the agent share one implementation. No-ops safely when no game is running or no `end_game_fn` is wired.

### Wiring
- `InterventionManager.__init__` gains an optional `end_game_fn`.
- `register_ambient_handlers()` does the one-line-per-flag registrations (additive; the parallel difficulty PR registers its own handlers separately).
- Servicer passes `end_game_fn=self._force_end_current_game` and calls `register_ambient_handlers()` on startup.

`interventions.py` changes are **additive** (new handler methods + a small revert-handler hook + module helpers); the tempo/sensitivity flags are untouched to minimize conflicts with the parallel PR C.

## Test plan

- New `services/game_coordinator/tests/test_intervention_handlers.py` — **21 tests**: audio cue plays/once-per-nonce/empty-defensive/no-game; volume apply + exact `GAME_VOLUME` restore on revert + no-client safety; controller effect per-serial vs broadcast-to-alive routing, unknown effect, malformed payload, no-stream safety; end_game delegates to force-end, once-per-nonce, safe no-op without a game / without fn; revert bypasses the allow-list; payload/effect helper units.
- `cd services/game_coordinator && uv run --extra test pytest` → **722 passed** (701 base + 21).
- `make lint` (ruff check + format) → **clean**.

Part of #730.

🤖 Generated with [Claude Code](https://claude.com/claude-code)