### PR TITLE
feat: ambient parameterization — effect timings, volumes, sentinel flags (#766 F7)

### DIFF
--- a/services/controller_manager/feedback_manager.py
+++ b/services/controller_manager/feedback_manager.py
@@ -35,6 +35,52 @@ CONTROLLER_SERIAL_ATTR = "controller.serial"
 # Module-level cache for winner rainbow duration from flagd
 _winner_rainbow_duration_ms: int | None = None
 
+# Effect timing constants (milliseconds) — hardcoded fallbacks that also serve
+# as the flagd defaults in the controller domain (F7, #766). Promotion is
+# behavior-neutral: these values reproduce the original inline magic numbers.
+DEFAULT_EFFECT_TIMINGS: dict[str, int] = {
+    "warning_flash_ms": 200,
+    "warning_vibration_ms": 200,
+    "death_rumble_ms": 150,
+    "death_red_hold_ms": 300,
+    "death_fade_ms": 700,
+}
+
+# Effect timing flag names in the controller domain (effect.<key> sub-structure).
+_EFFECT_TIMING_FLAGS: dict[str, str] = {key: f"effect.{key}" for key in DEFAULT_EFFECT_TIMINGS}
+
+# Module-level cache for effect timings, populated at init from the controller
+# domain. Starts as a copy of the defaults so reads work even before init.
+_effect_timings: dict[str, int] = dict(DEFAULT_EFFECT_TIMINGS)
+
+
+def get_effect_timing_ms(name: str) -> int:
+    """Get an effect timing (ms) from the controller-domain cache.
+
+    Falls back to the hardcoded default if the name is unknown or flagd was
+    never initialized. Read at init only (init-frozen), per F7 (#766).
+    """
+    return _effect_timings.get(name, DEFAULT_EFFECT_TIMINGS.get(name, 0))
+
+
+def _read_effect_timing(client, flag_name: str, default: int) -> int:
+    """Read and validate a single effect timing flag.
+
+    Returns the hardcoded default on any malformed (non-positive) value or
+    read error, so promotion stays behavior-neutral and crash-safe.
+    """
+    from openfeature.evaluation_context import EvaluationContext
+
+    try:
+        value = client.get_integer_value(flag_name, default, EvaluationContext())
+        if not isinstance(value, int) or value <= 0:
+            logger.warning(f"Malformed effect timing {flag_name}={value!r}, using default {default}")
+            return default
+        return value
+    except Exception as e:
+        logger.warning(f"Failed to read effect timing {flag_name}, using default {default}: {e}")
+        return default
+
 
 def get_winner_rainbow_duration_ms() -> int:
     """Get winner rainbow duration from flagd game domain.
@@ -73,6 +119,34 @@ def init_game_settings_listener() -> None:
 
     except Exception as e:
         logger.warning(f"Could not initialize game flags, using defaults: {e}")
+
+    # Effect timings live in the controller domain (this service is the consumer).
+    # Read once at init (init-frozen) with per-flag validation + fallback (F7, #766).
+    init_effect_timings()
+
+
+def init_effect_timings() -> None:
+    """Initialize effect timings from the flagd controller domain.
+
+    Read once at startup (init-frozen). Each flag is validated; malformed or
+    unavailable values fall back to the hardcoded defaults, keeping promotion
+    behavior-neutral.
+    """
+    global _effect_timings
+    try:
+        from lib.feature_flags import get_flag_client, init_flag_domain
+
+        init_flag_domain("controller")
+        client = get_flag_client("controller")
+
+        _effect_timings = {
+            key: _read_effect_timing(client, flag_name, DEFAULT_EFFECT_TIMINGS[key])
+            for key, flag_name in _EFFECT_TIMING_FLAGS.items()
+        }
+        logger.info(f"Effect timings initialized from flagd: {_effect_timings}")
+    except Exception as e:
+        _effect_timings = dict(DEFAULT_EFFECT_TIMINGS)
+        logger.warning(f"Could not initialize effect timings, using defaults: {e}")
 
 
 def _on_game_flags_changed(event_details) -> None:
@@ -344,14 +418,16 @@ class FeedbackManager(ControllerEffectsBase):
 
         Always pass truthy value to ensure restoration to base_colors at effect end.
         """
+        flash_ms = get_effect_timing_ms("warning_flash_ms")
+        vibration_ms = get_effect_timing_ms("warning_vibration_ms")
         with tracer.start_as_current_span("effect_player_warning", context=trace_context) as span:
             span.set_attribute(CONTROLLER_SERIAL_ATTR, serial)
 
-            span.add_event("flash_start", {"color": "white", "duration_ms": 200})
-            await self.play_effect_with_restore(serial, "flash", Colors.White.value, 200, 5, restore_color or True)
+            span.add_event("flash_start", {"color": "white", "duration_ms": flash_ms})
+            await self.play_effect_with_restore(serial, "flash", Colors.White.value, flash_ms, 5, restore_color or True)
 
-            span.add_event("vibration", {"intensity": 100, "duration_ms": 200})
-            await self.set_vibration(serial, 100, 200)
+            span.add_event("vibration", {"intensity": 100, "duration_ms": vibration_ms})
+            await self.set_vibration(serial, 100, vibration_ms)
 
     async def _effect_player_death(self, serial: str, trace_context: Context | None = None, **_kwargs) -> None:
         """Red + vibrate, then fade to off to signal player is out.
@@ -359,6 +435,9 @@ class FeedbackManager(ControllerEffectsBase):
         Improved transition: short sharp rumble + solid red briefly + fade to black.
         This feels more immediate and satisfying than slow blinking.
         """
+        rumble_ms = get_effect_timing_ms("death_rumble_ms")
+        red_hold_ms = get_effect_timing_ms("death_red_hold_ms")
+        fade_ms = get_effect_timing_ms("death_fade_ms")
         with tracer.start_as_current_span("effect_player_death", context=trace_context) as span:
             span.set_attribute(CONTROLLER_SERIAL_ATTR, serial)
 
@@ -366,23 +445,23 @@ class FeedbackManager(ControllerEffectsBase):
             span.add_event("cancel_existing_effect")
             await self.cancel_effect(serial)
 
-            # Short, sharp rumble (150ms feels snappier than 250ms)
-            span.add_event("vibration", {"intensity": 255, "duration_ms": 150})
-            await self.set_vibration(serial, 255, 150)
+            # Short, sharp rumble (default 150ms feels snappier than 250ms)
+            span.add_event("vibration", {"intensity": 255, "duration_ms": rumble_ms})
+            await self.set_vibration(serial, 255, rumble_ms)
 
-            # Solid red briefly (300ms) then fade to black (700ms) - total 1000ms
+            # Solid red briefly (default 300ms) then fade to black (default 700ms)
             # This replaces the awkward slow blink (1Hz over 1500ms)
             span.add_event("led_red")
             await self._set_led_color(serial, Colors.Red.value)
-            await asyncio.sleep(0.3)
+            await asyncio.sleep(red_hold_ms / 1000.0)
 
-            span.add_event("fade_to_black", {"duration_ms": 700})
+            span.add_event("fade_to_black", {"duration_ms": fade_ms})
             # Set base color to black BEFORE spawning the fade so a concurrent
             # base_color command (e.g., menu lobby reset) that lands during the
             # effect setup can't be clobbered afterwards — apply_base_color
             # writes win, and the fade's restore picks up the latest value (#757).
             self.base_colors[serial] = Colors.Black.value
-            await self.play_effect_with_restore(serial, "fade_out", Colors.Red.value, 700, 1, Colors.Black.value)
+            await self.play_effect_with_restore(serial, "fade_out", Colors.Red.value, fade_ms, 1, Colors.Black.value)
 
     async def _effect_player_respawn(self, serial: str, **_kwargs) -> None:
         """White during spawn protection."""

--- a/services/controller_manager/tests/test_effect_timings.py
+++ b/services/controller_manager/tests/test_effect_timings.py
@@ -1,0 +1,92 @@
+"""Unit tests for effect timing flags (F7, #766).
+
+Characterization: the flagd defaults reproduce the original hardcoded effect
+timings. Fallback: malformed flag values revert to the hardcoded defaults.
+"""
+
+from unittest.mock import MagicMock
+
+import services.controller_manager.feedback_manager as fm
+from services.controller_manager.feedback_manager import (
+    DEFAULT_EFFECT_TIMINGS,
+    _read_effect_timing,
+    get_effect_timing_ms,
+    init_effect_timings,
+)
+
+
+def test_defaults_match_original_constants():
+    """The promoted defaults must equal the original inline magic numbers."""
+    assert DEFAULT_EFFECT_TIMINGS == {
+        "warning_flash_ms": 200,
+        "warning_vibration_ms": 200,
+        "death_rumble_ms": 150,
+        "death_red_hold_ms": 300,
+        "death_fade_ms": 700,
+    }
+
+
+def test_get_effect_timing_falls_back_to_default_for_unknown_key():
+    assert get_effect_timing_ms("does_not_exist") == 0
+
+
+def test_read_effect_timing_accepts_valid_value():
+    client = MagicMock()
+    client.get_integer_value.return_value = 250
+    assert _read_effect_timing(client, "effect.death_rumble_ms", 150) == 250
+
+
+def test_read_effect_timing_rejects_non_positive():
+    client = MagicMock()
+    client.get_integer_value.return_value = 0
+    assert _read_effect_timing(client, "effect.death_rumble_ms", 150) == 150
+
+    client.get_integer_value.return_value = -5
+    assert _read_effect_timing(client, "effect.death_rumble_ms", 150) == 150
+
+
+def test_read_effect_timing_rejects_non_int():
+    client = MagicMock()
+    client.get_integer_value.return_value = "fast"
+    assert _read_effect_timing(client, "effect.death_fade_ms", 700) == 700
+
+
+def test_read_effect_timing_falls_back_on_read_error():
+    client = MagicMock()
+    client.get_integer_value.side_effect = RuntimeError("flagd down")
+    assert _read_effect_timing(client, "effect.warning_flash_ms", 200) == 200
+
+
+def test_init_effect_timings_falls_back_when_flagd_unavailable(monkeypatch):
+    """If the controller domain cannot be initialized, defaults are used."""
+
+    def _boom(*_args, **_kwargs):
+        raise RuntimeError("no flagd")
+
+    monkeypatch.setattr("lib.feature_flags.init_flag_domain", _boom, raising=False)
+    init_effect_timings()
+    for key, default in DEFAULT_EFFECT_TIMINGS.items():
+        assert get_effect_timing_ms(key) == default
+
+
+def test_init_effect_timings_reads_overrides(monkeypatch):
+    """Valid flag values override the cached timings."""
+    overrides = {
+        "effect.warning_flash_ms": 111,
+        "effect.warning_vibration_ms": 222,
+        "effect.death_rumble_ms": 99,
+        "effect.death_red_hold_ms": 333,
+        "effect.death_fade_ms": 555,
+    }
+    client = MagicMock()
+    client.get_integer_value.side_effect = lambda name, default, _ctx: overrides.get(name, default)
+
+    monkeypatch.setattr("lib.feature_flags.init_flag_domain", lambda *_a, **_k: None, raising=False)
+    monkeypatch.setattr("lib.feature_flags.get_flag_client", lambda *_a, **_k: client, raising=False)
+
+    init_effect_timings()
+    assert get_effect_timing_ms("warning_flash_ms") == 111
+    assert get_effect_timing_ms("death_fade_ms") == 555
+
+    # Restore defaults for isolation from other tests.
+    fm._effect_timings = dict(DEFAULT_EFFECT_TIMINGS)

--- a/services/flagd/controller.json
+++ b/services/flagd/controller.json
@@ -47,6 +47,51 @@
       },
       "defaultVariant": "none",
       "targeting": {}
