### PR TITLE
feat: promote death/warning threshold tables to game flags (#766 F1)

### DIFF
--- a/lib/feature_flags.py
+++ b/lib/feature_flags.py
@@ -178,6 +178,36 @@ def get_flag_client(domain: str):
     return api.get_client(domain=domain)
 
 
+def read_object_flag(domain: str, flag_key: str, default: dict) -> dict:
+    """
+    Read an object-typed flag once at init time, with a hardcoded fallback.
+
+    Init-frozen read helper for calibration flags (#766): the value is fetched
+    once (e.g. in a game mode ``__init__``) and never re-evaluated mid-game.
+    The domain is initialized lazily on first use, so callers do not need a
+    pre-wired client. On ANY failure (provider not ready, missing flag,
+    evaluation error) the supplied ``default`` is returned unchanged so the
+    promotion stays behavior-neutral.
+
+    Args:
+        domain: OpenFeature domain / flagSetId (e.g. "game")
+        flag_key: Object flag key (e.g. "thresholds")
+        default: Fallback value returned on any error or missing flag
+
+    Returns:
+        The flag's object value, or ``default`` on failure.
+    """
+    try:
+        init_flag_domain(domain)
+        client = get_flag_client(domain)
+        value = client.get_object_value(flag_key, default, EvaluationContext())
+        # get_object_value may return the default sentinel itself; either is fine.
+        return value if isinstance(value, dict) else default
+    except Exception as e:
+        logger.warning(f"read_object_flag({domain!r}, {flag_key!r}) failed, using default: {e}")
+        return default
+
+
 def set_game_transaction_context(
     game_mode: str,
     controller_count: int,

--- a/services/flagd/game.json
+++ b/services/flagd/game.json
@@ -123,6 +123,38 @@
         "long": 5000
       },
       "defaultVariant": "normal"
+    },
+    "thresholds": {
+      "state": "ENABLED",
+      "variants": {
+        "default": {
+          "slow_warning": [1.2, 1.3, 1.6, 2.0, 2.5],
+          "slow_max": [1.3, 1.5, 1.8, 2.5, 3.2],
+          "fast_warning": [1.4, 1.6, 1.9, 2.7, 2.8],
+          "fast_max": [1.6, 1.8, 2.8, 3.2, 3.5]
+        }
+      },
+      "defaultVariant": "default"
+    },
+    "zombie.thresholds": {
+      "state": "ENABLED",
+      "variants": {
+        "default": {
+          "warning": [1.4, 1.7, 2.1, 2.9, 3.5],
+          "max": [1.6, 1.9, 2.6, 3.9, 4.5]
+        }
+      },
+      "defaultVariant": "default"
+    },
+    "werewolf.thresholds": {
+      "state": "ENABLED",
+      "variants": {
+        "default": {
+          "warning": [1.4, 1.7, 2.1, 2.9, 3.5],
+          "max": [1.6, 1.9, 2.6, 3.9, 4.5]
+        }
+      },
+      "defaultVariant": "default"
     }
   }
 }

--- a/services/game_coordinator/games/base.py
+++ b/services/game_coordinator/games/base.py
@@ -28,7 +28,7 @@ from typing import TYPE_CHECKING, Any
 from opentelemetry import context as otel_context
 from opentelemetry import trace
 
-from lib.feature_flags import set_game_transaction_context
+from lib.feature_flags import read_object_flag, set_game_transaction_context
 from lib.telemetry import inject_trace_context
 from lib.types import GameEvent, Sensitivity, Sound
 from services.game_coordinator import metrics
@@ -96,6 +96,85 @@ SLOW_WARNING = [1.2, 1.3, 1.6, 2.0, 2.5]  # Warning thresholds when music is slo
 SLOW_MAX = [1.3, 1.5, 1.8, 2.5, 3.2]  # Death thresholds when music is slow
 FAST_WARNING = [1.4, 1.6, 1.9, 2.7, 2.8]  # Warning thresholds when music is fast
 FAST_MAX = [1.6, 1.8, 2.8, 3.2, 3.5]  # Death thresholds when music is fast
