### PR TITLE
feat: promote agent lifecycle constants to flags (#766 F5)

### DIFF
--- a/services/agent/README.md
+++ b/services/agent/README.md
@@ -392,6 +392,28 @@ All configuration is via environment variables:
 > The Go agent uses the flagd **RPC** resolver (gRPC evaluation port `8013`),
 > not the in-process sync port `8015` that the Python services use.
 
+### Lifecycle flags — read at startup (#766 F5)
+
+The agent's lifecycle and throttle calibration values live in the flagd `agent`
+domain ([`services/flagd/agent.json`](../flagd/agent.json)). Unlike the four
+decision-cycle flag layers above (evaluated **every cycle**, hot-reloadable),
+these are **read once at startup**: they configure the GameContext store TTLs,
+the eviction ticker, and the decision-loop log/span throttle, all of which are
+fixed at construction. **Changing one requires an agent restart** — it is *not*
+hot-reload by design (per #766 F5). If flagd is not yet reachable at startup each
+value falls back to its safe default, which reproduces the former hardcoded
+constant exactly (promotion is behavior-neutral).
+
+| Flag | Default | Configures |
+|------|---------|------------|
+| `lifecycle.player_ttl_seconds` | `5` | How long a silent player is retained before eviction |
+| `lifecycle.session_grace_seconds` | `15` | How long an ended session lingers before its session-scoped state resets |
+| `lifecycle.evict_interval_seconds` | `1` | How often the eviction ticker fires |
+| `decision.throttle_seconds` | `1` | How often the `agent.evaluate` log line and the `agent.disabled` span are emitted |
+
+A non-positive value for any of these falls back to its default (a zero TTL or
+ticker interval would be unsafe).
+
 ## Action sink (#730) — applying decisions as flag writes
 
 The agent **never calls the game services over gRPC**. It applies a decision by

--- a/services/agent/decision/decision.go
+++ b/services/agent/decision/decision.go
@@ -143,8 +143,11 @@ type EvalTrigger struct {
 	T0 time.Time
 }
 
-// throttleInterval bounds how often the evaluate log line is emitted.
-const throttleInterval = time.Second
+// DefaultThrottleInterval bounds how often the evaluate log line and the
+// agent.disabled span are emitted, when no explicit throttle is configured. It
+// is the behavior-neutral default for the decision.throttle_seconds flag (#766
+// F5); callers override it at startup via SetThrottle.
+const DefaultThrottleInterval = time.Second
 
 // Loop wires the flag source, rules engine, and action sink together and is
 // invoked once per gated signal update. It is safe for concurrent use: the gRPC
@@ -162,6 +165,10 @@ type Loop struct {
 	mu      sync.Mutex
 	lastLog time.Time
 	now     func() time.Time
+	// throttle bounds how often the evaluate log line and agent.disabled span are
+	// emitted. Read once at startup from decision.throttle_seconds (#766 F5); a
+	// zero value means DefaultThrottleInterval.
+	throttle time.Duration
 
 	// limiter is the unified weighted per-minute rate limiter spanning all
 	// dispatched interventions across cycles (#726 + #728, see ratelimit.go). It
@@ -184,13 +191,25 @@ func NewLoop(flagSource FlagSource, log *slog.Logger) *Loop {
 		flagSource = disabledFlags{}
 	}
 	return &Loop{
-		Flags:   flagSource,
-		Rules:   NoopRules{},
-		Actions: NoopActions{},
-		Log:     log,
-		Tracer:  otel.Tracer(instrumentationName),
-		now:     time.Now,
+		Flags:    flagSource,
+		Rules:    NoopRules{},
+		Actions:  NoopActions{},
+		Log:      log,
+		Tracer:   otel.Tracer(instrumentationName),
+		now:      time.Now,
+		throttle: DefaultThrottleInterval,
 	}
+}
+
+// SetThrottle overrides the log/span throttle interval. It is read once at
+// startup from decision.throttle_seconds (#766 F5); a non-positive value leaves
+// the default in place. Not safe to call concurrently with OnEvaluate — set it
+// during construction, before the loop starts serving.
+func (l *Loop) SetThrottle(d time.Duration) {
+	if d <= 0 {
+		return
+	}
+	l.throttle = d
 }
 
 // OnEvaluate runs one evaluation pass and returns the cycle's LayerState (also
@@ -397,8 +416,8 @@ func (l *Loop) runDecision(ctx context.Context, snapshot flags.Snapshot, c gamec
 // a single agent.decision child (no action child — nothing was decided) carrying
 // the existence + capability + permission attribution lifted from the disabled
 // LayerState. This makes "agent off, here are the flags that were in effect"
-// visible in a Jaeger trace (#729). It is throttled to one per throttleInterval
-// (shared with the evaluate log) so a disabled agent under heavy signal load
+// visible in a Jaeger trace (#729). It is throttled to one per the configured
+// throttle interval (shared with the evaluate log) so a disabled agent under heavy signal load
 // does not flood the trace backend — the steady-state disabled agent is silent.
 func (l *Loop) emitDisabledSpan(ctx context.Context, snapshot flags.Snapshot, c gamecontext.GameContext, trig EvalTrigger, state LayerState) {
 	if !l.shouldLog() {
@@ -476,18 +495,23 @@ func (l *Loop) batteryBlocks(snapshot flags.Snapshot, c gamecontext.GameContext,
 	return *player.BatteryPct < float64(snapshot.Policy.BatteryThreshold)
 }
 
-// shouldLog rate-limits the evaluate log line to once per throttleInterval.
-// Mutex-guarded: OnEvaluate runs concurrently from the trace and metrics
-// Export handler goroutines.
+// shouldLog rate-limits the evaluate log line to once per the configured
+// throttle interval (decision.throttle_seconds, default 1s). Mutex-guarded:
+// OnEvaluate runs concurrently from the trace and metrics Export handler
+// goroutines.
 func (l *Loop) shouldLog() bool {
 	now := l.now
 	if now == nil {
 		now = time.Now
 	}
+	throttle := l.throttle
+	if throttle <= 0 {
+		throttle = DefaultThrottleInterval
+	}
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	t := now()
-	if t.Sub(l.lastLog) < throttleInterval {
+	if t.Sub(l.lastLog) < throttle {
 		return false
 	}
 	l.lastLog = t

--- a/services/agent/decision/loop_test.go
+++ b/services/agent/decision/loop_test.go
@@ -359,3 +359,60 @@ func TestOnEvaluate_RendersFitnessAndObjectives(t *testing.T) {
 		t.Errorf("fitness.evaluated = %v, want %v", got, want)
 	}
 }
+
+// TestSetThrottle_HonorsConfiguredInterval verifies the read-at-startup throttle
+// (decision.throttle_seconds, #766 F5) governs how often the agent.disabled span
+// is emitted. With a disabled flag source, each gated update tries to emit a
+// throttled disabled span; the loop's injectable clock lets us assert the span
+// is suppressed until the configured interval has elapsed.
+func TestSetThrottle_HonorsConfiguredInterval(t *testing.T) {
+	l, sr, fl := newTestLoop(t)
+	fl.snap.Enabled = false // disabled path goes through the throttled span
+	l.SetThrottle(10 * time.Second)
+
+	clock := time.Now()
+	l.now = func() time.Time { return clock }
+
+	disabledSpans := func() int { return len(spansByName(sr.Ended(), SpanDisabled)) }
+
+	// First evaluation emits one disabled span (throttle "fires" on first call).
+	l.OnEvaluate(context.Background(), gamecontext.GameContext{}, testTrigger())
+	if got := disabledSpans(); got != 1 {
+		t.Fatalf("first eval: disabled spans = %d, want 1", got)
+	}
+
+	// Within the 10s window, further evals are throttled — no new span.
+	clock = clock.Add(9 * time.Second)
+	l.OnEvaluate(context.Background(), gamecontext.GameContext{}, testTrigger())
+	if got := disabledSpans(); got != 1 {
+		t.Fatalf("within throttle window: disabled spans = %d, want 1", got)
+	}
+
+	// Past the configured interval, a new span is emitted.
+	clock = clock.Add(2 * time.Second) // now 11s since first
+	l.OnEvaluate(context.Background(), gamecontext.GameContext{}, testTrigger())
+	if got := disabledSpans(); got != 2 {
+		t.Fatalf("after throttle window: disabled spans = %d, want 2", got)
+	}
+}
+
+// TestSetThrottle_NonPositiveKeepsDefault verifies a non-positive throttle leaves
+// the default in place (does not disable throttling).
+func TestSetThrottle_NonPositiveKeepsDefault(t *testing.T) {
+	l := NewLoop(nil, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if l.throttle != DefaultThrottleInterval {
+		t.Fatalf("initial throttle = %v, want %v", l.throttle, DefaultThrottleInterval)
+	}
+	l.SetThrottle(0)
+	if l.throttle != DefaultThrottleInterval {
+		t.Errorf("after SetThrottle(0): throttle = %v, want default %v", l.throttle, DefaultThrottleInterval)
+	}
+	l.SetThrottle(-5 * time.Second)
+	if l.throttle != DefaultThrottleInterval {
+		t.Errorf("after SetThrottle(negative): throttle = %v, want default %v", l.throttle, DefaultThrottleInterval)
+	}
+	l.SetThrottle(3 * time.Second)
+	if l.throttle != 3*time.Second {
+		t.Errorf("after SetThrottle(3s): throttle = %v, want 3s", l.throttle)
+	}
+}

--- a/services/agent/flags/flags.go
+++ b/services/agent/flags/flags.go
@@ -19,6 +19,7 @@ package flags
 import (
 	"context"
 	"log/slog"
+	"time"
 
 	"github.com/open-feature/go-sdk/openfeature"
 )
@@ -41,6 +42,15 @@ const (
 	keyBalancedMaxSkillGap         = "fitness.balanced.max_skill_gap"
 	keyBalancedSpikeSurvival       = "fitness.balanced.spike_survival_threshold"
 	keyAccelerateTargetSessionSecs = "fitness.accelerate.target_session_seconds"
+
+	// Lifecycle + throttle calibration flags (#766 F5). Unlike the layers above
+	// these are READ ONCE AT STARTUP (main.go), not per cycle: they configure the
+	// gamecontext store TTLs / eviction ticker and the decision loop's throttle,
+	// which are fixed at construction. Changing them requires an agent restart.
+	keyPlayerTTLSeconds     = "lifecycle.player_ttl_seconds"
+	keySessionGraceSeconds  = "lifecycle.session_grace_seconds"
+	keyEvictIntervalSeconds = "lifecycle.evict_interval_seconds"
+	keyDecisionThrottleSecs = "decision.throttle_seconds"
 )
 
 // Safe defaults applied when flagd is unreachable or a flag is undefined.
@@ -79,6 +89,26 @@ const (
 	// DefaultAccelerateTargetSessionSeconds: sessions running past this overshoot
 	// the accelerate target (fitness.accelerate.target_session_seconds).
 	DefaultAccelerateTargetSessionSeconds = 60
+
+	// Lifecycle + throttle defaults (#766 F5), mirroring the former hardcoded
+	// constants in main.go (playerTTL/sessionGrace/evictEvery) and decision.go
+	// (throttleInterval). Promotion is behavior-neutral: these defaults reproduce
+	// the prior values exactly. Applied at startup when flagd is unreachable.
+
+	// DefaultPlayerTTLSeconds: how long a silent player is retained before
+	// eviction (lifecycle.player_ttl_seconds; was main.go playerTTL = 5s).
+	DefaultPlayerTTLSeconds = 5.0
+	// DefaultSessionGraceSeconds: how long an ended session lingers before its
+	// session-scoped state resets (lifecycle.session_grace_seconds; was main.go
+	// sessionGrace = 15s).
+	DefaultSessionGraceSeconds = 15.0
+	// DefaultEvictIntervalSeconds: how often the eviction ticker fires
+	// (lifecycle.evict_interval_seconds; was main.go evictEvery = 1s).
+	DefaultEvictIntervalSeconds = 1.0
+	// DefaultDecisionThrottleSeconds: how often the evaluate log line and the
+	// agent.disabled span are emitted (decision.throttle_seconds; was decision.go
+	// throttleInterval = 1s).
+	DefaultDecisionThrottleSeconds = 1.0
 )
 
 // defaultObjectives is the fallback objectives weighting. Returned as a fresh
@@ -141,6 +171,54 @@ type Fitness struct {
 	// AccelerateTargetSessionSeconds: sessions past this overshoot the accelerate
 	// target (fitness.accelerate.target_session_seconds, default 60).
 	AccelerateTargetSessionSeconds int
+}
+
+// Lifecycle holds the agent's lifecycle + throttle calibration values (#766 F5).
+//
+// These are READ ONCE AT STARTUP, not per decision cycle: they configure the
+// gamecontext store TTLs, the eviction ticker, and the decision loop's log/span
+// throttle, all of which are fixed at construction. A flag change here requires
+// an agent restart to take effect (deliberately NOT hot-reload — the issue's
+// read-at-startup decision for the store TTLs). All values are durations.
+type Lifecycle struct {
+	// PlayerTTL bounds how long a silent player is retained before eviction
+	// (lifecycle.player_ttl_seconds, default 5s).
+	PlayerTTL time.Duration
+	// SessionGrace bounds how long an ended session lingers before its
+	// session-scoped state resets (lifecycle.session_grace_seconds, default 15s).
+	SessionGrace time.Duration
+	// EvictInterval is how often the eviction ticker fires
+	// (lifecycle.evict_interval_seconds, default 1s).
+	EvictInterval time.Duration
+	// DecisionThrottle bounds how often the evaluate log line and agent.disabled
+	// span are emitted (decision.throttle_seconds, default 1s).
+	DecisionThrottle time.Duration
+}
+
+// Lifecycle evaluates the read-at-startup lifecycle + throttle flags. Unlike
+// Evaluate (per cycle), this is called ONCE during main()'s startup, after the
+// flagd provider is registered. Each flag falls back to its safe default on any
+// evaluation error (e.g. flagd not yet ready), reproducing the former hardcoded
+// constants. Non-positive values fall back to the default to avoid a zero/negative
+// TTL or ticker interval.
+func (f *Flags) Lifecycle(ctx context.Context) Lifecycle {
+	return Lifecycle{
+		PlayerTTL:        f.durationFlag(ctx, keyPlayerTTLSeconds, DefaultPlayerTTLSeconds),
+		SessionGrace:     f.durationFlag(ctx, keySessionGraceSeconds, DefaultSessionGraceSeconds),
+		EvictInterval:    f.durationFlag(ctx, keyEvictIntervalSeconds, DefaultEvictIntervalSeconds),
+		DecisionThrottle: f.durationFlag(ctx, keyDecisionThrottleSecs, DefaultDecisionThrottleSeconds),
+	}
+}
+
+// durationFlag resolves a float "seconds" flag into a time.Duration, falling
+// back to def seconds on any error or on a non-positive value.
+func (f *Flags) durationFlag(ctx context.Context, key string, def float64) time.Duration {
+	secs := f.floatFlag(ctx, key, def)
+	if secs <= 0 {
+		f.log.Warn("flags duration non-positive, using default", "key", key, "value", secs, "default", def)
+		secs = def
+	}
+	return time.Duration(secs * float64(time.Second))
 }
 
 // Snapshot is the set of agent control flags captured for a single decision

--- a/services/agent/flags/flags_test.go
+++ b/services/agent/flags/flags_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/open-feature/go-sdk/openfeature"
 )
@@ -265,5 +266,90 @@ func TestSnapshotPermits(t *testing.T) {
 	empty := Snapshot{}
 	if empty.Permits("play_audio_cue") {
 		t.Errorf("empty allow-list permitted an intervention")
+	}
+}
+
+// defaultLifecycle is the expected lifecycle snapshot when every flag falls back
+// to its safe default (the former hardcoded constants; #766 F5).
+func defaultLifecycle() Lifecycle {
+	return Lifecycle{
+		PlayerTTL:        time.Duration(DefaultPlayerTTLSeconds * float64(time.Second)),
+		SessionGrace:     time.Duration(DefaultSessionGraceSeconds * float64(time.Second)),
+		EvictInterval:    time.Duration(DefaultEvictIntervalSeconds * float64(time.Second)),
+		DecisionThrottle: time.Duration(DefaultDecisionThrottleSeconds * float64(time.Second)),
+	}
+}
+
+func TestLifecycle_FlagdShape(t *testing.T) {
+	stub := stubEvaluator{floats: map[string]float64{
+		keyPlayerTTLSeconds:     3,
+		keySessionGraceSeconds:  30,
+		keyEvictIntervalSeconds: 0.5,
+		keyDecisionThrottleSecs: 5,
+	}}
+	got := New(stub, nil).Lifecycle(context.Background())
+
+	want := Lifecycle{
+		PlayerTTL:        3 * time.Second,
+		SessionGrace:     30 * time.Second,
+		EvictInterval:    500 * time.Millisecond,
+		DecisionThrottle: 5 * time.Second,
+	}
+	if got != want {
+		t.Errorf("Lifecycle = %+v, want %+v", got, want)
+	}
+}
+
+func TestLifecycle_DefaultsWhenMissing(t *testing.T) {
+	// Empty stub: every flag undefined. The former hardcoded constants must apply
+	// (promotion is behavior-neutral).
+	got := New(stubEvaluator{}, nil).Lifecycle(context.Background())
+	if got != defaultLifecycle() {
+		t.Errorf("Lifecycle = %+v, want defaults %+v", got, defaultLifecycle())
+	}
+	// Characterize the actual prior values: 5s / 15s / 1s / 1s.
+	want := Lifecycle{
+		PlayerTTL:        5 * time.Second,
+		SessionGrace:     15 * time.Second,
+		EvictInterval:    1 * time.Second,
+		DecisionThrottle: 1 * time.Second,
+	}
+	if got != want {
+		t.Errorf("Lifecycle defaults = %+v, want former constants %+v", got, want)
+	}
+}
+
+func TestLifecycle_DefaultsOnError(t *testing.T) {
+	boom := errors.New("flagd unreachable")
+	stub := stubEvaluator{errs: map[string]error{
+		keyPlayerTTLSeconds:     boom,
+		keySessionGraceSeconds:  boom,
+		keyEvictIntervalSeconds: boom,
+		keyDecisionThrottleSecs: boom,
+	}}
+	got := New(stub, nil).Lifecycle(context.Background())
+	if got != defaultLifecycle() {
+		t.Errorf("Lifecycle on error = %+v, want defaults %+v", got, defaultLifecycle())
+	}
+}
+
+func TestLifecycle_NonPositiveFallsBack(t *testing.T) {
+	// A zero or negative duration would break the store TTL / ticker, so the
+	// wrapper must fall back to the default for non-positive values.
+	stub := stubEvaluator{floats: map[string]float64{
+		keyPlayerTTLSeconds:     0,
+		keySessionGraceSeconds:  -5,
+		keyEvictIntervalSeconds: 2,
+		keyDecisionThrottleSecs: 0,
+	}}
+	got := New(stub, nil).Lifecycle(context.Background())
+	want := Lifecycle{
+		PlayerTTL:        time.Duration(DefaultPlayerTTLSeconds * float64(time.Second)),
+		SessionGrace:     time.Duration(DefaultSessionGraceSeconds * float64(time.Second)),
+		EvictInterval:    2 * time.Second,
+		DecisionThrottle: time.Duration(DefaultDecisionThrottleSeconds * float64(time.Second)),
+	}
+	if got != want {
+		t.Errorf("Lifecycle = %+v, want %+v", got, want)
 	}
 }

--- a/services/agent/main.go
+++ b/services/agent/main.go
@@ -34,14 +34,8 @@ import (
 	"github.com/joustmania/agent/gamecontext"
 )
 
-// Tunable lifecycle constants.
-const (
-	playerTTL    = 5 * time.Second
-	sessionGrace = 15 * time.Second
-	evictEvery   = 1 * time.Second
-	// probeInterval rate-limits the AGENT_PROBE_DECISIONS demo probe.
-	probeInterval = 5 * time.Second
-)
+// probeInterval rate-limits the AGENT_PROBE_DECISIONS demo probe.
+const probeInterval = 5 * time.Second
 
 // defaultServiceName is the agent's OTEL service name default. It MUST stay
 // identical everywhere it is used: the exported resource (otel.go) and the
@@ -128,7 +122,21 @@ func main() {
 	defer shutdownFlags()
 	slog.Info("OpenFeature flagd provider registered", "host", flagCfg.Host, "port", flagCfg.Port)
 
-	store := gamecontext.NewStore(playerTTL, sessionGrace, nil)
+	// Lifecycle + throttle calibration flags (#766 F5) are READ ONCE here, after
+	// the provider is registered. They configure the store TTLs, eviction ticker,
+	// and decision-loop throttle, all fixed at construction — so changing them
+	// requires an agent restart (deliberately NOT hot-reload). If flagd is not yet
+	// ready every value falls back to its safe default (the former hardcoded
+	// constants), so the agent still starts behavior-neutrally.
+	lifecycle := agentFlags.Lifecycle(ctx)
+	slog.Info("Agent lifecycle flags evaluated (read-at-startup; restart to change)",
+		"player_ttl", lifecycle.PlayerTTL,
+		"session_grace", lifecycle.SessionGrace,
+		"evict_interval", lifecycle.EvictInterval,
+		"decision_throttle", lifecycle.DecisionThrottle,
+	)
+
+	store := gamecontext.NewStore(lifecycle.PlayerTTL, lifecycle.SessionGrace, nil)
 	// Skip the agent's own telemetry when the collector fans it back to us
 	// (otlp/agent exporter) — breaks the self-ingestion feedback loop.
 	store.SetOwnService(resolveServiceName())
@@ -137,6 +145,9 @@ func main() {
 	// flags are evaluated every cycle, the kill switch / objectives / permission
 	// gate are applied, and decisions flow through the #724 audit spans.
 	loop := decision.NewLoop(agentFlags, logger)
+	// Throttle for the evaluate log line / agent.disabled span is read-at-startup
+	// from decision.throttle_seconds (#766 F5).
+	loop.SetThrottle(lifecycle.DecisionThrottle)
 	// The objective-weighted rules engine (#726) is the active default. Its
 	// objective weights are driven live from the `objectives` flag each cycle
 	// (NewObjectiveRulesLive publishes a LiveObjectives source the loop updates);
@@ -157,7 +168,7 @@ func main() {
 		slog.Warn("Probe decisions enabled (demo/verification mode)",
 			"interval", probeInterval)
 	}
-	pipe := newPipeline(store, loop, playerTTL)
+	pipe := newPipeline(store, loop, lifecycle.PlayerTTL)
 
 	grpcServer := grpc.NewServer()
 	ptraceotlp.RegisterGRPCServer(grpcServer, &traceReceiver{pipe: pipe})
@@ -188,7 +199,7 @@ func main() {
 	}()
 
 	// Eviction ticker.
-	ticker := time.NewTicker(evictEvery)
+	ticker := time.NewTicker(lifecycle.EvictInterval)
 	defer ticker.Stop()
 	go func() {
 		for {

--- a/services/flagd/agent.json
+++ b/services/flagd/agent.json
@@ -277,6 +277,42 @@
         "responsive": 2.0
       },
       "defaultVariant": "default"
+    },
+    "lifecycle.player_ttl_seconds": {
+      "state": "ENABLED",
+      "variants": {
+        "default": 5,
+        "short": 3,
+        "long": 10
+      },
+      "defaultVariant": "default"
+    },
+    "lifecycle.session_grace_seconds": {
+      "state": "ENABLED",
+      "variants": {
+        "default": 15,
+        "short": 5,
+        "long": 30
+      },
+      "defaultVariant": "default"
+    },
+    "lifecycle.evict_interval_seconds": {
+      "state": "ENABLED",
+      "variants": {
+        "default": 1,
+        "fast": 0.5,
+        "slow": 2
+      },
+      "defaultVariant": "default"
+    },
+    "decision.throttle_seconds": {
+      "state": "ENABLED",
+      "variants": {
+        "default": 1,
+        "chatty": 0.5,
+        "quiet": 5
+      },
+      "defaultVariant": "default"
     }
   }
 }


### PR DESCRIPTION
Part of #766 (F5).

Promotes the Go agent's hardcoded lifecycle/throttle constants to flagd `agent`-domain flags. Promotion is behavior-neutral: every default variant carries the prior hardcoded value.

## What changed

**`services/flagd/agent.json`** — four new flags (#725 naming convention):
- `lifecycle.player_ttl_seconds` (default 5)
- `lifecycle.session_grace_seconds` (default 15)
- `lifecycle.evict_interval_seconds` (default 1)
- `decision.throttle_seconds` (default 1)

**`services/agent/flags/flags.go`** — new keys, defaults, and a `Lifecycle` sub-struct with a `Lifecycle(ctx)` evaluation method (duration coercion from float seconds; non-positive values fall back to the default).

**`services/agent/main.go`** — read-at-startup wiring. The lifecycle flags are evaluated **once**, after the flagd provider is registered (falling back to defaults if flagd isn't ready), then passed into the gamecontext store TTLs, the pipeline player TTL, the eviction ticker, and `Loop.SetThrottle`. These are deliberately **NOT hot-reload** — a restart is required to pick up changes (per the issue's read-at-startup decision).

**`services/agent/decision/decision.go`** — the formerly-const `throttleInterval` becomes a `Loop.throttle` field (defaulting to `DefaultThrottleInterval`), set at startup via `SetThrottle`; `shouldLog` honors it.

**`services/agent/README.md`** — lifecycle-flags table + read-at-startup note. (`docs/feature-flags.md` is F8's scope, intentionally untouched.)

## Test plan

- `go test -race ./...` — all packages pass
- `go vet ./...` — clean
- `gofmt -l .` — empty
- `go mod tidy` — idempotent
- `agent.json` parses as JSON

New tests:
- `flags`: Lifecycle evaluates flagd values, defaults-when-missing (characterizes the former 5/15/1/1s constants), defaults-on-error, non-positive fallback
- `decision`: throttle honors the configured interval via the loop's injectable clock; non-positive `SetThrottle` keeps the default

Refs #722 #725.

🤖 Generated with [Claude Code](https://claude.com/claude-code)