+    },
+    "effect.warning_flash_ms": {
+      "state": "ENABLED",
+      "variants": {
+        "short": 100,
+        "default": 200,
+        "long": 400
+      },
+      "defaultVariant": "default"
+    },
+    "effect.warning_vibration_ms": {
+      "state": "ENABLED",
+      "variants": {
+        "short": 100,
+        "default": 200,
+        "long": 400
+      },
+      "defaultVariant": "default"
+    },
+    "effect.death_rumble_ms": {
+      "state": "ENABLED",
+      "variants": {
+        "short": 100,
+        "default": 150,
+        "long": 250
+      },
+      "defaultVariant": "default"
+    },
+    "effect.death_red_hold_ms": {
+      "state": "ENABLED",
+      "variants": {
+        "short": 150,
+        "default": 300,
+        "long": 500
+      },
+      "defaultVariant": "default"
+    },
+    "effect.death_fade_ms": {
+      "state": "ENABLED",
+      "variants": {
+        "short": 400,
+        "default": 700,
+        "long": 1200
+      },
+      "defaultVariant": "default"
     }
   }
 }

--- a/services/flagd/system.json
+++ b/services/flagd/system.json
@@ -49,6 +49,51 @@
       },
       "defaultVariant": "5min"
     },
+    "sentinel.update_hz": {
+      "state": "ENABLED",
+      "variants": {
+        "slow": 5,
+        "default": 10,
+        "fast": 20
+      },
+      "defaultVariant": "default"
+    },
+    "sentinel.min_brightness": {
+      "state": "ENABLED",
+      "variants": {
+        "dim": 0.05,
+        "default": 0.09,
+        "bright": 0.15
+      },
+      "defaultVariant": "default"
+    },
+    "sentinel.max_brightness": {
+      "state": "ENABLED",
+      "variants": {
+        "dim": 0.2,
+        "default": 0.3,
+        "bright": 0.5
+      },
+      "defaultVariant": "default"
+    },
+    "sentinel.breath_period_seconds": {
+      "state": "ENABLED",
+      "variants": {
+        "fast": 2.0,
+        "default": 4.0,
+        "slow": 8.0
+      },
+      "defaultVariant": "default"
+    },
+    "sentinel.hue_period_seconds": {
+      "state": "ENABLED",
+      "variants": {
+        "fast": 15.0,
+        "default": 30.0,
+        "slow": 60.0
+      },
+      "defaultVariant": "default"
+    },
     "pairing.poll_interval": {
       "state": "ENABLED",
       "variants": {

--- a/services/flagd/user.json
+++ b/services/flagd/user.json
@@ -50,6 +50,51 @@
         "off": false
       },
       "defaultVariant": "on"
+    },
+    "audio_volume.game": {
+      "state": "ENABLED",
+      "variants": {
+        "quiet": 0.5,
+        "default": 0.7,
+        "loud": 0.9
+      },
+      "defaultVariant": "default"
+    },
+    "audio_volume.countdown_music": {
+      "state": "ENABLED",
+      "variants": {
+        "silent": 0.0,
+        "default": 0.15,
+        "loud": 0.3
+      },
+      "defaultVariant": "default"
+    },
+    "audio_volume.lobby_music": {
+      "state": "ENABLED",
+      "variants": {
+        "quiet": 0.2,
+        "default": 0.4,
+        "loud": 0.6
+      },
+      "defaultVariant": "default"
+    },
+    "audio_volume.menu_sound": {
+      "state": "ENABLED",
+      "variants": {
+        "quiet": 0.6,
+        "default": 0.8,
+        "loud": 1.0
+      },
+      "defaultVariant": "default"
+    },
+    "audio_volume.menu_voice": {
+      "state": "ENABLED",
+      "variants": {
+        "quiet": 0.7,
+        "default": 0.9,
+        "loud": 1.0
+      },
+      "defaultVariant": "default"
     }
   }
 }

