### PR TITLE
feat: shield and lifecycle interventions (#730)

### DIFF
--- a/services/game_coordinator/games/base.py
+++ b/services/game_coordinator/games/base.py
@@ -1153,13 +1153,177 @@ class BaseGameMode(ABC):
             )
             await self.gameplay_stream.write(effect_cmd)
 
-    async def _kill_player(self, serial: str, accel_mag: float):
+    async def grant_shield(self, serial: str, seconds: float) -> bool:
+        """
+        Grant a temporary shield (invulnerability) to a player (#730, N3).
+
+        A shield extends the player's ``grace_until`` timestamp: the per-frame
+        check in ``_process_controller_state`` already skips all death/warning
+        checks while ``time.time() < grace_until``, so this is the natural,
+        mode-agnostic shield primitive (Tournament/Fight Club ``invincible_until``
+        and Nonstop ``spawn_protected`` are the same idea). FFA-first per
+        docs/research/722-intervention-surface.md §3, but the primitive lives on
+        ``BaseGameMode`` so every mode inherits it. Mode-level opt-outs (e.g.
+        hidden-role LED leaks) are enforced by the intervention manager's §9
+        capability matrix BEFORE the handler runs — this primitive does not
+        re-check mode.
+
+        Idempotent-extend semantics: a new shield only ever extends an existing
+        one. If the player is already shielded past ``now + seconds`` the existing
+        (longer) grace is kept; a shorter request never shortens it.
+
+        A visible pulse effect (``GAME_EFFECT_PULSE``) is sent to the controller
+        so the shield is observable, reusing the same gameplay-stream effect
+        mechanism as warnings/deaths.
+
+        Args:
+            serial: Controller serial number.
+            seconds: Shield duration in seconds. Non-positive durations are a
+                no-op (returns False).
+
+        Returns:
+            True if a shield was granted/extended, False if the player is
+            unknown/dead or the duration was non-positive.
+        """
+        if seconds <= 0:
+            return False
+
+        player = self.players.get(serial)
+        if not player or not player.alive:
+            return False
+
+        new_grace = time.time() + seconds
+        # Extend-not-shorten: never pull an existing (longer) shield in.
+        if new_grace <= player.grace_until:
+            logger.info(
+                f"Shield for {serial}: existing grace ({player.grace_until:.2f}) "
+                f"already exceeds requested ({new_grace:.2f}); kept"
+            )
+            return True
+
+        player.grace_until = new_grace
+        logger.info(f"Shield granted to {serial} for {seconds:.1f}s (grace_until={new_grace:.2f})")
+
+        if player.span:
+            player.span.add_event("shield_granted", attributes={"shield_seconds": seconds})
+
+        # Visible pulse effect so the shield is observable on the controller.
+        if self.gameplay_stream:
+            from proto import controller_manager_pb2
+
+            trace_parent, trace_state = inject_trace_context(player.span)
+            effect_cmd = controller_manager_pb2.GameplayStreamControl(
+                game_effect=controller_manager_pb2.GameEffectCommand(
+                    serial=serial,
+                    effect=controller_manager_pb2.GAME_EFFECT_PULSE,
+                    trace_parent=trace_parent,
+                    trace_state=trace_state,
+                )
+            )
+            await self.gameplay_stream.write(effect_cmd)
+
+        return True
+
+    # Spawn grace applied to a revived player so they don't instantly re-die
+    # before they can stop moving (#730, N5). Mirrors Nonstop/Zombie respawn grace.
+    REVIVE_SPAWN_GRACE = 2.0
+
+    async def revive_player(self, serial: str, spawn_grace: float | None = None) -> bool:
+        """
+        Revive a dead player, re-entering them into the game (#730, N5).
+
+        Whether reviving is allowed at all in a given mode is decided by the
+        intervention manager's §9 capability matrix BEFORE this runs (it denies
+        ``revive_player`` for permanent-elimination / bracket / hidden-role
+        modes). This method only implements the actual re-entry once allowed.
+
+        Re-entry restores the player to the alive state, clears stale
+        warning/motion state, restores the controller LED to the player's color,
+        and grants a brief spawn grace (via the shield grace mechanism) so the
+        revived player can't instantly re-die. Modes with a native respawn path
+        (Nonstop ``_respawn_player``) delegate to it so their mode-specific state
+        (spawn protection, scoring) stays consistent; other modes use the generic
+        re-entry below.
+
+        Args:
+            serial: Controller serial number.
+            spawn_grace: Spawn-protection grace in seconds; defaults to
+                ``REVIVE_SPAWN_GRACE``.
+
+        Returns:
+            True if the player was revived, False if unknown / already alive.
+        """
+        player = self.players.get(serial)
+        if player is None:
+            logger.warning(f"revive_player: unknown serial {serial}, ignoring")
+            return False
+        if player.alive:
+            logger.info(f"revive_player: {serial} already alive, no-op")
+            return False
+
+        grace = self.REVIVE_SPAWN_GRACE if spawn_grace is None else spawn_grace
+
+        # Prefer a mode-native respawn path so mode-specific state stays correct.
+        native = getattr(self, "_respawn_player", None)
+        if callable(native):
+            await native(serial)
+            # Ensure spawn grace even if the native path uses its own scheme.
+            player.grace_until = max(player.grace_until, time.time() + grace)
+            logger.info(f"revive_player: {serial} revived via native respawn")
+            return True
+
+        # Generic re-entry for modes without a native respawn path.
+        player.alive = True
+        player.warning_until = 0.0
+        player.smoothed_accel = 0.0
+        player.grace_until = time.time() + grace
+
+        metrics.player_alive.labels(serial=serial).set(1)
+        alive_count = len([p for p in self.players.values() if p.alive])
+        metrics.players_alive.set(alive_count)
+
+        if player.span:
+            player.span.add_event("player_revived", attributes={"spawn_grace": grace})
+
+        if self.gameplay_stream:
+            from proto import controller_manager_pb2
+
+            trace_parent, trace_state = inject_trace_context(player.span)
+            # Restore the player's base LED color, then a respawn pulse.
+            base_color_cmd = controller_manager_pb2.GameplayStreamControl(
+                base_color=controller_manager_pb2.ControllerColorConfig(
+                    serial=serial,
+                    color=controller_manager_pb2.RGB(r=player.color[0], g=player.color[1], b=player.color[2]),
+                )
+            )
+            await self.gameplay_stream.write(base_color_cmd)
+            respawn_cmd = controller_manager_pb2.GameplayStreamControl(
+                game_effect=controller_manager_pb2.GameEffectCommand(
+                    serial=serial,
+                    effect=controller_manager_pb2.GAME_EFFECT_PLAYER_RESPAWN,
+                    trace_parent=trace_parent,
+                    trace_state=trace_state,
+                )
+            )
+            await self.gameplay_stream.write(respawn_cmd)
+
+        await self.event_publisher("player_revived", {"serial": serial})
+        logger.info(f"revive_player: {serial} revived (generic re-entry, grace {grace:.1f}s)")
+        return True
+
+    async def _kill_player(self, serial: str, accel_mag: float, reason: str = "motion"):
         """
         Kill a player (template method calling subclass implementation).
 
         Args:
             serial: Controller serial number
-            accel_mag: Acceleration magnitude that caused death
+            accel_mag: Acceleration magnitude that caused death (0.0 for
+                non-motion deaths such as agent interventions)
+            reason: What caused the death. ``"motion"`` for natural threshold
+                deaths; ``"agent_intervention"`` (#730) when the death is forced
+                by an ``eliminate_player`` agent intervention. Recorded on the
+                player_death span event so forced deaths are distinguishable from
+                natural ones while still emitting identical spans/events/metrics.
         """
         player = self.players.get(serial)
         if not player or not player.alive:
@@ -1202,6 +1366,7 @@ class BaseGameMode(ABC):
                     "sensitivity_factor": player.sensitivity_factor,
                     "music_speed": self.music_speed,
                     "alive_remaining": alive_count_before - 1,
+                    "death.reason": reason,
                 },
             )
 

--- a/services/game_coordinator/lifecycle_handlers.py
+++ b/services/game_coordinator/lifecycle_handlers.py
@@ -1,0 +1,155 @@
+"""
+Shield + lifecycle intervention handlers for JoustMania (#730, PR D).
+
+Registers the real effect handlers for the three *shield / lifecycle*
+intervention flags against the InterventionManager registry built in PR A:
+
+- ``shield_seconds``   — N3: per-serial ``targeting_key`` evaluation grants a
+  temporary shield (``grant_shield`` on ``BaseGameMode``) to each targeted
+  player with a value > 0; serials with the neutral default (0) are skipped.
+  Reverting to none expires naturally (shields simply run out — no early
+  revocation).
+- ``eliminate_player`` — N4: edge-triggered. The payload is the target serial;
+  the player is killed through the game's existing ``_kill_player`` path with
+  reason ``agent_intervention`` and accel 0.0, so spans/events/metrics fire
+  identically to natural deaths.
+- ``revive_player``    — N5: edge-triggered. The payload is the target serial;
+  the player is re-entered through ``BaseGameMode.revive_player`` (which prefers
+  a mode-native respawn path and applies brief spawn grace). Whether reviving is
+  allowed at all per mode is enforced by the manager's §9 capability matrix
+  BEFORE this handler runs.
+
+Handler contract (PR A): handlers are ``async def handler(ctx) -> None``, called
+only after the enforcement chain passes (they do NOT re-check policy), and the
+manager records the metric + publishes the EventBus event around the call. The
+handlers below mutate live game state; they are defensive (no live game / unknown
+serial / already-dead-or-alive → log + no-op) because exceptions are swallowed by
+the manager as a ``handler_error`` blocked outcome.
+
+PR D does not edit ``INTERVENTION_SPECS`` — it only attaches handlers via
+``register_handler`` (one line per flag), so the parallel ambience PR (E) does
+not conflict structurally.
+"""
+
+import logging
+
+from .interventions import InterventionContext, InterventionManager
+
+logger = logging.getLogger(__name__)
+
+# Reason recorded on the player_death span event for forced eliminations (§3 N4).
+ELIMINATE_REASON = "agent_intervention"
+# Eliminations are not motion deaths — record zero accel magnitude.
+ELIMINATE_ACCEL = 0.0
+# Neutral shield value (no shield). Matches shield_seconds none variant.
+SHIELD_NONE = 0.0
+
+
+async def handle_shield_seconds(ctx: InterventionContext, manager: InterventionManager) -> None:
+    """Grant per-player shields via per-serial targeting resolution (N3).
+
+    Uses the manager's reusable ``resolve_player_targets`` helper to evaluate the
+    flag once per active serial with ``EvaluationContext(targeting_key=serial)``.
+    Serials resolving to a value > 0 get a shield of that many seconds via
+    ``game.grant_shield`` (extend-not-shorten, with a visible pulse). Serials at
+    the neutral default (0) — or battery-gated by the helper — are skipped.
+    Reverting to none requires no action: existing shields simply expire.
+    """
+    game = ctx.game
+    if game is None:
+        logger.debug("shield_seconds: no live game, ignoring")
+        return
+
+    shields = manager.resolve_player_targets(
+        flag_key=ctx.spec.flag_key,
+        default=SHIELD_NONE,
+        game=game,
+        value_kind="float",
+        battery_gate=True,
+    )
+
+    grant = getattr(game, "grant_shield", None)
+    if not callable(grant):
+        logger.debug("shield_seconds: game has no grant_shield, ignoring")
+        return
+
+    for serial, seconds in shields.items():
+        if seconds <= SHIELD_NONE:
+            continue  # neutral default: no shield for this serial
+        await grant(serial, seconds)
+
+
+async def handle_eliminate_player(ctx: InterventionContext) -> None:
+    """Force-eliminate the targeted player through the natural kill path (N4).
+
+    The payload is the target serial. Routes through ``game._kill_player`` with
+    reason ``agent_intervention`` and accel 0.0 so the same spans, EventBus
+    events, and metrics fire as for a natural death. Defensive: no live game /
+    unknown serial / already-dead → log + no-op (``_kill_player`` itself ignores
+    unknown/dead serials, but we check first to log a clear reason).
+    """
+    game = ctx.game
+    if game is None:
+        logger.debug("eliminate_player: no live game, ignoring")
+        return
+
+    serial = (ctx.payload or ctx.target_serial or "").strip()
+    if not serial:
+        logger.warning("eliminate_player: empty target serial, ignoring")
+        return
+
+    players = getattr(game, "players", {})
+    player = players.get(serial)
+    if player is None:
+        logger.warning(f"eliminate_player: unknown serial {serial}, ignoring")
+        return
+    if not getattr(player, "alive", False):
+        logger.info(f"eliminate_player: {serial} already dead, no-op")
+        return
+
+    logger.info(f"eliminate_player: forcing elimination of {serial} ({ELIMINATE_REASON})")
+    await game._kill_player(serial, ELIMINATE_ACCEL, reason=ELIMINATE_REASON)
+
+
+async def handle_revive_player(ctx: InterventionContext) -> None:
+    """Revive the targeted player through the mode's re-entry path (N5).
+
+    The payload is the target serial. Routes through ``game.revive_player`` which
+    prefers a mode-native respawn path and grants brief spawn grace. Mode
+    eligibility is already enforced by the §9 capability matrix before this
+    handler runs. Defensive: no live game / unknown serial / already-alive → the
+    primitive logs + no-ops.
+    """
+    game = ctx.game
+    if game is None:
+        logger.debug("revive_player: no live game, ignoring")
+        return
+
+    serial = (ctx.payload or ctx.target_serial or "").strip()
+    if not serial:
+        logger.warning("revive_player: empty target serial, ignoring")
+        return
+
+    revive = getattr(game, "revive_player", None)
+    if not callable(revive):
+        logger.debug("revive_player: game has no revive_player, ignoring")
+        return
+
+    logger.info(f"revive_player: reviving {serial}")
+    await revive(serial)
+
+
+def register_lifecycle_handlers(manager: InterventionManager) -> None:
+    """Wire the shield + lifecycle handlers onto the manager (one line per flag).
+
+    Called from the servicer after the manager is constructed. Kept one-line-
+    per-flag so the parallel ambience PR (E) appends rather than conflicts.
+    """
+    # shield_seconds needs the manager (for the reusable targeting helper), so
+    # bind it via a small closure.
+    manager.register_handler(
+        "shield_seconds",
+        lambda ctx: handle_shield_seconds(ctx, manager),
+    )
+    manager.register_handler("eliminate_player", handle_eliminate_player)
+    manager.register_handler("revive_player", handle_revive_player)

