### PR TITLE
feat: promote perception thresholds to agent flags (#766 F4)

### DIFF
--- a/services/flagd/agent.json
+++ b/services/flagd/agent.json
@@ -196,6 +196,87 @@
         "lenient": 5
       },
       "defaultVariant": "default"
+    },
+    "perception.zone_still_max": {
+      "state": "ENABLED",
+      "variants": {
+        "default": 1.1,
+        "twitchy": 0.9,
+        "relaxed": 1.3
+      },
+      "defaultVariant": "default"
+    },
+    "perception.zone_active_max": {
+      "state": "ENABLED",
+      "variants": {
+        "default": 1.5,
+        "twitchy": 1.3,
+        "relaxed": 1.7
+      },
+      "defaultVariant": "default"
+    },
+    "perception.zone_warning_max": {
+      "state": "ENABLED",
+      "variants": {
+        "default": 2.0,
+        "twitchy": 1.8,
+        "relaxed": 2.2
+      },
+      "defaultVariant": "default"
+    },
+    "perception.playstyle.aggressive_warning_danger_min": {
+      "state": "ENABLED",
+      "variants": {
+        "default": 30,
+        "strict": 40,
+        "lenient": 20
+      },
+      "defaultVariant": "default"
+    },
+    "perception.playstyle.calm_still_min": {
+      "state": "ENABLED",
+      "variants": {
+        "default": 70,
+        "strict": 80,
+        "lenient": 60
+      },
+      "defaultVariant": "default"
+    },
+    "perception.playstyle.calm_warning_danger_max": {
+      "state": "ENABLED",
+      "variants": {
+        "default": 10,
+        "strict": 5,
+        "lenient": 15
+      },
+      "defaultVariant": "default"
+    },
+    "perception.playstyle.balanced_still_min": {
+      "state": "ENABLED",
+      "variants": {
+        "default": 40,
+        "strict": 50,
+        "lenient": 30
+      },
+      "defaultVariant": "default"
+    },
+    "perception.playstyle.balanced_warning_danger_max": {
+      "state": "ENABLED",
+      "variants": {
+        "default": 20,
+        "strict": 15,
+        "lenient": 25
+      },
+      "defaultVariant": "default"
+    },
+    "perception.ema_weight": {
+      "state": "ENABLED",
+      "variants": {
+        "default": 4.0,
+        "smooth": 6.0,
+        "responsive": 2.0
+      },
+      "defaultVariant": "default"
     }
   }
 }

--- a/services/game_coordinator/games/analytics.py
+++ b/services/game_coordinator/games/analytics.py
@@ -129,6 +129,30 @@ class PlayerAnalytics:
     # Track last zone for metrics
     _last_zone: MovementZone = MovementZone.STILL
 