--- a/services/game_coordinator/games/base.py
+++ b/services/game_coordinator/games/base.py
@@ -80,9 +80,34 @@ END_MAX_MUSIC_FAST_TIME = 10
 END_MIN_MUSIC_SLOW_TIME = 8
 END_MAX_MUSIC_SLOW_TIME = 12
 
-# Volume levels
+# Volume levels — module constants double as flagd defaults and as the
+# revert target for the volume_override intervention (interventions.py).
 GAME_VOLUME = 0.7
 COUNTDOWN_MUSIC_VOLUME = 0.15  # Soft background music during countdown
+
+
+def _read_volume_flag(flag_name: str, default: float) -> float:
+    """Read a per-channel volume from the flagd user domain (F7, #766).
+
+    Validates the value is a number in [0.0, 1.0]; falls back to the hardcoded
+    default on malformed values or any read error, so promotion stays
+    behavior-neutral. Read at game init only (init-frozen).
+    """
+    try:
+        from openfeature.evaluation_context import EvaluationContext
+
+        from lib.feature_flags import get_flag_client, init_flag_domain
+
+        init_flag_domain("user")
+        client = get_flag_client("user")
+        value = client.get_float_value(flag_name, default, EvaluationContext())
+        if not isinstance(value, int | float) or isinstance(value, bool) or not (0.0 <= value <= 1.0):
+            logger.warning(f"Malformed volume {flag_name}={value!r}, using default {default}")
+            return default
+        return float(value)
+    except Exception as e:
+        logger.warning(f"Failed to read volume {flag_name}, using default {default}: {e}")
+        return default
 
 
 # Threshold arrays from original JoustMania (in g-force units, 1.0 = 1g)
@@ -359,6 +384,12 @@ class BaseGameMode(ABC):
 
         # Tracked async tasks for automatic cleanup on game end
         self._tasks: set[asyncio.Task] = set()
+
+        # Per-channel volumes (F7, #766) — read once at game init from the user
+        # domain (init-frozen). Defaults reproduce the original constants, so
+        # promotion is behavior-neutral. Malformed values fall back to defaults.
+        self.game_volume = _read_volume_flag("audio_volume.game", GAME_VOLUME)
+        self.countdown_music_volume = _read_volume_flag("audio_volume.countdown_music", COUNTDOWN_MUSIC_VOLUME)
 
         logger.info(f"{self.get_game_name()} game initialized: {self.game_id}")
 