+
+# Number of sensitivity levels (0=ULTRA_SLOW .. 4=ULTRA_FAST); every threshold
+# array must carry exactly this many entries.
+SENSITIVITY_LEVELS = 5
+
+
+def _valid_threshold_row(row) -> bool:
+    """A threshold array must hold exactly SENSITIVITY_LEVELS numeric entries."""
+    if not isinstance(row, (list, tuple)) or len(row) != SENSITIVITY_LEVELS:
+        return False
+    return all(isinstance(v, (int, float)) and not isinstance(v, bool) for v in row)
+
+
+def resolve_base_thresholds(flag_value: dict) -> dict[str, list]:
+    """
+    Validate the ``game.thresholds`` object flag and resolve the four arrays.
+
+    Each of slow_warning/slow_max/fast_warning/fast_max must be a 5-element
+    numeric array, and per sensitivity row warning < max (slow and fast). On
+    ANY malformed entry the corresponding hardcoded module constant is used as
+    the fallback source of truth, keeping the promotion behavior-neutral.
+
+    Args:
+        flag_value: Object value from the ``thresholds`` flag (may be partial/invalid)
+
+    Returns:
+        Dict with keys slow_warning, slow_max, fast_warning, fast_max -> lists.
+    """
+    defaults = {
+        "slow_warning": list(SLOW_WARNING),
+        "slow_max": list(SLOW_MAX),
+        "fast_warning": list(FAST_WARNING),
+        "fast_max": list(FAST_MAX),
+    }
+    if not isinstance(flag_value, dict):
+        return defaults
+
+    resolved = {}
+    for key in ("slow_warning", "slow_max", "fast_warning", "fast_max"):
+        candidate = flag_value.get(key)
+        resolved[key] = list(candidate) if _valid_threshold_row(candidate) else defaults[key]
+
+    # Per-row sanity: warning must be strictly below max at every sensitivity.
+    # If any row violates it, fall back to the matching default pair so we never
+    # ship an unkillable or instant-death configuration.
+    for warn_key, max_key in (("slow_warning", "slow_max"), ("fast_warning", "fast_max")):
+        if any(w >= m for w, m in zip(resolved[warn_key], resolved[max_key], strict=False)):
+            resolved[warn_key] = defaults[warn_key]
+            resolved[max_key] = defaults[max_key]
+
+    return resolved
+
+
+def resolve_mode_thresholds(flag_value: dict, default_table: dict) -> dict:
+    """
+    Validate a per-mode override flag (zombie/werewolf) -> ``{Sensitivity: (warn, max)}``.
+
+    The flag carries two 5-element arrays ``warning`` and ``max`` (indexed by
+    sensitivity 0..4). On any malformed entry or warning>=max row, the supplied
+    ``default_table`` (the mode's hardcoded dict) is returned unchanged.
+
+    Args:
+        flag_value: Object value from ``<mode>.thresholds`` flag
+        default_table: Hardcoded ``{Sensitivity: (warn, max)}`` fallback
+
+    Returns:
+        A ``{Sensitivity: (warn, max)}`` dict.
+    """
+    if not isinstance(flag_value, dict):
+        return default_table
+
+    warning = flag_value.get("warning")
+    death = flag_value.get("max")
+    if not _valid_threshold_row(warning) or not _valid_threshold_row(death):
+        return default_table
+    if any(w >= m for w, m in zip(warning, death, strict=False)):
+        return default_table
+
+    return {Sensitivity(i): (warning[i], death[i]) for i in range(SENSITIVITY_LEVELS)}
 
 
 # Warning feedback duration (seconds) - flash + rumble time
@@ -241,6 +320,16 @@ class BaseGameMode(ABC):
         else:
             logger.warning(f"Sensitivity {sensitivity} out of range, using MEDIUM")
             self.sensitivity = Sensitivity.MEDIUM
+
+        # #766 F1: death/warning threshold tables promoted to the ``game.thresholds``
+        # object flag. Read ONCE here (init-frozen by design — no live re-evaluation);
+        # malformed/missing values fall back to the module constants.
+        flag_thresholds = read_object_flag("game", "thresholds", {})
+        tables = resolve_base_thresholds(flag_thresholds)
+        self.slow_warning = tables["slow_warning"]
+        self.slow_max = tables["slow_max"]
+        self.fast_warning = tables["fast_warning"]
+        self.fast_max = tables["fast_max"]
 
         # Phase 70: Music tempo control state
         self.music_track_id = None
