### PR TITLE
feat: full flag and decision attribution on decision spans (#729)

### DIFF
--- a/services/agent/README.md
+++ b/services/agent/README.md
@@ -202,24 +202,70 @@ including decisions that end up *blocked*. Idle evaluations cost no spans.
 Blocked actions are recorded (`decision.blocked = true` on both the decision
 and action spans, ActionSink **not** called), never silently dropped.
 
-### Decision-span attributes
+### Decision-span attributes (#724 + #729)
 
-Every `agent.decision` span always carries the **full** schema; subsystems that
-do not exist yet contribute explicit placeholders so the trace shows its
-complete shape from day one:
+Every `agent.decision` span always carries the **full** schema. Issue #729 lifts
+the cycle's entire `LayerState` (every flag evaluated this cycle) onto the span
+verbatim, so a single Jaeger trace answers: **which flags were in effect, which
+backend decided, which objective was served, why this action, and was it
+permitted.** Subsystems that do not exist yet contribute explicit placeholders so
+the trace shows its complete shape from day one.
+
+**Cycle-level flag attribution** (lifted from `LayerState`, same on every
+decision in the cycle):
+
+| Attribute | Source | Today | Real value arrives with |
+|-----------|--------|-------|-------------------------|
+| `agent.enabled` | existence flag `enabled` | live bool | — |
+| `agent.mode` | existence flag `mode` | `"rules"` | LLM backend (M4) |
+| `agent.objectives` | objective flag `objectives` | sorted `k=v` weights / `"unset"` | — |
+| `agent.model` | capability flag `model` | live (e.g. `"phi4-mini"`) | consumed by M4 |
+| `agent.prompt_variant` | capability flag `prompt_variant` | live | consumed by M4 |
+| `interventions.allowed` | permission flag `interventions_allowed` | `"none"` / `a,b,c` | — |
+| `policy.battery_threshold` | policy flag | live int | — |
+| `policy.movement_variance_window` | policy flag | live int | — |
+| `policy.max_interventions_per_minute` | policy flag | live int | — |
+| `inference.configured` | the `model` flag value | live (e.g. `"phi4-mini"`) | — |
+| `inference.used` | the engine that ran | `"rules"` | `"llm"` once M4 lands |
+| `inference.fallback_reason` | why `llm` fell back | `"llm_path_not_implemented"` when `mode=llm`, else `""` | empties once M4 lands |
+| `fitness.evaluated` (cycle) | `LayerState.FitnessEvaluated` | **absent** | #731 (see below) |
+| `gen_ai.agent.name` | agent identity | `"joustmania-agent"` | — |
+
+**Per-decision attribution** (one decision per `agent.decision` span):
 
 | Attribute | Today | Real value arrives with |
 |-----------|-------|-------------------------|
-| `agent.mode` | `"rules"` | LLM backend issue |
-| `agent.objectives` | `"unset"` | #725 / #731 |
-| `interventions.allowed` | `"unrestricted"` | #725 (flagd) |
-| `inference.configured` / `inference.used` | `"none"` | LLM backend |
-| `inference.fallback_reason` | `""` | LLM backend |
 | `decision.action` / `decision.reason` | real (rules/probe) | — |
-| `decision.objective_served` | `"unset"` | #731 |
-| `decision.blocked` | from `Permissions.Allowed()` | #725 |
-| `fitness.evaluated` | `[]` | #731 |
-| `gen_ai.agent.name` | `"joustmania-agent"` | — |
+| `decision.objective_served` | the objective the rule served / `"unset"` | — |
+| `decision.blocked` | from the permission chain | — |
+| `decision.block_reason` | `not_allowed` / `battery_threshold` / `rate_limit` (only when blocked) | — |
+| `fitness.evaluated` (per-decision) | the rule's evaluated fitness values (`[]` until rules populate them) | #731 |
+
+The attribution attaches where **both** the rules and (future M4) LLM paths
+converge (`decisionAttributes`, fed by the shared `LayerState`), so it is
+path-agnostic — it works for the LLM path automatically once M4 lands.
+
+#### Kill-switch trace (`agent.disabled`)
+
+When the existence layer reports the agent **off** (`enabled=false`) the loop
+short-circuits before any rules run, but still emits a **throttled** kill-switch
+trace so "agent off" is visible in Jaeger: a root `agent.span_received` with a
+single `agent.disabled` child (no `agent.action` child — nothing was decided)
+carrying the same cycle-level flag attribution above (`agent.enabled=false`, the
+capability and permission flags that were in effect). Throttled to one per second
+so a disabled agent under heavy signal load does not flood the trace backend.
+
+#### `fitness.evaluated` hook for #731
+
+`LayerState.FitnessEvaluated` (`map[string]float64`) is the cycle-level hook
+#731 populates with fitness-function results (e.g. `session_duration`,
+`target_session_seconds`). It is **empty/absent until #731**: when non-empty it
+is lifted onto the decision (and disabled) span as the `fitness.evaluated`
+attribute, rendered as a sorted `k=v` string slice. #731 only needs to fill the
+map on the returned `LayerState` (or have the rules engine stamp it) — the
+span-attribute wiring is already in place. Per-decision fitness already rides on
+`Decision.Fitness` and the per-decision `fitness.evaluated` attribute; this is
+the cycle-wide companion.
 
 ### Semantic conventions
 