@@ -1643,7 +1674,7 @@ class BaseGameMode(ABC):
 
                 # Start game music BEFORE countdown at low volume.
                 # OGG decode happens during countdown, so music is ready instantly after.
-                await self._start_game_music(volume=COUNTDOWN_MUSIC_VOLUME)
+                await self._start_game_music(volume=self.countdown_music_volume)
 
             # Game starts
             self.state = GameState.RUNNING
@@ -1711,7 +1742,7 @@ class BaseGameMode(ABC):
                     try:
                         from proto import audio_pb2
 
-                        await self.audio_client.SetVolume(audio_pb2.SetVolumeRequest(volume=GAME_VOLUME))
+                        await self.audio_client.SetVolume(audio_pb2.SetVolumeRequest(volume=self.game_volume))
                     except Exception as e:
                         logger.warning(f"Failed to set game volume: {e}")
 
@@ -1954,15 +1985,19 @@ class BaseGameMode(ABC):
         metrics.effective_warning_threshold.set(effective_warn)
         metrics.effective_death_threshold.set(effective_death)
 
-    async def _start_game_music(self, volume: float = GAME_VOLUME):
+    async def _start_game_music(self, volume: float | None = None):
         """
         Start game music with tempo control (Phase 70).
 
-        Sets volume and starts music at normal speed.
+        Sets volume and starts music at normal speed. When ``volume`` is None,
+        uses the per-game configured game volume (F7, #766).
         Note: play_audio setting is checked centrally in audio service.
         """
         if not self.audio_client:
             return
+
+        if volume is None:
+            volume = self.game_volume
 
         try:
             from proto import audio_pb2

--- a/services/game_coordinator/tests/test_volume_flags.py
+++ b/services/game_coordinator/tests/test_volume_flags.py
@@ -1,0 +1,90 @@
+"""Unit tests for per-channel volume flags (F7, #766).
+
+Characterization: defaults reproduce GAME_VOLUME / COUNTDOWN_MUSIC_VOLUME.
+Fallback: malformed flag values revert to the hardcoded defaults.
+"""
+
+from unittest.mock import MagicMock
+
+from services.game_coordinator.games.base import (
+    COUNTDOWN_MUSIC_VOLUME,
+    GAME_VOLUME,
+    _read_volume_flag,
+)
+
+
+def _patch_user_client(monkeypatch, client):
+    monkeypatch.setattr("lib.feature_flags.init_flag_domain", lambda *_a, **_k: None, raising=False)
+    monkeypatch.setattr("lib.feature_flags.get_flag_client", lambda *_a, **_k: client, raising=False)
+
+
+def test_default_constants_unchanged():
+    assert GAME_VOLUME == 0.7
+    assert COUNTDOWN_MUSIC_VOLUME == 0.15
+
+
+def test_read_volume_returns_valid_value(monkeypatch):
+    client = MagicMock()
+    client.get_float_value.return_value = 0.5
+    _patch_user_client(monkeypatch, client)
+    assert _read_volume_flag("audio_volume.game", GAME_VOLUME) == 0.5
+
+
+def test_read_volume_rejects_out_of_range(monkeypatch):
+    client = MagicMock()
+    client.get_float_value.return_value = 1.7
+    _patch_user_client(monkeypatch, client)
+    assert _read_volume_flag("audio_volume.game", GAME_VOLUME) == GAME_VOLUME
+
+    client.get_float_value.return_value = -0.2
+    assert _read_volume_flag("audio_volume.game", GAME_VOLUME) == GAME_VOLUME
+
+
+def test_read_volume_rejects_non_numeric(monkeypatch):
+    client = MagicMock()
+    client.get_float_value.return_value = "loud"
+    _patch_user_client(monkeypatch, client)
+    assert _read_volume_flag("audio_volume.game", GAME_VOLUME) == GAME_VOLUME
+
+
+def test_read_volume_rejects_bool(monkeypatch):
+    client = MagicMock()
+    client.get_float_value.return_value = True
+    _patch_user_client(monkeypatch, client)
+    assert _read_volume_flag("audio_volume.game", GAME_VOLUME) == GAME_VOLUME
+
+
+def test_read_volume_falls_back_on_error(monkeypatch):
+    def _boom(*_a, **_k):
+        raise RuntimeError("no flagd")
+
+    monkeypatch.setattr("lib.feature_flags.init_flag_domain", _boom, raising=False)
+    assert _read_volume_flag("audio_volume.countdown_music", COUNTDOWN_MUSIC_VOLUME) == COUNTDOWN_MUSIC_VOLUME
+
+
+def test_base_init_uses_default_volumes_without_flagd(monkeypatch):
+    """A constructed game mode exposes instance volumes equal to the constants.
+
+    With flagd unavailable, _read_volume_flag returns its default, so the
+    instance attributes match the original module constants (behavior-neutral).
+    """
+    from services.game_coordinator.games.ffa import FFAGame
+    from services.game_coordinator.tests.test_base_game import (
+        MockControllerManagerService,
+        async_noop,
+    )
+
+    def _boom(*_a, **_k):
+        raise RuntimeError("no flagd")
+
+    monkeypatch.setattr("lib.feature_flags.init_flag_domain", _boom, raising=False)
+
+    game = FFAGame(
+        controller_manager_client=MockControllerManagerService(num_controllers=2),
+        event_publisher=async_noop,
+        audio_client=None,
+        game_id="test_volume",
+    )
+
+    assert game.game_volume == GAME_VOLUME
+    assert game.countdown_music_volume == COUNTDOWN_MUSIC_VOLUME