@@ -883,9 +972,9 @@ class BaseGameMode(ABC):
         speed_percent = (self.music_speed - SLOW_MUSIC_SPEED) / speed_range if speed_range > 0 else 0.0
         speed_percent = max(0.0, min(1.0, speed_percent))  # Clamp to [0, 1]
 
-        # LERP between slow and fast thresholds
-        base_warn = self._lerp(SLOW_WARNING[sens_idx], FAST_WARNING[sens_idx], speed_percent)
-        base_death = self._lerp(SLOW_MAX[sens_idx], FAST_MAX[sens_idx], speed_percent)
+        # LERP between slow and fast thresholds (instance tables, #766 F1)
+        base_warn = self._lerp(self.slow_warning[sens_idx], self.fast_warning[sens_idx], speed_percent)
+        base_death = self._lerp(self.slow_max[sens_idx], self.fast_max[sens_idx], speed_percent)
 
         # Apply per-player sensitivity factor
         # Clamp factor to [0.5, 2.0] for safety, then divide thresholds
@@ -1677,8 +1766,8 @@ class BaseGameMode(ABC):
         speed_percent = (self.music_speed - SLOW_MUSIC_SPEED) / speed_range if speed_range > 0 else 0.0
         speed_percent = max(0.0, min(1.0, speed_percent))
 
-        effective_warn = self._lerp(SLOW_WARNING[sens_idx], FAST_WARNING[sens_idx], speed_percent)
-        effective_death = self._lerp(SLOW_MAX[sens_idx], FAST_MAX[sens_idx], speed_percent)
+        effective_warn = self._lerp(self.slow_warning[sens_idx], self.fast_warning[sens_idx], speed_percent)
+        effective_death = self._lerp(self.slow_max[sens_idx], self.fast_max[sens_idx], speed_percent)
 
         metrics.effective_warning_threshold.set(effective_warn)
         metrics.effective_death_threshold.set(effective_death)

--- a/services/game_coordinator/games/werewolf.py
+++ b/services/game_coordinator/games/werewolf.py
@@ -17,9 +17,17 @@ from opentelemetry import trace
 from opentelemetry.trace import Status, StatusCode
 
 from lib.colors import Colors
+from lib.feature_flags import read_object_flag
 from lib.types import Sound
 from proto import controller_manager_pb2
-from services.game_coordinator.games.base import GAME_MODE_ATTR, BaseGameMode, Phase, Player, Sensitivity
+from services.game_coordinator.games.base import (
+    GAME_MODE_ATTR,
+    BaseGameMode,
+    Phase,
+    Player,
+    Sensitivity,
+    resolve_mode_thresholds,
+)
 
 logger = logging.getLogger(__name__)
 tracer = trace.get_tracer(__name__)
@@ -91,6 +99,12 @@ class WerewolfGame(BaseGameMode):
             game_id=game_id,
             initial_players=initial_players,
             sensitivity=sensitivity,
+        )
+
+        # #766 F1: werewolf threshold overrides promoted to ``game.werewolf.thresholds``.
+        # Read once at init (init-frozen); malformed values fall back to WEREWOLF_THRESHOLDS.
+        self.werewolf_thresholds = resolve_mode_thresholds(
+            read_object_flag("game", "werewolf.thresholds", {}), WEREWOLF_THRESHOLDS
         )
 
         self.werewolf_serials: list[str] = []