+    # Playstyle classification thresholds (percentages). Promoted to the agent
+    # domain `perception.playstyle.*` flags (#766 F4) and populated from
+    # AnalyticsConfig when the tracker is created (see games that instantiate
+    # PlayerAnalytics). Defaults reproduce the previously hardcoded literals so
+    # callers that do not pass them keep the historical behavior.
+    playstyle_aggressive_warning_danger_min: float = 30.0
+    playstyle_calm_still_min: float = 70.0
+    playstyle_calm_warning_danger_max: float = 10.0
+    playstyle_balanced_still_min: float = 40.0
+    playstyle_balanced_warning_danger_max: float = 20.0
+
+    @classmethod
+    def from_config(cls, serial: str, game_start_time: float, config: "AnalyticsConfig") -> "PlayerAnalytics":
+        """Create a tracker with playstyle thresholds sourced from config (#766 F4)."""
+        return cls(
+            serial=serial,
+            game_start_time=game_start_time,
+            playstyle_aggressive_warning_danger_min=config.playstyle_aggressive_warning_danger_min,
+            playstyle_calm_still_min=config.playstyle_calm_still_min,
+            playstyle_calm_warning_danger_max=config.playstyle_calm_warning_danger_max,
+            playstyle_balanced_still_min=config.playstyle_balanced_still_min,
+            playstyle_balanced_warning_danger_max=config.playstyle_balanced_warning_danger_max,
+        )
+
     def record_sample(
         self,
         accel_x: float,
@@ -296,11 +320,14 @@ class PlayerAnalytics:
         zones = self.get_zone_percentages()
         warning_danger = zones["warning"] + zones["danger"]
 
-        if warning_danger > 30:
+        if warning_danger > self.playstyle_aggressive_warning_danger_min:
             return Playstyle.AGGRESSIVE
-        if zones["still"] > 70 and warning_danger < 10:
+        if zones["still"] > self.playstyle_calm_still_min and warning_danger < self.playstyle_calm_warning_danger_max:
             return Playstyle.CALM
-        if zones["still"] > 40 and warning_danger < 20:
+        if (
+            zones["still"] > self.playstyle_balanced_still_min
+            and warning_danger < self.playstyle_balanced_warning_danger_max
+        ):
             return Playstyle.BALANCED
         return Playstyle.ACTIVE
 

--- a/services/game_coordinator/games/base.py
+++ b/services/game_coordinator/games/base.py
@@ -331,6 +331,15 @@ class BaseGameMode(ABC):
         self.fast_warning = tables["fast_warning"]
         self.fast_max = tables["fast_max"]
 
+        # EMA filter weight (#766 F4, agent-domain `perception.ema_weight`).
+        # READ ONCE HERE AT GAME INIT and frozen for the life of the game. It is
+        # intentionally never re-evaluated mid-game: changing the smoothing
+        # weight while running would invalidate the per-player movement variance
+        # baseline that the agent's perception layer relies on (#722 §5 —
+        # difficulty/filter changes "invalidate the variance baseline"). Falls
+        # back to the hardcoded default (4.0) when flagd is unavailable.
+        self._ema_weight = get_config_manager().read_ema_weight()
+
         # Phase 70: Music tempo control state
         self.music_track_id = None
         self.music_speed = SLOW_MUSIC_SPEED
@@ -646,7 +655,7 @@ class BaseGameMode(ABC):
                     serial = controller_data.serial
                     if serial in self.players and self.players[serial].alive:
                         accel_mag = self._compute_accel_magnitude(controller_data.accel)
-                        self._update_ema(self.players[serial], accel_mag)
+                        self._update_ema(self.players[serial], accel_mag, self._ema_weight)
                 frames_consumed += 1
 
                 if time.time() - warmup_start >= warmup_duration:
@@ -934,22 +943,30 @@ class BaseGameMode(ABC):
         return math.sqrt(accel.x**2 + accel.y**2 + accel.z**2)
 
     @staticmethod
-    def _update_ema(player: Player, accel_mag: float) -> None:
+    def _update_ema(player: Player, accel_mag: float, weight: float = 4.0) -> None:
         """
         Apply exponential moving average filter to acceleration.
 
-        Formula: smoothed = (smoothed * 4 + raw) / 5
-        Gives 80% weight to previous value, 20% to current - smooths sensor noise.
-        First reading primes the filter to prevent false deaths at game start.
+        Formula: smoothed = (smoothed * weight + raw) / (weight + 1)
+        With weight=4 (default): 80% weight to previous value, 20% to current —
+        smooths sensor noise. First reading primes the filter to prevent false
+        deaths at game start.
+
+        ``weight`` is sourced from the agent-domain ``perception.ema_weight`` flag
+        (#766 F4), frozen per game at init (``self._ema_weight``); see __init__
+        for why it is never re-read mid-game (#722 §5 variance-baseline caveat).
+        The default of 4.0 preserves the historical hardcoded behavior for
+        callers that do not pass a weight (e.g. unit tests).
 
         Args:
             player: Player whose EMA to update
             accel_mag: Raw acceleration magnitude for this frame
+            weight: EMA weight on the previous smoothed value (default 4.0)
         """
         if player.smoothed_accel < 1e-9:  # Check for uninitialized (avoids float equality)
             player.smoothed_accel = accel_mag  # Prime filter with first real reading
         else:
-            player.smoothed_accel = (player.smoothed_accel * 4 + accel_mag) / 5
+            player.smoothed_accel = (player.smoothed_accel * weight + accel_mag) / (weight + 1)
         player.last_accel_mag = player.smoothed_accel
 
     def _compute_effective_thresholds(self, player: Player) -> tuple[float, float]:
@@ -1185,7 +1202,7 @@ class BaseGameMode(ABC):
             )
             return  # In grace period, skip death/warning checks
 