--- a/services/menu/idle_monitor.py
+++ b/services/menu/idle_monitor.py
@@ -14,6 +14,7 @@ import asyncio
 import logging
 import math
 import time
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from opentelemetry import context as otel_context
@@ -26,12 +27,79 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# Sentinel LED parameters
+# Sentinel LED parameters — these defaults double as the flagd system-domain
+# defaults (F7, #766), so promotion is behavior-neutral.
 _SENTINEL_UPDATE_HZ = 10  # LED update rate for sentinel pulse
 _SENTINEL_MIN_BRIGHTNESS = 0.09  # 9% minimum brightness
 _SENTINEL_MAX_BRIGHTNESS = 0.30  # 30% maximum brightness
 _SENTINEL_BREATH_PERIOD = 4.0  # Seconds per breathing cycle
 _SENTINEL_HUE_PERIOD = 30.0  # Seconds for full hue rotation
+
+
+@dataclass(frozen=True)
+class SentinelAnimation:
+    """Sentinel pulse animation parameters (F7, #766).
+
+    Read once at sentinel-loop start (init-frozen): a 10Hz loop must not call
+    flagd per frame.
+    """
+
+    update_hz: float = _SENTINEL_UPDATE_HZ
+    min_brightness: float = _SENTINEL_MIN_BRIGHTNESS
+    max_brightness: float = _SENTINEL_MAX_BRIGHTNESS
+    breath_period_seconds: float = _SENTINEL_BREATH_PERIOD
+    hue_period_seconds: float = _SENTINEL_HUE_PERIOD
+
+
+def _read_positive_float(client, flag_name: str, default: float) -> float:
+    """Read a strictly-positive float flag, falling back to default on error."""
+    try:
+        value = client.get_float_value(flag_name, default)
+        if not isinstance(value, int | float) or isinstance(value, bool) or value <= 0:
+            logger.warning(f"Malformed sentinel param {flag_name}={value!r}, using default {default}")
+            return default
+        return float(value)
+    except Exception as e:
+        logger.warning(f"Failed to read sentinel param {flag_name}, using default {default}: {e}")
+        return default
+
+
+def _read_unit_float(client, flag_name: str, default: float) -> float:
+    """Read a float flag constrained to [0.0, 1.0], falling back on error."""
+    try:
+        value = client.get_float_value(flag_name, default)
+        if not isinstance(value, int | float) or isinstance(value, bool) or not (0.0 <= value <= 1.0):
+            logger.warning(f"Malformed sentinel param {flag_name}={value!r}, using default {default}")
+            return default
+        return float(value)
+    except Exception as e:
+        logger.warning(f"Failed to read sentinel param {flag_name}, using default {default}: {e}")
+        return default
+
+
+def read_sentinel_animation(client) -> SentinelAnimation:
+    """Build a validated SentinelAnimation from the system flag domain (F7, #766).
+
+    Each field falls back to its hardcoded default on malformed values or any
+    read error. Brightness ordering (min < max) is enforced; if violated, both
+    revert to defaults.
+    """
+    if client is None:
+        return SentinelAnimation()
+
+    min_b = _read_unit_float(client, "sentinel.min_brightness", _SENTINEL_MIN_BRIGHTNESS)
+    max_b = _read_unit_float(client, "sentinel.max_brightness", _SENTINEL_MAX_BRIGHTNESS)
+    if min_b >= max_b:
+        logger.warning(f"sentinel brightness range invalid (min={min_b} >= max={max_b}), using defaults")
+        min_b, max_b = _SENTINEL_MIN_BRIGHTNESS, _SENTINEL_MAX_BRIGHTNESS
+
+    return SentinelAnimation(
+        update_hz=_read_positive_float(client, "sentinel.update_hz", _SENTINEL_UPDATE_HZ),
+        min_brightness=min_b,
+        max_brightness=max_b,
+        breath_period_seconds=_read_positive_float(client, "sentinel.breath_period_seconds", _SENTINEL_BREATH_PERIOD),
+        hue_period_seconds=_read_positive_float(client, "sentinel.hue_period_seconds", _SENTINEL_HUE_PERIOD),
+    )
 
 
 def _hsv_to_rgb(h: float, s: float, v: float) -> tuple[int, int, int]:
@@ -80,6 +148,7 @@ class IdleMonitor:
         get_idle_timeout: callable,
         get_sentinel_count: callable,
         get_rotation_minutes: callable,
+        get_sentinel_animation: callable | None = None,
     ):
         """
         Initialize idle monitor.
@@ -90,12 +159,15 @@ class IdleMonitor:
             get_idle_timeout: Callable returning int for timeout in minutes
             get_sentinel_count: Callable returning int for number of sentinels
             get_rotation_minutes: Callable returning int for rotation interval
+            get_sentinel_animation: Callable returning a SentinelAnimation (F7, #766).
+                Read once at sentinel-loop start; defaults to hardcoded params.
         """
         self._state_manager = state_manager
         self._get_idle_enabled = get_idle_enabled
         self._get_idle_timeout = get_idle_timeout
         self._get_sentinel_count = get_sentinel_count
         self._get_rotation_minutes = get_rotation_minutes
+        self._get_sentinel_animation = get_sentinel_animation or SentinelAnimation
 
         self._last_activity_time: float = time.monotonic()
         self._idle_active: bool = False
@@ -328,7 +400,10 @@ class IdleMonitor:
 
     async def _sentinel_pulse_loop(self) -> None:
         """Animate sentinel controllers with a slow breathing HSV color pulse."""
-        interval = 1.0 / _SENTINEL_UPDATE_HZ
+        # Read animation params once at loop start (init-frozen): the 10Hz loop
+        # must not call flagd per frame (F7, #766).
+        anim = self._get_sentinel_animation()
+        interval = 1.0 / anim.update_hz
         start_time = time.monotonic()
 
         try:
@@ -336,12 +411,12 @@ class IdleMonitor:
                 elapsed = time.monotonic() - start_time
 
                 # Breathing brightness: sine wave between min and max
