### PR TITLE
feat: fitness function evaluation per objective (#731)

### DIFF
--- a/services/agent/README.md
+++ b/services/agent/README.md
@@ -84,6 +84,12 @@ model**, applied in order:
      `LiveObjectives` source (`decision/objectives.go`); the engine reads it
      inside `Evaluate`, falling back to `{endurance: 1.0}` when the flag resolves
      nothing. This replaces the engine's static objective source (#726).
+   - `fitness.*` (numbers): the per-objective fitness thresholds (#731). The loop
+     publishes the per-cycle values into the engine through a `LiveFitness`
+     source (`decision/fitnesssource.go`); the engine evaluates the fitness
+     functions against the live game context each cycle and amplifies the
+     candidates serving a *failing* objective. See **[Fitness functions
+     (#731)](#fitness-functions-731)** below.
 3. **Capability** (selects the model/prompt for the M4 LLM path) —
    - `model` (string, default `phi4-mini`) and `prompt_variant` (string, default
      `conservative`). Evaluated and **recorded** every cycle; not consumed until
@@ -177,14 +183,71 @@ per second. The weighted per-minute budget is enforced downstream by the loop
   2 decisions per evaluation; `cd.cost` survives as a deterministic
   cheaper-first tie-break.
 
-**Configuration seam (#726/#727):** objectives, policy, and fitness thresholds
-come from the `ObjectivesSource` / `PolicySource` / `FitnessSource` interfaces
-(`decision/config.go`). #727 wires the **objectives** source to OpenFeature: the
-loop publishes the per-cycle `objectives` flag into a `LiveObjectives` source
-(`decision/objectives.go`) that the engine reads each evaluation, so objective
-changes take effect with no restart. Policy and fitness still run on
-`DefaultStaticConfig()` (the flagd-schema defaults) and fall back to objectives
-`{endurance: 1.0}` whenever the flag resolves nothing.
+**Configuration seam (#726/#727/#731):** objectives, policy, and fitness
+thresholds come from the `ObjectivesSource` / `PolicySource` / `FitnessSource`
+interfaces (`decision/config.go`). #727 wires the **objectives** source to
+OpenFeature: the loop publishes the per-cycle `objectives` flag into a
+`LiveObjectives` source (`decision/objectives.go`) that the engine reads each
+evaluation. #731 wires the **fitness** source the same way: the loop publishes
+the per-cycle `fitness.*` flags into a `LiveFitness` source
+(`decision/fitnesssource.go`), so threshold changes take effect on the next
+cycle with no restart. Only **policy** still runs on `DefaultStaticConfig()`
+(the flagd-schema defaults); objectives fall back to `{endurance: 1.0}` whenever
+the flag resolves nothing.
+
+## Fitness functions (#731)
+
+Fitness functions turn "is this session *succeeding* for objective X?" into
+observable, runtime-tunable numbers. The thresholds come entirely from the
+`fitness.*` flags (never code), are evaluated **every cycle** against the live
+`GameContext`, and both (a) **steer action selection** and (b) ride onto the
+decision span as `fitness.evaluated`.
+
+Three objectives have a fitness function; **chaos has none** — chaos is
+*unpredictability* by definition ([#722 research
+§4](../../docs/research/722-intervention-surface.md)), so there is no
+success/degradation target to measure. It contributes no fitness value and no
+selection pressure.
+
+Each function produces a normalized `progress` in `0..1` (1 = satisfied, 0 =
+maximally failing) and a `pressure = 1 − progress`. Functions whose required
+signals are missing are **skipped** — they emit no value rather than fabricating
+one.
+
+| Objective | Flag (threshold) | Signal | Progress |
+|-----------|------------------|--------|----------|
+| `endurance` | `fitness.endurance.min_session_seconds` (120) | `session.duration_seconds` | `duration / min`, clamped to 1 — long sessions win |
+| `balanced` | `fitness.balanced.max_skill_gap` (0.4) | spread (max−min) of per-player `skill_level` (≥ 2 known) | `1 − gap/(2·max)` — the 0.5 point is exactly at the threshold |
+| `balanced` | `fitness.balanced.spike_survival_threshold` (0.8) | derived (see below) | `survival_ratio / threshold`, clamped to 1 |
+| `accelerate` | `fitness.accelerate.target_session_seconds` (60) | `session.duration_seconds` | 1 up to the target, then `1 − overshoot/target` — overshoot = failing |
+
+**Balanced is two sub-checks** (skill gap AND spike survival). The result's
+`progress` is the *worse* of the two computable sub-checks and it is satisfied
+only when every computed sub-check passes; the result is emitted when at least
+one sub-check is computable.
+
+**Spike-survival derivation.** There is no direct "survived a spike" signal, so
+it is derived from the available per-player signals: a player **survives** when
+their `movement_variance ≤ movement_intensity` — erratic swings (variance) that
+exceed sustained effort (intensity) indicate a player thrown by spikes. The
+`survival_ratio` is `survivors / active players with both signals`; the session
+passes when `ratio ≥ spike_survival_threshold`. When no active player has both
+signals the sub-check is skipped (the gap is honest, not fabricated).
+
+**How results steer decisions.** In `scoreAndSort`, each candidate's score is
+`urgency × weight[objective] × (1 + pressure[objective])`. A satisfied,
+unevaluated, or fitness-less (chaos) objective contributes `pressure = 0` (no
+change); a maximally failing one contributes `pressure = 1` (up to double the
+effective urgency). So a failing endurance fitness amplifies the
+endurance-serving candidates and can **flip the selected winner between
+objectives** — without ever blocking a candidate outright. The cycle's full
+evaluation is retained on the engine (`LastFitness()`) and read back by the loop
+into `LayerState.FitnessEvaluated`.
+
+**Runtime tunability.** Because the thresholds are evaluated and published every
+cycle, changing a `fitness.*` flag mid-session changes the **next** cycle's
+evaluation and the resulting action selection, with no restart (covered by
+`TestLoop_MidSessionFlagChangeChangesOutcome`).
 
 ## Span schema (#724) — the trace is the audit log
 
@@ -228,7 +291,7 @@ decision in the cycle):
 | `inference.configured` | the `model` flag value | live (e.g. `"phi4-mini"`) | — |
 | `inference.used` | the engine that ran | `"rules"` | `"llm"` once M4 lands |
 | `inference.fallback_reason` | why `llm` fell back | `"llm_path_not_implemented"` when `mode=llm`, else `""` | empties once M4 lands |
-| `fitness.evaluated` (cycle) | `LayerState.FitnessEvaluated` | **absent** | #731 (see below) |
+| `fitness.evaluated` (cycle) | `LayerState.FitnessEvaluated` — dotted per-objective thresholds + results (#731) | live (e.g. `endurance.session_progress=0.5`) | — |
 | `gen_ai.agent.name` | agent identity | `"joustmania-agent"` | — |
 
 **Per-decision attribution** (one decision per `agent.decision` span):
@@ -239,7 +302,7 @@ decision in the cycle):
 | `decision.objective_served` | the objective the rule served / `"unset"` | — |
 | `decision.blocked` | from the permission chain | — |
 | `decision.block_reason` | `not_allowed` / `battery_threshold` / `rate_limit` (only when blocked) | — |
-| `fitness.evaluated` (per-decision) | the rule's evaluated fitness values (`[]` until rules populate them) | #731 |
+| `fitness.evaluated` (per-decision fallback) | the cycle-level evaluation (above) is authoritative; only Probe/Noop engines fall back to the rule's own `Decision.Fitness` | — |
 
 The attribution attaches where **both** the rules and (future M4) LLM paths
 converge (`decisionAttributes`, fed by the shared `LayerState`), so it is
@@ -255,17 +318,30 @@ carrying the same cycle-level flag attribution above (`agent.enabled=false`, the
 capability and permission flags that were in effect). Throttled to one per second
 so a disabled agent under heavy signal load does not flood the trace backend.
 
-#### `fitness.evaluated` hook for #731
+#### `fitness.evaluated` (#731)
 
-`LayerState.FitnessEvaluated` (`map[string]float64`) is the cycle-level hook
-#731 populates with fitness-function results (e.g. `session_duration`,
-`target_session_seconds`). It is **empty/absent until #731**: when non-empty it
-is lifted onto the decision (and disabled) span as the `fitness.evaluated`
-attribute, rendered as a sorted `k=v` string slice. #731 only needs to fill the
-map on the returned `LayerState` (or have the rules engine stamp it) — the
-span-attribute wiring is already in place. Per-decision fitness already rides on
-`Decision.Fitness` and the per-decision `fitness.evaluated` attribute; this is
-the cycle-wide companion.
+`LayerState.FitnessEvaluated` (`map[string]float64`) holds the cycle-level
+fitness evaluation — every threshold **and** every computed result, under dotted
+`objective.signal` keys. The loop fills it each cycle by reading the engine's
+`LastFitness().Evaluated()` and the existing span wiring lifts it onto the
+decision (and disabled) span as the `fitness.evaluated` attribute, rendered as a
+sorted `k=v` string slice. When the cycle-level evaluation is present it is
+**authoritative** for the attribute; only engines without a fitness function
+(Probe/Noop) fall back to the per-decision `Decision.Fitness` view, so the
+attribute is always present on the span.
+
+The full key vocabulary recorded on the span:
+
+```
+endurance.min_session_seconds   endurance.session_seconds   endurance.session_progress
+balanced.max_skill_gap          balanced.skill_gap          balanced.skill_gap_progress
+balanced.spike_survival_threshold  balanced.spike_survival_ratio  balanced.spike_survival_progress
+accelerate.target_session_seconds  accelerate.session_seconds  accelerate.session_progress
+```
+
+Keys for an objective whose signals were missing that cycle are simply absent
+(the function was skipped, not fabricated). chaos has no fitness function and so
+no keys.
 
 ### Semantic conventions
 

--- a/services/agent/decision/decision.go
+++ b/services/agent/decision/decision.go
@@ -113,6 +113,23 @@ type objectivePublisher interface {
 	SetObjectives(map[string]float64)
 }
 
+// fitnessPublisher is the optional seam the loop uses to push the per-cycle
+// fitness thresholds (fitness.* flags, #731) into the rules engine, mirroring
+// objectivePublisher. *ObjectiveRules (via its LiveFitness source) satisfies it;
+// engines that ignore fitness (Noop/Probe) do not.
+type fitnessPublisher interface {
+	SetFitness(FitnessThresholds)
+}
+
+// fitnessReader is the optional seam the loop uses to read back the per-cycle
+// fitness evaluation the engine computed, so the cycle-level values can be lifted
+// onto the decision span as fitness.evaluated (#731). *ObjectiveRules satisfies
+// it; engines without a fitness function do not, and the span simply carries no
+// cycle-level fitness values for them.
+type fitnessReader interface {
+	LastFitness() FitnessEvaluation
+}
+
 // EvalTrigger describes the OTLP Export that triggered an evaluation, used to
 // annotate the agent.span_received root span with rpc.* semconv attributes and
 // backdate it to the moment the Export arrived.
@@ -216,6 +233,13 @@ func (l *Loop) OnEvaluate(ctx context.Context, c gamecontext.GameContext, trig E
 	if pub, ok := l.Rules.(objectivePublisher); ok {
 		pub.SetObjectives(snapshot.Objectives)
 	}
+	// Objective layer (fitness half, #731): publish the per-cycle fitness
+	// thresholds so the engine's fitness functions score against the live flag
+	// values. Per-cycle publication is what makes a mid-session flag change take
+	// effect on the very next decision.
+	if pub, ok := l.Rules.(fitnessPublisher); ok {
+		pub.SetFitness(fitnessThresholds(snapshot.Fitness))
+	}
 
 	if l.shouldLog() {
 		l.Log.Info("agent.evaluate",
@@ -233,6 +257,18 @@ func (l *Loop) OnEvaluate(ctx context.Context, c gamecontext.GameContext, trig E
 	}
 
 	decisions := l.decide(ctx, snapshot, c)
+
+	// Lift the cycle-level fitness evaluation the engine just computed onto the
+	// LayerState so it rides the decision span as fitness.evaluated (#731). Read
+	// after decide so it reflects this cycle's thresholds and live context. This
+	// happens even on an empty-decision cycle so a future cycle-scoped consumer
+	// still sees the evaluation, but it only reaches a span when a decision emits.
+	if rd, ok := l.Rules.(fitnessReader); ok {
+		if vals := rd.LastFitness().Evaluated(); len(vals) > 0 {
+			state.FitnessEvaluated = vals
+		}
+	}
+
 	if len(decisions) == 0 {
 		l.setLastLayer(state) // no decision, no trace
 		return state
@@ -484,8 +520,17 @@ func decisionAttributes(state *LayerState, d Decision, blocked bool, reason Bloc
 		attribute.String(AttrDecisionReason, d.Reason),
 		attribute.String(AttrDecisionObjective, objective),
 		attribute.Bool(AttrDecisionBlocked, blocked),
-		attribute.StringSlice(AttrFitnessEvaluated, renderFitness(d.Fitness)),
 	)
+	// fitness.evaluated (#731): the cycle-level fitness evaluation (dotted
+	// per-objective keys) is authoritative and was already emitted by
+	// layerStateAttributes when populated. Only fall back to the per-decision
+	// rule fitness (the pre-#731 view, e.g. the rule's own session_duration) when
+	// the cycle-level evaluation is absent — engines without a fitness function
+	// (Probe/Noop) still surface what the rule recorded, and the attribute is
+	// always present on the span.
+	if len(state.FitnessEvaluated) == 0 {
+		attrs = append(attrs, attribute.StringSlice(AttrFitnessEvaluated, renderFitness(d.Fitness)))
+	}
 	if blocked {
 		attrs = append(attrs, attribute.String(AttrDecisionBlockReason, string(reason)))
 	}
@@ -590,6 +635,18 @@ type disabledFlags struct{}
 
 func (disabledFlags) Evaluate(context.Context) flags.Snapshot {
 	return flags.Snapshot{Enabled: flags.DefaultEnabled, Mode: flags.DefaultMode}
+}
+
+// fitnessThresholds converts the flag-layer fitness snapshot into the engine's
+// FitnessThresholds (the flag carries seconds as ints; the engine works in
+// float seconds). #731.
+func fitnessThresholds(f flags.Fitness) FitnessThresholds {
+	return FitnessThresholds{
+		EnduranceMinSessionSeconds:     float64(f.EnduranceMinSessionSeconds),
+		BalancedMaxSkillGap:            f.BalancedMaxSkillGap,
+		BalancedSpikeSurvivalThreshold: f.BalancedSpikeSurvivalThreshold,
+		AccelerateTargetSessionSeconds: float64(f.AccelerateTargetSessionSeconds),
+	}
 }
 
 func derefStr(p *string) string {

--- a/services/agent/decision/fitness.go
+++ b/services/agent/decision/fitness.go
@@ -1,0 +1,322 @@
+package decision
+
+import (
+	"sort"
+
+	"github.com/joustmania/agent/gamecontext"
+)
+
+// Fitness functions (#731) score the live game context against the per-objective
+// thresholds resolved from the fitness.* flags. They turn "is this session
+// succeeding for objective X?" into observable, runtime-tunable numbers that
+// steer action selection and ride onto the decision span as fitness.evaluated.
+//
+// Three objectives have a fitness function; chaos does not. chaos is
+// unpredictability by definition (docs/research/722-intervention-surface.md §4:
+// "chaos (unpredictability)"), so there is no success/degradation target to
+// measure — a chaos objective neither passes nor fails a fitness check and so
+// contributes nothing here. This is intentional, not an omission.
+//
+// Each function emits:
+//   - threshold values (so the trace records the flag in effect), and
+//   - a normalized 0..1 progress toward the objective's target, plus a
+//     satisfied bool, when the signals it needs are present.
+//
+// Missing signals are handled gracefully: a function whose required signal is
+// unknown (nil session duration, no skill levels, …) is SKIPPED — it emits
+// neither a progress value nor a satisfied flag, so the engine never fabricates
+// a fitness number from absent data.
+
+// FitnessResult is one objective's fitness evaluation for a cycle.
+type FitnessResult struct {
+	// Objective is the objective this result scores (endurance/balanced/...).
+	Objective string
+	// Evaluated is true when the required signals were present and the function
+	// ran. False means the function was skipped (missing signals) and Progress /
+	// Satisfied are meaningless.
+	Evaluated bool
+	// Progress is the normalized 0..1 progress toward satisfying the objective:
+	// 1.0 = fully satisfied, 0.0 = maximally failing. Only meaningful when
+	// Evaluated.
+	Progress float64
+	// Satisfied reports whether the objective's fitness target is currently met.
+	// Only meaningful when Evaluated.
+	Satisfied bool
+	// Pressure is 1-Progress: how strongly a failing fitness should amplify
+	// candidates serving this objective. 0 when satisfied, up to 1 when maximally
+	// failing. Only meaningful when Evaluated.
+	Pressure float64
+	// Values holds the threshold + computed signals to record on the span under
+	// dotted keys (e.g. "endurance.session_progress").
+	Values map[string]float64
+}
+
+// FitnessEvaluation is the full per-cycle fitness picture across objectives.
+type FitnessEvaluation struct {
+	// Results is keyed by objective name; only objectives whose function ran are
+	// present (chaos is never present — it has no fitness function).
+	Results map[string]FitnessResult
+}
+
+// Pressure returns the failing-fitness pressure for an objective: 0 when the
+// objective is satisfied, was not evaluated (missing signals), or has no fitness
+// function (chaos). A higher value means the objective is failing and its
+// candidates should be amplified.
+func (e FitnessEvaluation) Pressure(objective string) float64 {
+	r, ok := e.Results[objective]
+	if !ok || !r.Evaluated {
+		return 0
+	}
+	return r.Pressure
+}
+
+// Evaluated reports the cycle-level fitness values for the span's
+// fitness.evaluated attribute: every threshold and every computed signal across
+// all objectives that ran, under dotted "objective.signal" keys.
+func (e FitnessEvaluation) Evaluated() map[string]float64 {
+	out := make(map[string]float64)
+	for _, r := range e.Results {
+		for k, v := range r.Values {
+			out[k] = v
+		}
+	}
+	return out
+}
+
+// EvaluateFitness runs every objective's fitness function against the live game
+// context and the flag-resolved thresholds. Functions whose required signals are
+// missing are skipped (not present in the result), never fabricated.
+func EvaluateFitness(c gamecontext.GameContext, fit FitnessThresholds) FitnessEvaluation {
+	eval := FitnessEvaluation{Results: make(map[string]FitnessResult, 3)}
+	if r, ok := evaluateEndurance(c, fit); ok {
+		eval.Results[ObjectiveEndurance] = r
+	}
+	if r, ok := evaluateBalanced(c, fit); ok {
+		eval.Results[ObjectiveBalanced] = r
+	}
+	if r, ok := evaluateAccelerate(c, fit); ok {
+		eval.Results[ObjectiveAccelerate] = r
+	}
+	return eval
+}
+
+// evaluateEndurance: endurance wants long sessions. Progress is the session
+// duration as a fraction of the min-session target, clamped to 1.0. Satisfied
+// once the session has reached the target. Requires session duration; skipped
+// when it is unknown.
+func evaluateEndurance(c gamecontext.GameContext, fit FitnessThresholds) (FitnessResult, bool) {
+	dur := sessionDuration(c)
+	if dur < 0 || fit.EnduranceMinSessionSeconds <= 0 {
+		return FitnessResult{}, false
+	}
+	progress := clamp01(dur / fit.EnduranceMinSessionSeconds)
+	return FitnessResult{
+		Objective: ObjectiveEndurance,
+		Evaluated: true,
+		Progress:  progress,
+		Satisfied: dur >= fit.EnduranceMinSessionSeconds,
+		Pressure:  1 - progress,
+		Values: map[string]float64{
+			"endurance.min_session_seconds": fit.EnduranceMinSessionSeconds,
+			"endurance.session_seconds":     dur,
+			"endurance.session_progress":    progress,
+		},
+	}, true
+}
+
+// evaluateBalanced: balanced wants a small skill gap AND spike survival.
+//
+// Skill gap: the spread (max-min) of per-player skill_level. Satisfied when the
+// gap is within max_skill_gap. Requires at least two players with a skill level;
+// skipped otherwise.
+//
+// Spike survival: the fraction of active players who "survive" movement spikes,
+// derived from the available per-player signals. We treat a player's
+// movement_variance as the spikiness of their play; a player survives spikes
+// when their variance is bounded relative to their movement intensity — large
+// erratic swings (variance) relative to sustained effort (intensity) indicate a
+// player being thrown by spikes. survival_ratio = active survivors / active
+// players with both signals. Documented derivation: a player survives when
+// variance <= intensity (spikes do not dominate their movement); the session
+// passes when survival_ratio >= spike_survival_threshold. This part is skipped
+// when no active player has both signals, so the gap is honest rather than
+// fabricated.
+//
+// The balanced result combines both sub-checks: Progress is the lower (worse) of
+// the two sub-progresses that could be computed; Satisfied requires every
+// computed sub-check to pass. The result is emitted when at least one sub-check
+// could be computed.
+func evaluateBalanced(c gamecontext.GameContext, fit FitnessThresholds) (FitnessResult, bool) {
+	values := map[string]float64{
+		"balanced.max_skill_gap":            fit.BalancedMaxSkillGap,
+		"balanced.spike_survival_threshold": fit.BalancedSpikeSurvivalThreshold,
+	}
+	var progresses []float64
+	satisfied := true
+	computed := false
+
+	// Skill-gap sub-check.
+	if gap, ok := skillGap(c); ok {
+		computed = true
+		values["balanced.skill_gap"] = gap
+		gapProgress := skillGapProgress(gap, fit.BalancedMaxSkillGap)
+		values["balanced.skill_gap_progress"] = gapProgress
+		progresses = append(progresses, gapProgress)
+		if gap > fit.BalancedMaxSkillGap {
+			satisfied = false
+		}
+	}
+
+	// Spike-survival sub-check.
+	if ratio, ok := spikeSurvivalRatio(c); ok {
+		computed = true
+		values["balanced.spike_survival_ratio"] = ratio
+		survivalProgress := survivalProgress(ratio, fit.BalancedSpikeSurvivalThreshold)
+		values["balanced.spike_survival_progress"] = survivalProgress
+		progresses = append(progresses, survivalProgress)
+		if ratio < fit.BalancedSpikeSurvivalThreshold {
+			satisfied = false
+		}
+	}
+
+	if !computed {
+		return FitnessResult{}, false
+	}
+	progress := minFloat(progresses)
+	return FitnessResult{
+		Objective: ObjectiveBalanced,
+		Evaluated: true,
+		Progress:  progress,
+		Satisfied: satisfied,
+		Pressure:  1 - progress,
+		Values:    values,
+	}, true
+}
+
+// evaluateAccelerate: accelerate wants short sessions, so overshooting the
+// target is failing. Progress is 1.0 up to the target and decays toward 0 as the
+// session runs past it (a full target's worth past = 0). Satisfied while at or
+// under the target. Requires session duration; skipped when unknown.
+func evaluateAccelerate(c gamecontext.GameContext, fit FitnessThresholds) (FitnessResult, bool) {
+	dur := sessionDuration(c)
+	if dur < 0 || fit.AccelerateTargetSessionSeconds <= 0 {
+		return FitnessResult{}, false
+	}
+	target := fit.AccelerateTargetSessionSeconds
+	overshoot := dur - target
+	var progress float64
+	switch {
+	case overshoot <= 0:
+		progress = 1
+	default:
+		// One full target past the goal drives progress to 0.
+		progress = clamp01(1 - overshoot/target)
+	}
+	return FitnessResult{
+		Objective: ObjectiveAccelerate,
+		Evaluated: true,
+		Progress:  progress,
+		Satisfied: dur <= target,
+		Pressure:  1 - progress,
+		Values: map[string]float64{
+			"accelerate.target_session_seconds": target,
+			"accelerate.session_seconds":        dur,
+			"accelerate.session_progress":       progress,
+		},
+	}, true
+}
+
+// skillGap returns the spread (max-min) of skill levels across all players that
+// report one, and whether at least two such players exist.
+func skillGap(c gamecontext.GameContext) (float64, bool) {
+	var levels []float64
+	for _, p := range c.Players {
+		if p != nil && p.SkillLevel != nil {
+			levels = append(levels, *p.SkillLevel)
+		}
+	}
+	if len(levels) < 2 {
+		return 0, false
+	}
+	minV, maxV := levels[0], levels[0]
+	for _, v := range levels[1:] {
+		if v < minV {
+			minV = v
+		}
+		if v > maxV {
+			maxV = v
+		}
+	}
+	return maxV - minV, true
+}
+
+// skillGapProgress maps a skill gap to 0..1 progress: 1.0 at gap 0, decaying to
+// 0 as the gap reaches double the allowed maximum (so being exactly at the
+// threshold is the 0.5 boundary). A non-positive threshold means "any gap is
+// failing", returning 0.
+func skillGapProgress(gap, maxGap float64) float64 {
+	if maxGap <= 0 {
+		return 0
+	}
+	return clamp01(1 - gap/(2*maxGap))
+}
+
+// spikeSurvivalRatio derives the fraction of active players who survive movement
+// spikes from the available signals (see evaluateBalanced for the rationale): a
+// player survives when their movement_variance does not exceed their
+// movement_intensity. Returns the ratio and whether any active player had both
+// signals.
+func spikeSurvivalRatio(c gamecontext.GameContext) (float64, bool) {
+	var total, survivors int
+	for _, p := range activePlayers(c) {
+		if p.MovementVariance == nil || p.MovementIntensity == nil {
+			continue
+		}
+		total++
+		if *p.MovementVariance <= *p.MovementIntensity {
+			survivors++
+		}
+	}
+	if total == 0 {
+		return 0, false
+	}
+	return float64(survivors) / float64(total), true
+}
+
+// survivalProgress maps a survival ratio to 0..1 progress relative to its
+// threshold: the ratio scaled so that hitting the threshold yields 1.0 (fully
+// satisfied) and 0 survival yields 0. A non-positive threshold means any
+// survival passes, returning 1.0 whenever the check ran.
+func survivalProgress(ratio, threshold float64) float64 {
+	if threshold <= 0 {
+		return 1
+	}
+	return clamp01(ratio / threshold)
+}
+
+// minFloat returns the smallest value, or 1.0 for an empty slice (no computed
+// sub-check means no pressure).
+func minFloat(vs []float64) float64 {
+	if len(vs) == 0 {
+		return 1
+	}
+	m := vs[0]
+	for _, v := range vs[1:] {
+		if v < m {
+			m = v
+		}
+	}
+	return m
+}
+
+// sortedFitnessKeys returns the Values keys of an evaluation sorted, used by
+// tests to assert a stable key vocabulary.
+func sortedFitnessKeys(e FitnessEvaluation) []string {
+	seen := e.Evaluated()
+	keys := make([]string, 0, len(seen))
+	for k := range seen {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/services/agent/decision/fitness_loop_test.go
+++ b/services/agent/decision/fitness_loop_test.go
@@ -1,0 +1,159 @@
+package decision
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"math/rand/v2"
+	"testing"
+	"time"
+
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"github.com/joustmania/agent/flags"
+	"github.com/joustmania/agent/gamecontext"
+)
+
+// liveEngine builds an ObjectiveRules over LiveObjectives + LiveFitness sources
+// with an injected clock, so the loop can publish flag-driven thresholds each
+// cycle and tests can step the engine's eval interval deterministically.
+func liveEngine(weights map[string]float64, clock *time.Time) *ObjectiveRules {
+	now := func() time.Time { return *clock }
+	rng := rand.New(rand.NewPCG(1, 2))
+	r := newObjectiveRules(NewLiveObjectives(), DefaultStaticConfig(), NewLiveFitness(), now, rng)
+	r.SetObjectives(weights)
+	return r
+}
+
+// loopWithEngine wires a recording-tracer loop over a mutable flag source and
+// the given real rules engine (so the fitness publish/read seams run).
+func loopWithEngine(t *testing.T, fl *settableFlags, engine RulesEngine) (*Loop, *tracetest.SpanRecorder) {
+	t.Helper()
+	sr := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+	l := NewLoop(fl, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	l.Tracer = tp.Tracer("test")
+	l.Rules = engine
+	l.Actions = &fakeSink{}
+	return l, sr
+}
+
+// spanFitness extracts the fitness.evaluated k=v slice from the decision span.
+func spanFitness(t *testing.T, sr *tracetest.SpanRecorder) []string {
+	t.Helper()
+	decs := spansByName(sr.Ended(), SpanDecision)
+	if len(decs) == 0 {
+		t.Fatal("no decision span emitted")
+	}
+	v, ok := attrValue(decs[len(decs)-1], AttrFitnessEvaluated)
+	if !ok {
+		t.Fatal("decision span missing fitness.evaluated")
+	}
+	return v.AsStringSlice()
+}
+
+// fitnessValue scans a k=v slice for a key and returns its string value.
+func fitnessValue(kvs []string, key string) (string, bool) {
+	for _, kv := range kvs {
+		if len(kv) > len(key)+1 && kv[:len(key)] == key && kv[len(key)] == '=' {
+			return kv[len(key)+1:], true
+		}
+	}
+	return "", false
+}
+
+// firingCtx is a young session (20s) with one elimination — the endurance rule
+// always fires here, so a decision (and thus a decision span) is emitted every
+// cycle regardless of the accelerate threshold under test. The fitness functions
+// still evaluate every objective, so accelerate fitness rides the span too.
+func firingCtx() gamecontext.GameContext {
+	c := ctxWithDuration(fp(20))
+	c.Session.EliminationSequence = []string{"GONE"}
+	c.Players["A"] = &gamecontext.PlayerSignals{Serial: "A", Active: bp(true)}
+	return c
+}
+
+func enduranceFlags() flags.Snapshot {
+	return flags.Snapshot{
+		Enabled:              true,
+		Mode:                 "rules",
+		Objectives:           map[string]float64{ObjectiveEndurance: 1.0},
+		InterventionsAllowed: []string{"adjust_music_tempo", "play_audio_cue"},
+		Policy:               flags.Policy{MaxInterventionsPerMinute: 100},
+		Fitness: flags.Fitness{
+			EnduranceMinSessionSeconds:     120,
+			BalancedMaxSkillGap:            0.4,
+			BalancedSpikeSurvivalThreshold: 0.8,
+			AccelerateTargetSessionSeconds: 60,
+		},
+	}
+}
+
+// TestLoop_FitnessLiftedOntoSpan: a cycle that emits a decision carries the
+// cycle-level fitness.evaluated values (dotted keys) on the decision span (#731).
+func TestLoop_FitnessLiftedOntoSpan(t *testing.T) {
+	clock := time.Unix(10_000, 0)
+	engine := liveEngine(map[string]float64{ObjectiveEndurance: 1.0}, &clock)
+	fl := &settableFlags{snap: enduranceFlags()}
+	l, sr := loopWithEngine(t, fl, engine)
+
+	l.OnEvaluate(context.Background(), firingCtx(), testTrigger())
+
+	kvs := spanFitness(t, sr)
+	if v, ok := fitnessValue(kvs, "endurance.min_session_seconds"); !ok || v != "120" {
+		t.Errorf("endurance.min_session_seconds = %q (present=%v), want 120", v, ok)
+	}
+	if v, ok := fitnessValue(kvs, "endurance.session_seconds"); !ok || v != "20" {
+		t.Errorf("endurance.session_seconds = %q (present=%v), want 20", v, ok)
+	}
+	if v, ok := fitnessValue(kvs, "accelerate.target_session_seconds"); !ok || v != "60" {
+		t.Errorf("accelerate.target_session_seconds = %q (present=%v), want 60", v, ok)
+	}
+}
+
+// TestLoop_MidSessionFlagChangeChangesOutcome is the #731 runtime-tunability
+// acceptance test: with NOTHING changing but the accelerate target flag between
+// two cycles, the evaluated fitness on the span changes — proving the threshold
+// is read from the flag every cycle, not cached.
+func TestLoop_MidSessionFlagChangeChangesOutcome(t *testing.T) {
+	clock := time.Unix(10_000, 0)
+	engine := liveEngine(map[string]float64{ObjectiveEndurance: 1.0}, &clock)
+
+	base := enduranceFlags()
+	fl := &settableFlags{snap: base}
+	l, sr := loopWithEngine(t, fl, engine)
+
+	c := firingCtx() // 20s session, unchanged across cycles
+
+	// Cycle 1: endurance min 120s -> 20/120 -> session_progress ~0.1667.
+	l.OnEvaluate(context.Background(), c, testTrigger())
+	prog1, _ := fitnessValue(spanFitness(t, sr), "endurance.session_progress")
+	if prog1 == "" {
+		t.Fatal("cycle 1 missing endurance.session_progress")
+	}
+
+	// Mid-session flag change: lower the endurance minimum to 40s. Step the
+	// engine clock past evalInterval so the rules re-run.
+	flChanged := base
+	flChanged.Fitness.EnduranceMinSessionSeconds = 40
+	fl.snap = flChanged
+	advance(&clock, 2*time.Second)
+
+	// Cycle 2: SAME 20s session, but min is now 40s -> 20/40 -> session_progress
+	// 0.5. The evaluation changed solely because the flag changed (never cached).
+	l.OnEvaluate(context.Background(), c, testTrigger())
+	kvs2 := spanFitness(t, sr)
+	min2, _ := fitnessValue(kvs2, "endurance.min_session_seconds")
+	prog2, _ := fitnessValue(kvs2, "endurance.session_progress")
+	if min2 != "40" {
+		t.Errorf("cycle 2 endurance.min_session_seconds = %q, want 40 (flag changed)", min2)
+	}
+	if prog2 != "0.5" {
+		t.Errorf("cycle 2 endurance.session_progress = %q, want 0.5", prog2)
+	}
+	if prog1 == prog2 {
+		t.Errorf("mid-session flag change did not change the evaluated fitness (%q == %q)", prog1, prog2)
+	}
+}

--- a/services/agent/decision/fitness_test.go
+++ b/services/agent/decision/fitness_test.go
@@ -1,0 +1,253 @@
+package decision
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/joustmania/agent/gamecontext"
+)
+
+func fp(v float64) *float64 { return &v }
+func bp(v bool) *bool       { return &v }
+
+// ctxWithDuration builds a session-only context with the given duration.
+func ctxWithDuration(dur *float64) gamecontext.GameContext {
+	return gamecontext.GameContext{
+		SessionID: "s1",
+		Session:   gamecontext.SessionSignals{DurationSeconds: dur},
+		Players:   map[string]*gamecontext.PlayerSignals{},
+	}
+}
+
+func TestEvaluateEndurance(t *testing.T) {
+	fit := defaultFit() // min_session_seconds = 120
+	tests := []struct {
+		name          string
+		dur           *float64
+		wantEvaluated bool
+		wantSatisfied bool
+		wantProgress  float64
+	}{
+		{name: "missing duration skipped", dur: nil, wantEvaluated: false},
+		{name: "empty session zero progress", dur: fp(0), wantEvaluated: true, wantSatisfied: false, wantProgress: 0},
+		{name: "halfway", dur: fp(60), wantEvaluated: true, wantSatisfied: false, wantProgress: 0.5},
+		{name: "at threshold satisfied", dur: fp(120), wantEvaluated: true, wantSatisfied: true, wantProgress: 1},
+		{name: "past threshold clamped", dur: fp(300), wantEvaluated: true, wantSatisfied: true, wantProgress: 1},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r, ok := evaluateEndurance(ctxWithDuration(tc.dur), fit)
+			if ok != tc.wantEvaluated {
+				t.Fatalf("evaluated = %v, want %v", ok, tc.wantEvaluated)
+			}
+			if !ok {
+				return
+			}
+			if r.Satisfied != tc.wantSatisfied {
+				t.Errorf("satisfied = %v, want %v", r.Satisfied, tc.wantSatisfied)
+			}
+			if r.Progress != tc.wantProgress {
+				t.Errorf("progress = %v, want %v", r.Progress, tc.wantProgress)
+			}
+			if r.Pressure != 1-tc.wantProgress {
+				t.Errorf("pressure = %v, want %v", r.Pressure, 1-tc.wantProgress)
+			}
+			if r.Values["endurance.min_session_seconds"] != 120 {
+				t.Errorf("threshold not recorded: %v", r.Values)
+			}
+		})
+	}
+}
+
+func TestEvaluateAccelerate(t *testing.T) {
+	fit := defaultFit() // target_session_seconds = 60
+	tests := []struct {
+		name          string
+		dur           *float64
+		wantEvaluated bool
+		wantSatisfied bool
+		wantProgress  float64
+	}{
+		{name: "missing duration skipped", dur: nil, wantEvaluated: false},
+		{name: "under target satisfied", dur: fp(30), wantEvaluated: true, wantSatisfied: true, wantProgress: 1},
+		{name: "at target boundary", dur: fp(60), wantEvaluated: true, wantSatisfied: true, wantProgress: 1},
+		{name: "half target overshoot", dur: fp(90), wantEvaluated: true, wantSatisfied: false, wantProgress: 0.5},
+		{name: "full target overshoot fails", dur: fp(120), wantEvaluated: true, wantSatisfied: false, wantProgress: 0},
+		{name: "way past clamped to zero", dur: fp(300), wantEvaluated: true, wantSatisfied: false, wantProgress: 0},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r, ok := evaluateAccelerate(ctxWithDuration(tc.dur), fit)
+			if ok != tc.wantEvaluated {
+				t.Fatalf("evaluated = %v, want %v", ok, tc.wantEvaluated)
+			}
+			if !ok {
+				return
+			}
+			if r.Satisfied != tc.wantSatisfied {
+				t.Errorf("satisfied = %v, want %v", r.Satisfied, tc.wantSatisfied)
+			}
+			if r.Progress != tc.wantProgress {
+				t.Errorf("progress = %v, want %v", r.Progress, tc.wantProgress)
+			}
+		})
+	}
+}
+
+// playersCtx builds a context with the given players (active by default).
+func playersCtx(players ...*gamecontext.PlayerSignals) gamecontext.GameContext {
+	m := make(map[string]*gamecontext.PlayerSignals, len(players))
+	for _, p := range players {
+		if p.Active == nil {
+			p.Active = bp(true)
+		}
+		m[p.Serial] = p
+	}
+	return gamecontext.GameContext{SessionID: "s1", Players: m}
+}
+
+func TestEvaluateBalanced_SkillGap(t *testing.T) {
+	fit := defaultFit() // max_skill_gap = 0.4
+	tests := []struct {
+		name          string
+		players       []*gamecontext.PlayerSignals
+		wantEvaluated bool
+		wantSatisfied bool
+		wantGap       float64
+	}{
+		{name: "no skills skipped", players: []*gamecontext.PlayerSignals{{Serial: "a"}}, wantEvaluated: false},
+		{
+			name:          "single skill skipped",
+			players:       []*gamecontext.PlayerSignals{{Serial: "a", SkillLevel: fp(0.5)}},
+			wantEvaluated: false,
+		},
+		{
+			name: "small gap satisfied",
+			players: []*gamecontext.PlayerSignals{
+				{Serial: "a", SkillLevel: fp(0.5)}, {Serial: "b", SkillLevel: fp(0.7)},
+			},
+			wantEvaluated: true, wantSatisfied: true, wantGap: 0.2,
+		},
+		{
+			name: "gap at threshold satisfied",
+			players: []*gamecontext.PlayerSignals{
+				{Serial: "a", SkillLevel: fp(0.5)}, {Serial: "b", SkillLevel: fp(0.9)},
+			},
+			wantEvaluated: true, wantSatisfied: true, wantGap: 0.4,
+		},
+		{
+			name: "gap over threshold fails",
+			players: []*gamecontext.PlayerSignals{
+				{Serial: "a", SkillLevel: fp(0.1)}, {Serial: "b", SkillLevel: fp(0.9)},
+			},
+			wantEvaluated: true, wantSatisfied: false, wantGap: 0.8,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r, ok := evaluateBalanced(playersCtx(tc.players...), fit)
+			if ok != tc.wantEvaluated {
+				t.Fatalf("evaluated = %v, want %v", ok, tc.wantEvaluated)
+			}
+			if !ok {
+				return
+			}
+			if r.Satisfied != tc.wantSatisfied {
+				t.Errorf("satisfied = %v, want %v (values %v)", r.Satisfied, tc.wantSatisfied, r.Values)
+			}
+			if got := r.Values["balanced.skill_gap"]; got < tc.wantGap-1e-9 || got > tc.wantGap+1e-9 {
+				t.Errorf("skill_gap = %v, want %v", got, tc.wantGap)
+			}
+		})
+	}
+}
+
+func TestEvaluateBalanced_SpikeSurvival(t *testing.T) {
+	fit := defaultFit() // spike_survival_threshold = 0.8
+	// Three active players with movement signals: two survive (variance <=
+	// intensity), one does not -> ratio 2/3 = 0.667 < 0.8 -> fails survival.
+	c := playersCtx(
+		&gamecontext.PlayerSignals{Serial: "a", MovementIntensity: fp(1.0), MovementVariance: fp(0.5)},
+		&gamecontext.PlayerSignals{Serial: "b", MovementIntensity: fp(1.0), MovementVariance: fp(0.9)},
+		&gamecontext.PlayerSignals{Serial: "c", MovementIntensity: fp(1.0), MovementVariance: fp(2.0)},
+	)
+	r, ok := evaluateBalanced(c, fit)
+	if !ok {
+		t.Fatal("expected evaluation")
+	}
+	if got := r.Values["balanced.spike_survival_ratio"]; got < 0.66 || got > 0.67 {
+		t.Errorf("survival_ratio = %v, want ~0.667", got)
+	}
+	if r.Satisfied {
+		t.Error("survival 0.667 < 0.8 must fail balanced")
+	}
+}
+
+func TestEvaluateBalanced_MissingSignalsSkipped(t *testing.T) {
+	// Players are active but have neither skill nor movement signals -> nothing
+	// computable -> skipped entirely.
+	c := playersCtx(
+		&gamecontext.PlayerSignals{Serial: "a"},
+		&gamecontext.PlayerSignals{Serial: "b"},
+	)
+	if _, ok := evaluateBalanced(c, defaultFit()); ok {
+		t.Error("balanced must be skipped when no sub-check is computable")
+	}
+}
+
+func TestEvaluateFitness_EmptySession(t *testing.T) {
+	// Empty session (no duration, no players): every function is skipped, so no
+	// fitness is fabricated.
+	eval := EvaluateFitness(gamecontext.GameContext{SessionID: "s1"}, defaultFit())
+	if len(eval.Results) != 0 {
+		t.Errorf("empty session produced %d fitness results, want 0", len(eval.Results))
+	}
+	if len(eval.Evaluated()) != 0 {
+		t.Errorf("empty session produced span values, want none")
+	}
+	// chaos never has a fitness function.
+	if eval.Pressure(ObjectiveChaos) != 0 {
+		t.Error("chaos must never report fitness pressure")
+	}
+}
+
+func TestEvaluateFitness_KeyVocabulary(t *testing.T) {
+	// A fully-populated context exercises every function and pins the dotted key
+	// vocabulary recorded on the span.
+	c := playersCtx(
+		&gamecontext.PlayerSignals{Serial: "a", SkillLevel: fp(0.1), MovementIntensity: fp(1.0), MovementVariance: fp(0.5)},
+		&gamecontext.PlayerSignals{Serial: "b", SkillLevel: fp(0.9), MovementIntensity: fp(1.0), MovementVariance: fp(2.0)},
+	)
+	c.Session.DurationSeconds = fp(90)
+	eval := EvaluateFitness(c, defaultFit())
+
+	want := []string{
+		"accelerate.session_progress",
+		"accelerate.session_seconds",
+		"accelerate.target_session_seconds",
+		"balanced.max_skill_gap",
+		"balanced.skill_gap",
+		"balanced.skill_gap_progress",
+		"balanced.spike_survival_progress",
+		"balanced.spike_survival_ratio",
+		"balanced.spike_survival_threshold",
+		"endurance.min_session_seconds",
+		"endurance.session_progress",
+		"endurance.session_seconds",
+	}
+	if got := sortedFitnessKeys(eval); !reflect.DeepEqual(got, want) {
+		t.Errorf("fitness key vocabulary =\n%v\nwant\n%v", got, want)
+	}
+}
+
+func TestFitnessPressure_FailingObjective(t *testing.T) {
+	// A young session fails endurance (progress < 1 -> pressure > 0) and passes
+	// accelerate (under target -> pressure 0).
+	eval := EvaluateFitness(ctxWithDuration(fp(30)), defaultFit())
+	if p := eval.Pressure(ObjectiveEndurance); p <= 0 {
+		t.Errorf("endurance pressure = %v, want > 0 (failing)", p)
+	}
+	if p := eval.Pressure(ObjectiveAccelerate); p != 0 {
+		t.Errorf("accelerate pressure = %v, want 0 (satisfied)", p)
+	}
+}

--- a/services/agent/decision/fitnesssource.go
+++ b/services/agent/decision/fitnesssource.go
@@ -1,0 +1,44 @@
+package decision
+
+import "sync"
+
+// LiveFitness is a goroutine-safe FitnessSource whose value the decision loop
+// refreshes every cycle from the evaluated fitness.* flags (#731). The rules
+// engine reads it inside Evaluate, so changing a fitness threshold takes effect
+// on the next decision with no restart. Until the loop publishes the first
+// value, it serves the flagd-schema defaults so the engine is never thresholdless.
+type LiveFitness struct {
+	mu        sync.RWMutex
+	threshold FitnessThresholds
+}
+
+// NewLiveFitness builds a source seeded with the flagd-schema default
+// thresholds (so the engine has sane values before the first flag publication).
+func NewLiveFitness() *LiveFitness {
+	return &LiveFitness{threshold: DefaultStaticConfig().FitnessThresholds}
+}
+
+// Set replaces the published fitness thresholds.
+func (f *LiveFitness) Set(t FitnessThresholds) {
+	f.mu.Lock()
+	f.threshold = t
+	f.mu.Unlock()
+}
+
+// Fitness implements FitnessSource, returning the current thresholds.
+func (f *LiveFitness) Fitness() FitnessThresholds {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	return f.threshold
+}
+
+// SetFitness lets the decision loop publish the per-cycle fitness thresholds
+// into the engine (fitnessPublisher seam, mirroring SetObjectives). It is a
+// no-op unless the engine was built over a *LiveFitness source
+// (NewObjectiveRulesLive); engines constructed from a StaticConfig ignore the
+// published value and keep their fixed thresholds.
+func (r *ObjectiveRules) SetFitness(t FitnessThresholds) {
+	if live, ok := r.fitness.(*LiveFitness); ok {
+		live.Set(t)
+	}
+}

--- a/services/agent/decision/objectives.go
+++ b/services/agent/decision/objectives.go
@@ -59,13 +59,16 @@ func (r *ObjectiveRules) SetObjectives(weights map[string]float64) {
 }
 
 // NewObjectiveRulesLive builds the rules engine with a *LiveObjectives source
-// so the decision loop can drive the objective weights from the `objectives`
-// flag each cycle (#727). policy and fitness come from cfg (nil -> flagd-schema
-// defaults). The returned engine satisfies objectivePublisher.
+// AND a *LiveFitness source so the decision loop can drive both the objective
+// weights (`objectives` flag, #727) and the fitness thresholds (`fitness.*`
+// flags, #731) each cycle. policy comes from cfg (nil -> flagd-schema defaults);
+// fitness starts at the flagd-schema defaults until the loop publishes the first
+// flag value. The returned engine satisfies objectivePublisher and
+// fitnessPublisher.
 func NewObjectiveRulesLive(cfg *StaticConfig) *ObjectiveRules {
 	c := DefaultStaticConfig()
 	if cfg != nil {
 		c = *cfg
 	}
-	return newObjectiveRules(NewLiveObjectives(), c, c, nil, nil)
+	return newObjectiveRules(NewLiveObjectives(), c, NewLiveFitness(), nil, nil)
 }

--- a/services/agent/decision/rules.go
+++ b/services/agent/decision/rules.go
@@ -42,6 +42,10 @@ type ObjectiveRules struct {
 	rng              *rand.Rand
 	lastEval         time.Time
 	lastDifficultyAt time.Time
+	// lastFitness is the most recent per-cycle fitness evaluation, retained so
+	// the decision loop can lift its cycle-level values onto the span as
+	// fitness.evaluated (#731).
+	lastFitness FitnessEvaluation
 }
 
 // NewObjectiveRules builds the engine. cfg may be nil, in which case
@@ -74,6 +78,15 @@ func newObjectiveRules(obj ObjectivesSource, pol PolicySource, fit FitnessSource
 	}
 }
 
+// LastFitness returns the most recent per-cycle fitness evaluation. The decision
+// loop reads it after Evaluate to lift the cycle-level fitness.evaluated values
+// onto the decision span (#731). Safe for concurrent use.
+func (r *ObjectiveRules) LastFitness() FitnessEvaluation {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.lastFitness
+}
+
 // Evaluate implements RulesEngine: run the rule set (at most once per
 // evalInterval), score candidates by the objective weights, apply policy
 // filters, and emit the best decisions the weighted budget allows.
@@ -91,6 +104,13 @@ func (r *ObjectiveRules) Evaluate(_ context.Context, c gamecontext.GameContext) 
 	pol := r.policy.Policy()
 	fit := r.fitness.Fitness()
 
+	// Evaluate the per-objective fitness functions against the live context and
+	// the flag-resolved thresholds (#731). The evaluation both steers selection
+	// (failing fitness amplifies the candidates serving that objective) and is
+	// retained for the span's cycle-level fitness.evaluated attribute.
+	fitEval := EvaluateFitness(c, fit)
+	r.lastFitness = fitEval
+
 	// R9's randomness is drawn here so the rule functions stay pure.
 	roll, rollTarget := r.chaosRoll(c)
 
@@ -101,7 +121,7 @@ func (r *ObjectiveRules) Evaluate(_ context.Context, c gamecontext.GameContext) 
 
 	cands = applyBatteryPolicy(cands, c, pol, weights)
 	cands = r.applyVarianceCooldown(cands, now, pol)
-	cands = scoreAndSort(cands, weights)
+	cands = scoreAndSort(cands, weights, fitEval)
 
 	// Emission is bounded to maxDecisionsPerEval per evaluation. The weighted
 	// per-minute budget (policy.max_interventions_per_minute) is NOT enforced
@@ -219,17 +239,27 @@ func (r *ObjectiveRules) applyVarianceCooldown(cands []candidate, now time.Time,
 	return kept
 }
 
-// scoreAndSort scores candidates (urgency x weight[objective]), drops those
-// below minScore, and orders them deterministically: higher score first, then
-// cheaper/safer, then lexicographic intervention and target.
-func scoreAndSort(cands []candidate, weights map[string]float64) []candidate {
+// scoreAndSort scores candidates (urgency x weight[objective] x fitness
+// amplification), drops those below minScore, and orders them deterministically:
+// higher score first, then cheaper/safer, then lexicographic intervention and
+// target.
+//
+// Fitness amplification (#731): a failing fitness function makes the candidates
+// serving its objective more urgent. The multiplier is 1 + pressure, where
+// pressure is 0 for a satisfied (or unevaluated, or fitness-less like chaos)
+// objective and up to 1 for a maximally failing one — so a failing endurance
+// fitness up to doubles the effective urgency of endurance candidates, which can
+// flip the selected winner between objectives without ever blocking a candidate
+// outright.
+func scoreAndSort(cands []candidate, weights map[string]float64, fit FitnessEvaluation) []candidate {
 	type scored struct {
 		candidate
 		score float64
 	}
 	kept := make([]scored, 0, len(cands))
 	for _, cd := range cands {
-		s := clamp01(cd.urgency) * weights[cd.objective]
+		amp := 1 + fit.Pressure(cd.objective)
+		s := clamp01(cd.urgency) * weights[cd.objective] * amp
 		if s < minScore {
 			continue
 		}

--- a/services/agent/decision/rules_test.go
+++ b/services/agent/decision/rules_test.go
@@ -274,3 +274,73 @@ func TestObjectiveRules_WeightsMapIsCopied(t *testing.T) {
 		t.Fatalf("decision weights = %v, want a snapshot unaffected by source mutation", out[0].Objectives)
 	}
 }
+
+// TestObjectiveRules_FitnessAmplifiesWinner verifies #731's core selection
+// effect: with two objectives weighted EQUALLY and both firing a candidate, the
+// objective whose fitness is failing wins because its candidate's urgency is
+// amplified by the failing-fitness pressure. The same candidate set with that
+// objective's fitness satisfied lets the other objective win instead.
+func TestObjectiveRules_FitnessAmplifiesWinner(t *testing.T) {
+	// Equal weights so the base scores tie and fitness pressure is the tiebreaker.
+	weights := map[string]float64{ObjectiveEndurance: 0.5, ObjectiveBalanced: 0.5}
+
+	// A context that fires BOTH an endurance candidate (young session with
+	// eliminations) and a balanced candidate (skill gap 0.6 > the 0.4 max). The
+	// gap is chosen so the balanced score sits BETWEEN endurance's amplified
+	// (failing) and un-amplified (satisfied) scores — so the endurance fitness
+	// state alone decides the winner.
+	c := gameCtx(20, []string{"GONE"}, map[string]testPlayer{
+		"WEAK":   {skill: fptr(0.2), active: true},
+		"STRONG": {skill: fptr(0.8), active: true}, // gap 0.6 > 0.4
+	})
+
+	// Case 1: endurance threshold high (120s) -> a 20s session is deep in
+	// endurance failure -> strong endurance pressure -> endurance wins.
+	cfgFail := DefaultStaticConfig()
+	cfgFail.ObjectiveWeights = weights
+	clock1 := time.Unix(10_000, 0)
+	rFail := newTestEngine(cfgFail, &clock1)
+	failOut := rFail.Evaluate(context.Background(), c)
+	if len(failOut) == 0 {
+		t.Fatal("expected decisions (failing endurance)")
+	}
+	if failOut[0].ObjectiveServed != ObjectiveEndurance {
+		t.Fatalf("failing endurance fitness must amplify endurance to the top, got %q", failOut[0].ObjectiveServed)
+	}
+
+	// Case 2: endurance threshold lowered below the session age (10s) so the 20s
+	// session SATISFIES endurance -> zero endurance pressure. Balance still fails
+	// (gap 0.8 > 0.4) so balanced pressure now dominates -> balanced wins. Same
+	// candidate set, fitness flips the winner.
+	cfgPass := DefaultStaticConfig()
+	cfgPass.ObjectiveWeights = weights
+	cfgPass.FitnessThresholds.EnduranceMinSessionSeconds = 10
+	clock2 := time.Unix(10_000, 0)
+	rPass := newTestEngine(cfgPass, &clock2)
+	passOut := rPass.Evaluate(context.Background(), c)
+	if len(passOut) == 0 {
+		t.Fatal("expected decisions (satisfied endurance)")
+	}
+	if passOut[0].ObjectiveServed != ObjectiveBalanced {
+		t.Fatalf("satisfied endurance + failing balance must let balanced win, got %q", passOut[0].ObjectiveServed)
+	}
+}
+
+// TestObjectiveRules_LastFitnessExposed verifies the engine retains the cycle's
+// fitness evaluation for the loop to lift onto the span (#731), under the dotted
+// key vocabulary.
+func TestObjectiveRules_LastFitnessExposed(t *testing.T) {
+	cfg := DefaultStaticConfig()
+	clock := time.Unix(10_000, 0)
+	r := newTestEngine(cfg, &clock)
+	c := gameCtx(30, nil, map[string]testPlayer{"A": {active: true}})
+
+	_ = r.Evaluate(context.Background(), c)
+	vals := r.LastFitness().Evaluated()
+	if vals["endurance.session_seconds"] != 30 {
+		t.Errorf("endurance.session_seconds = %v, want 30", vals["endurance.session_seconds"])
+	}
+	if vals["accelerate.target_session_seconds"] != 60 {
+		t.Errorf("accelerate.target_session_seconds = %v, want 60", vals["accelerate.target_session_seconds"])
+	}
+}

--- a/services/agent/flags/flags.go
+++ b/services/agent/flags/flags.go
@@ -34,6 +34,13 @@ const (
 	keyBatteryThreshold          = "policy.battery_threshold"
 	keyMovementVarianceWindow    = "policy.movement_variance_window"
 	keyMaxInterventionsPerMinute = "policy.max_interventions_per_minute"
+
+	// Fitness thresholds (#731). The game-objective fitness flags; the
+	// fitness.bluetooth.* flags are system-level and out of scope here.
+	keyEnduranceMinSessionSeconds  = "fitness.endurance.min_session_seconds"
+	keyBalancedMaxSkillGap         = "fitness.balanced.max_skill_gap"
+	keyBalancedSpikeSurvival       = "fitness.balanced.spike_survival_threshold"
+	keyAccelerateTargetSessionSecs = "fitness.accelerate.target_session_seconds"
 )
 
 // Safe defaults applied when flagd is unreachable or a flag is undefined.
@@ -55,6 +62,23 @@ const (
 	DefaultMovementVarianceWindow = 10
 	// DefaultMaxInterventionsPerMinute is the weighted per-minute budget.
 	DefaultMaxInterventionsPerMinute = 2
+
+	// Fitness threshold defaults (#731), mirroring the services/flagd/agent.json
+	// defaultVariants. Applied when flagd is unreachable or a flag is undefined.
+
+	// DefaultEnduranceMinSessionSeconds: sessions ending earlier fail endurance
+	// (fitness.endurance.min_session_seconds).
+	DefaultEnduranceMinSessionSeconds = 120
+	// DefaultBalancedMaxSkillGap: larger skill spreads fail balance
+	// (fitness.balanced.max_skill_gap).
+	DefaultBalancedMaxSkillGap = 0.4
+	// DefaultBalancedSpikeSurvivalThreshold: the survival ratio a player must
+	// hold through movement spikes to pass balance
+	// (fitness.balanced.spike_survival_threshold).
+	DefaultBalancedSpikeSurvivalThreshold = 0.8
+	// DefaultAccelerateTargetSessionSeconds: sessions running past this overshoot
+	// the accelerate target (fitness.accelerate.target_session_seconds).
+	DefaultAccelerateTargetSessionSeconds = 60
 )
 
 // defaultObjectives is the fallback objectives weighting. Returned as a fresh
@@ -70,6 +94,7 @@ type Evaluator interface {
 	BooleanValue(ctx context.Context, flag string, defaultValue bool, evalCtx openfeature.EvaluationContext, options ...openfeature.Option) (bool, error)
 	StringValue(ctx context.Context, flag string, defaultValue string, evalCtx openfeature.EvaluationContext, options ...openfeature.Option) (string, error)
 	IntValue(ctx context.Context, flag string, defaultValue int64, evalCtx openfeature.EvaluationContext, options ...openfeature.Option) (int64, error)
+	FloatValue(ctx context.Context, flag string, defaultValue float64, evalCtx openfeature.EvaluationContext, options ...openfeature.Option) (float64, error)
 	ObjectValue(ctx context.Context, flag string, defaultValue any, evalCtx openfeature.EvaluationContext, options ...openfeature.Option) (any, error)
 }
 
@@ -96,6 +121,28 @@ type Policy struct {
 	MaxInterventionsPerMinute int
 }
 
+// Fitness is the fitness-threshold half of the objective layer (#731): the
+// per-objective success/degradation thresholds the fitness evaluator scores the
+// live game context against. Evaluated every cycle (never cached) so flipping a
+// threshold mid-session changes the next cycle's evaluation. chaos has no
+// fitness function (it is unpredictability by definition; see README), so it has
+// no threshold here.
+type Fitness struct {
+	// EnduranceMinSessionSeconds: sessions shorter than this fail endurance
+	// (fitness.endurance.min_session_seconds, default 120).
+	EnduranceMinSessionSeconds int
+	// BalancedMaxSkillGap: a skill spread above this fails balance
+	// (fitness.balanced.max_skill_gap, default 0.4).
+	BalancedMaxSkillGap float64
+	// BalancedSpikeSurvivalThreshold: the survival ratio a player must hold
+	// through movement spikes to pass balance
+	// (fitness.balanced.spike_survival_threshold, default 0.8).
+	BalancedSpikeSurvivalThreshold float64
+	// AccelerateTargetSessionSeconds: sessions past this overshoot the accelerate
+	// target (fitness.accelerate.target_session_seconds, default 60).
+	AccelerateTargetSessionSeconds int
+}
+
 // Snapshot is the set of agent control flags captured for a single decision
 // cycle. It is a plain value so the decision loop reasons over a consistent view.
 type Snapshot struct {
@@ -112,6 +159,8 @@ type Snapshot struct {
 	InterventionsAllowed []string
 	// Policy holds the numeric permission-layer constraints.
 	Policy Policy
+	// Fitness holds the per-objective fitness thresholds (#731).
+	Fitness Fitness
 }
 
 // Permits reports whether the named intervention is in the allow-list.
@@ -157,6 +206,12 @@ func (f *Flags) Evaluate(ctx context.Context) Snapshot {
 			MovementVarianceWindow:    f.intFlag(ctx, keyMovementVarianceWindow, DefaultMovementVarianceWindow),
 			MaxInterventionsPerMinute: f.intFlag(ctx, keyMaxInterventionsPerMinute, DefaultMaxInterventionsPerMinute),
 		},
+		Fitness: Fitness{
+			EnduranceMinSessionSeconds:     f.intFlag(ctx, keyEnduranceMinSessionSeconds, DefaultEnduranceMinSessionSeconds),
+			BalancedMaxSkillGap:            f.floatFlag(ctx, keyBalancedMaxSkillGap, DefaultBalancedMaxSkillGap),
+			BalancedSpikeSurvivalThreshold: f.floatFlag(ctx, keyBalancedSpikeSurvival, DefaultBalancedSpikeSurvivalThreshold),
+			AccelerateTargetSessionSeconds: f.intFlag(ctx, keyAccelerateTargetSessionSecs, DefaultAccelerateTargetSessionSeconds),
+		},
 	}
 }
 
@@ -178,6 +233,16 @@ func (f *Flags) intFlag(ctx context.Context, key string, def int) int {
 		return def
 	}
 	return int(v)
+}
+
+// floatFlag resolves a float fitness flag, falling back to def on any error.
+func (f *Flags) floatFlag(ctx context.Context, key string, def float64) float64 {
+	v, err := f.client.FloatValue(ctx, key, def, openfeature.EvaluationContext{})
+	if err != nil {
+		f.log.Debug("flags float fell back to default", "key", key, "error", err, "default", def)
+		return def
+	}
+	return v
 }
 
 func (f *Flags) enabled(ctx context.Context) bool {

--- a/services/agent/flags/flags_test.go
+++ b/services/agent/flags/flags_test.go
@@ -16,6 +16,7 @@ type stubEvaluator struct {
 	booleans map[string]bool
 	strings  map[string]string
 	ints     map[string]int64
+	floats   map[string]float64
 	objects  map[string]any
 	errs     map[string]error
 }
@@ -50,6 +51,16 @@ func (s stubEvaluator) IntValue(_ context.Context, flag string, def int64, _ ope
 	return def, nil
 }
 
+func (s stubEvaluator) FloatValue(_ context.Context, flag string, def float64, _ openfeature.EvaluationContext, _ ...openfeature.Option) (float64, error) {
+	if err := s.errs[flag]; err != nil {
+		return def, err
+	}
+	if v, ok := s.floats[flag]; ok {
+		return v, nil
+	}
+	return def, nil
+}
+
 func (s stubEvaluator) ObjectValue(_ context.Context, flag string, def any, _ openfeature.EvaluationContext, _ ...openfeature.Option) (any, error) {
 	if err := s.errs[flag]; err != nil {
 		return def, err
@@ -69,9 +80,15 @@ func TestEvaluate_FlagdShape(t *testing.T) {
 			keyPromptVariant: "aggressive",
 		},
 		ints: map[string]int64{
-			keyBatteryThreshold:          30,
-			keyMovementVarianceWindow:    20,
-			keyMaxInterventionsPerMinute: 4,
+			keyBatteryThreshold:            30,
+			keyMovementVarianceWindow:      20,
+			keyMaxInterventionsPerMinute:   4,
+			keyEnduranceMinSessionSeconds:  300,
+			keyAccelerateTargetSessionSecs: 30,
+		},
+		floats: map[string]float64{
+			keyBalancedMaxSkillGap:   0.2,
+			keyBalancedSpikeSurvival: 0.9,
 		},
 		objects: map[string]any{
 			// flagd surfaces object flags as map[string]any / []any.
@@ -103,6 +120,15 @@ func TestEvaluate_FlagdShape(t *testing.T) {
 	wantPolicy := Policy{BatteryThreshold: 30, MovementVarianceWindow: 20, MaxInterventionsPerMinute: 4}
 	if got.Policy != wantPolicy {
 		t.Errorf("Policy = %+v, want %+v", got.Policy, wantPolicy)
+	}
+	wantFitness := Fitness{
+		EnduranceMinSessionSeconds:     300,
+		BalancedMaxSkillGap:            0.2,
+		BalancedSpikeSurvivalThreshold: 0.9,
+		AccelerateTargetSessionSeconds: 30,
+	}
+	if got.Fitness != wantFitness {
+		t.Errorf("Fitness = %+v, want %+v", got.Fitness, wantFitness)
 	}
 }
 
@@ -136,6 +162,19 @@ func TestEvaluate_DefaultsWhenMissing(t *testing.T) {
 	if got.Policy != wantPolicy {
 		t.Errorf("Policy = %+v, want defaults %+v", got.Policy, wantPolicy)
 	}
+	if got.Fitness != defaultFitness() {
+		t.Errorf("Fitness = %+v, want defaults %+v", got.Fitness, defaultFitness())
+	}
+}
+
+// defaultFitness is the expected fitness snapshot when every flag falls back.
+func defaultFitness() Fitness {
+	return Fitness{
+		EnduranceMinSessionSeconds:     DefaultEnduranceMinSessionSeconds,
+		BalancedMaxSkillGap:            DefaultBalancedMaxSkillGap,
+		BalancedSpikeSurvivalThreshold: DefaultBalancedSpikeSurvivalThreshold,
+		AccelerateTargetSessionSeconds: DefaultAccelerateTargetSessionSeconds,
+	}
 }
 
 func TestEvaluate_DefaultsOnError(t *testing.T) {
@@ -143,15 +182,19 @@ func TestEvaluate_DefaultsOnError(t *testing.T) {
 	// the agent must come up disabled with no permitted interventions.
 	boom := errors.New("flagd unreachable")
 	stub := stubEvaluator{errs: map[string]error{
-		keyEnabled:                   boom,
-		keyMode:                      boom,
-		keyObjectives:                boom,
-		keyModel:                     boom,
-		keyPromptVariant:             boom,
-		keyInterventionsAllowed:      boom,
-		keyBatteryThreshold:          boom,
-		keyMovementVarianceWindow:    boom,
-		keyMaxInterventionsPerMinute: boom,
+		keyEnabled:                     boom,
+		keyMode:                        boom,
+		keyObjectives:                  boom,
+		keyModel:                       boom,
+		keyPromptVariant:               boom,
+		keyInterventionsAllowed:        boom,
+		keyBatteryThreshold:            boom,
+		keyMovementVarianceWindow:      boom,
+		keyMaxInterventionsPerMinute:   boom,
+		keyEnduranceMinSessionSeconds:  boom,
+		keyBalancedMaxSkillGap:         boom,
+		keyBalancedSpikeSurvival:       boom,
+		keyAccelerateTargetSessionSecs: boom,
 	}}
 	f := New(stub, nil)
 	got := f.Evaluate(context.Background())
@@ -179,6 +222,9 @@ func TestEvaluate_DefaultsOnError(t *testing.T) {
 	}
 	if got.Policy != wantPolicy {
 		t.Errorf("Policy = %+v on error, want defaults %+v", got.Policy, wantPolicy)
+	}
+	if got.Fitness != defaultFitness() {
+		t.Errorf("Fitness = %+v on error, want defaults %+v", got.Fitness, defaultFitness())
 	}
 }
 


### PR DESCRIPTION
Closes #731

Stacked on #761 (`feat/729-flag-trace-attribution`); this PR targets that branch, not `main`. The `services/agent/actions/` package + `main.go` sink wiring belong to the parallel #730-F PR — untouched here.

## Summary

Fitness functions per objective in the agent: success/degradation defined as observable, runtime-tunable, flag-driven values that steer action selection and ride onto every decision span.

- **Flags** (`flags/flags.go`): a new `Fitness` sub-struct evaluates the four game-objective `fitness.*` flags **every cycle** (never cached) with safe-defaults-on-error. Adds `FloatValue` to the evaluator seam for the float thresholds.
- **Evaluator** (`decision/fitness.go`): `EvaluateFitness` scores the live `GameContext` per objective:
  - `endurance` — session duration vs `min_session_seconds` (progress = duration/min, long sessions win).
  - `balanced` — skill-gap spread vs `max_skill_gap` AND a derived spike-survival ratio vs `spike_survival_threshold` (a player survives when `movement_variance ≤ movement_intensity`; documented in the README and code).
  - `accelerate` — overshoot vs `target_session_seconds` (running past target = failing).
  - `chaos` — **no fitness function** (unpredictability by definition; confirmed against #722 research §4).
  - Missing signals **skip** a function rather than fabricate a value.
- **Selection** (`decision/rules.go`, `fitnesssource.go`): a `LiveFitness` source (mirroring `LiveObjectives`) lets the loop publish thresholds each cycle through the engine's existing `FitnessSource` seam. `scoreAndSort` amplifies each candidate by `(1 + pressure[objective])`, so a failing objective's candidates rise and can flip the selected winner without blocking anything.
- **Span** (`decision/decision.go`): the loop reads the engine's `LastFitness()` into `LayerState.FitnessEvaluated`; the existing #729 wiring lifts it onto `agent.decision` as `fitness.evaluated` (dotted per-objective keys, authoritative over the per-decision view).
- **Runtime tunability**: per-cycle evaluation means changing a `fitness.*` flag mid-session changes the next cycle's evaluation and selection — with an explicit two-cycle test.

## Test plan

- `go test -race ./...`, `go vet ./...`, `gofmt -l .` clean from `services/agent`.
- Each fitness function against synthetic contexts: boundary at threshold, missing signals, empty session.
- Flag-driven threshold change between two cycles changes the evaluated outcome (`TestLoop_MidSessionFlagChangeChangesOutcome`).
- Fitness flips the engine winner between objectives (`TestObjectiveRules_FitnessAmplifiesWinner`).
- `fitness.evaluated` lifted onto the span (`TestLoop_FitnessLiftedOntoSpan`), following the `attribution_test.go` patterns.
- Flag evaluation/defaults/error coverage extended in `flags_test.go`.
- [ ] Pi 5 live verification (manual)

## Fitness key vocabulary on spans

```
endurance.min_session_seconds   endurance.session_seconds   endurance.session_progress
balanced.max_skill_gap          balanced.skill_gap          balanced.skill_gap_progress
balanced.spike_survival_threshold  balanced.spike_survival_ratio  balanced.spike_survival_progress
accelerate.target_session_seconds  accelerate.session_seconds  accelerate.session_progress
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)