--- a/services/agent/decision/attribution_test.go
+++ b/services/agent/decision/attribution_test.go
@@ -1,0 +1,237 @@
+package decision
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"github.com/joustmania/agent/flags"
+	"github.com/joustmania/agent/gamecontext"
+)
+
+// recordingLoop builds a Loop over the given flag snapshot with a recording
+// tracer, a fixed-decision rules engine, and a no-op action sink. It is the
+// #729 span-attribution fixture: drive a cycle, then read the spans back.
+func recordingLoop(t *testing.T, snap flags.Snapshot, out []Decision) (*Loop, *tracetest.SpanRecorder) {
+	t.Helper()
+	sr := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+	l := NewLoop(&settableFlags{snap: snap}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	l.Tracer = tp.Tracer("test")
+	l.Rules = fakeRules{out: out}
+	l.Actions = &fakeSink{}
+	return l, sr
+}
+
+// TestDecisionSpan_FullFlagSetLifted is the core #729 assertion: every flag
+// evaluated this cycle appears on the agent.decision span. A single trace must
+// answer which flags were in effect.
+func TestDecisionSpan_FullFlagSetLifted(t *testing.T) {
+	snap := flags.Snapshot{
+		Enabled:    true,
+		Mode:       "rules",
+		Objectives: map[string]float64{"endurance": 0.6, "chaos": 0.4},
+		Capability: flags.Capability{Model: "gemma3:4b", PromptVariant: "balanced"},
+		InterventionsAllowed: []string{
+			"grant_shield", "play_audio_cue",
+		},
+		Policy: flags.Policy{
+			BatteryThreshold:          25,
+			MovementVarianceWindow:    12,
+			MaxInterventionsPerMinute: 3,
+		},
+	}
+	l, sr := recordingLoop(t, snap, []Decision{{
+		Intervention:    "grant_shield",
+		Reason:          "balance the field",
+		ObjectiveServed: "balanced",
+		Objectives:      map[string]float64{"endurance": 0.6, "chaos": 0.4},
+	}})
+
+	l.OnEvaluate(context.Background(), gamecontext.GameContext{SessionID: "s1"}, testTrigger())
+
+	dec := spansByName(sr.Ended(), SpanDecision)[0]
+
+	wantStr := map[string]string{
+		AttrEnabled:              "true",
+		AttrMode:                 "rules",
+		AttrObjectives:           "chaos=0.4,endurance=0.6",
+		AttrModel:                "gemma3:4b",
+		AttrPromptVariant:        "balanced",
+		AttrInferenceConfigured:  "gemma3:4b",
+		AttrInferenceUsed:        InferenceRules,
+		AttrInferenceFallback:    "",
+		AttrInterventionsAllowed: "grant_shield,play_audio_cue",
+		AttrDecisionAction:       "grant_shield",
+		AttrDecisionReason:       "balance the field",
+		AttrDecisionObjective:    "balanced",
+	}
+	for key, expected := range wantStr {
+		if v, ok := attrValue(dec, key); !ok || v.Emit() != expected {
+			t.Errorf("attr %s = %q (present=%v), want %q", key, v.Emit(), ok, expected)
+		}
+	}
+	wantInt := map[string]int64{
+		AttrPolicyBatteryThreshold:       25,
+		AttrPolicyMovementVarianceWindow: 12,
+		AttrPolicyMaxPerMinute:           3,
+	}
+	for key, expected := range wantInt {
+		if v, ok := attrValue(dec, key); !ok || v.AsInt64() != expected {
+			t.Errorf("attr %s = %d (present=%v), want %d", key, v.AsInt64(), ok, expected)
+		}
+	}
+	if v, ok := attrValue(dec, AttrDecisionBlocked); !ok || v.AsBool() {
+		t.Errorf("decision.blocked = %v, want false", v.AsBool())
+	}
+}
+
+// TestDecisionSpan_BlockedAttribution: a blocked decision carries
+// decision.blocked=true and decision.block_reason on the span (#729 acceptance).
+func TestDecisionSpan_BlockedAttribution(t *testing.T) {
+	snap := flags.Snapshot{
+		Enabled:              true,
+		Mode:                 "rules",
+		InterventionsAllowed: []string{"play_audio_cue"}, // eliminate_player not allowed
+		Policy:               flags.Policy{MaxInterventionsPerMinute: 10},
+	}
+	l, sr := recordingLoop(t, snap, []Decision{{Intervention: "eliminate_player", Reason: "x"}})
+
+	l.OnEvaluate(context.Background(), gamecontext.GameContext{}, testTrigger())
+
+	dec := spansByName(sr.Ended(), SpanDecision)[0]
+	if v, ok := attrValue(dec, AttrDecisionBlocked); !ok || !v.AsBool() {
+		t.Error("decision.blocked must be true")
+	}
+	if v, ok := attrValue(dec, AttrDecisionBlockReason); !ok || v.AsString() != string(ReasonNotAllowed) {
+		t.Errorf("decision.block_reason = %q, want %q", v.AsString(), ReasonNotAllowed)
+	}
+}
+
+// TestDisabledSpan_EmittedWithFlagAttribution: the kill switch (enabled=false)
+// still emits a trace showing "agent off" with the flags in effect (#729 §4).
+func TestDisabledSpan_EmittedWithFlagAttribution(t *testing.T) {
+	snap := flags.Snapshot{
+		Enabled:    false,
+		Mode:       "rules",
+		Capability: flags.Capability{Model: "phi4-mini", PromptVariant: "conservative"},
+		Policy:     flags.Policy{BatteryThreshold: 20, MaxInterventionsPerMinute: 2},
+	}
+	// Rules would return a decision, but the disabled path must short-circuit
+	// before they run — the span must still be emitted.
+	l, sr := recordingLoop(t, snap, []Decision{{Intervention: "play_audio_cue"}})
+
+	l.OnEvaluate(context.Background(), gamecontext.GameContext{SessionID: "s1"}, testTrigger())
+
+	ended := sr.Ended()
+	roots := spansByName(ended, SpanReceived)
+	disabled := spansByName(ended, SpanDisabled)
+	if len(roots) != 1 || len(disabled) != 1 {
+		t.Fatalf("spans = %d root + %d disabled, want 1/1 (no action span)", len(roots), len(disabled))
+	}
+	if len(spansByName(ended, SpanAction)) != 0 {
+		t.Error("disabled path must not emit an action span")
+	}
+	d := disabled[0]
+	if v, ok := attrValue(d, AttrEnabled); !ok || v.AsBool() {
+		t.Error("agent.enabled must be false on the disabled span")
+	}
+	if v, ok := attrValue(d, AttrModel); !ok || v.AsString() != "phi4-mini" {
+		t.Errorf("agent.model = %q, want phi4-mini (capability still recorded)", v.AsString())
+	}
+	if v, ok := attrValue(d, AttrPolicyBatteryThreshold); !ok || v.AsInt64() != 20 {
+		t.Errorf("policy.battery_threshold = %d, want 20", v.AsInt64())
+	}
+	if d.Parent().SpanID() != roots[0].SpanContext().SpanID() {
+		t.Error("disabled span must be a child of agent.span_received")
+	}
+}
+
+// TestDisabledSpan_Throttled: a disabled agent under heavy signal load emits at
+// most one kill-switch trace per throttle interval, not one per export.
+func TestDisabledSpan_Throttled(t *testing.T) {
+	snap := flags.Snapshot{Enabled: false, Mode: "rules"}
+	l, sr := recordingLoop(t, snap, nil)
+
+	for i := 0; i < 20; i++ {
+		l.OnEvaluate(context.Background(), gamecontext.GameContext{}, testTrigger())
+	}
+	if n := len(spansByName(sr.Ended(), SpanDisabled)); n != 1 {
+		t.Errorf("disabled spans = %d, want 1 (throttled)", n)
+	}
+}
+
+// TestInferenceAttribution_LLMFallback: mode=llm records the fallback to rules
+// with a reason; mode=rules records no fallback. Path-agnostic per #729 §5.
+func TestInferenceAttribution_LLMFallback(t *testing.T) {
+	tests := []struct {
+		name         string
+		mode         string
+		wantUsed     string
+		wantFallback string
+	}{
+		{name: "rules mode", mode: "rules", wantUsed: InferenceRules, wantFallback: ""},
+		{name: "llm mode falls back", mode: "llm", wantUsed: InferenceRules, wantFallback: FallbackLLMNotImplemented},
+		{name: "unknown mode runs rules", mode: "weird", wantUsed: InferenceRules, wantFallback: ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			snap := flags.Snapshot{
+				Enabled:              true,
+				Mode:                 tc.mode,
+				Capability:           flags.Capability{Model: "phi4-mini"},
+				InterventionsAllowed: []string{"play_audio_cue"},
+				Policy:               flags.Policy{MaxInterventionsPerMinute: 10},
+			}
+			l, sr := recordingLoop(t, snap, []Decision{{Intervention: "play_audio_cue"}})
+
+			l.OnEvaluate(context.Background(), gamecontext.GameContext{}, testTrigger())
+
+			dec := spansByName(sr.Ended(), SpanDecision)[0]
+			if v, ok := attrValue(dec, AttrInferenceConfigured); !ok || v.AsString() != "phi4-mini" {
+				t.Errorf("inference.configured = %q, want phi4-mini", v.AsString())
+			}
+			if v, ok := attrValue(dec, AttrInferenceUsed); !ok || v.AsString() != tc.wantUsed {
+				t.Errorf("inference.used = %q, want %q", v.AsString(), tc.wantUsed)
+			}
+			if v, ok := attrValue(dec, AttrInferenceFallback); !ok || v.AsString() != tc.wantFallback {
+				t.Errorf("inference.fallback_reason = %q, want %q", v.AsString(), tc.wantFallback)
+			}
+		})
+	}
+}
+
+// TestFitnessHook_CycleLevel verifies the #731 hook: LayerState.FitnessEvaluated
+// is absent from the span when empty (the steady state until #731) and lifted as
+// fitness.evaluated when populated.
+func TestFitnessHook_CycleLevel(t *testing.T) {
+	// Empty: attribute absent (no "evaluated nothing" placeholder at cycle scope).
+	emptyAttrs := layerStateAttributes(&LayerState{Enabled: true, Mode: "rules"})
+	for _, kv := range emptyAttrs {
+		if string(kv.Key) == AttrFitnessEvaluated {
+			t.Fatalf("fitness.evaluated must be absent when FitnessEvaluated is empty")
+		}
+	}
+
+	// Populated (simulating #731): lifted as a sorted k=v slice.
+	state := &LayerState{
+		Enabled:          true,
+		Mode:             "rules",
+		FitnessEvaluated: map[string]float64{"session_duration": 95, "target_session_seconds": 60},
+	}
+	var got []string
+	for _, kv := range layerStateAttributes(state) {
+		if string(kv.Key) == AttrFitnessEvaluated {
+			got = kv.Value.AsStringSlice()
+		}
+	}
+	want := []string{"session_duration=95", "target_session_seconds=60"}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Errorf("fitness.evaluated = %v, want %v", got, want)
+	}
+}