-                breath_phase = (elapsed / _SENTINEL_BREATH_PERIOD) * 2 * math.pi
-                brightness_range = _SENTINEL_MAX_BRIGHTNESS - _SENTINEL_MIN_BRIGHTNESS
-                brightness = _SENTINEL_MIN_BRIGHTNESS + (brightness_range * (0.5 + 0.5 * math.sin(breath_phase)))
+                breath_phase = (elapsed / anim.breath_period_seconds) * 2 * math.pi
+                brightness_range = anim.max_brightness - anim.min_brightness
+                brightness = anim.min_brightness + (brightness_range * (0.5 + 0.5 * math.sin(breath_phase)))
 
                 # Slow hue rotation
-                hue = (elapsed / _SENTINEL_HUE_PERIOD) % 1.0
+                hue = (elapsed / anim.hue_period_seconds) % 1.0
 
                 # Convert to RGB
                 color = _hsv_to_rgb(hue, 1.0, brightness)

--- a/services/menu/servicer.py
+++ b/services/menu/servicer.py
@@ -21,7 +21,7 @@ from services.menu.controller_events import ControllerEventLoop
 from services.menu.event_publisher import EventPublisher
 from services.menu.handlers import AdminModeHandler, ConnectedHandler, IdleHandler, ReadyHandler
 from services.menu.handlers.base import ControllerState
-from services.menu.idle_monitor import IdleMonitor
+from services.menu.idle_monitor import IdleMonitor, read_sentinel_animation
 from services.menu.state_manager import StateManager
 from services.menu.utils import AudioHelper, LedController
 from services.menu.utils.audio import GAME_MODE_VOICE
@@ -87,7 +87,7 @@ class MenuServicer(menu_pb2_grpc.MenuServiceServicer):
 
         # Utility classes
         self.led = LedController(self.controller_channel)
-        self.audio = AudioHelper(self.audio_channel)
+        self.audio = AudioHelper(self.audio_channel, user_prefs_client=self.user_prefs_client)
 
         # Event publisher for streaming menu events
         self.event_publisher = EventPublisher(tracer, metrics)
@@ -129,6 +129,7 @@ class MenuServicer(menu_pb2_grpc.MenuServiceServicer):
             get_idle_timeout=lambda: self.system_client.get_integer_value("idle.timeout_minutes", 15),
             get_sentinel_count=lambda: self.system_client.get_integer_value("sentinel.count", 2),
             get_rotation_minutes=lambda: self.system_client.get_integer_value("sentinel.rotation_minutes", 5),
+            get_sentinel_animation=lambda: read_sentinel_animation(self.system_client),
         )
 
         # Wire idle handler's wake callback to idle monitor