@@ -317,7 +331,7 @@ class WerewolfGame(BaseGameMode):
         """
         wolf_player = player
         if wolf_player.is_werewolf:
-            return WEREWOLF_THRESHOLDS.get(self.sensitivity, (2.1, 2.6))
+            return self.werewolf_thresholds.get(self.sensitivity, (2.1, 2.6))
         return super()._compute_effective_thresholds(player)
 
     async def _check_win_condition(self) -> bool:

--- a/services/game_coordinator/games/zombie.py
+++ b/services/game_coordinator/games/zombie.py
@@ -21,9 +21,17 @@ from opentelemetry import trace
 from opentelemetry.trace import Status, StatusCode
 
 from lib.colors import Colors
+from lib.feature_flags import read_object_flag
 from lib.types import Sound
 from proto import controller_manager_pb2
-from services.game_coordinator.games.base import GAME_MODE_ATTR, BaseGameMode, Phase, Player, Sensitivity
+from services.game_coordinator.games.base import (
+    GAME_MODE_ATTR,
+    BaseGameMode,
+    Phase,
+    Player,
+    Sensitivity,
+    resolve_mode_thresholds,
+)
 
 logger = logging.getLogger(__name__)
 tracer = trace.get_tracer(__name__)
@@ -113,6 +121,12 @@ class ZombieGame(BaseGameMode):
             game_id=game_id,
             initial_players=initial_players,
             sensitivity=sensitivity,
+        )
+
+        # #766 F1: zombie threshold overrides promoted to ``game.zombie.thresholds``.
+        # Read once at init (init-frozen); malformed values fall back to ZOMBIE_THRESHOLDS.
+        self.zombie_thresholds = resolve_mode_thresholds(
+            read_object_flag("game", "zombie.thresholds", {}), ZOMBIE_THRESHOLDS
         )
 
         self.zombie_serials: list[str] = []
@@ -264,7 +278,7 @@ class ZombieGame(BaseGameMode):
         """
         zombie_player = player
         if zombie_player.is_zombie:
-            return ZOMBIE_THRESHOLDS.get(self.sensitivity, (2.1, 2.6))
+            return self.zombie_thresholds.get(self.sensitivity, (2.1, 2.6))
         return super()._compute_effective_thresholds(player)
 
     async def _game_timer(self):