-        self._update_ema(player, accel_mag)
+        self._update_ema(player, accel_mag, self._ema_weight)
 
         effective_warn, effective_death = self._compute_effective_thresholds(player)
         smoothed = player.smoothed_accel

--- a/services/game_coordinator/games/ffa.py
+++ b/services/game_coordinator/games/ffa.py
@@ -60,9 +60,10 @@ class FFAGame(BaseGameMode):
             # Initialize analytics if enabled
             analytics = None
             if config.analytics.enabled:
-                analytics = PlayerAnalytics(
+                analytics = PlayerAnalytics.from_config(
                     serial=controller.serial,
                     game_start_time=game_start_time,
+                    config=config.analytics,
                 )
 
             player = Player(

--- a/services/game_coordinator/games/nonstop_joust.py
+++ b/services/game_coordinator/games/nonstop_joust.py
@@ -123,9 +123,10 @@ class NonstopJoustGame(BaseGameMode):
             # Initialize analytics if enabled
             analytics = None
             if config.analytics.enabled:
-                analytics = PlayerAnalytics(
+                analytics = PlayerAnalytics.from_config(
                     serial=controller.serial,
                     game_start_time=game_start_time,
+                    config=config.analytics,
                 )
 
             player = NonstopPlayer(

--- a/services/game_coordinator/games/random_teams.py
+++ b/services/game_coordinator/games/random_teams.py
@@ -151,9 +151,10 @@ class RandomTeamsGame(TeamsGameBase):
             # Initialize analytics if enabled
             analytics = None
             if config.analytics.enabled:
-                analytics = PlayerAnalytics(
+                analytics = PlayerAnalytics.from_config(
                     serial=controller.serial,
                     game_start_time=game_start_time,
+                    config=config.analytics,
                 )
 
             player = Player(

--- a/services/game_coordinator/games/teams.py
+++ b/services/game_coordinator/games/teams.py
@@ -71,9 +71,10 @@ class SimpleTeamsGame(TeamsGameBase):
             # Initialize analytics if enabled
             analytics = None
             if config.analytics.enabled:
-                analytics = PlayerAnalytics(
+                analytics = PlayerAnalytics.from_config(
                     serial=controller.serial,
                     game_start_time=game_start_time,
+                    config=config.analytics,
                 )
 
             player = Player(

--- a/services/game_coordinator/runtime_config.py
+++ b/services/game_coordinator/runtime_config.py
@@ -140,7 +140,7 @@ class RuntimeConfigManager:
 
             # Agent domain (perception.* — #766 F4): zone boundaries + playstyle
             # classification thresholds (change-event refreshed) and ema_weight
-            # (read once at startup; see _read_ema_weight_at_init).
+            # (read once per game at init; see read_ema_weight).
             init_flag_domain("agent")
             self.agent_client = get_flag_client("agent")
 

--- a/services/game_coordinator/runtime_config.py
+++ b/services/game_coordinator/runtime_config.py
@@ -14,6 +14,7 @@ setting countdown_phase_duration_ms=0 (the "skip" variant).
 """
 
 import logging
+import math
 import threading
 from dataclasses import dataclass, field
 
@@ -35,12 +36,24 @@ class AnalyticsConfig:
     enable_replay: bool = False  # Store 60Hz samples for replay/testing
     replay_ttl_seconds: int = 3600  # Redis TTL for replay data (1 hour)
 
-    # Fixed zone thresholds (in g-force units, ~4096 raw = 1g)
-    # These define movement intensity zones for activity classification
+    # Zone thresholds (in g-force units, ~4096 raw = 1g). Defaults promoted to
+    # the agent domain `perception.zone_*` flags (#766 F4); the values here are
+    # the behavior-neutral fallbacks used when flagd is unavailable/malformed.
+    # These define movement intensity zones for activity classification.
     zone_still_max: float = 1.1  # < 1.1g = still
     zone_active_max: float = 1.5  # 1.1-1.5g = active movement
     zone_warning_max: float = 2.0  # 1.5-2.0g = warning zone
     # > 2.0g = danger zone
+
+    # Playstyle classification thresholds (percentages of time-in-zone).
+    # Promoted to agent-domain `perception.playstyle.*` flags (#766 F4); the
+    # defaults below reproduce the previously hardcoded analytics.py literals.
+    # Consumed by PlayerAnalytics.get_playstyle (see games/analytics.py).
+    playstyle_aggressive_warning_danger_min: float = 30.0  # > this => AGGRESSIVE
+    playstyle_calm_still_min: float = 70.0  # still % above this (+ low w/d) => CALM
+    playstyle_calm_warning_danger_max: float = 10.0  # w/d % below this for CALM
+    playstyle_balanced_still_min: float = 40.0  # still % above this => BALANCED
+    playstyle_balanced_warning_danger_max: float = 20.0  # w/d % below this for BALANCED
 
     # Metrics emission interval (emit Prometheus gauges every N frames)
     metrics_emit_interval_frames: int = 6  # ~100ms at 60Hz (10Hz updates)
@@ -72,6 +85,17 @@ class GamePerformanceConfig:
     # controller_poll_degraded span. Evaluated over a 2-second window.
     poll_drop_threshold: int = 10
 
+    # EMA filter weight for acceleration smoothing (#766 F4, agent domain flag
+    # `perception.ema_weight`). Formula: smoothed = (smoothed * W + raw) / (W + 1).
+    # W=4 gives 80% weight to the previous value (the historical default).
+    #
+    # READ AT GAME INIT ONLY — never re-evaluated mid-game. Changing the EMA
+    # weight while a game is running would invalidate the per-player variance
+    # baseline that the agent's perception layer depends on (#722 §5: difficulty
+    # interventions "invalidate the variance baseline"). The value is therefore
+    # frozen into each game at __init__ and not refreshed by flag-change events.
+    ema_weight: float = 4.0
+
 
 class RuntimeConfigManager:
     """
@@ -92,6 +116,7 @@ class RuntimeConfigManager:
         self.system_client = None  # system domain
         self.controller_client = None  # controller domain
         self.game_client = None  # game domain
+        self.agent_client = None  # agent domain (perception.* — #766 F4)
         self._setup_feature_flags()
 
     def _setup_feature_flags(self):
@@ -113,7 +138,13 @@ class RuntimeConfigManager:
             init_flag_domain("game")
             self.game_client = get_flag_client("game")
 
-            logger.info("Feature flag clients initialized (system, controller, game)")
+            # Agent domain (perception.* — #766 F4): zone boundaries + playstyle
+            # classification thresholds (change-event refreshed) and ema_weight
+            # (read once at startup; see _read_ema_weight_at_init).
+            init_flag_domain("agent")
+            self.agent_client = get_flag_client("agent")
+
+            logger.info("Feature flag clients initialized (system, controller, game, agent)")
 
             # Register event handler for configuration changes
             api.add_handler(ProviderEvent.PROVIDER_CONFIGURATION_CHANGED, self._on_flags_changed)
@@ -126,11 +157,13 @@ class RuntimeConfigManager:
             self.system_client = None
             self.controller_client = None
             self.game_client = None
+            self.agent_client = None
             logger.warning("Could not initialize feature flags, using defaults")
         except Exception as e:
             self.system_client = None
             self.controller_client = None
             self.game_client = None
+            self.agent_client = None
             logger.error(f"Failed to initialize feature flags: {e}")
 
     def _on_flags_changed(self, event_details):
@@ -237,9 +270,106 @@ class RuntimeConfigManager:
 
                     metrics.flag_evaluations_total.labels(flag_key="winner_rainbow_duration_ms").inc()
 
+                # === Agent domain flags (#766 F4: perception.*) ===
+                #
+                # Zone boundaries and playstyle thresholds follow the natural read
+                # point of their consumers — they live on `config.analytics`, read
+                # fresh by each game at start — so they are refreshed here on flag
+                # change, consistent with this manager's other domains.
+                #
+                # NOTE: `perception.ema_weight` is deliberately NOT read here. It is
+                # read once at game init (see _read_ema_weight_at_init) and frozen
+                # for the life of the game (#722 §5 variance-baseline caveat).
+                if self.agent_client:
+                    self._refresh_perception_flags(metrics)
+
         except Exception as e:
             # Don't crash on flag evaluation failure, just log and keep defaults
             logger.warning(f"Failed to evaluate flags: {e}")
+
+    def _refresh_perception_flags(self, metrics) -> None:
+        """Refresh zone-boundary and playstyle thresholds from the agent domain.
+
+        Each value validates to a positive number; on malformed/invalid values
+        the current config value (ultimately the hardcoded default) is kept, so
+        the promotion is behavior-neutral. Caller holds ``self._config_lock``.
+        """
+        analytics = self.config.analytics
+
+        # Zone boundaries (g-force). Must be strictly increasing and positive.
+        zone_specs = [
+            ("perception.zone_still_max", "zone_still_max"),
+            ("perception.zone_active_max", "zone_active_max"),
+            ("perception.zone_warning_max", "zone_warning_max"),
+        ]
+        new_zones = {}
+        for flag_key, attr in zone_specs:
+            current = getattr(analytics, attr)
+            value = self.agent_client.get_float_value(flag_key, current, EvaluationContext())
+            metrics.flag_evaluations_total.labels(flag_key=flag_key).inc()
+            new_zones[attr] = value if self._valid_positive(value) else current
+
+        # Only apply zone boundaries if they form a strictly increasing ladder;
+        # otherwise keep the existing (default) values to avoid corrupting
+        # classification.
+        if new_zones["zone_still_max"] < new_zones["zone_active_max"] < new_zones["zone_warning_max"]:
+            for attr, value in new_zones.items():
+                if value != getattr(analytics, attr):
+                    logger.info(f"Config updated: analytics.{attr} -> {value}")
+                    setattr(analytics, attr, value)
+                    metrics.config_changes_total.labels(parameter=attr).inc()
+        else:
+            logger.warning(f"Ignoring perception zone flags (not strictly increasing): {new_zones}; keeping defaults")
+
+        # Playstyle classification thresholds (percentages, 0-100).
+        playstyle_specs = [
+            ("perception.playstyle.aggressive_warning_danger_min", "playstyle_aggressive_warning_danger_min"),
+            ("perception.playstyle.calm_still_min", "playstyle_calm_still_min"),
+            ("perception.playstyle.calm_warning_danger_max", "playstyle_calm_warning_danger_max"),
+            ("perception.playstyle.balanced_still_min", "playstyle_balanced_still_min"),
+            ("perception.playstyle.balanced_warning_danger_max", "playstyle_balanced_warning_danger_max"),
+        ]
+        for flag_key, attr in playstyle_specs:
+            current = getattr(analytics, attr)
+            value = self.agent_client.get_float_value(flag_key, current, EvaluationContext())
+            metrics.flag_evaluations_total.labels(flag_key=flag_key).inc()
+            if not self._valid_percentage(value):
+                value = current
+            if value != current:
+                logger.info(f"Config updated: analytics.{attr} -> {value}")
+                setattr(analytics, attr, value)
+                metrics.config_changes_total.labels(parameter=attr).inc()
+
+    @staticmethod
+    def _valid_positive(value) -> bool:
+        """True if value is a finite, strictly positive number."""
+        return isinstance(value, (int, float)) and math.isfinite(value) and value > 0
+
+    @staticmethod
+    def _valid_percentage(value) -> bool:
+        """True if value is a finite number in [0, 100]."""
+        return isinstance(value, (int, float)) and math.isfinite(value) and 0 <= value <= 100
+
+    def read_ema_weight(self) -> float:
+        """Read the EMA filter weight from the agent domain (#766 F4).
+
+        Called ONCE per game at game init (BaseGameMode.__init__). The value is
+        frozen for the life of the game and never re-evaluated mid-game: changing
+        the EMA weight while running would invalidate the per-player movement
+        variance baseline the agent's perception layer relies on (#722 §5).
+
+        Returns the validated flag value, or the hardcoded default
+        (``config.ema_weight``) on a missing/malformed/non-positive value.
+        """
+        default = self.config.ema_weight
+        if not self.agent_client:
+            return default
+        try:
+            value = self.agent_client.get_float_value("perception.ema_weight", default, EvaluationContext())
+        except Exception as e:
+            logger.warning(f"Failed to read perception.ema_weight, using default: {e}")
+            return default
+        return value if self._valid_positive(value) else default
 
     def get_config(self) -> GamePerformanceConfig:
         """

--- a/services/game_coordinator/tests/test_perception_flags.py
+++ b/services/game_coordinator/tests/test_perception_flags.py
@@ -1,0 +1,238 @@
+"""Tests for #766 F4: perception thresholds promoted to agent-domain flags.
+
+Covers three guarantees from the issue's consistency rules:
+
+1. Characterization — the flag defaults reproduce the previously hardcoded
+   behavior (zone boundaries, playstyle classification, EMA weight).
+2. Malformed fallback — invalid flag values fall back to the hardcoded
+   defaults so promotion stays behavior-neutral.
+3. ``perception.ema_weight`` is read once at game init and frozen for the life
+   of the game; changing the flag mid-game has no effect on a running game
+   (#722 §5 variance-baseline caveat).
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from services.game_coordinator.games.analytics import PlayerAnalytics, Playstyle
+from services.game_coordinator.games.base import BaseGameMode
+from services.game_coordinator.games.ffa import FFAGame
+from services.game_coordinator.runtime_config import AnalyticsConfig, RuntimeConfigManager
+
+# --- Current hardcoded values (the behavior-neutral defaults) -----------------
+DEFAULT_ZONE_STILL_MAX = 1.1
+DEFAULT_ZONE_ACTIVE_MAX = 1.5
+DEFAULT_ZONE_WARNING_MAX = 2.0
+DEFAULT_EMA_WEIGHT = 4.0
+
+
+# =============================================================================
+# agent.json structure
+# =============================================================================
+
+
+def test_agent_json_has_perception_flags_with_default_values():
+    """agent.json parses and every perception flag's `default` variant equals the
+    current hardcoded value (behavior-neutral promotion)."""
+    agent_path = Path(__file__).resolve().parents[3] / "services" / "flagd" / "agent.json"
+    data = json.loads(agent_path.read_text())
+    flags = data["flags"]
+
+    expected = {
+        "perception.zone_still_max": 1.1,
+        "perception.zone_active_max": 1.5,
+        "perception.zone_warning_max": 2.0,
+        "perception.playstyle.aggressive_warning_danger_min": 30,
+        "perception.playstyle.calm_still_min": 70,
+        "perception.playstyle.calm_warning_danger_max": 10,
+        "perception.playstyle.balanced_still_min": 40,
+        "perception.playstyle.balanced_warning_danger_max": 20,
+        "perception.ema_weight": 4.0,
+    }
+    for key, value in expected.items():
+        assert key in flags, f"missing flag {key}"
+        assert flags[key]["variants"]["default"] == value
+        assert flags[key]["defaultVariant"] == "default"
+
+
+# =============================================================================
+# Characterization: defaults reproduce current behavior
+# =============================================================================
+
+
+def test_default_zone_boundaries_reproduce_classification():
+    """The default zone boundaries classify accel magnitudes into the historical
+    zones (still <1.1 < active <1.5 < warning <2.0 < danger)."""
+    a = PlayerAnalytics(serial="s", game_start_time=0.0)
+    cfg = AnalyticsConfig()
+    # Names map to MovementZone members.
+    assert a._classify_zone(1.0, cfg).name == "STILL"
+    assert a._classify_zone(1.3, cfg).name == "ACTIVE"
+    assert a._classify_zone(1.8, cfg).name == "WARNING"
+    assert a._classify_zone(2.5, cfg).name == "DANGER"
+
+
+def test_default_playstyle_thresholds_reproduce_classification():
+    """Default playstyle thresholds reproduce the previously hardcoded literals."""
+    a = PlayerAnalytics.from_config("s", 0.0, AnalyticsConfig())
+
+    # >30% warning+danger => AGGRESSIVE
+    a.time_still_ms, a.time_active_ms, a.time_warning_ms, a.time_danger_ms = 0, 0, 350, 0
+    a.time_active_ms = 650
+    assert a.get_playstyle() == Playstyle.AGGRESSIVE
+
+    # >70% still, <10% w/d => CALM
+    a.time_still_ms, a.time_active_ms, a.time_warning_ms, a.time_danger_ms = 800, 150, 50, 0
+    assert a.get_playstyle() == Playstyle.CALM
+
+    # 40-70% still, <20% w/d => BALANCED
+    a.time_still_ms, a.time_active_ms, a.time_warning_ms, a.time_danger_ms = 500, 350, 150, 0
+    assert a.get_playstyle() == Playstyle.BALANCED
+
+    # otherwise ACTIVE
+    a.time_still_ms, a.time_active_ms, a.time_warning_ms, a.time_danger_ms = 300, 550, 150, 0
+    assert a.get_playstyle() == Playstyle.ACTIVE
+
+
+def test_default_ema_weight_reproduces_smoothing_formula():
+    """Default EMA weight 4.0 yields the historical (smoothed*4 + raw)/5 formula."""
+    player = MagicMock()
+    player.smoothed_accel = 1.0
+    BaseGameMode._update_ema(player, 2.0, DEFAULT_EMA_WEIGHT)
+    # (1.0 * 4 + 2.0) / 5 == 1.2
+    assert player.smoothed_accel == 1.2
+
+
+def test_update_ema_default_weight_matches_legacy_static_call():
+    """Calling _update_ema without a weight keeps the legacy weight-4 behavior."""
+    player = MagicMock()
+    player.smoothed_accel = 1.0
+    BaseGameMode._update_ema(player, 2.0)
+    assert player.smoothed_accel == 1.2
+
+
+# =============================================================================
+# Malformed fallback
+# =============================================================================
+
+
+def _make_manager_with_agent(agent_values):
+    """Build a RuntimeConfigManager whose agent client returns `agent_values`
+    (keyed by flag name), and whose other clients echo their defaults."""
+
+    def agent_get_float(key, default, _ctx):
+        return agent_values.get(key, default)
+
+    agent_client = MagicMock()
+    agent_client.get_float_value.side_effect = agent_get_float
+
+    other_client = MagicMock()
+    other_client.get_integer_value.side_effect = lambda _k, d, _c: d
+
+    def get_client(domain):
+        return agent_client if domain == "agent" else other_client
+
+    with patch("openfeature.api.add_handler"), patch("lib.feature_flags.get_flag_client", side_effect=get_client):
+        return RuntimeConfigManager()
+
+
+def test_malformed_zone_flags_fall_back_to_defaults():
+    """Non-increasing / non-positive zone values are rejected; defaults kept."""
+    # active < still (not strictly increasing) and a negative value.
+    manager = _make_manager_with_agent(
+        {
+            "perception.zone_still_max": 1.5,
+            "perception.zone_active_max": 1.1,
+            "perception.zone_warning_max": -2.0,
+        }
+    )
+    analytics = manager.get_config().analytics
+    assert analytics.zone_still_max == DEFAULT_ZONE_STILL_MAX
+    assert analytics.zone_active_max == DEFAULT_ZONE_ACTIVE_MAX
+    assert analytics.zone_warning_max == DEFAULT_ZONE_WARNING_MAX
+
+
+def test_malformed_playstyle_flag_falls_back_to_default():
+    """An out-of-range playstyle percentage falls back to its default."""
+    manager = _make_manager_with_agent(
+        {
+            "perception.playstyle.aggressive_warning_danger_min": 150.0,  # >100, invalid
+            "perception.playstyle.calm_still_min": 65.0,  # valid override
+        }
+    )
+    analytics = manager.get_config().analytics
+    assert analytics.playstyle_aggressive_warning_danger_min == 30.0  # default kept
+    assert analytics.playstyle_calm_still_min == 65.0  # valid value applied
+
+
+def test_valid_zone_override_is_applied():
+    """A strictly-increasing valid set of zone flags is applied."""
+    manager = _make_manager_with_agent(
+        {
+            "perception.zone_still_max": 0.9,
+            "perception.zone_active_max": 1.3,
+            "perception.zone_warning_max": 1.8,
+        }
+    )
+    analytics = manager.get_config().analytics
+    assert analytics.zone_still_max == 0.9
+    assert analytics.zone_active_max == 1.3
+    assert analytics.zone_warning_max == 1.8
+
+
+def test_read_ema_weight_malformed_falls_back_to_default():
+    """read_ema_weight returns the default for non-positive / non-finite values."""
+    manager = _make_manager_with_agent({"perception.ema_weight": -3.0})
+    assert manager.read_ema_weight() == DEFAULT_EMA_WEIGHT
+
+
+def test_read_ema_weight_valid_override():
+    manager = _make_manager_with_agent({"perception.ema_weight": 6.0})
+    assert manager.read_ema_weight() == 6.0
+
+
+def test_read_ema_weight_default_when_no_agent_client():
+    manager = RuntimeConfigManager()
+    manager.agent_client = None
+    assert manager.read_ema_weight() == DEFAULT_EMA_WEIGHT
+
+
+# =============================================================================
+# ema_weight frozen at game init
+# =============================================================================
+
+
+def test_ema_weight_frozen_at_game_init():
+    """A running game reads ema_weight ONCE at init; changing the flag mid-game
+    does not alter the running game's smoothing weight (#722 §5)."""
+
+    weight_box = {"value": 6.0}
+
+    def fake_read_ema_weight():
+        return weight_box["value"]
+
+    manager = MagicMock()
+    manager.read_ema_weight.side_effect = fake_read_ema_weight
+
+    with patch("services.game_coordinator.games.base.get_config_manager", return_value=manager):
+        game = FFAGame(
+            controller_manager_client=MagicMock(),
+            event_publisher=MagicMock(),
+            game_id="test_frozen_ema",
+        )
+        # Captured at init.
+        assert game._ema_weight == 6.0
+
+        # Simulate a mid-game flag change.
+        weight_box["value"] = 2.0
+
+        # The running game still uses the frozen weight: smoothing is computed
+        # with weight 6, not the new 2.
+        player = MagicMock()
+        player.smoothed_accel = 1.0
+        BaseGameMode._update_ema(player, 2.0, game._ema_weight)
+        # (1.0 * 6 + 2.0) / 7 == 1.142857...
+        assert abs(player.smoothed_accel - (6.0 + 2.0) / 7) < 1e-9
+        # The manager was consulted exactly once (at init).
+        assert manager.read_ema_weight.call_count == 1


### PR DESCRIPTION
Part of #766 (F4).

Promotes the perception-layer calibration constants to the `agent` flagd domain. Promotion is **behavior-neutral**: every flag's `default` variant equals the previously hardcoded value.

## Flags added (`services/flagd/agent.json`)
- `perception.zone_still_max` (1.1), `perception.zone_active_max` (1.5), `perception.zone_warning_max` (2.0) — movement zone boundaries (was `runtime_config.AnalyticsConfig`)
- `perception.playstyle.{aggressive_warning_danger_min, calm_still_min, calm_warning_danger_max, balanced_still_min, balanced_warning_danger_max}` (30/70/10/40/20) — playstyle classification (was hardcoded literals in `games/analytics.py::get_playstyle`)
- `perception.ema_weight` (4.0) — EMA smoothing weight (was `base.py` literal)

Naming follows the #725 convention (bare `snake_case`, dots only for genuine sub-structure).

## Read semantics
- **Zone boundaries + playstyle thresholds**: initialized via the new `agent` domain in `RuntimeConfigManager` and refreshed on `PROVIDER_CONFIGURATION_CHANGED` events — the natural read point of their on-config consumers (games read `config.analytics` fresh at start), consistent with how the manager already handles its other domains.
- **`perception.ema_weight`**: read **once at game init** (`BaseGameMode.__init__`) and frozen for the life of the game; never re-evaluated mid-game. Changing it on a running game would invalidate the per-player movement variance baseline the agent's perception layer relies on (#722 §5). Documented in code.

## Validation / fallback
Malformed values fall back to the hardcoded defaults: zone boundaries must be finite, positive, and strictly increasing; playstyle thresholds must be finite in [0, 100]; `ema_weight` must be finite and positive.

## Test plan
`cd services/game_coordinator && uv run pytest` — **755 passed** (743 existing + 12 new in `tests/test_perception_flags.py`):
- characterization: defaults reproduce current zone/playstyle/EMA behavior
- malformed fallback: bad zone/playstyle/ema_weight values keep defaults; valid overrides apply
- `ema_weight` frozen at init: a mid-game flag change has no effect on a running game (manager consulted exactly once)

`make lint` clean; `agent.json` parses as JSON.

Refs #722 #725 #730. No proto changes. Docs (`docs/feature-flags.md`) intentionally untouched — handled by F8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)