--- a/services/menu/tests/test_sentinel_animation.py
+++ b/services/menu/tests/test_sentinel_animation.py
@@ -1,0 +1,120 @@
+"""Unit tests for sentinel animation flags (F7, #766).
+
+Characterization: SentinelAnimation defaults reproduce the original constants.
+Fallback: malformed flag values revert to the hardcoded defaults.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from services.menu.idle_monitor import (
+    _SENTINEL_BREATH_PERIOD,
+    _SENTINEL_HUE_PERIOD,
+    _SENTINEL_MAX_BRIGHTNESS,
+    _SENTINEL_MIN_BRIGHTNESS,
+    _SENTINEL_UPDATE_HZ,
+    IdleMonitor,
+    SentinelAnimation,
+    read_sentinel_animation,
+)
+
+
+def test_defaults_match_original_constants():
+    anim = SentinelAnimation()
+    assert anim.update_hz == _SENTINEL_UPDATE_HZ == 10
+    assert anim.min_brightness == _SENTINEL_MIN_BRIGHTNESS == 0.09
+    assert anim.max_brightness == _SENTINEL_MAX_BRIGHTNESS == 0.30
+    assert anim.breath_period_seconds == _SENTINEL_BREATH_PERIOD == 4.0
+    assert anim.hue_period_seconds == _SENTINEL_HUE_PERIOD == 30.0
+
+
+def test_read_with_none_client_returns_defaults():
+    assert read_sentinel_animation(None) == SentinelAnimation()
+
+
+def test_read_valid_overrides():
+    values = {
+        "sentinel.update_hz": 20,
+        "sentinel.min_brightness": 0.1,
+        "sentinel.max_brightness": 0.5,
+        "sentinel.breath_period_seconds": 2.0,
+        "sentinel.hue_period_seconds": 60.0,
+    }
+    client = MagicMock()
+    client.get_float_value.side_effect = lambda name, default: values.get(name, default)
+
+    anim = read_sentinel_animation(client)
+    assert anim.update_hz == 20
+    assert anim.min_brightness == 0.1
+    assert anim.max_brightness == 0.5
+    assert anim.breath_period_seconds == 2.0
+    assert anim.hue_period_seconds == 60.0
+
+
+def test_non_positive_period_falls_back():
+    client = MagicMock()
+    client.get_float_value.side_effect = lambda name, default: 0 if name == "sentinel.update_hz" else default
+    anim = read_sentinel_animation(client)
+    assert anim.update_hz == _SENTINEL_UPDATE_HZ
+
+
+def test_brightness_out_of_range_falls_back():
+    client = MagicMock()
+    client.get_float_value.side_effect = lambda name, default: 1.5 if name == "sentinel.max_brightness" else default
+    anim = read_sentinel_animation(client)
+    # max reverted to default; min unchanged from default -> ordering preserved
+    assert anim.max_brightness == _SENTINEL_MAX_BRIGHTNESS
+    assert anim.min_brightness == _SENTINEL_MIN_BRIGHTNESS
+
+
+def test_inverted_brightness_range_resets_both():
+    client = MagicMock()
+    overrides = {"sentinel.min_brightness": 0.4, "sentinel.max_brightness": 0.2}
+    client.get_float_value.side_effect = lambda name, default: overrides.get(name, default)
+    anim = read_sentinel_animation(client)
+    assert anim.min_brightness == _SENTINEL_MIN_BRIGHTNESS
+    assert anim.max_brightness == _SENTINEL_MAX_BRIGHTNESS
+
+
+def test_read_error_falls_back():
+    client = MagicMock()
+    client.get_float_value.side_effect = RuntimeError("flagd down")
+    anim = read_sentinel_animation(client)
+    assert anim == SentinelAnimation()
+
+
+@pytest.mark.asyncio
+async def test_sentinel_loop_reads_animation_once():
+    """The pulse loop snapshots the animation getter once at start (init-frozen)."""
+    state_manager = MagicMock()
+    state_manager.led.set_color = AsyncMock(return_value=True)
+
+    calls = {"n": 0}
+
+    def getter():
+        calls["n"] += 1
+        # Fast update rate so the loop iterates quickly under test.
+        return SentinelAnimation(update_hz=1000)
+
+    monitor = IdleMonitor(
+        state_manager=state_manager,
+        get_idle_enabled=lambda: True,
+        get_idle_timeout=lambda: 15,
+        get_sentinel_count=lambda: 1,
+        get_rotation_minutes=lambda: 5,
+        get_sentinel_animation=getter,
+    )
+    monitor._sentinel_serials = ["s1"]
+
+    task = asyncio.create_task(monitor._sentinel_pulse_loop())
+    await asyncio.sleep(0.02)
+    task.cancel()
+    # The loop swallows CancelledError to clean up LEDs (NOSONAR pattern), so
+    # awaiting completes normally rather than re-raising.
+    await task
+
+    # Getter consulted exactly once despite many loop iterations.
+    assert calls["n"] == 1
+    assert state_manager.led.set_color.await_count >= 1

--- a/services/menu/tests/test_utils.py
+++ b/services/menu/tests/test_utils.py
@@ -22,6 +22,63 @@ class TestAudioHelper:
         """AudioHelper should initialize correctly."""
         assert audio.lobby_music_track_id is None
 
+    def test_default_volumes_without_client(self, audio):
+        """Without a user-prefs client, volumes equal the hardcoded defaults (F7, #766)."""
+        from services.menu.utils.audio import (
+            DEFAULT_LOBBY_MUSIC_VOLUME,
+            DEFAULT_SOUND_VOLUME,
+            DEFAULT_VOICE_VOLUME,
+        )
+
+        assert audio.sound_volume == DEFAULT_SOUND_VOLUME == 0.8
+        assert audio.voice_volume == DEFAULT_VOICE_VOLUME == 0.9
+        assert audio.lobby_music_volume == DEFAULT_LOBBY_MUSIC_VOLUME == 0.4
+
+    def test_valid_volume_overrides_from_flags(self):
+        """Valid user-domain flag values override the channel volumes."""
+        values = {
+            "audio_volume.menu_sound": 0.6,
+            "audio_volume.menu_voice": 1.0,
+            "audio_volume.lobby_music": 0.2,
+        }
+        client = MagicMock()
+        client.get_float_value.side_effect = lambda name, default: values.get(name, default)
+
+        audio = AudioHelper(MagicMock(), user_prefs_client=client)
+        assert audio.sound_volume == 0.6
+        assert audio.voice_volume == 1.0
+        assert audio.lobby_music_volume == 0.2
+
+    def test_malformed_volume_falls_back_to_default(self):
+        """Out-of-range / non-numeric flag values fall back to defaults."""
+        from services.menu.utils.audio import DEFAULT_SOUND_VOLUME, DEFAULT_VOICE_VOLUME
+
+        bad = {"audio_volume.menu_sound": 5.0, "audio_volume.menu_voice": "loud"}
+        client = MagicMock()
+        client.get_float_value.side_effect = lambda name, default: bad.get(name, default)
+
+        audio = AudioHelper(MagicMock(), user_prefs_client=client)
+        assert audio.sound_volume == DEFAULT_SOUND_VOLUME
+        assert audio.voice_volume == DEFAULT_VOICE_VOLUME
+
+    @pytest.mark.asyncio
+    async def test_play_sound_uses_configured_volume(self):
+        """play_sound with no explicit volume uses the configured sound volume."""
+        client = MagicMock()
+        client.get_float_value.side_effect = lambda name, default: (
+            0.55 if name == "audio_volume.menu_sound" else default
+        )
+        audio = AudioHelper(MagicMock(), user_prefs_client=client)
+
+        with patch("proto.audio_pb2_grpc.AudioServiceStub") as mock_stub_class:
+            mock_stub = MagicMock()
+            mock_stub.PlaySound = AsyncMock()
+            mock_stub_class.return_value = mock_stub
+
+            await audio.play_sound("test/sound.ogg")
+
+            assert mock_stub.PlaySound.call_args.args[0].volume == pytest.approx(0.55)
+
     @pytest.mark.asyncio
     async def test_play_sound_string(self, audio):
         """play_sound should handle string sound paths."""

--- a/services/menu/utils/audio.py
+++ b/services/menu/utils/audio.py
@@ -8,6 +8,31 @@ from lib.types import Sound
 
 logger = logging.getLogger(__name__)
 
+# Default per-channel volumes (F7, #766). These double as the flagd user-domain
+# defaults, so promotion is behavior-neutral.
+DEFAULT_SOUND_VOLUME = 0.8
+DEFAULT_VOICE_VOLUME = 0.9
+DEFAULT_LOBBY_MUSIC_VOLUME = 0.4
+
+
+def _read_volume(client, flag_name: str, default: float) -> float:
+    """Read a per-channel volume from the user domain with validation.
+
+    Falls back to the hardcoded default on malformed values (not a number in
+    [0.0, 1.0]) or any read error / missing client.
+    """
+    if client is None:
+        return default
+    try:
+        value = client.get_float_value(flag_name, default)
+        if not isinstance(value, int | float) or isinstance(value, bool) or not (0.0 <= value <= 1.0):
+            logger.warning(f"Malformed volume {flag_name}={value!r}, using default {default}")
+            return default
+        return float(value)
+    except Exception as e:
+        logger.warning(f"Failed to read volume {flag_name}, using default {default}: {e}")
+        return default
+
 
 # Game mode voice announcements
 GAME_MODE_VOICE: dict[str, Sound] = {
@@ -33,24 +58,36 @@ class AudioHelper:
     Provides methods for playing sounds, voice announcements, and lobby music.
     """
 
-    def __init__(self, audio_channel: grpc.aio.Channel):
+    def __init__(self, audio_channel: grpc.aio.Channel, user_prefs_client=None):
         """
         Initialize audio helper.
 
         Args:
             audio_channel: gRPC channel to Audio service
+            user_prefs_client: OpenFeature client for the user domain (F7, #766).
+                Per-channel volumes are read once at init; falls back to the
+                hardcoded defaults when None or on malformed flag values.
         """
         self.audio_channel = audio_channel
         self.lobby_music_track_id: str | None = None
 
-    async def play_sound(self, sound: str | Sound, volume: float = 0.8) -> None:
+        # Per-channel volumes — read once at menu init (init-frozen).
+        self.sound_volume = _read_volume(user_prefs_client, "audio_volume.menu_sound", DEFAULT_SOUND_VOLUME)
+        self.voice_volume = _read_volume(user_prefs_client, "audio_volume.menu_voice", DEFAULT_VOICE_VOLUME)
+        self.lobby_music_volume = _read_volume(
+            user_prefs_client, "audio_volume.lobby_music", DEFAULT_LOBBY_MUSIC_VOLUME
+        )
+
+    async def play_sound(self, sound: str | Sound, volume: float | None = None) -> None:
         """
         Play a sound effect via the audio service (fire-and-forget).
 
         Args:
             sound: Sound enum or relative path to audio file
-            volume: Volume level 0.0-1.0
+            volume: Volume level 0.0-1.0; None uses the configured sound volume
         """
+        if volume is None:
+            volume = self.sound_volume
         try:
             from proto import audio_pb2, audio_pb2_grpc
 
@@ -69,14 +106,16 @@ class AudioHelper:
         except Exception as e:
             logger.debug(f"Could not play sound {sound}: {e}")
 
-    async def play_voice(self, voice: str | Sound, volume: float = 0.9) -> None:
+    async def play_voice(self, voice: str | Sound, volume: float | None = None) -> None:
         """
         Play a voice announcement.
 
         Args:
             voice: Sound enum or voice file name (audio service resolves the path)
-            volume: Volume level 0.0-1.0
+            volume: Volume level 0.0-1.0; None uses the configured voice volume
         """
+        if volume is None:
+            volume = self.voice_volume
         await self.play_sound(voice, volume)
 
     async def play_game_mode_voice(self, game_mode: str) -> None:
@@ -102,7 +141,7 @@ class AudioHelper:
             stub = audio_pb2_grpc.AudioServiceStub(self.audio_channel)
 
             # Set lobby volume (quieter than game)
-            await stub.SetVolume(audio_pb2.SetVolumeRequest(volume=0.4))
+            await stub.SetVolume(audio_pb2.SetVolumeRequest(volume=self.lobby_music_volume))
 
             # Start lobby music
             response = await stub.PlayMusic(


### PR DESCRIPTION
Part of #766 (F7).

Promotes audited ambient constants to flags, each in the flag domain of its **consumer**, behavior-neutral (defaults reproduce current values, malformed values fall back to hardcoded defaults). Refs #722 #725.

## Changes

### `controller.json` — effect timings (consumer: controller_manager)
`feedback_manager.py` inline magic numbers → `effect.warning_flash_ms` (200), `effect.warning_vibration_ms` (200), `effect.death_rumble_ms` (150), `effect.death_red_hold_ms` (300), `effect.death_fade_ms` (700). Read once at init in `init_effect_timings()` (called from the existing `init_game_settings_listener()` startup hook), per-flag validated (positive ints).

### `user.json` — per-channel volumes (consumers: game_coordinator, menu)
- `games/base.py`: `audio_volume.game` (0.7), `audio_volume.countdown_music` (0.15) — read at `BaseGameMode.__init__` into `self.game_volume` / `self.countdown_music_volume`. Module constants retained as the `volume_override` intervention revert target.
- `menu/utils/audio.py`: `audio_volume.menu_sound` (0.8), `audio_volume.menu_voice` (0.9), `audio_volume.lobby_music` (0.4) — read at `AudioHelper.__init__` (user-prefs client injected from servicer).
- Validation: number in [0.0, 1.0], rejects bool.

### `system.json` — sentinel animation (consumer: menu)
The five `idle_monitor.py` constants → `sentinel.update_hz` (10), `sentinel.min_brightness` (0.09), `sentinel.max_brightness` (0.30), `sentinel.breath_period_seconds` (4.0), `sentinel.hue_period_seconds` (30.0). Built into a frozen `SentinelAnimation` via `read_sentinel_animation()`, snapshotted **once at sentinel-loop start** (init-frozen — a 10Hz loop must not call flagd per frame). Validates positive periods, unit-range brightness, and min < max (resets both on inversion).

## Discrepancies (line drift / path)
- **feedback_manager**: issue cited lines 351-380 as "effect timing constants"; those lines are effect-handler methods. The actual timings are inline magic numbers inside `_effect_player_warning` / `_effect_player_death` — promoted those.
- **idle_monitor**: issue cited `services/system/idle_monitor.py:30-34`; the file lives at `services/menu/idle_monitor.py` (lines 30-34 match exactly).

## Test plan
New tests per service (characterization that defaults reproduce current behavior + malformed-value fallback):
- `services/controller_manager/tests/test_effect_timings.py` (8)
- `services/game_coordinator/tests/test_volume_flags.py` (7)
- `services/menu/tests/test_sentinel_animation.py` (8) + extended `test_utils.py` AudioHelper volume tests

Results: controller_manager **568 passed**, game_coordinator **750 passed**, menu **357 passed**. `make lint` clean. All three flagd JSON files parse.

Docs (`docs/feature-flags.md`) intentionally untouched — handled by F8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)