--- a/services/game_coordinator/tests/test_threshold_flags.py
+++ b/services/game_coordinator/tests/test_threshold_flags.py
@@ -1,0 +1,291 @@
+"""
+Tests for #766 F1: death/warning threshold tables promoted to game flags.
+
+Covers:
+- Characterization: flag defaults reproduce the current hardcoded behavior exactly.
+- resolve_base_thresholds validation + fallback (wrong length, warning>=max,
+  non-numeric, missing keys, non-dict).
+- resolve_mode_thresholds validation + fallback for zombie/werewolf overrides.
+- Game modes read the flag once at init and store instance threshold tables.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Setup paths for imports
+test_dir = Path(__file__).parent
+service_dir = test_dir.parent
+project_root = service_dir.parent.parent
+sys.path.insert(0, str(project_root))
+sys.path.insert(0, str(test_dir))
+
+from conftest import EventCollector, async_noop
+
+from services.game_coordinator.games.base import (
+    FAST_MAX,
+    FAST_WARNING,
+    SLOW_MAX,
+    SLOW_WARNING,
+    resolve_base_thresholds,
+    resolve_mode_thresholds,
+)
+from services.game_coordinator.games.ffa import FFAGame
+from services.game_coordinator.games.werewolf import WEREWOLF_THRESHOLDS, WerewolfGame
+from services.game_coordinator.games.zombie import ZOMBIE_THRESHOLDS, ZombieGame
+
+# The exact object the game.json default variant carries (must mirror the
+# module constants — that is the whole point of behavior-neutral promotion).
+GAME_JSON_DEFAULT = {
+    "slow_warning": [1.2, 1.3, 1.6, 2.0, 2.5],
+    "slow_max": [1.3, 1.5, 1.8, 2.5, 3.2],
+    "fast_warning": [1.4, 1.6, 1.9, 2.7, 2.8],
+    "fast_max": [1.6, 1.8, 2.8, 3.2, 3.5],
+}
+
+ZOMBIE_JSON_DEFAULT = {
+    "warning": [1.4, 1.7, 2.1, 2.9, 3.5],
+    "max": [1.6, 1.9, 2.6, 3.9, 4.5],
+}
+
+
+# ========================================================================
+# resolve_base_thresholds — characterization + validation/fallback
+# ========================================================================
+
+
+def test_game_json_default_matches_module_constants():
+    """The flag's default variant must equal the hardcoded module constants."""
+    assert GAME_JSON_DEFAULT["slow_warning"] == SLOW_WARNING
+    assert GAME_JSON_DEFAULT["slow_max"] == SLOW_MAX
+    assert GAME_JSON_DEFAULT["fast_warning"] == FAST_WARNING
+    assert GAME_JSON_DEFAULT["fast_max"] == FAST_MAX
+
+
+def test_default_flag_reproduces_current_behavior():
+    """Resolving the game.json default yields exactly the module constants."""
+    resolved = resolve_base_thresholds(GAME_JSON_DEFAULT)
+    assert resolved["slow_warning"] == SLOW_WARNING
+    assert resolved["slow_max"] == SLOW_MAX
+    assert resolved["fast_warning"] == FAST_WARNING
+    assert resolved["fast_max"] == FAST_MAX
+
+
+def test_empty_dict_falls_back_to_defaults():
+    resolved = resolve_base_thresholds({})
+    assert resolved["slow_warning"] == SLOW_WARNING
+    assert resolved["fast_max"] == FAST_MAX
+
+
+def test_non_dict_falls_back_to_defaults():
+    for bad in (None, [], "nope", 5):
+        resolved = resolve_base_thresholds(bad)
+        assert resolved["slow_warning"] == SLOW_WARNING
+        assert resolved["slow_max"] == SLOW_MAX
+
+
+def test_wrong_length_row_falls_back_per_key():
+    bad = dict(GAME_JSON_DEFAULT)
+    bad["slow_warning"] = [1.0, 1.0, 1.0]  # only 3 entries
+    resolved = resolve_base_thresholds(bad)
+    # Bad row falls back, others honored
+    assert resolved["slow_warning"] == SLOW_WARNING
+    assert resolved["fast_warning"] == FAST_WARNING
+
+
+def test_non_numeric_row_falls_back():
+    bad = dict(GAME_JSON_DEFAULT)
+    bad["fast_max"] = [1.6, 1.8, "x", 3.2, 3.5]
+    resolved = resolve_base_thresholds(bad)
+    assert resolved["fast_max"] == FAST_MAX
+
+
+def test_bool_entries_rejected():
+    # bool is a subclass of int; must be rejected as non-numeric threshold.
+    bad = dict(GAME_JSON_DEFAULT)
+    bad["slow_max"] = [True, False, 1.8, 2.5, 3.2]
+    resolved = resolve_base_thresholds(bad)
+    assert resolved["slow_max"] == SLOW_MAX
+
+
+def test_missing_key_falls_back_for_that_key_only():
+    partial = {k: v for k, v in GAME_JSON_DEFAULT.items() if k != "fast_warning"}
+    resolved = resolve_base_thresholds(partial)
+    assert resolved["fast_warning"] == FAST_WARNING  # missing -> default
+    assert resolved["slow_warning"] == SLOW_WARNING  # present -> honored
+
+
+def test_warning_not_below_max_falls_back_pair():
+    # slow_warning[2] >= slow_max[2] -> the whole slow pair reverts to defaults.
+    bad = {
+        "slow_warning": [1.2, 1.3, 5.0, 2.0, 2.5],
+        "slow_max": [1.3, 1.5, 1.8, 2.5, 3.2],
+        "fast_warning": [1.0, 1.1, 1.2, 1.3, 1.4],
+        "fast_max": [2.0, 2.1, 2.2, 2.3, 2.4],
+    }
+    resolved = resolve_base_thresholds(bad)
+    assert resolved["slow_warning"] == SLOW_WARNING
+    assert resolved["slow_max"] == SLOW_MAX
+    # The valid fast pair is preserved untouched.
+    assert resolved["fast_warning"] == [1.0, 1.1, 1.2, 1.3, 1.4]
+    assert resolved["fast_max"] == [2.0, 2.1, 2.2, 2.3, 2.4]
+
+
+def test_custom_valid_override_is_honored():
+    custom = {
+        "slow_warning": [1.0, 1.1, 1.2, 1.3, 1.4],
+        "slow_max": [2.0, 2.1, 2.2, 2.3, 2.4],
+        "fast_warning": [1.5, 1.6, 1.7, 1.8, 1.9],
+        "fast_max": [3.0, 3.1, 3.2, 3.3, 3.4],
+    }
+    resolved = resolve_base_thresholds(custom)
+    assert resolved == {k: list(v) for k, v in custom.items()}
+
+
+# ========================================================================
+# resolve_mode_thresholds — zombie/werewolf override validation
+# ========================================================================
+
+
+def test_mode_default_reproduces_hardcoded_table():
+    resolved = resolve_mode_thresholds(ZOMBIE_JSON_DEFAULT, ZOMBIE_THRESHOLDS)
+    assert resolved == ZOMBIE_THRESHOLDS
+
+
+def test_mode_non_dict_falls_back():
+    assert resolve_mode_thresholds(None, WEREWOLF_THRESHOLDS) == WEREWOLF_THRESHOLDS
+    assert resolve_mode_thresholds([], WEREWOLF_THRESHOLDS) == WEREWOLF_THRESHOLDS
+
+
+def test_mode_wrong_length_falls_back():
+    bad = {"warning": [1.4, 1.7], "max": [1.6, 1.9, 2.6, 3.9, 4.5]}
+    assert resolve_mode_thresholds(bad, ZOMBIE_THRESHOLDS) == ZOMBIE_THRESHOLDS
+
+
+def test_mode_non_numeric_falls_back():
+    bad = {"warning": [1.4, 1.7, "x", 2.9, 3.5], "max": [1.6, 1.9, 2.6, 3.9, 4.5]}
+    assert resolve_mode_thresholds(bad, ZOMBIE_THRESHOLDS) == ZOMBIE_THRESHOLDS
+
+
+def test_mode_missing_key_falls_back():
+    bad = {"warning": [1.4, 1.7, 2.1, 2.9, 3.5]}  # no "max"
+    assert resolve_mode_thresholds(bad, ZOMBIE_THRESHOLDS) == ZOMBIE_THRESHOLDS
+
+
+def test_mode_warning_not_below_max_falls_back():
+    bad = {"warning": [9.0, 1.7, 2.1, 2.9, 3.5], "max": [1.6, 1.9, 2.6, 3.9, 4.5]}
+    assert resolve_mode_thresholds(bad, WEREWOLF_THRESHOLDS) == WEREWOLF_THRESHOLDS
+
+
+def test_mode_custom_valid_override_honored():
+    from services.game_coordinator.games.base import Sensitivity
+
+    custom = {"warning": [1.0, 1.1, 1.2, 1.3, 1.4], "max": [2.0, 2.1, 2.2, 2.3, 2.4]}
+    resolved = resolve_mode_thresholds(custom, ZOMBIE_THRESHOLDS)
+    assert resolved[Sensitivity.ULTRA_SLOW] == (1.0, 2.0)
+    assert resolved[Sensitivity.ULTRA_FAST] == (1.4, 2.4)
+
+
+# ========================================================================
+# Game-mode init reads (flag unavailable in tests -> fallback path)
+# ========================================================================
+
+
+def _make_ffa():
+    return FFAGame(
+        controller_manager_client=None,
+        event_publisher=EventCollector().publish,
+        sensitivity=2,
+    )
+
+
+def test_base_init_stores_instance_tables_from_defaults():
+    """With no flagd, init falls back to module constants (behavior-neutral)."""
+    game = _make_ffa()
+    assert game.slow_warning == SLOW_WARNING
+    assert game.slow_max == SLOW_MAX
+    assert game.fast_warning == FAST_WARNING
+    assert game.fast_max == FAST_MAX
+
+
+def test_base_init_reads_flag_once():
+    """The threshold flag is read exactly once at init (init-frozen)."""
+    with patch("services.game_coordinator.games.base.read_object_flag", return_value={}) as mock_read:
+        _make_ffa()
+    assert mock_read.call_count == 1
+    assert mock_read.call_args.args == ("game", "thresholds", {})
+
+
+def test_base_init_applies_flag_override():
+    custom = {
+        "slow_warning": [1.0, 1.1, 1.2, 1.3, 1.4],
+        "slow_max": [2.0, 2.1, 2.2, 2.3, 2.4],
+        "fast_warning": [1.5, 1.6, 1.7, 1.8, 1.9],
+        "fast_max": [3.0, 3.1, 3.2, 3.3, 3.4],
+    }
+    with patch("services.game_coordinator.games.base.read_object_flag", return_value=custom):
+        game = _make_ffa()
+    assert game.slow_warning == [1.0, 1.1, 1.2, 1.3, 1.4]
+    assert game.fast_max == [3.0, 3.1, 3.2, 3.3, 3.4]
+
+
+def test_compute_thresholds_unchanged_with_default_flag():
+    """End-to-end: effective thresholds match the pre-promotion computation."""
+    from services.game_coordinator.games.base import Player
+
+    game = _make_ffa()
+    game.sensitivity = type(game.sensitivity)(2)  # MEDIUM
+    game.music_speed = game.music_speed  # slow default
+    player = Player(serial="s", sensitivity_factor=1.0)
+    warn, death = game._compute_effective_thresholds(player)
+    # At slow music, MEDIUM -> slow tables index 2.
+    assert warn == pytest.approx(SLOW_WARNING[2])
+    assert death == pytest.approx(SLOW_MAX[2])
+
+
+def test_zombie_init_reads_override_flag():
+    with patch("services.game_coordinator.games.zombie.read_object_flag", return_value={}) as mock_read:
+        game = ZombieGame(
+            controller_manager_client=None,
+            event_publisher=async_noop,
+            sensitivity=2,
+        )
+    assert mock_read.call_args.args == ("game", "zombie.thresholds", {})
+    assert game.zombie_thresholds == ZOMBIE_THRESHOLDS
+
+
+def test_zombie_init_applies_override_flag():
+    custom = {"warning": [1.0, 1.1, 1.2, 1.3, 1.4], "max": [2.0, 2.1, 2.2, 2.3, 2.4]}
+    with patch("services.game_coordinator.games.zombie.read_object_flag", return_value=custom):
+        game = ZombieGame(
+            controller_manager_client=None,
+            event_publisher=async_noop,
+            sensitivity=2,
+        )
+    from services.game_coordinator.games.base import Sensitivity
+
+    assert game.zombie_thresholds[Sensitivity.MEDIUM] == (1.2, 2.2)
+
+
+def test_werewolf_init_reads_override_flag():
+    with patch("services.game_coordinator.games.werewolf.read_object_flag", return_value={}) as mock_read:
+        game = WerewolfGame(
+            controller_manager_client=None,
+            event_publisher=async_noop,
+            sensitivity=2,
+        )
+    assert mock_read.call_args.args == ("game", "werewolf.thresholds", {})
+    assert game.werewolf_thresholds == WEREWOLF_THRESHOLDS
+
+
+def test_werewolf_init_malformed_override_falls_back():
+    bad = {"warning": [1.0, 1.1], "max": [2.0, 2.1, 2.2, 2.3, 2.4]}
+    with patch("services.game_coordinator.games.werewolf.read_object_flag", return_value=bad):
+        game = WerewolfGame(
+            controller_manager_client=None,
+            event_publisher=async_noop,
+            sensitivity=2,
+        )
+    assert game.werewolf_thresholds == WEREWOLF_THRESHOLDS