--- a/services/agent/decision/decision.go
+++ b/services/agent/decision/decision.go
@@ -10,6 +10,8 @@
 // applies them in order:
 //
 //	Existence:  enabled    kill switch; false short-circuits the whole loop
+//	                       (a throttled agent.disabled span still records the
+//	                       evaluated flags so "agent off" is visible in traces)
 //	            mode       selects the "rules" vs "llm" decision path
 //	Objective:  objectives session-goal weights driven into the rules engine via
 //	                       a LiveObjectives source (#726 engine reads it each cycle)
@@ -167,8 +169,9 @@ func NewLoop(flagSource FlagSource, log *slog.Logger) *Loop {
 // OnEvaluate runs one evaluation pass and returns the cycle's LayerState (also
 // retained on the loop for #729). Steps:
 //  1. evaluate all four flag layers (never cached);
-//  2. existence — if enabled is false, return the disabled LayerState before
-//     any rules run or spans are emitted;
+//  2. existence — if enabled is false, emit a throttled agent.disabled span with
+//     the evaluated-flag attribution and return the disabled LayerState before
+//     any rules run;
 //  3. publish the objectives flag into the rules engine and run the rules;
 //  4. when the rules return at least one decision, emit the audit trace lazily
 //     (idle evaluations cost no spans); the root span is backdated to trig.T0 so
@@ -186,10 +189,13 @@ func (l *Loop) OnEvaluate(ctx context.Context, c gamecontext.GameContext, trig E
 	snapshot := l.Flags.Evaluate(ctx)
 	state := newLayerState(snapshot)
 
-	// Existence layer: enabled=false short-circuits before any rules evaluation
-	// or span emission. This is the safe default when flagd is unreachable. The
-	// disabled state is still recorded so #729 can show "agent off" on the span.
+	// Existence layer: enabled=false short-circuits before any rules evaluation.
+	// This is the safe default when flagd is unreachable. The disabled state is
+	// still recorded AND emitted as a throttled agent.disabled span so a Jaeger
+	// trace shows "agent off" with the flags in effect (#729). Throttled so a
+	// disabled agent under heavy signal load does not flood the trace backend.
 	if !snapshot.Enabled {
+		l.emitDisabledSpan(ctx, snapshot, c, trig, state)
 		l.setLastLayer(state)
 		return state
 	}
@@ -294,7 +300,7 @@ func (l *Loop) runDecision(ctx context.Context, snapshot flags.Snapshot, c gamec
 	reason, blocked := l.evaluatePermission(snapshot, c, d, now, cost)
 
 	dCtx, dSpan := l.Tracer.Start(ctx, SpanDecision,
-		trace.WithAttributes(decisionAttributes(snapshot, d, blocked, reason, allowed)...))
+		trace.WithAttributes(decisionAttributes(state, d, blocked, reason)...))
 	defer dSpan.End()
 
 	// The interventions.allowed evaluation as a feature_flag.* span event
@@ -338,6 +344,41 @@ func (l *Loop) runDecision(ctx context.Context, snapshot flags.Snapshot, c gamec
 		l.Log.Error("agent.apply_failed",
 			"error", err, "intervention", d.Intervention)
 	}
+}
+
+// emitDisabledSpan emits the kill-switch trace for a cycle where the existence
+// layer reported the agent off (enabled=false): a root agent.span_received with
+// a single agent.decision child (no action child — nothing was decided) carrying
+// the existence + capability + permission attribution lifted from the disabled
+// LayerState. This makes "agent off, here are the flags that were in effect"
+// visible in a Jaeger trace (#729). It is throttled to one per throttleInterval
+// (shared with the evaluate log) so a disabled agent under heavy signal load
+// does not flood the trace backend — the steady-state disabled agent is silent.
+func (l *Loop) emitDisabledSpan(ctx context.Context, snapshot flags.Snapshot, c gamecontext.GameContext, trig EvalTrigger, state LayerState) {
+	if !l.shouldLog() {
+		return
+	}
+	rootCtx, root := l.Tracer.Start(ctx, SpanReceived,
+		trace.WithTimestamp(trig.T0),
+		trace.WithSpanKind(trace.SpanKindServer),
+		trace.WithAttributes(
+			semconv.RPCSystemGRPC,
+			semconv.RPCService(trig.RPCService),
+			semconv.RPCMethod("Export"),
+			attribute.String("otlp.signal", trig.Signal),
+			attribute.String("session.id", c.SessionID),
+		),
+	)
+	defer root.End()
+
+	// One agent.disabled span carrying the full flag attribution; it is named
+	// distinctly (not agent.decision) so kill-switch traces are trivial to find
+	// in Jaeger. There is no action child because the kill switch decided
+	// nothing. AttrDecisionAction is empty (no action) and AttrDecisionBlocked is
+	// false (no decision was blocked by a permission gate — the loop never ran).
+	_, dSpan := l.Tracer.Start(rootCtx, SpanDisabled,
+		trace.WithAttributes(decisionAttributes(&state, Decision{}, false, "")...))
+	dSpan.End()
 }
 
 // evaluatePermission runs the permission chain over one decision in order:
@@ -407,39 +448,91 @@ func (l *Loop) shouldLog() bool {
 	return true
 }
 
-// decisionAttributes builds the complete #724 decision-span schema. Every span
-// carries every attribute; subsystems that do not exist yet contribute explicit
-// placeholder values (see telemetry.go). The mode, objectives, and
-// interventions.allowed values come from the evaluated flag snapshot (#727); the
-// block reason (#728) is carried when a decision is blocked so #729 sees the
-// attribution on the span as well as in the LayerState.
-func decisionAttributes(snapshot flags.Snapshot, d Decision, blocked bool, reason BlockReason, allowed []string) []attribute.KeyValue {
+// decisionAttributes builds the complete #724 + #729 decision-span schema for
+// one decision. It lifts every evaluated flag from the cycle's LayerState
+// verbatim (cycle-level: existence/capability/permission/policy), the
+// path-agnostic inference attribution, and the per-decision outcome (action,
+// reason, objective served, fitness, blocked + reason). Every span carries every
+// attribute; subsystems that do not exist yet contribute explicit placeholder
+// values (see telemetry.go). The block reason (#728) is carried only when a
+// decision is blocked.
+func decisionAttributes(state *LayerState, d Decision, blocked bool, reason BlockReason) []attribute.KeyValue {
 	objective := d.ObjectiveServed
 	if objective == "" {
 		objective = DefaultObjectives
 	}
-	mode := snapshot.Mode
-	if mode == "" {
-		mode = DefaultMode
-	}
-	attrs := []attribute.KeyValue{
-		semconv.GenAIAgentName(AgentName),
-		attribute.String(AttrMode, mode),
-		attribute.String(AttrObjectives, summarizeObjectives(d.Objectives)),
-		attribute.String(AttrInterventionsAllowed, allowedSummary(allowed)),
-		attribute.String(AttrInferenceConfigured, DefaultInference),
-		attribute.String(AttrInferenceUsed, DefaultInference),
-		attribute.String(AttrInferenceFallback, ""),
+	attrs := []attribute.KeyValue{semconv.GenAIAgentName(AgentName)}
+	// Cycle-level flag attribution: lift the whole LayerState onto the span so a
+	// single trace answers "which flags were in effect" (#729). agent.objectives
+	// is recorded there from the cycle's evaluated weights; the rules engine
+	// stamps the same normalized weights onto each Decision, so the per-decision
+	// view (d.Objectives) is identical and not re-emitted.
+	attrs = append(attrs, layerStateAttributes(state)...)
+	// Per-decision attribution: the chosen action and why.
+	attrs = append(attrs,
 		attribute.String(AttrDecisionAction, d.Intervention),
 		attribute.String(AttrDecisionReason, d.Reason),
 		attribute.String(AttrDecisionObjective, objective),
 		attribute.Bool(AttrDecisionBlocked, blocked),
 		attribute.StringSlice(AttrFitnessEvaluated, renderFitness(d.Fitness)),
-	}
+	)
 	if blocked {
 		attrs = append(attrs, attribute.String(AttrDecisionBlockReason, string(reason)))
 	}
 	return attrs
+}
+
+// layerStateAttributes lifts the cycle's evaluated flag set from the LayerState
+// onto a span verbatim — the heart of #729. It is path-agnostic (rules and the
+// M4 llm path converge on the same LayerState) and used by both the live
+// decision span and the disabled kill-switch span. Inference attribution is
+// derived from the mode: configured = the capability model flag, used = the
+// engine that actually ran (rules until M4), fallback_reason set only when
+// mode=llm fell back.
+func layerStateAttributes(state *LayerState) []attribute.KeyValue {
+	mode := state.Mode
+	if mode == "" {
+		mode = DefaultMode
+	}
+	inferenceUsed, fallback := inferenceAttribution(mode)
+	attrs := []attribute.KeyValue{
+		// Existence layer.
+		attribute.Bool(AttrEnabled, state.Enabled),
+		attribute.String(AttrMode, mode),
+		// Objective layer (cycle-wide weights as evaluated this cycle).
+		attribute.String(AttrObjectives, summarizeObjectives(state.Objectives)),
+		// Capability layer.
+		attribute.String(AttrModel, state.Model),
+		attribute.String(AttrPromptVariant, state.PromptVariant),
+		// Inference attribution (path-agnostic).
+		attribute.String(AttrInferenceConfigured, state.Model),
+		attribute.String(AttrInferenceUsed, inferenceUsed),
+		attribute.String(AttrInferenceFallback, fallback),
+		// Permission layer.
+		attribute.String(AttrInterventionsAllowed, allowedSummary(state.InterventionsAllowed)),
+		attribute.Int(AttrPolicyBatteryThreshold, state.PolicyBatteryThreshold),
+		attribute.Int(AttrPolicyMovementVarianceWindow, state.PolicyMovementVarianceWin),
+		attribute.Int(AttrPolicyMaxPerMinute, state.PolicyMaxPerMinute),
+	}
+	// Fitness layer (#731 hook): only present when populated, so the attribute
+	// stays absent until the fitness engine lands rather than carrying an
+	// empty-slice placeholder that looks like "evaluated nothing".
+	if len(state.FitnessEvaluated) > 0 {
+		attrs = append(attrs, attribute.StringSlice(AttrFitnessEvaluated, renderFitness(state.FitnessEvaluated)))
+	}
+	return attrs
+}
+
+// inferenceAttribution maps the decision mode to the inference.used /
+// inference.fallback_reason pair. mode=llm falls back to the rules engine until
+// the M4 LLM path exists, recording why; mode=rules (and any unknown mode) runs
+// rules with no fallback. inference.configured is the model flag, set by the
+// caller. Path-agnostic: once M4 lands, the llm branch returns ("llm", "").
+func inferenceAttribution(mode string) (used, fallbackReason string) {
+	if mode == "llm" {
+		return InferenceRules, FallbackLLMNotImplemented
+	}
+	return InferenceRules, ""
 }
 
 // summarizeObjectives renders the objective weights as a stable sorted "k=v"

--- a/services/agent/decision/layerstate.go
+++ b/services/agent/decision/layerstate.go
@@ -62,6 +62,15 @@ type LayerState struct {
 	PolicyMovementVarianceWin int
 	PolicyMaxPerMinute        int
 
+	// --- Fitness layer (#731 hook) ---
+	// FitnessEvaluated holds the cycle-level fitness-function results that #731
+	// will populate (e.g. session_duration, target_session_seconds). It is the
+	// span-attribute hook for fitness.evaluated at the cycle scope: empty/absent
+	// until #731 wires the fitness engine, lifted onto the decision span only
+	// when non-empty. Per-decision fitness already rides on Decision.Fitness and
+	// the per-decision fitness.evaluated attribute; this is the cycle-wide view.
+	FitnessEvaluated map[string]float64
+
 	// --- Per-decision outcomes ---
 	Candidates int
 	Dispatched int

--- a/services/agent/decision/loop_test.go
+++ b/services/agent/decision/loop_test.go
@@ -103,6 +103,7 @@ func TestOnEvaluate_NoDecisionsNoSpans(t *testing.T) {
 func TestOnEvaluate_EmitsFullHierarchy(t *testing.T) {
 	l, sr, fl := newTestLoop(t)
 	fl.snap.InterventionsAllowed = []string{"noop"}
+	fl.snap.Capability = flags.Capability{Model: "phi4-mini", PromptVariant: "conservative"}
 	sink := &fakeSink{}
 	l.Rules = fakeRules{out: []Decision{{Intervention: "noop", Reason: "test"}}}
 	l.Actions = sink
@@ -143,13 +144,18 @@ func TestOnEvaluate_EmitsFullHierarchy(t *testing.T) {
 		t.Errorf("rpc.service = %v, want %s", v.AsString(), trig.RPCService)
 	}
 
-	// Full #724 schema with placeholders on the decision span.
+	// Full #724 + #729 schema on the decision span: cycle-level flags lifted from
+	// the LayerState plus the per-decision outcome. inference.configured is the
+	// capability model flag; inference.used is the rules engine that actually ran.
 	want := map[string]string{
+		AttrEnabled:              "true",
 		AttrMode:                 DefaultMode,
 		AttrObjectives:           DefaultObjectives,
+		AttrModel:                "phi4-mini",
+		AttrPromptVariant:        "conservative",
 		AttrInterventionsAllowed: "noop",
-		AttrInferenceConfigured:  DefaultInference,
-		AttrInferenceUsed:        DefaultInference,
+		AttrInferenceConfigured:  "phi4-mini",
+		AttrInferenceUsed:        InferenceRules,
 		AttrInferenceFallback:    "",
 		AttrDecisionAction:       "noop",
 		AttrDecisionReason:       "test",
@@ -157,8 +163,25 @@ func TestOnEvaluate_EmitsFullHierarchy(t *testing.T) {
 		"gen_ai.agent.name":      AgentName,
 	}
 	for key, expected := range want {
-		if v, ok := attrValue(dec, key); !ok || v.AsString() != expected {
-			t.Errorf("decision attr %s = %q (present=%v), want %q", key, v.AsString(), ok, expected)
+		v, ok := attrValue(dec, key)
+		if !ok {
+			t.Errorf("decision attr %s missing", key)
+			continue
+		}
+		// AttrEnabled is a bool; compare via the rendered string for table reuse.
+		got := v.Emit()
+		if got != expected {
+			t.Errorf("decision attr %s = %q, want %q", key, got, expected)
+		}
+	}
+	// Policy values lift as ints.
+	for key, expected := range map[string]int64{
+		AttrPolicyBatteryThreshold:       0,
+		AttrPolicyMovementVarianceWindow: 0,
+		AttrPolicyMaxPerMinute:           100,
+	} {
+		if v, ok := attrValue(dec, key); !ok || v.AsInt64() != expected {
+			t.Errorf("decision attr %s = %d (present=%v), want %d", key, v.AsInt64(), ok, expected)
 		}
 	}
 	if v, ok := attrValue(dec, AttrDecisionBlocked); !ok || v.AsBool() {
@@ -303,7 +326,11 @@ func TestOnEvaluate_ConcurrentExportHandlers(t *testing.T) {
 }
 
 func TestOnEvaluate_RendersFitnessAndObjectives(t *testing.T) {
-	l, sr, _ := newTestLoop(t)
+	l, sr, fl := newTestLoop(t)
+	// agent.objectives is the cycle-level evaluated flag, lifted from the
+	// LayerState (#729); set it on the snapshot. The rules engine stamps the same
+	// normalized weights onto each Decision in production.
+	fl.snap.Objectives = map[string]float64{"endurance": 0.7, "balanced": 0.3}
 	l.Rules = fakeRules{out: []Decision{{
 		Intervention:    "adjust_music_tempo",
 		Reason:          "test",

--- a/services/agent/decision/telemetry.go
+++ b/services/agent/decision/telemetry.go
@@ -27,14 +27,37 @@ const (
 	SpanAction   = "agent.action"
 )
 
+// SpanDisabled is the kill-switch trace emitted when the existence layer reports
+// the agent off (enabled=false). It is a single agent.decision span (no action
+// child — nothing was decided) carrying the existence + capability attribution
+// lifted from the disabled-path LayerState, so a Jaeger trace shows "agent off"
+// with the flags that were in effect (#729). It is rate-limited to one per
+// throttleInterval so a disabled agent under heavy signal load does not flood
+// the trace backend.
+const SpanDisabled = "agent.disabled"
+
 // Custom attribute keys of the decision-span schema (issue #724). Attributes
 // covered by a semantic convention (gen_ai.agent.name, rpc.*, error.type,
 // feature_flag.*) use the semconv constants directly and are not listed here.
 const (
+	// AttrEnabled is the existence-layer kill switch (agent.enabled). Lifted from
+	// the cycle's LayerState onto every decision span (including the disabled
+	// kill-switch span) so a trace shows whether the agent was live (#729).
+	AttrEnabled = "agent.enabled"
 	// AttrMode is the inference mode driving decisions: "rules" or "llm".
 	AttrMode = "agent.mode"
 	// AttrObjectives is the objective weights being pursued (#725/#731).
 	AttrObjectives = "agent.objectives"
+	// AttrModel / AttrPromptVariant are the capability-layer selections recorded
+	// on every decision span for the M4 LLM path (#728/#729).
+	AttrModel         = "agent.model"
+	AttrPromptVariant = "agent.prompt_variant"
+	// AttrPolicyBatteryThreshold / AttrPolicyMovementVarianceWindow /
+	// AttrPolicyMaxPerMinute lift the three numeric permission-layer policy flags
+	// onto the decision span so a single trace shows the policy in effect (#729).
+	AttrPolicyBatteryThreshold       = "policy.battery_threshold"
+	AttrPolicyMovementVarianceWindow = "policy.movement_variance_window"
+	AttrPolicyMaxPerMinute           = "policy.max_interventions_per_minute"
 	// AttrInterventionsAllowed summarizes the permission list in effect. The
 	// individual flag evaluation is additionally recorded as a feature_flag.*
 	// span event (semconv) on the decision span.
@@ -69,8 +92,18 @@ const (
 	AgentName = "joustmania-agent"
 	// DefaultMode until an LLM mode exists.
 	DefaultMode = "rules"
-	// DefaultInference until an inference backend exists.
+	// DefaultInference is the #724 placeholder, retained for reference. #729
+	// supersedes inference.configured/used/fallback_reason with honest values:
+	// configured = the capability model flag, used = InferenceRules (what ran),
+	// fallback_reason = FallbackLLMNotImplemented when mode=llm fell back.
 	DefaultInference = "none"
+	// InferenceRules is inference.used on every cycle until the M4 LLM path
+	// runs: the deterministic rules engine is what actually decided.
+	InferenceRules = "rules"
+	// FallbackLLMNotImplemented is inference.fallback_reason when mode=llm is
+	// selected but the M4 LLM path does not exist and the loop falls back to the
+	// rules engine. Empty when not applicable (mode=rules).
+	FallbackLLMNotImplemented = "llm_path_not_implemented"
 	// DefaultObjectives until the objectives flag schema exists (#725).
 	DefaultObjectives = "unset"
 	// UnrestrictedAllowed is the interventions.allowed summary while the


### PR DESCRIPTION
Closes #729

**Stacked on #754** (`feat/728-flag-layers`) — this PR targets that branch, not `main`. Merge after #754.

## Summary

Makes every flag evaluation visible in traces. A single Jaeger trace now answers: *which flags were in effect, which backend decided, which objective was served, why this action, and was it permitted.*

- **Cycle-level flag lift** — every flag evaluated this cycle is lifted from the cycle's `LayerState` onto the `agent.decision` span verbatim: `agent.enabled`, `agent.mode`, `agent.objectives`, `agent.model`, `agent.prompt_variant`, `interventions.allowed`, `policy.battery_threshold`, `policy.movement_variance_window`, `policy.max_interventions_per_minute`.
- **Inference attribution** (path-agnostic, attached where the rules and future M4 LLM paths converge): `inference.configured` = the `model` flag, `inference.used` = the engine that ran (`rules`), `inference.fallback_reason` = `llm_path_not_implemented` when `mode=llm` falls back (empty otherwise).
- **Decision outcome attribution** — `decision.action`, `decision.reason`, `decision.objective_served` (from the #726 objective-weighted engine, already threaded through `Decision`), `decision.blocked`, `decision.block_reason`.
- **Kill-switch visibility** — the `enabled=false` path now emits a **throttled** `agent.disabled` trace (root `agent.span_received` + one `agent.disabled` child, no action child) carrying the same flag attribution, so "agent off" is visible in Jaeger with the flags that were in effect. Throttled to 1/sec so a disabled agent under load doesn't flood the backend.
- **`fitness.evaluated` hook for #731** — `LayerState.FitnessEvaluated map[string]float64`, absent until populated, lifted onto the span when non-empty.
- Updated the `services/agent/README.md` span-attribute table.

Naming follows the existing #724 span schema vocabulary in `telemetry.go`. `main.go`/`receiver.go` untouched (sibling Go ActionSink PR owns that surface; no `actions` package created).

## Test plan

- [x] `go test -race ./...` clean (services/agent)
- [x] `go vet ./...` clean
- [x] `gofmt -l .` clean
- [x] New `decision/attribution_test.go`: full flag set on a normal cycle; blocked decision shows `decision.blocked`+`decision.block_reason`; disabled cycle emits `agent.disabled` with `agent.enabled=false` + capability/policy flags (and is throttled); inference attribution for rules and llm-fallback modes; cycle-level fitness hook (absent when empty, lifted when populated)
- [x] Existing #724 hierarchy/objectives tests updated to the LayerState-sourced semantics
- [ ] Verified end-to-end in Jaeger on the Pi 5 — **user's manual step**

## fitness.evaluated hook contract for #731

`LayerState.FitnessEvaluated` (`map[string]float64`). #731 populates it with cycle-level fitness-function results; when non-empty it is lifted onto the decision (and disabled) span as `fitness.evaluated`, rendered as a sorted `k=v` string slice. Empty/absent until #731. Per-decision fitness already rides on `Decision.Fitness`; this is the cycle-wide companion. #731 only needs to fill the map on the returned `LayerState` — the span wiring is in place (`layerStateAttributes`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)