--- a/services/game_coordinator/servicer.py
+++ b/services/game_coordinator/servicer.py
@@ -24,6 +24,7 @@ from services.game_coordinator.event_bus import EventBus
 from services.game_coordinator.game_factory import GameFactory
 from services.game_coordinator.grpc_clients import GrpcClientManager
 from services.game_coordinator.interventions import InterventionManager
+from services.game_coordinator.lifecycle_handlers import register_lifecycle_handlers
 
 logger = logging.getLogger(__name__)
 
@@ -85,6 +86,9 @@ class GameCoordinatorServicer(game_coordinator_pb2_grpc.GameCoordinatorServiceSe
         # Register difficulty intervention handlers (#730 PR C): music tempo
         # override, global sensitivity override, per-player sensitivity factor.
         register_difficulty_handlers(self.intervention_manager)
+        # Register shield + lifecycle intervention handlers (#730 PR D):
+        # shield_seconds (per-player grace shield), eliminate_player, revive_player.
+        register_lifecycle_handlers(self.intervention_manager)
         self.intervention_manager.start()
 
         logger.info("GameCoordinator initialized")

--- a/services/game_coordinator/tests/test_lifecycle_interventions.py
+++ b/services/game_coordinator/tests/test_lifecycle_interventions.py
@@ -1,0 +1,352 @@
+"""
+Unit tests for the shield + lifecycle intervention handlers (#730, PR D).
+
+Covers the three shield/lifecycle interventions and the BaseGameMode primitives
+they drive:
+
+- grant_shield (BaseGameMode): sets grace_until, sends a visible pulse effect,
+  and extends-not-shortens an existing shield; defensive on unknown/dead player.
+- shield_seconds handler: per-serial targeting (targeted serials shielded,
+  value-0 default skipped), battery-gated skip, no-live-game no-op.
+- eliminate_player handler: routes through _kill_player with reason
+  ``agent_intervention`` + accel 0.0; defensive on unknown / already-dead /
+  empty serial / no game.
+- revive_player handler + revive_player primitive: native respawn path (Nonstop),
+  generic re-entry with spawn grace, defensive on unknown / already-alive.
+
+Telemetry is disabled via conftest; the intervention metric is patched per the
+repo metric-testing convention (.claude/rules/development.md).
+"""
+
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+# Setup paths for imports
+test_dir = Path(__file__).parent
+service_dir = test_dir.parent
+project_root = service_dir.parent.parent
+sys.path.insert(0, str(project_root))
+sys.path.insert(0, str(test_dir))
+
+from conftest import MockControllerManagerService, async_noop
+
+from proto import controller_manager_pb2
+from services.game_coordinator.games.base import Player
+from services.game_coordinator.games.ffa import FFAGame
+from services.game_coordinator.games.nonstop_joust import NonstopJoustGame
+from services.game_coordinator.interventions import (
+    INTERVENTION_SPECS,
+    InterventionContext,
+    InterventionManager,
+)
+from services.game_coordinator.lifecycle_handlers import (
+    ELIMINATE_REASON,
+    handle_eliminate_player,
+    handle_revive_player,
+    handle_shield_seconds,
+    register_lifecycle_handlers,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures / fakes
+# --------------------------------------------------------------------------- #
+class RecordingGameplayStream:
+    """Gameplay stream mock that records every written GameplayStreamControl."""
+
+    def __init__(self):
+        self.writes = []
+
+    async def write(self, message):
+        self.writes.append(message)
+
+    def effects(self):
+        """Return the list of GameEffectCommand effect enums written."""
+        return [m.game_effect.effect for m in self.writes if m.HasField("game_effect")]
+
+
+def make_ffa_game(num_players=2, record_stream=True):
+    """Build a real FFAGame with a recording gameplay stream."""
+    mock_cm = MockControllerManagerService(num_controllers=num_players)
+    game = FFAGame(
+        controller_manager_client=mock_cm,
+        event_publisher=async_noop,
+        audio_client=None,
+        game_id="test_lifecycle_ffa",
+    )
+    if record_stream:
+        game.gameplay_stream = RecordingGameplayStream()
+    for i in range(num_players):
+        s = f"p{i + 1}"
+        game.players[s] = Player(serial=s, alive=True, color=(255, 0, 0))
+    return game
+
+
+def make_nonstop_game(num_players=2):
+    """Build a real NonstopJoustGame with initialized players + recording stream."""
+    mock_cm = MockControllerManagerService(num_controllers=num_players)
+    game = NonstopJoustGame(
+        controller_manager_client=mock_cm,
+        event_publisher=async_noop,
+        audio_client=None,
+        game_id="test_lifecycle_nonstop",
+    )
+    game.gameplay_stream = RecordingGameplayStream()
+    return game, mock_cm
+
+
+class TargetingFlagClient:
+    """Flag client resolving per-serial via EvaluationContext.targeting_key."""
+
+    def __init__(self, default, per_serial=None):
+        self.default = default
+        self.per_serial = per_serial or {}
+
+    def _resolve(self, ctx, default):
+        key = getattr(ctx, "targeting_key", None) if ctx is not None else None
+        if key in self.per_serial:
+            return self.per_serial[key]
+        return self.default if self.default is not None else default
+
+    def get_float_value(self, _key, default, ctx=None):
+        return float(self._resolve(ctx, default))
+
+    def get_integer_value(self, _key, default, ctx=None):
+        return int(self._resolve(ctx, default))
+
+
+class _AgentStub:
+    def __init__(self, threshold):
+        self._threshold = threshold
+
+    def get_integer_value(self, key, default, _ctx=None):
+        if key == "policy.battery_threshold":
+            return self._threshold
+        return default
+
+    def get_object_value(self, _key, default, _ctx=None):
+        return default
+
+
+def make_manager(game=None, battery=None, threshold=20):
+    """Manager bypassing start(); records published events."""
+    events = []
+
+    async def publisher(event_type, data):
+        events.append((event_type, data))
+
+    mgr = InterventionManager(
+        event_publisher=publisher,
+        get_game=lambda: game,
+        battery_provider=(lambda s: battery.get(s)) if battery is not None else None,
+    )
+    mgr._agent_client = _AgentStub(threshold)
+    return mgr, events
+
+
+def _spec(flag_key):
+    return next(s for s in INTERVENTION_SPECS if s.flag_key == flag_key)
+
+
+def make_ctx(flag_key, value, game, *, payload="", target=None):
+    return InterventionContext(
+        spec=_spec(flag_key),
+        value=value,
+        payload=payload,
+        target_serial=target,
+        game=game,
+        objective="balanced",
+    )
+
+
+# --------------------------------------------------------------------------- #
+# grant_shield primitive (BaseGameMode)
+# --------------------------------------------------------------------------- #
+class TestGrantShieldPrimitive:
+    @pytest.mark.asyncio
+    async def test_sets_grace_and_pulse(self):
+        game = make_ffa_game()
+        before = time.time()
+        granted = await game.grant_shield("p1", 5.0)
+        assert granted is True
+        # grace_until pushed roughly 5s into the future.
+        assert game.players["p1"].grace_until >= before + 4.5
+        # A visible pulse effect was sent.
+        assert controller_manager_pb2.GAME_EFFECT_PULSE in game.gameplay_stream.effects()
+
+    @pytest.mark.asyncio
+    async def test_extends_not_shortens(self):
+        game = make_ffa_game()
+        await game.grant_shield("p1", 10.0)
+        long_grace = game.players["p1"].grace_until
+        # A shorter shield must NOT pull the longer grace in.
+        await game.grant_shield("p1", 1.0)
+        assert game.players["p1"].grace_until == pytest.approx(long_grace)
+
+    @pytest.mark.asyncio
+    async def test_extends_when_longer(self):
+        game = make_ffa_game()
+        await game.grant_shield("p1", 1.0)
+        short_grace = game.players["p1"].grace_until
+        await game.grant_shield("p1", 10.0)
+        assert game.players["p1"].grace_until > short_grace
+
+    @pytest.mark.asyncio
+    async def test_unknown_or_dead_or_nonpositive_is_noop(self):
+        game = make_ffa_game()
+        assert await game.grant_shield("nope", 5.0) is False
+        assert await game.grant_shield("p1", 0.0) is False
+        game.players["p1"].alive = False
+        assert await game.grant_shield("p1", 5.0) is False
+
+
+# --------------------------------------------------------------------------- #
+# shield_seconds handler
+# --------------------------------------------------------------------------- #
+class TestShieldSecondsHandler:
+    @pytest.mark.asyncio
+    async def test_shields_only_targeted_serials(self):
+        game = make_ffa_game(num_players=3)
+        mgr, _ = make_manager(game=game)
+        # p1 gets a 5s shield; p2/p3 resolve to the neutral default (0).
+        mgr._interventions_client = TargetingFlagClient(default=0, per_serial={"p1": 5})
+
+        before = time.time()
+        await handle_shield_seconds(make_ctx("shield_seconds", 5, game), mgr)
+
+        assert game.players["p1"].grace_until >= before + 4.5
+        assert game.players["p2"].grace_until == 0.0
+        assert game.players["p3"].grace_until == 0.0
+
+    @pytest.mark.asyncio
+    async def test_battery_gated_serial_skipped(self):
+        game = make_ffa_game(num_players=2)
+        # p2 below threshold -> dropped by resolve_player_targets entirely.
+        mgr, _ = make_manager(game=game, battery={"p1": 90, "p2": 5}, threshold=20)
+        mgr._interventions_client = TargetingFlagClient(default=0, per_serial={"p1": 5, "p2": 5})
+
+        await handle_shield_seconds(make_ctx("shield_seconds", 5, game), mgr)
+        assert game.players["p1"].grace_until > 0.0
+        assert game.players["p2"].grace_until == 0.0
+
+    @pytest.mark.asyncio
+    async def test_no_live_game_is_noop(self):
+        mgr, _ = make_manager(game=None)
+        mgr._interventions_client = TargetingFlagClient(default=0)
+        await handle_shield_seconds(make_ctx("shield_seconds", 5, None), mgr)  # no raise
+
+
+# --------------------------------------------------------------------------- #
+# eliminate_player handler
+# --------------------------------------------------------------------------- #
+class TestEliminatePlayerHandler:
+    @pytest.mark.asyncio
+    async def test_kills_via_kill_player_with_agent_reason(self):
+        game = make_ffa_game(num_players=2)
+        captured = {}
+        orig_kill = game._kill_player
+
+        async def spy_kill(serial, accel_mag, reason="motion"):
+            captured["serial"] = serial
+            captured["accel_mag"] = accel_mag
+            captured["reason"] = reason
+            await orig_kill(serial, accel_mag, reason)
+
+        game._kill_player = spy_kill
+
+        await handle_eliminate_player(make_ctx("eliminate_player", "n1:p1", game, payload="p1", target="p1"))
+
+        assert captured["serial"] == "p1"
+        assert captured["accel_mag"] == 0.0
+        assert captured["reason"] == ELIMINATE_REASON
+        assert game.players["p1"].alive is False
+
+    @pytest.mark.asyncio
+    async def test_defensive_paths(self):
+        game = make_ffa_game(num_players=1)
+        calls = []
+        orig = game._kill_player
+
+        async def counting_kill(serial, accel_mag, reason="motion"):
+            calls.append(serial)
+            await orig(serial, accel_mag, reason)
+
+        game._kill_player = counting_kill
+
+        # Unknown serial -> no kill.
+        await handle_eliminate_player(make_ctx("eliminate_player", "", game, payload="ghost"))
+        # Empty serial -> no kill.
+        await handle_eliminate_player(make_ctx("eliminate_player", "", game, payload=""))
+        # Already dead -> no kill.
+        game.players["p1"].alive = False
+        await handle_eliminate_player(make_ctx("eliminate_player", "", game, payload="p1"))
+        # No game -> no raise.
+        await handle_eliminate_player(make_ctx("eliminate_player", "", None, payload="p1"))
+
+        assert calls == []
+
+
+# --------------------------------------------------------------------------- #
+# revive_player handler + primitive
+# --------------------------------------------------------------------------- #
+class TestRevivePlayer:
+    @pytest.mark.asyncio
+    async def test_revive_in_respawn_mode_uses_native_path(self):
+        game, mock_cm = make_nonstop_game(num_players=2)
+        await game._initialize_players_impl(mock_cm.controllers)
+        serial = next(iter(game.players))
+        game.players[serial].alive = False
+
+        before = time.time()
+        await handle_revive_player(make_ctx("revive_player", "", game, payload=serial))
+
+        player = game.players[serial]
+        assert player.alive is True
+        # Native respawn applies spawn protection; revive ensures spawn grace too.
+        assert player.grace_until >= before
+
+    @pytest.mark.asyncio
+    async def test_generic_reentry_grants_spawn_grace(self):
+        # FFA has no _respawn_player -> generic re-entry path.
+        game = make_ffa_game(num_players=2)
+        assert not hasattr(game, "_respawn_player")
+        game.players["p1"].alive = False
+
+        before = time.time()
+        revived = await game.revive_player("p1")
+        assert revived is True
+        player = game.players["p1"]
+        assert player.alive is True
+        assert player.grace_until >= before + 1.5  # REVIVE_SPAWN_GRACE ~2.0
+        # LED restored to base color + respawn effect emitted.
+        effects = game.gameplay_stream.effects()
+        assert controller_manager_pb2.GAME_EFFECT_PLAYER_RESPAWN in effects
+        assert any(m.HasField("base_color") for m in game.gameplay_stream.writes)
+
+    @pytest.mark.asyncio
+    async def test_defensive_unknown_and_already_alive(self):
+        game = make_ffa_game(num_players=1)
+        # Unknown serial.
+        assert await game.revive_player("ghost") is False
+        # Already alive.
+        assert game.players["p1"].alive is True
+        assert await game.revive_player("p1") is False
+        # Handler no-ops with no game.
+        await handle_revive_player(make_ctx("revive_player", "", None, payload="p1"))  # no raise
+        # Handler no-ops with empty serial.
+        await handle_revive_player(make_ctx("revive_player", "", game, payload=""))  # no raise
+
+
+# --------------------------------------------------------------------------- #
+# registration wiring
+# --------------------------------------------------------------------------- #
+class TestRegistration:
+    def test_register_lifecycle_handlers_wires_all_three(self):
+        mgr, _ = make_manager()
+        register_lifecycle_handlers(mgr)
+        for flag in ("shield_seconds", "eliminate_player", "revive_player"):
+            handler = mgr._handlers[flag]
+            assert handler is not mgr._noop_handler


### PR DESCRIPTION
## Summary

**PR D** of the stacked #730 plan — the **shield + lifecycle interventions**: real handlers for the three shield/lifecycle flags. **Stacked on #756** (PR C, difficulty interventions); this PR targets `feat/730-difficulty-interventions`, **not** `main`.

Implements N3/N4/N5 from [722-intervention-surface](docs/research/722-intervention-surface.md) §2/§3/§9 by attaching handlers to PR A's registry — no edits to `INTERVENTION_SPECS`, no enforcement-chain changes. A sibling PR E (ambient interventions) runs in parallel against PR #755's branch; `interventions.py` is untouched here so the two stay additive.

## What this adds

- **`games/base.py`** (primitives + reason arg):
  - **`grant_shield(serial, seconds)`** — N3. Sets `player.grace_until` (the per-frame check at `_process_controller_state` already skips death/warning while in grace) with **extend-not-shorten** semantics, plus a visible `GAME_EFFECT_PULSE` so the shield is observable. FFA-first per §3 but lives on `BaseGameMode` so every mode inherits it; mode opt-outs are the manager's §9 capability matrix (the primitive does not re-check mode).
  - **`revive_player(serial)`** — N5. Re-enters a dead player: prefers a mode-native respawn path (Nonstop `_respawn_player`), else generic re-entry (alive, LED restored to base color, brief spawn grace via `grace_until`) so they can't instantly re-die.
  - **`_kill_player(..., reason="motion")`** — records `death.reason` on the `player_death` span event so agent-forced eliminations are distinguishable while emitting identical spans/events/metrics.

- **`lifecycle_handlers.py`** (new) + servicer wiring:
  - `shield_seconds` → per-serial targeting via `manager.resolve_player_targets` (PR C's reusable helper); serials with value > 0 get `grant_shield`, neutral-default (0) and battery-gated serials skipped. Revert-to-none expires naturally (no early revocation).
  - `eliminate_player` (edge) → payload = serial; routes through `_kill_player` with reason `agent_intervention` + accel 0.0. Defensive on unknown / already-dead / empty serial.
  - `revive_player` (edge) → payload = serial; routes through `game.revive_player`. Mode eligibility is enforced by the §9 matrix before the handler runs.
  - `register_lifecycle_handlers(manager)` — one `register_handler` line per flag (so the ambience PR E appends without structural conflict), wired in the servicer after `register_difficulty_handlers`.

## Test plan

`cd services/game_coordinator && uv run --extra test pytest` — 13 new tests + full suite **735 passed**. `make lint` clean.

Covered: grant_shield (grace + pulse + extend-not-shorten + defensive); shield_seconds via targeting (targeted only, value-0 skipped, battery-gated skipped, no-game); eliminate_player through `_kill_player` with `agent_intervention` reason + defensive paths; revive in Nonstop (native path) + FFA generic re-entry grace/LED + defensive paths; registration wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)