### PR TITLE
fix: deflake test_full_game_lifecycle — grace/EMA spike memory, kill verification (#757)

### DIFF
--- a/services/controller_manager/feedback_manager.py
+++ b/services/controller_manager/feedback_manager.py
@@ -377,8 +377,12 @@ class FeedbackManager(ControllerEffectsBase):
             await asyncio.sleep(0.3)
 
             span.add_event("fade_to_black", {"duration_ms": 700})
-            await self.play_effect_with_restore(serial, "fade_out", Colors.Red.value, 700, 1, Colors.Black.value)
+            # Set base color to black BEFORE spawning the fade so a concurrent
+            # base_color command (e.g., menu lobby reset) that lands during the
+            # effect setup can't be clobbered afterwards — apply_base_color
+            # writes win, and the fade's restore picks up the latest value (#757).
             self.base_colors[serial] = Colors.Black.value
+            await self.play_effect_with_restore(serial, "fade_out", Colors.Red.value, 700, 1, Colors.Black.value)
 
     async def _effect_player_respawn(self, serial: str, **_kwargs) -> None:
         """White during spawn protection."""

--- a/services/controller_manager/mock_control_service.py
+++ b/services/controller_manager/mock_control_service.py
@@ -19,6 +19,12 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# How long SimulateDeath holds death-level acceleration. Long enough for the
+# game loop to reliably detect it (>= 60 frames at 60Hz), but well below the
+# 2.0s post-swap/respawn grace period — a hold that outlives grace re-kills
+# the player the moment grace expires (#757).
+DEATH_HOLD_SECONDS = 1.0
+
 
 class MockControllerService(controller_manager_mock_pb2_grpc.MockControllerServiceServicer):
     """Service for controlling mock controllers during integration tests."""
@@ -60,7 +66,7 @@ class MockControllerService(controller_manager_mock_pb2_grpc.MockControllerServi
             return controller_manager_mock_pb2.MovementResponse(success=False, error=str(e))
 
     def SimulateDeath(self, request, _context):
-        """Simulate death by setting high acceleration and holding it for 2 seconds."""
+        """Simulate death by setting high acceleration and holding it briefly."""
         try:
             serial = request.serial
             if serial not in self.backend.controllers:
@@ -70,11 +76,17 @@ class MockControllerService(controller_manager_mock_pb2_grpc.MockControllerServi
             death_accel = {AxisKey.X: 5.0, AxisKey.Y: 3.0, AxisKey.Z: 4.0}
             accel_mag = (5.0**2 + 3.0**2 + 4.0**2) ** 0.5  # ~7.07g
 
-            # Hold death acceleration for 2 seconds to ensure game loop catches it
+            # Hold death acceleration for 1 second so the game loop reliably
+            # sees it (>= 60 frames at 60Hz). Must stay well below the 2.0s
+            # post-swap/respawn grace period: a hold that outlives grace
+            # re-kills the player the moment grace expires (#757).
             self.backend.controllers[serial]["death_accel"] = death_accel
-            self.backend.controllers[serial]["death_hold_until"] = time.time() + 2.0
+            self.backend.controllers[serial]["death_hold_until"] = time.time() + DEATH_HOLD_SECONDS
 
-            logger.info(f"Mock: Simulated death for {serial} with {accel_mag:.2f}g acceleration, holding for 2.0s")
+            logger.info(
+                f"Mock: Simulated death for {serial} with {accel_mag:.2f}g acceleration, "
+                f"holding for {DEATH_HOLD_SECONDS}s"
+            )
             return controller_manager_mock_pb2.DeathResponse(success=True, accel_magnitude=accel_mag)
 
         except Exception as e:
@@ -220,7 +232,7 @@ class MockControllerService(controller_manager_mock_pb2_grpc.MockControllerServi
                         # Set death-level acceleration (same as SimulateDeath)
                         # Use AxisKey enum for consistency with mock_backend.py
                         controller["death_accel"] = {AxisKey.X: 5.0, AxisKey.Y: 3.0, AxisKey.Z: 4.0}
-                        controller["death_hold_until"] = time.time() + 2.0
+                        controller["death_hold_until"] = time.time() + DEATH_HOLD_SECONDS
                         logger.info(f"Mock: Auto-killed player {serial}")
                     await asyncio.sleep(0.3)  # Stagger deaths for better trace visualization
 

--- a/services/controller_manager/tests/test_feedback_manager_effects.py
+++ b/services/controller_manager/tests/test_feedback_manager_effects.py
@@ -198,6 +198,71 @@ class TestBaseColorDuringEffect:
         # 5. Should show lobby color
         assert mock_backend.get_current_color(serial) == lobby_color
 
+    @pytest.mark.asyncio
+    async def test_death_effect_sets_black_base_before_fade_spawns(self, feedback_manager, mock_backend):
+        """
+        Regression test for #757: base_colors must be black BEFORE the fade
+        task is spawned. If it's written after, a base_color command (menu
+        lobby reset) interleaving during the fade setup gets clobbered, and
+        the fade restore leaves the LED permanently black.
+        """
+        serial = "test_ctrl"
+        feedback_manager.base_colors[serial] = (255, 255, 0)
+
+        base_at_spawn = {}
+        orig = feedback_manager.play_effect_with_restore
+
+        async def capture(s, *args, **kwargs):
+            base_at_spawn["value"] = feedback_manager.base_colors.get(s)
+            return await orig(s, *args, **kwargs)
+
+        with patch.object(feedback_manager, "play_effect_with_restore", side_effect=capture):
+            await feedback_manager.handle_game_effect(
+                serial,
+                controller_manager_pb2.GAME_EFFECT_PLAYER_DEATH,
+                "test_stream",
+            )
+            active = feedback_manager.active_effects.get(serial)
+            if active:
+                await active.task
+
+        assert base_at_spawn["value"] == (0, 0, 0), (
+            "base_colors must already be black when the fade spawns, so a "
+            "concurrent lobby reset always wins the write race"
+        )
+
+    @pytest.mark.asyncio
+    async def test_lobby_reset_during_death_fade_wins(self, feedback_manager, mock_backend):
+        """
+        A menu lobby reset arriving while the death fade is still running
+        must end with the lobby color, not black (#757).
+        """
+        serial = "test_ctrl"
+        team_color = (255, 255, 0)
+        lobby_color = (0, 60, 76)
+
+        feedback_manager.base_colors[serial] = team_color
+        await feedback_manager.set_controller_color(serial, team_color)
+
+        # Death effect: red phase + spawns 700ms fade task
+        await feedback_manager.handle_game_effect(
+            serial,
+            controller_manager_pb2.GAME_EFFECT_PLAYER_DEATH,
+            "test_stream",
+        )
+        active = feedback_manager.active_effects.get(serial)
+        assert active is not None, "Fade task should be running"
+
+        # Menu lobby reset lands mid-fade
+        await feedback_manager.apply_base_color(serial, lobby_color, label="test")
+
+        await active.task
+
+        assert feedback_manager.base_colors[serial] == lobby_color
+        assert mock_backend.get_current_color(serial) == lobby_color, (
+            "Fade restore must pick up the lobby color set during the fade"
+        )
+
 
 class TestEffectRestoreLogic:
     """Test the restore_color logic in play_effect_with_restore."""

--- a/services/game_coordinator/games/base.py
+++ b/services/game_coordinator/games/base.py
@@ -1064,6 +1064,29 @@ class BaseGameMode(ABC):
 
         accel = controller_state.accel
         accel_mag = self._compute_accel_magnitude(accel)
+
+        # Check grace period first - no death or warning during grace period
+        # Matches original JoustMania: if time.time() > no_rumble
+        current_time = time.time()
+        if current_time < player.grace_until:
+            # During grace, reset the EMA so it re-primes from the first
+            # post-grace frame. Invincibility must *forget* the death spike:
+            # otherwise the EMA still holds it when grace expires and the
+            # player is instantly re-killed by stale filter memory (#757).
+            # Same re-prime pattern as NonStop revive (nonstop_joust.py).
+            player.smoothed_accel = 0.0
+            player.last_accel_mag = accel_mag
+            self._record_player_analytics(
+                player,
+                serial,
+                accel,
+                accel_mag,
+                accel_mag,
+                self._compute_effective_thresholds(player)[1],
+                controller_state,
+            )
+            return  # In grace period, skip death/warning checks
+
         self._update_ema(player, accel_mag)
 
         effective_warn, effective_death = self._compute_effective_thresholds(player)
@@ -1071,12 +1094,6 @@ class BaseGameMode(ABC):
 
         # Record analytics (handles enabled check internally)
         self._record_player_analytics(player, serial, accel, accel_mag, smoothed, effective_death, controller_state)
-
-        # Check grace period first - no death or warning during grace period
-        # Matches original JoustMania: if time.time() > no_rumble
-        current_time = time.time()
-        if current_time < player.grace_until:
-            return  # In grace period, skip all checks
 
         # Death and warning checks (matches original JoustMania logic)
         # Key: warning is just feedback, NOT protection - player can die during warning!

--- a/services/game_coordinator/games/zombie.py
+++ b/services/game_coordinator/games/zombie.py
@@ -373,6 +373,9 @@ class ZombieGame(BaseGameMode):
             zombie_player.is_zombie = True
             zombie_player.color = ZOMBIE_COLOR
             zombie_player.team = 1
+            # Grace period so the death spike that converted the human can't
+            # instantly re-kill the fresh zombie (#757). Matches respawn grace.
+            zombie_player.grace_until = time.time() + 2.0
 
             # Update lists
             if serial in self.human_serials:

--- a/services/game_coordinator/tests/test_base_game.py
+++ b/services/game_coordinator/tests/test_base_game.py
@@ -302,6 +302,105 @@ class TestWarningBehavior:
         assert messages_after == messages_before, "Should not send warning when already in warning state"
 
 
+class TestGracePeriodSpikeMemory:
+    """Grace period must forget the death spike (#757).
+
+    Without this, the EMA still holds the spike that killed the player when
+    grace expires, and the first post-grace frame instantly re-kills them
+    (Swapper bounce-back, zombie insta-rekill).
+    """
+
+    @pytest.fixture
+    def game_with_player(self):
+        """Create game with one alive player in grace period."""
+        mock_cm = MockControllerManagerService(num_controllers=2)
+
+        game = FFAGame(
+            controller_manager_client=mock_cm,
+            event_publisher=async_noop,
+            audio_client=None,
+            game_id="test_grace_spike",
+        )
+
+        game.players["test_serial"] = Player(
+            serial="test_serial",
+            team=0,
+            alive=True,
+            color=(255, 0, 0),
+            smoothed_accel=1.0,  # Prime EMA
+        )
+        game.gameplay_stream = MockGameplayStream()
+        game.music_speed = SLOW_MUSIC_SPEED
+        game.start_time = time.time()
+
+        return game
+
+    @staticmethod
+    def _frame(x: float, y: float, z: float):
+        return controller_manager_pb2.GameplayData(
+            serial="test_serial",
+            accel=controller_manager_pb2.Vector3(x=x, y=y, z=z),
+        )
+
+    @pytest.mark.asyncio
+    async def test_spike_during_grace_does_not_kill_after_grace(self, game_with_player):
+        """Lethal frames during grace must not leave EMA memory that kills
+        the player on the first calm frame after grace expires."""
+        game = game_with_player
+        player = game.players["test_serial"]
+        player.grace_until = time.time() + 60.0  # In grace
+
+        kill_called = []
+
+        async def mock_kill(serial, accel_mag):
+            kill_called.append((serial, accel_mag))
+            player.alive = False
+
+        game._kill_player = mock_kill
+
+        # Feed sustained lethal acceleration (~7g) during grace —
+        # this is exactly what the mock's held death accel produces
+        for _ in range(30):
+            await game._process_controller_state(self._frame(5.0, 3.0, 4.0))
+
+        assert not kill_called, "Player must not die during grace"
+
+        # Grace expires; motion is calm again (~1g)
+        player.grace_until = 0.0
+        await game._process_controller_state(self._frame(0.0, 0.0, 1.0))
+
+        assert not kill_called, "Calm frame after grace must not kill — EMA held stale spike memory"
+
+    @pytest.mark.asyncio
+    async def test_sustained_motion_past_grace_still_kills(self, game_with_player):
+        """Grace forgives the spike, not ongoing violent motion: if lethal
+        acceleration continues past grace expiry, the player dies."""
+        game = game_with_player
+        player = game.players["test_serial"]
+        player.grace_until = time.time() + 60.0  # In grace
+
+        kill_called = []
+
+        async def mock_kill(serial, accel_mag):
+            kill_called.append((serial, accel_mag))
+            player.alive = False
+
+        game._kill_player = mock_kill
+
+        # Lethal acceleration during grace
+        for _ in range(10):
+            await game._process_controller_state(self._frame(5.0, 3.0, 4.0))
+        assert not kill_called
+
+        # Grace expires; lethal acceleration continues
+        player.grace_until = 0.0
+        for _ in range(3):
+            if player.alive:
+                await game._process_controller_state(self._frame(5.0, 3.0, 4.0))
+
+        assert kill_called, "Sustained lethal motion past grace expiry must kill"
+
+
 class TestDeathDetection:
     """Tests for death detection at threshold boundaries."""
 
@@ -518,7 +617,9 @@ class TestEMAFilter:
         """First reading should prime EMA instead of smoothing from 0."""
         game = game_with_player
         player = game.players["test_serial"]
-        player.grace_until = time.time() + 10.0  # Grace period to prevent death
+        # No grace: during grace the EMA is held reset (#757). The readings
+        # here are sub-threshold, so no death can trigger.
+        player.grace_until = 0.0
 
         assert player.smoothed_accel == 0.0
 
@@ -538,7 +639,9 @@ class TestEMAFilter:
         """Subsequent readings should be smoothed with 80/20 weighting."""
         game = game_with_player
         player = game.players["test_serial"]
-        player.grace_until = time.time() + 10.0
+        # No grace: during grace the EMA is held reset (#757). The smoothed
+        # result (1.2) stays below all thresholds, so no death can trigger.
+        player.grace_until = 0.0
         player.smoothed_accel = 1.0  # Pre-prime
 
         # New reading of 2.0

--- a/services/game_coordinator/tests/test_motion_processing.py
+++ b/services/game_coordinator/tests/test_motion_processing.py
@@ -13,6 +13,7 @@ For each game mode, tests:
 """
 
 import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -410,20 +411,34 @@ class TestZombieMotionProcessing:
 
     @pytest.mark.asyncio
     async def test_lethal_motion_causes_death(self, game):
-        """Lethal motion with real proto should kill human player."""
+        """Lethal motion with real proto should convert human, then (after
+        the conversion grace period) kill the resulting zombie."""
         game, mock_cm = game
         game.gameplay_stream = MockGameplayStream()
         await game._initialize_players_impl(mock_cm.controllers)
 
         # Find a human player
         serial = next(s for s, p in game.players.items() if not p.is_zombie)
-        game.players[serial].grace_until = 0.0
+        player = game.players[serial]
+        player.grace_until = 0.0
 
         for _ in range(10):
-            if game.players[serial].alive:
+            if player.alive and not player.is_zombie:
                 await game._process_controller_state(_lethal_state(serial))
 
-        assert game.players[serial].alive is False
+        # Human's "death" is conversion; the fresh zombie is protected by
+        # the conversion grace period (#757), not insta-rekilled
+        assert player.is_zombie is True
+        assert player.alive is True
+        assert player.grace_until > time.time()
+
+        # Once grace expires, sustained lethal motion kills the zombie
+        player.grace_until = 0.0
+        for _ in range(10):
+            if player.alive:
+                await game._process_controller_state(_lethal_state(serial))
+
+        assert player.alive is False
 
     @pytest.mark.asyncio
     async def test_zombie_survives_human_lethal_accel(self, game):

--- a/services/game_coordinator/tests/test_zombie.py
+++ b/services/game_coordinator/tests/test_zombie.py
@@ -9,6 +9,7 @@ Tests the core Zombie mechanics:
 """
 
 import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -293,6 +294,27 @@ class TestZombieKillMechanics:
         assert len(conversion_events) == 1
         assert conversion_events[0]["serial"] == human_serial
         assert conversion_events[0]["remaining_humans"] == initial_human_count - 1
+
+    @pytest.mark.asyncio
+    async def test_human_conversion_sets_grace_period(self, zombie_game):
+        """Conversion must grant grace so the death spike that converted the
+        human can't instantly re-kill the fresh zombie (#757)."""
+        game, mock_controller_manager, _ = zombie_game
+        game.gameplay_stream = MockGameplayStream()
+        game.running = True
+
+        await game._initialize_players_impl(mock_controller_manager.controllers)
+
+        human_serial = game.human_serials[0]
+        player = game.players[human_serial]
+        assert player.grace_until <= time.time()
+
+        before = time.time()
+        await game._kill_player_impl(human_serial, accel_mag=3.0)
+
+        # Grace should extend ~2s past the conversion
+        assert player.grace_until >= before + 1.9
+        assert player.grace_until <= time.time() + 2.1
 
     @pytest.mark.asyncio
     async def test_zombie_killed_sets_respawn(self, zombie_game):

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -767,16 +767,98 @@ def verify_lobby_colors_restored(events: list, serials: list[str]):
 # Game kill helpers
 # =============================================================================
 
+# SimulateDeath holds death-level acceleration for 1.0s (DEATH_HOLD_SECONDS in
+# mock_control_service.py). Retry no sooner than that, so a retry only fires
+# once the previous attempt's hold has fully expired.
+KILL_RETRY_INTERVAL = 1.5
+KILL_VERIFY_TIMEOUT = 12.0
+_VERIFY_POLL_INTERVAL = 0.2
+
+
+async def get_player_states(game_client) -> dict | None:
+    """Query current game state and return {serial: PlayerInfo}.
+
+    Returns None if the game is no longer running (ended or not started),
+    so callers can distinguish "game over" from "kill not registered yet".
+    """
+    response = await game_client.GetGameState(game_coordinator_pb2.GetGameStateRequest())
+    if not response.success:
+        return None
+    if response.game_info.state != game_coordinator_pb2.RUNNING:
+        return None
+    return {p.serial: p for p in response.game_info.players}
+
+
+async def kill_player_verified(
+    mock_client,
+    game_client,
+    serial: str,
+    registered,
+    timeout: float = KILL_VERIFY_TIMEOUT,
+) -> bool:
+    """SimulateDeath and verify it registered in the game, retrying if dropped.
+
+    Kills fired during countdown/EMA-warmup/grace windows are silently ignored
+    by the game loop (#757), so a single fire-and-forget SimulateDeath is not
+    reliable under CI load. This helper polls GetGameState until `registered`
+    is satisfied and re-fires SimulateDeath every KILL_RETRY_INTERVAL.
+
+    Args:
+        mock_client: Mock controller service gRPC client
+        game_client: GameCoordinator gRPC client
+        serial: Controller serial to kill
+        registered: Predicate PlayerInfo -> bool, true once the kill took
+            effect (e.g., lambda p: not p.alive)
+        timeout: Max total time to keep trying
+
+    Returns:
+        True if the kill registered, False if the game stopped running first
+        (e.g., this kill ended the game before the poll observed it).
+
+    Raises:
+        TimeoutError: If the kill never registered while the game kept running
+    """
+    deadline = asyncio.get_event_loop().time() + timeout
+    next_kill_at = 0.0
+
+    while True:
+        now = asyncio.get_event_loop().time()
+        if now >= next_kill_at:
+            response = await mock_client.SimulateDeath(
+                controller_manager_mock_pb2.DeathRequest(serial=serial)
+            )
+            assert response.success, f"SimulateDeath RPC failed for {serial}"
+            next_kill_at = now + KILL_RETRY_INTERVAL
+
+        players = await get_player_states(game_client)
+        if players is None:
+            # Game ended (possibly because this kill landed) — nothing left to verify
+            return False
+        player = players.get(serial)
+        if player is None or registered(player):
+            return True
+
+        if asyncio.get_event_loop().time() >= deadline:
+            raise TimeoutError(
+                f"Kill of {serial} did not register within {timeout}s "
+                f"(alive={player.alive}, team={player.team})"
+            )
+        await asyncio.sleep(_VERIFY_POLL_INTERVAL)
+
 
 async def kill_players_until_one_remains(
-    mock_client, serials: list[str], delay: float = 0.5
+    mock_client, serials: list[str], delay: float = 0.5, game_client=None
 ) -> list[str]:
     """Kill players one by one until only one remains.
+
+    Each kill is verified via GetGameState (player no longer alive) and
+    retried if it was dropped by the game loop.
 
     Args:
         mock_client: Mock controller service gRPC client
         serials: List of all controller serials
         delay: Delay between kills in seconds
+        game_client: GameCoordinator gRPC client for kill verification
 
     Returns:
         List of serials that were killed (all except the last one)
@@ -785,25 +867,27 @@ async def kill_players_until_one_remains(
     # Kill all but the last player
     for serial in serials[:-1]:
         await asyncio.sleep(delay)
-        response = await mock_client.SimulateDeath(
-            controller_manager_mock_pb2.DeathRequest(serial=serial)
-        )
-        assert response.success, f"Failed to kill {serial}"
+        if not await kill_player_verified(
+            mock_client, game_client, serial, lambda p: not p.alive
+        ):
+            break  # Game already ended
         killed.append(serial)
     return killed
 
 
 async def kill_players_for_team_win(
-    mock_client, serials: list[str], delay: float = 0.5
+    mock_client, serials: list[str], delay: float = 0.5, game_client=None
 ) -> list[str]:
     """Kill enough players to trigger a team game win.
 
     For team games, killing 3 of 4 players guarantees one team is eliminated.
+    Each kill is verified via GetGameState and retried if dropped.
 
     Args:
         mock_client: Mock controller service gRPC client
         serials: List of all controller serials
         delay: Delay between kills in seconds
+        game_client: GameCoordinator gRPC client for kill verification
 
     Returns:
         List of serials that were killed
@@ -813,10 +897,10 @@ async def kill_players_for_team_win(
     players_to_kill = serials[:3] if len(serials) >= 4 else serials[:-1]
     for serial in players_to_kill:
         await asyncio.sleep(delay)
-        response = await mock_client.SimulateDeath(
-            controller_manager_mock_pb2.DeathRequest(serial=serial)
-        )
-        assert response.success, f"Failed to kill {serial}"
+        if not await kill_player_verified(
+            mock_client, game_client, serial, lambda p: not p.alive
+        ):
+            break  # Game already ended
         killed.append(serial)
     return killed
 
@@ -827,7 +911,7 @@ async def kill_players_for_team_win(
 
 
 async def end_swapper_game(
-    mock_client, serials: list[str], game_client, delay: float = 0.3
+    mock_client, serials: list[str], game_client, delay: float = 0.3, timeout: float = 30.0
 ) -> list[str]:
     """End a Swapper game by swapping all players to one team.
 
@@ -835,43 +919,50 @@ async def end_swapper_game(
     Game ends when all players are on the same team.
     The last player to swap is excluded from winners.
 
-    Strategy: Query actual team assignments via GetGameState, then kill
-    all players on one team to swap them to the other.
+    Strategy: State-driven convergence loop. Re-query team assignments via
+    GetGameState each round and kill one player on team 1, verifying the swap
+    registered. Re-querying makes this robust against dropped kills and
+    against "bounce-backs" (a player swapping twice off one death spike, #757).
 
     Args:
         mock_client: Mock controller service gRPC client
         serials: List of all controller serials (unused, kept for API compat)
         game_client: GameCoordinator client for GetGameState
         delay: Delay between kills in seconds
+        timeout: Max total time for the convergence loop
 
     Returns:
         List of serials that were swapped (killed)
     """
-    # Get actual team assignments from game state
-    state_response = await game_client.GetGameState(
-        game_coordinator_pb2.GetGameStateRequest()
-    )
-    if not state_response.success:
-        raise RuntimeError(f"GetGameState failed: {state_response.error}")
-
-    # Find players on team 1 (we'll swap them all to team 0)
-    team_1_players = [p.serial for p in state_response.game_info.players if p.team == 1]
-    print(f"Swapper: Found {len(team_1_players)} players on team 1: {team_1_players}")
-
     killed = []
-    for serial in team_1_players:
-        await asyncio.sleep(delay)
-        response = await mock_client.SimulateDeath(
-            controller_manager_mock_pb2.DeathRequest(serial=serial)
-        )
-        assert response.success, f"Failed to kill {serial}"
-        killed.append(serial)
+    deadline = asyncio.get_event_loop().time() + timeout
 
-    return killed
+    while True:
+        players = await get_player_states(game_client)
+        if players is None:
+            return killed  # Game ended — converged
+
+        team_1 = [s for s, p in players.items() if p.team == 1]
+        if not team_1:
+            # All players on team 0 — game end should be imminent
+            return killed
+
+        if asyncio.get_event_loop().time() >= deadline:
+            counts = {s: p.team for s, p in players.items()}
+            raise TimeoutError(f"Swapper did not converge within {timeout}s: {counts}")
+
+        serial = team_1[0]
+        print(f"Swapper: killing {serial} (team 1 has {len(team_1)} players)")
+        await asyncio.sleep(delay)
+        if not await kill_player_verified(
+            mock_client, game_client, serial, lambda p: p.team == 0
+        ):
+            return killed  # Game ended during the kill
+        killed.append(serial)
 
 
 async def end_werewolf_game(
-    mock_client, serials: list[str], delay: float = 0.3
+    mock_client, serials: list[str], delay: float = 0.3, game_client=None
 ) -> list[str]:
     """End a Werewolf game by killing all but one player.
 
@@ -879,12 +970,14 @@ async def end_werewolf_game(
     Win conditions: all humans dead OR all werewolves dead.
 
     Strategy: Kill all but one player. This guarantees one team is fully
-    eliminated regardless of random role assignment.
+    eliminated regardless of random role assignment. Each kill is verified
+    via GetGameState and retried if dropped.
 
     Args:
         mock_client: Mock controller service gRPC client
         serials: List of all controller serials
         delay: Delay between kills in seconds
+        game_client: GameCoordinator gRPC client for kill verification
 
     Returns:
         List of serials that were killed
@@ -894,49 +987,64 @@ async def end_werewolf_game(
     print(f"Killing {len(serials) - 1} players to end Werewolf game")
     for serial in serials[:-1]:
         await asyncio.sleep(delay)
-        response = await mock_client.SimulateDeath(
-            controller_manager_mock_pb2.DeathRequest(serial=serial)
-        )
-        assert response.success, f"Failed to kill {serial}"
+        if not await kill_player_verified(
+            mock_client, game_client, serial, lambda p: not p.alive
+        ):
+            break  # Game already ended (one team eliminated early)
         killed.append(serial)
 
     return killed
 
 
 async def end_zombies_game(
-    mock_client, serials: list[str], delay: float = 0.3
+    mock_client, serials: list[str], delay: float = 0.3, game_client=None, timeout: float = 30.0
 ) -> list[str]:
     """End a Zombies game by converting all humans to zombies.
 
     In Zombies, humans become zombies when killed (not eliminated).
     Game ends when all humans are converted OR time expires.
 
-    Strategy: Kill all players. Zombie assignment is random, so we can't
-    know which are humans. Killing a zombie just triggers a respawn (no
-    impact on win condition). Killing a human converts them to zombie.
-    After killing all, every human is converted and the game ends.
+    Strategy: State-driven loop. Humans are team 0, zombies team 1 — query
+    GetGameState and kill only the remaining humans, verifying each
+    conversion (team flips to 1). Re-query each round so dropped kills are
+    retried. Killing zombies is avoided entirely (it only causes respawn
+    churn and death-effect LED noise near game end, #757).
 
     Args:
         mock_client: Mock controller service gRPC client
-        serials: List of all controller serials
+        serials: List of all controller serials (unused, kept for API compat)
         delay: Delay between kills in seconds
+        game_client: GameCoordinator gRPC client for state queries
+        timeout: Max total time for the conversion loop
 
     Returns:
-        List of serials that were killed
+        List of serials that were killed (converted)
     """
     killed = []
-    # Kill all players — zombies just respawn, humans convert to zombies
-    # Game ends when 0 humans remain
-    print(f"Killing all {len(serials)} players to end Zombies game")
-    for serial in serials:
-        await asyncio.sleep(delay)
-        response = await mock_client.SimulateDeath(
-            controller_manager_mock_pb2.DeathRequest(serial=serial)
-        )
-        assert response.success, f"Failed to kill {serial}"
-        killed.append(serial)
+    deadline = asyncio.get_event_loop().time() + timeout
 
-    return killed
+    while True:
+        players = await get_player_states(game_client)
+        if players is None:
+            return killed  # Game ended — all humans converted
+
+        humans = [s for s, p in players.items() if p.team == 0]
+        if not humans:
+            return killed  # Conversion complete — game end imminent
+
+        if asyncio.get_event_loop().time() >= deadline:
+            raise TimeoutError(
+                f"Zombies: {len(humans)} humans still unconverted after {timeout}s: {humans}"
+            )
+
+        serial = humans[0]
+        print(f"Zombies: converting {serial} ({len(humans)} humans remain)")
+        await asyncio.sleep(delay)
+        if not await kill_player_verified(
+            mock_client, game_client, serial, lambda p: p.team == 1
+        ):
+            return killed  # Game ended during the kill
+        killed.append(serial)
 
 
 async def end_fight_club_game(

--- a/tests/integration/test_full_game_lifecycle.py
+++ b/tests/integration/test_full_game_lifecycle.py
@@ -34,8 +34,8 @@ from tests.integration.helpers import (
     setup_mock_controllers,
     start_game_via_menu,
     verify_controllers_have_color,
-    verify_lobby_colors,
     verify_lobby_colors_restored,
+    wait_for_lobby_colors,
 )
 
 # =============================================================================
@@ -72,33 +72,33 @@ async def configure_test_settings(docker_compose, game_mode: str):
     pass
 
 
-async def end_ffa_game(mock_client, serials: list[str], _game_client, _event_collector) -> None:
-    """End FFA game by killing all but one player."""
-    await kill_players_until_one_remains(mock_client, serials, delay=0.1)
+async def end_ffa_game(mock_client, serials: list[str], game_client, _event_collector) -> None:
+    """End FFA game by killing all but one player (verified kills)."""
+    await kill_players_until_one_remains(mock_client, serials, delay=0.1, game_client=game_client)
 
 
-async def end_team_game(mock_client, serials: list[str], _game_client, _event_collector) -> None:
-    """End team game by eliminating one team."""
-    await kill_players_for_team_win(mock_client, serials, delay=0.1)
+async def end_team_game(mock_client, serials: list[str], game_client, _event_collector) -> None:
+    """End team game by eliminating one team (verified kills)."""
+    await kill_players_for_team_win(mock_client, serials, delay=0.1, game_client=game_client)
 
 
 async def end_swapper(mock_client, serials: list[str], game_client, _event_collector) -> None:
-    """End Swapper by swapping all to one team."""
+    """End Swapper by swapping all to one team (state-driven convergence)."""
     await end_swapper_game(mock_client, serials, game_client, delay=0.3)
 
 
-async def end_zombies(mock_client, serials: list[str], _game_client, _event_collector) -> None:
-    """End Zombies by converting all humans."""
-    await end_zombies_game(mock_client, serials, delay=0.3)
+async def end_zombies(mock_client, serials: list[str], game_client, _event_collector) -> None:
+    """End Zombies by converting all humans (state-driven, verified kills)."""
+    await end_zombies_game(mock_client, serials, delay=0.3, game_client=game_client)
 
 
-async def end_werewolf(mock_client, serials: list[str], _game_client, _event_collector) -> None:
-    """End Werewolf by killing all but one player.
+async def end_werewolf(mock_client, serials: list[str], game_client, _event_collector) -> None:
+    """End Werewolf by killing all but one player (verified kills).
 
     Werewolf roles are randomly assigned, so we can't target specific roles.
     Killing all but one guarantees one team is fully eliminated.
     """
-    await end_werewolf_game(mock_client, serials, delay=0.3)
+    await end_werewolf_game(mock_client, serials, delay=0.3, game_client=game_client)
 
 
 async def end_tournament(mock_client, serials: list[str], _game_client, _event_collector) -> None:
@@ -241,11 +241,9 @@ async def test_full_game_lifecycle(
                         print(f"  - {event.event_type}: {dict(event.data)}")
                     raise
 
-            # 6. Wait for menu to fully reset controller colors
-            await asyncio.sleep(3.0)
-
-            # 7. Verify LED colors are restored (not stuck at black)
-            await verify_lobby_colors(mock_client, serials)
+            # 6+7. Wait for menu to reset controller colors (poll instead of a
+            # fixed sleep — menu reset timing varies under CI load, #757)
+            await wait_for_lobby_colors(mock_client, serials, timeout=10.0)
 
             # 8. Verify event sequence shows lobby colors restored
             events = observer.get_events()


### PR DESCRIPTION
## Root cause (fixes #757)

Three distinct failure mechanisms, all stemming from `SimulateDeath` holding 7.07g for **2.0s** fire-and-forget, and all knife-edge timing races that CI CPU contention flips:

### 1. Swapper bounce-back (the failure currently painting main red)
Swapper grants exactly 2.0s post-swap grace — the **same duration as the mock's accel hold**. The death spike is baked into the EMA filter (`(smoothed*4 + raw)/5`), which needs ~9 frames to decay after raw accel normalizes, but the margin between hold-end and grace-end is only the death-detection latency (**measured 15ms locally**). Any swapped player whose grace expires while the game is still running re-dies deterministically and bounces back to their old team — visible directly in the CI debug output of run [26967743303](https://github.com/WatchMeJoustMyFlags/JoustMania/actions/runs/26967743303):

```
player_swapped: MOCK0000 1→0  {0: 3, 1: 1}
player_swapped: MOCK0000 0→1  {0: 2, 1: 2}   ← bounced back
player_swapped: MOCK0003 1→0  {0: 3, 1: 1}   ← stuck at 3-1, win never fires
```

It normally passes only because the game ends ~1s after the last swap, inside everyone's grace window.

### 2. FFA/Teams: kills silently swallowed
`game_started` is published **before** the countdown, and the first tests of a CI session race the flagd config sync (failing run shows `phase_duration_ms: 750` — the code default — instead of CI's `skip`). Kills landing in the countdown + EMA-warmup-drain + startup-grace window are deliberately discarded; under first-test CI starvation the entire 2s hold falls inside it → zero `player_death` events → timeout.

### 3. LED stuck at black
- Zombie human→zombie conversion set **no grace** → the still-held death accel insta-rekilled the fresh zombie (extra death effect, black LED until a respawn that may never come).
- `_effect_player_death` wrote `base_colors = Black` **after** spawning the fade task, so a concurrent menu lobby reset could be clobbered, leaving the restore target permanently black.

## Changes

**Production:**
- `base.py`: during a grace period, reset the EMA so it re-primes from the first post-grace frame — invincibility *forgets* the spike (same re-prime pattern NonStop uses on revive). Sustained violent motion past grace expiry still kills.
- `zombie.py`: 2.0s grace on human→zombie conversion (matches respawn grace).
- `feedback_manager.py`: write black base color before spawning the death fade (latest `base_color` write always wins).
- `mock_control_service.py`: death hold 2.0s → `DEATH_HOLD_SECONDS = 1.0` (still ≥60 frames at 60Hz; must stay below the 2.0s grace).

**Test hardening:**
- `kill_player_verified`: poll `GetGameState` until the kill registers, re-firing `SimulateDeath` every 1.5s — kills can no longer be silently swallowed.
- Swapper/Zombies end strategies are state-driven convergence loops (re-query teams each round) — self-correcting under any timing.
- LED check polls via `wait_for_lobby_colors` instead of `sleep(3)` + one-shot assert.

## Validation
- 704 game-coordinator + 562 controller-manager unit tests pass (new regression tests for grace/EMA memory, conversion grace, base-color ordering).
- Full integration suite 10/10 twice consecutively, and **faster**: 3:18 / 3:50 vs 8:35 in CI (state-driven helpers don't over-wait).
- Acceptance asks for 10+ consecutive green CI runs — suggest re-running the Integration job on this PR a few times before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)