### PR DESCRIPTION
Part of #766 (F1).

Promotes the death/warning threshold tables (and the zombie/werewolf per-mode overrides) to object-typed `game.json` flags. Read once at game init (init-frozen by design — no live re-evaluation); malformed/missing flag values fall back to the hardcoded module constants, so the promotion is **behavior-neutral**.

Refs #722 #725.

## Changes
- `services/flagd/game.json`: new object flags `thresholds` (the four 5-element arrays `slow_warning`/`slow_max`/`fast_warning`/`fast_max`), `zombie.thresholds`, `werewolf.thresholds`, each defaulting to the modes' current tables (#725 bare snake_case naming).
- `lib/feature_flags.py`: reusable `read_object_flag(domain, key, default)` init-read helper (lazily inits the domain, returns `default` on any failure). **F2 will reuse this** for its init-read flags.
- `services/game_coordinator/games/base.py`: validation helpers `resolve_base_thresholds` / `resolve_mode_thresholds` (require exactly 5 numeric entries per row and warning < max per sensitivity, else fall back). `BaseGameMode.__init__` reads the flag once and stores instance tables; the two module-constant LERP sites (`_compute_effective_thresholds`, `_emit_threshold_metrics`) now use the instance tables.
- `zombie.py` / `werewolf.py`: read their override flags at init into instance dicts, preserving existing override semantics.

## Test plan
- `cd services/game_coordinator && uv run --extra test pytest` — **768 passed**.
- New `tests/test_threshold_flags.py` (25 tests): characterization that flag defaults reproduce current behavior exactly; malformed-value fallback (wrong length, warning>=max, non-numeric incl. bool, missing key, non-dict); read-once-at-init assertion; zombie/werewolf override + fallback paths.
- `python3 -c "import json; json.load(open('services/flagd/game.json'))"` — OK.
- `make lint` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)