### PR TITLE
feat: promote durations, roles, and scoring to game flags (#766 F2)

### DIFF
--- a/lib/feature_flags.py
+++ b/lib/feature_flags.py
@@ -208,6 +208,73 @@ def read_object_flag(domain: str, flag_key: str, default: dict) -> dict:
         return default
 
 
+def read_float_flag(domain: str, flag_key: str, default: float) -> float:
+    """
+    Read a number-typed flag once at init time, with a hardcoded fallback.
+
+    Init-frozen scalar sibling of :func:`read_object_flag` (#766 F2): the value
+    is fetched once (e.g. in a game mode ``__init__``) and never re-evaluated
+    mid-game. The domain is initialized lazily on first use. On ANY failure
+    (provider not ready, missing flag, evaluation error, non-numeric value) the
+    supplied ``default`` is returned so the promotion stays behavior-neutral.
+
+    Note: range/sanity validation is the caller's responsibility (it owns the
+    semantics, e.g. "positive duration" or "fraction in (0,1)").
+
+    Args:
+        domain: OpenFeature domain / flagSetId (e.g. "game")
+        flag_key: Number flag key (e.g. "death_grace_period_seconds")
+        default: Fallback value returned on any error or missing flag
+
+    Returns:
+        The flag's float value, or ``default`` on failure.
+    """
+    try:
+        init_flag_domain(domain)
+        client = get_flag_client(domain)
+        value = client.get_object_value(flag_key, default, EvaluationContext())
+        # bool is a subclass of int/float; reject it as a numeric flag value.
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            return default
+        return float(value)
+    except Exception as e:
+        logger.warning(f"read_float_flag({domain!r}, {flag_key!r}) failed, using default: {e}")
+        return default
+
+
+def read_int_flag(domain: str, flag_key: str, default: int) -> int:
+    """
+    Read an integer-typed flag once at init time, with a hardcoded fallback.
+
+    Init-frozen scalar sibling of :func:`read_object_flag` (#766 F2). Same
+    semantics as :func:`read_float_flag` but coerces to ``int``; non-integral
+    numeric values (e.g. 2.5) are rejected in favour of the default to avoid
+    surprising truncation. Range/sanity validation is the caller's job.
+
+    Args:
+        domain: OpenFeature domain / flagSetId (e.g. "game")
+        flag_key: Integer flag key (e.g. "zombie.initial_count")
+        default: Fallback value returned on any error or missing flag
+
+    Returns:
+        The flag's int value, or ``default`` on failure.
+    """
+    try:
+        init_flag_domain(domain)
+        client = get_flag_client(domain)
+        value = client.get_object_value(flag_key, default, EvaluationContext())
+        if isinstance(value, bool):
+            return default
+        if isinstance(value, int):
+            return value
+        if isinstance(value, float) and value.is_integer():
+            return int(value)
+        return default
+    except Exception as e:
+        logger.warning(f"read_int_flag({domain!r}, {flag_key!r}) failed, using default: {e}")
+        return default
+
+
 def set_game_transaction_context(
     game_mode: str,
     controller_count: int,

--- a/lib/tests/test_feature_flags.py
+++ b/lib/tests/test_feature_flags.py
@@ -6,7 +6,66 @@ from unittest.mock import MagicMock, patch
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 import lib.feature_flags as ff_module
-from lib.feature_flags import get_flag_client, init_flag_domain
+from lib.feature_flags import (
+    get_flag_client,
+    init_flag_domain,
+    read_float_flag,
+    read_int_flag,
+)
+
+
+def _mock_flag_value(value):
+    """Patch init/get_flag_client so the domain client returns ``value``."""
+    client = MagicMock()
+    client.get_object_value.return_value = value
+    return (
+        patch("lib.feature_flags.init_flag_domain"),
+        patch("lib.feature_flags.get_flag_client", return_value=client),
+    )
+
+
+def test_read_float_flag_returns_numeric():
+    init_p, get_p = _mock_flag_value(3.5)
+    with init_p, get_p:
+        assert read_float_flag("game", "k", 1.0) == 3.5
+    # ints are coerced to float
+    init_p, get_p = _mock_flag_value(7)
+    with init_p, get_p:
+        assert read_float_flag("game", "k", 1.0) == 7.0
+
+
+def test_read_float_flag_rejects_bool_and_nonnumeric():
+    for bad in (True, "x", None, [1.0]):
+        init_p, get_p = _mock_flag_value(bad)
+        with init_p, get_p:
+            assert read_float_flag("game", "k", 1.0) == 1.0
+
+
+def test_read_float_flag_fails_safe_on_exception():
+    with patch("lib.feature_flags.init_flag_domain", side_effect=RuntimeError("boom")):
+        assert read_float_flag("game", "k", 2.5) == 2.5
+
+
+def test_read_int_flag_accepts_int_and_integral_float():
+    init_p, get_p = _mock_flag_value(4)
+    with init_p, get_p:
+        assert read_int_flag("game", "k", 1) == 4
+    # integral float coerced; bool subclass rejected
+    init_p, get_p = _mock_flag_value(6.0)
+    with init_p, get_p:
+        assert read_int_flag("game", "k", 1) == 6
+
+
+def test_read_int_flag_rejects_nonintegral_bool_nonnumeric():
+    for bad in (2.5, True, "x", None):
+        init_p, get_p = _mock_flag_value(bad)
+        with init_p, get_p:
+            assert read_int_flag("game", "k", 9) == 9
+
+
+def test_read_int_flag_fails_safe_on_exception():
+    with patch("lib.feature_flags.init_flag_domain", side_effect=RuntimeError("boom")):
+        assert read_int_flag("game", "k", 3) == 3
 
 
 @patch("lib.feature_flags.FlagdProvider")

--- a/services/flagd/game.json
+++ b/services/flagd/game.json
@@ -124,6 +124,121 @@
       },
       "defaultVariant": "normal"
     },
+    "death_grace_period_seconds": {
+      "state": "ENABLED",
+      "variants": {
+        "default": 0.5,
+        "none": 0.0,
+        "short": 0.25,
+        "long": 1.0
+      },
+      "defaultVariant": "default"
+    },
+    "nonstop.respawn_seconds": {
+      "state": "ENABLED",
+      "variants": {
+        "default": 3.0,
+        "fast": 1.5,
+        "slow": 5.0
+      },
+      "defaultVariant": "default"
+    },
+    "nonstop.spawn_protection_seconds": {
+      "state": "ENABLED",
+      "variants": {
+        "default": 2.0,
+        "none": 0.0,
+        "long": 4.0
+      },
+      "defaultVariant": "default"
+    },
+    "nonstop.scoring": {
+      "state": "ENABLED",
+      "variants": {
+        "default": {
+          "base": 100,
+          "death_penalty": 10
+        }
+      },
+      "defaultVariant": "default"
+    },
+    "fight_club.round_seconds": {
+      "state": "ENABLED",
+      "variants": {
+        "default": 22.0,
+        "short": 15.0,
+        "long": 30.0
+      },
+      "defaultVariant": "default"
+    },
+    "tournament.match_seconds": {
+      "state": "ENABLED",
+      "variants": {
+        "default": 22.0,
+        "short": 15.0,
+        "long": 30.0
+      },
+      "defaultVariant": "default"
+    },
+    "tournament.time_between_matches_seconds": {
+      "state": "ENABLED",
+      "variants": {
+        "default": 5.0,
+        "short": 3.0,
+        "long": 8.0
+      },
+      "defaultVariant": "default"
+    },
+    "werewolf.werewolf_fraction": {
+      "state": "ENABLED",
+      "variants": {
+        "default": 0.44,
+        "third": 0.33,
+        "half": 0.5
+      },
+      "defaultVariant": "default"
+    },
+    "traitor.count_tiers": {
+      "state": "ENABLED",
+      "variants": {
+        "default": {
+          "tiers": [
+            {"max_players": 5, "count": 1},
+            {"max_players": 8, "count": 2},
+            {"max_players": 11, "count": 3}
+          ],
+          "fallback_divisor": 3
+        }
+      },
+      "defaultVariant": "default"
+    },
+    "zombie.initial_count": {
+      "state": "ENABLED",
+      "variants": {
+        "default": 2,
+        "one": 1,
+        "three": 3
+      },
+      "defaultVariant": "default"
+    },
+    "zombie.respawn_min_seconds": {
+      "state": "ENABLED",
+      "variants": {
+        "default": 2.0,
+        "fast": 1.0,
+        "slow": 4.0
+      },
+      "defaultVariant": "default"
+    },
+    "zombie.respawn_max_seconds": {
+      "state": "ENABLED",
+      "variants": {
+        "default": 10.0,
+        "fast": 6.0,
+        "slow": 15.0
+      },
+      "defaultVariant": "default"
+    },
     "thresholds": {
       "state": "ENABLED",
       "variants": {

--- a/services/game_coordinator/games/base.py
+++ b/services/game_coordinator/games/base.py
@@ -28,7 +28,7 @@ from typing import TYPE_CHECKING, Any
 from opentelemetry import context as otel_context
 from opentelemetry import trace
 
-from lib.feature_flags import read_object_flag, set_game_transaction_context
+from lib.feature_flags import read_float_flag, read_object_flag, set_game_transaction_context
 from lib.telemetry import inject_trace_context
 from lib.types import GameEvent, Sensitivity, Sound
 from services.game_coordinator import metrics
@@ -175,6 +175,21 @@ def resolve_mode_thresholds(flag_value: dict, default_table: dict) -> dict:
         return default_table
 
     return {Sensitivity(i): (warning[i], death[i]) for i in range(SENSITIVITY_LEVELS)}
+
+
+def resolve_non_negative_duration(value, default: float) -> float:
+    """
+    Validate a promoted duration flag (#766 F2): finite, numeric, ``>= 0``.
+
+    Durations of exactly ``0`` are allowed (e.g. "no grace", "no spawn
+    protection"); negatives, non-numbers and NaN/inf fall back to ``default``
+    so the promotion stays behavior-neutral.
+    """
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return default
+    if value != value or value in (float("inf"), float("-inf")):  # NaN / inf
+        return default
+    return float(value) if value >= 0 else default
 
 
 # Warning feedback duration (seconds) - flash + rumble time
@@ -339,6 +354,14 @@ class BaseGameMode(ABC):
         # difficulty/filter changes "invalidate the variance baseline"). Falls
         # back to the hardcoded default (4.0) when flagd is unavailable.
         self._ema_weight = get_config_manager().read_ema_weight()
+
+        # #766 F2: post-death grace period promoted to ``game.death_grace_period_seconds``.
+        # Read ONCE here (init-frozen); malformed/negative values fall back to the
+        # DEATH_GRACE_PERIOD module constant (the source of truth).
+        self.death_grace_period = resolve_non_negative_duration(
+            read_float_flag("game", "death_grace_period_seconds", DEATH_GRACE_PERIOD),
+            DEATH_GRACE_PERIOD,
+        )
 
         # Phase 70: Music tempo control state
         self.music_track_id = None

--- a/services/game_coordinator/games/fight_club.py
+++ b/services/game_coordinator/games/fight_club.py
@@ -18,9 +18,16 @@ from opentelemetry import trace
 from opentelemetry.trace import Status, StatusCode
 
 from lib.colors import Colors
+from lib.feature_flags import read_float_flag
 from lib.types import Sound
 from proto import controller_manager_pb2
-from services.game_coordinator.games.base import GAME_MODE_ATTR, BaseGameMode, Phase, Player
+from services.game_coordinator.games.base import (
+    GAME_MODE_ATTR,
+    BaseGameMode,
+    Phase,
+    Player,
+    resolve_non_negative_duration,
+)
 
 logger = logging.getLogger(__name__)
 tracer = trace.get_tracer(__name__)
@@ -115,6 +122,15 @@ class FightClubGame(BaseGameMode):
         # Configurable timing - now passed via config
         self._invincibility_duration: float = invincibility_seconds
         self._min_rounds: int = min_rounds
+
+        # #766 F2: round duration promoted to ``game.fight_club.round_seconds``.
+        # Read ONCE here (init-frozen); a non-positive/malformed value falls back
+        # to the ROUND_DURATION module constant (a 0s round would break play).
+        round_seconds = resolve_non_negative_duration(
+            read_float_flag("game", "fight_club.round_seconds", ROUND_DURATION),
+            ROUND_DURATION,
+        )
+        self._round_duration: float = round_seconds if round_seconds > 0 else ROUND_DURATION
 
     def get_game_name(self) -> str:
         """Return game mode identifier."""
@@ -246,7 +262,7 @@ class FightClubGame(BaseGameMode):
 
         # Set round end time
         if not self.face_off_mode:
-            self.round_end_time = time.time() + ROUND_DURATION
+            self.round_end_time = time.time() + self._round_duration
         else:
             self.round_end_time = float("inf")  # No time limit in face-off
 

--- a/services/game_coordinator/games/nonstop_joust.py
+++ b/services/game_coordinator/games/nonstop_joust.py
@@ -19,9 +19,15 @@ from dataclasses import dataclass
 from opentelemetry import trace
 from opentelemetry.trace import Status, StatusCode
 
+from lib.feature_flags import read_float_flag, read_object_flag
 from lib.types import GameEvent, Sound
 from services.game_coordinator.games.analytics import PlayerAnalytics
-from services.game_coordinator.games.base import BaseGameMode, Phase, Player
+from services.game_coordinator.games.base import (
+    BaseGameMode,
+    Phase,
+    Player,
+    resolve_non_negative_duration,
+)
 from services.game_coordinator.runtime_config import get_config_manager
 
 tracer = trace.get_tracer(__name__)
@@ -31,6 +37,31 @@ logger = logging.getLogger(__name__)
 # UPDATE_FREQUENCY is now read from runtime_config (Phase 43)
 RESPAWN_DURATION = 3.0  # seconds to respawn
 SPAWN_PROTECTION_DURATION = 2.0  # seconds of invulnerability after spawn
+
+# Final-score formula: score = max(0, SCORE_BASE - deaths * SCORE_DEATH_PENALTY)
+SCORE_BASE = 100  # starting score with zero deaths
+SCORE_DEATH_PENALTY = 10  # points lost per death
+
+
+def resolve_scoring(flag_value, default_base: int, default_penalty: int) -> tuple[int, int]:
+    """
+    Validate the ``nonstop.scoring`` object flag -> ``(base, death_penalty)``.
+
+    Both entries must be non-negative integers; on any malformed value the
+    hardcoded module constants are used, keeping the promotion behavior-neutral
+    (#766 F2).
+    """
+    if not isinstance(flag_value, dict):
+        return default_base, default_penalty
+
+    def _non_neg_int(value, default: int) -> int:
+        if isinstance(value, bool) or not isinstance(value, int):
+            return default
+        return value if value >= 0 else default
+
+    base = _non_neg_int(flag_value.get("base"), default_base)
+    penalty = _non_neg_int(flag_value.get("death_penalty"), default_penalty)
+    return base, penalty
 
 
 @dataclass
@@ -104,6 +135,23 @@ class NonstopJoustGame(BaseGameMode):
         # Nonstop-specific settings - now passed via config
         self.time_limit = time_limit_seconds  # 0 = unlimited, otherwise seconds
         self.players: dict[str, NonstopPlayer] = {}  # Override type hint
+
+        # #766 F2: respawn/spawn-protection durations and scoring weights promoted
+        # to game flags. Read ONCE here (init-frozen); malformed values fall back
+        # to the module constants (the source of truth).
+        self.respawn_duration = resolve_non_negative_duration(
+            read_float_flag("game", "nonstop.respawn_seconds", RESPAWN_DURATION),
+            RESPAWN_DURATION,
+        )
+        self.spawn_protection_duration = resolve_non_negative_duration(
+            read_float_flag("game", "nonstop.spawn_protection_seconds", SPAWN_PROTECTION_DURATION),
+            SPAWN_PROTECTION_DURATION,
+        )
+        self.score_base, self.score_death_penalty = resolve_scoring(
+            read_object_flag("game", "nonstop.scoring", {}),
+            SCORE_BASE,
+            SCORE_DEATH_PENALTY,
+        )
 
     def get_game_name(self) -> str:
         """Return game mode identifier."""
@@ -212,7 +260,7 @@ class NonstopJoustGame(BaseGameMode):
         player.alive = False
         player.deaths += 1
         player.current_streak = 0
-        player.respawn_timer = RESPAWN_DURATION
+        player.respawn_timer = self.respawn_duration
 
         logger.info(f"Player died: {serial} (kills: {player.kills}, deaths: {player.deaths}, score: {player.score})")
 
@@ -409,7 +457,7 @@ class NonstopJoustGame(BaseGameMode):
         player = self.players[serial]
         player.alive = True
         player.spawn_protected = True
-        player.spawn_protection_end = time.time() + SPAWN_PROTECTION_DURATION
+        player.spawn_protection_end = time.time() + self.spawn_protection_duration
         # Reset warning state for clean respawn
         player.warning_until = 0.0
         player.smoothed_accel = 0.0
@@ -490,9 +538,9 @@ class NonstopJoustGame(BaseGameMode):
         self.state = GameState.ENDING
 
         # Calculate final scores (inverse of deaths - fewer deaths = higher score)
-        # Score = 100 - (deaths * 10), minimum 0
+        # Score = score_base - (deaths * score_death_penalty), minimum 0 (#766 F2)
         for player in self.players.values():
-            player.score = max(0, 100 - (player.deaths * 10))
+            player.score = max(0, self.score_base - (player.deaths * self.score_death_penalty))
 
         # Determine winner (highest score, tie-break by fewest deaths)
         winner = max(self.players.values(), key=lambda p: (p.score, -p.deaths), default=None)

--- a/services/game_coordinator/games/tournament.py
+++ b/services/game_coordinator/games/tournament.py
@@ -19,9 +19,15 @@ from enum import Enum
 from opentelemetry import trace
 from opentelemetry.trace import Status, StatusCode
 
+from lib.feature_flags import read_float_flag
 from lib.types import Sound
 from proto import controller_manager_pb2
-from services.game_coordinator.games.base import BaseGameMode, Phase, Player
+from services.game_coordinator.games.base import (
+    BaseGameMode,
+    Phase,
+    Player,
+    resolve_non_negative_duration,
+)
 
 logger = logging.getLogger(__name__)
 tracer = trace.get_tracer(__name__)
@@ -126,6 +132,20 @@ class TournamentGame(BaseGameMode):
         self.match_span: trace.Span | None = None
         # Configurable timing - now passed via config
         self._invincibility_duration: float = invincibility_seconds
+
+        # #766 F2: match duration and inter-match pause promoted to game flags.
+        # Read ONCE here (init-frozen); malformed values fall back to module
+        # constants. A 0s match would break play, so it must be strictly positive;
+        # a 0s inter-match pause is acceptable.
+        match_seconds = resolve_non_negative_duration(
+            read_float_flag("game", "tournament.match_seconds", MATCH_DURATION),
+            MATCH_DURATION,
+        )
+        self._match_duration: float = match_seconds if match_seconds > 0 else MATCH_DURATION
+        self._time_between_matches: float = resolve_non_negative_duration(
+            read_float_flag("game", "tournament.time_between_matches_seconds", TIME_BETWEEN_MATCHES),
+            TIME_BETWEEN_MATCHES,
+        )
 
     def get_game_name(self) -> str:
         """Return game mode identifier."""
@@ -433,7 +453,7 @@ class TournamentGame(BaseGameMode):
         while self.running and not match.is_complete:
             elapsed = time.time() - match_start
 
-            if elapsed >= MATCH_DURATION:
+            if elapsed >= self._match_duration:
                 # Time's up - both survive, random winner
                 match.winner_serial = random.choice([match.player1_serial, match.player2_serial])
                 logger.info(f"Match {match.match_id} timeout - random winner: {match.winner_serial}")
@@ -564,7 +584,7 @@ class TournamentGame(BaseGameMode):
             self.current_match = None
 
             # Pause between matches
-            for _ in range(int(TIME_BETWEEN_MATCHES * 10)):
+            for _ in range(int(self._time_between_matches * 10)):
                 if not self.running:
                     break
                 await asyncio.sleep(0.1)

--- a/services/game_coordinator/games/traitor.py
+++ b/services/game_coordinator/games/traitor.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass
 from opentelemetry import trace
 from opentelemetry.trace import Status, StatusCode
 
+from lib.feature_flags import read_object_flag
 from lib.types import Sound
 from proto import controller_manager_pb2
 from services.game_coordinator.games.base import Player
@@ -24,6 +25,55 @@ from services.game_coordinator.games.teams_base import TeamsGameBase
 
 logger = logging.getLogger(__name__)
 tracer = trace.get_tracer(__name__)
+
+# Traitor count tiers (source-of-truth defaults, #766 F2).
+# Ordered ascending by ``max_players``: the first tier whose ``max_players`` is
+# >= the player count decides the traitor count; beyond the last tier the count
+# is ``num_players // fallback_divisor``.
+DEFAULT_TRAITOR_COUNT_TIERS = [
+    {"max_players": 5, "count": 1},
+    {"max_players": 8, "count": 2},
+    {"max_players": 11, "count": 3},
+]
+DEFAULT_TRAITOR_FALLBACK_DIVISOR = 3
+
+
+def resolve_count_tiers(flag_value, default_tiers: list, default_divisor: int) -> tuple[list, int]:
+    """
+    Validate the ``traitor.count_tiers`` object flag -> ``(tiers, fallback_divisor)``.
+
+    A well-formed flag carries a ``tiers`` list of ``{max_players, count}`` dicts
+    (positive ints, strictly ascending ``max_players``) and a positive integer
+    ``fallback_divisor``. On ANY malformed component the hardcoded defaults are
+    returned, keeping role assignment behavior-neutral (#766 F2).
+    """
+    if not isinstance(flag_value, dict):
+        return default_tiers, default_divisor
+
+    raw_tiers = flag_value.get("tiers")
+    divisor = flag_value.get("fallback_divisor")
+
+    if isinstance(divisor, bool) or not isinstance(divisor, int) or divisor <= 0:
+        return default_tiers, default_divisor
+
+    if not isinstance(raw_tiers, list) or not raw_tiers:
+        return default_tiers, default_divisor
+
+    tiers: list[dict] = []
+    prev_max = 0
+    for entry in raw_tiers:
+        if not isinstance(entry, dict):
+            return default_tiers, default_divisor
+        max_players = entry.get("max_players")
+        count = entry.get("count")
+        if isinstance(max_players, bool) or not isinstance(max_players, int) or max_players <= prev_max:
+            return default_tiers, default_divisor
+        if isinstance(count, bool) or not isinstance(count, int) or count < 1:
+            return default_tiers, default_divisor
+        tiers.append({"max_players": max_players, "count": count})
+        prev_max = max_players
+
+    return tiers, divisor
 
 
 @dataclass
@@ -93,6 +143,15 @@ class TraitorGame(TeamsGameBase):
 
         self.traitor_serials: list[str] = []
 
+        # #766 F2: traitor count tiers promoted to ``game.traitor.count_tiers``.
+        # Read ONCE here (init-frozen); malformed values fall back to the module
+        # defaults (the source of truth).
+        self._count_tiers, self._count_fallback_divisor = resolve_count_tiers(
+            read_object_flag("game", "traitor.count_tiers", {}),
+            DEFAULT_TRAITOR_COUNT_TIERS,
+            DEFAULT_TRAITOR_FALLBACK_DIVISOR,
+        )
+
     def get_game_name(self) -> str:
         """Return game mode identifier."""
         return "Traitor"
@@ -101,19 +160,21 @@ class TraitorGame(TeamsGameBase):
         """
         Determine number of traitors based on player count.
 
+        Walks the resolved count tiers ascending: the first tier whose
+        ``max_players`` covers ``num_players`` wins; beyond the last tier the
+        count is ``num_players // fallback_divisor`` (#766 F2). With the default
+        tiers this reproduces the original 1/2/3/``//3`` behavior.
+
         Args:
             num_players: Total number of players
 
         Returns:
             Number of traitors to assign
         """
-        if num_players <= 5:
-            return 1
-        if num_players <= 8:
-            return 2
-        if num_players <= 11:
-            return 3
-        return num_players // 3
+        for tier in self._count_tiers:
+            if num_players <= tier["max_players"]:
+                return tier["count"]
+        return num_players // self._count_fallback_divisor
 
     async def _initialize_players_impl(self, controllers: list):
         """

--- a/services/game_coordinator/games/werewolf.py
+++ b/services/game_coordinator/games/werewolf.py
@@ -17,7 +17,7 @@ from opentelemetry import trace
 from opentelemetry.trace import Status, StatusCode
 
 from lib.colors import Colors
-from lib.feature_flags import read_object_flag
+from lib.feature_flags import read_float_flag, read_object_flag
 from lib.types import Sound
 from proto import controller_manager_pb2
 from services.game_coordinator.games.base import (
@@ -34,6 +34,23 @@ tracer = trace.get_tracer(__name__)
 
 # Game constants (defaults, can be overridden via settings)
 DEFAULT_REVEAL_TIME = 35.0  # Seconds until werewolves are revealed
+WEREWOLF_FRACTION = 0.44  # ~44% of players become werewolves (minimum 1)
+
+
+def resolve_fraction(value, default: float) -> float:
+    """
+    Validate a fraction flag (#766 F2): numeric and strictly in ``(0, 1)``.
+
+    Values at or outside the open interval (and non-numbers / NaN) fall back to
+    ``default`` so role assignment stays behavior-neutral.
+    """
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return default
+    if value != value:  # NaN
+        return default
+    return float(value) if 0.0 < value < 1.0 else default
+
+
 HUMAN_COLOR = Colors.Yellow.value  # Yellow for humans (and all players before reveal)
 WEREWOLF_COLOR = Colors.LightBlue.value  # Blue for werewolves after reveal
 
@@ -107,6 +124,13 @@ class WerewolfGame(BaseGameMode):
             read_object_flag("game", "werewolf.thresholds", {}), WEREWOLF_THRESHOLDS
         )
 
+        # #766 F2: werewolf population fraction promoted to ``game.werewolf.werewolf_fraction``.
+        # Read once at init (init-frozen); out-of-range values fall back to WEREWOLF_FRACTION.
+        self.werewolf_fraction = resolve_fraction(
+            read_float_flag("game", "werewolf.werewolf_fraction", WEREWOLF_FRACTION),
+            WEREWOLF_FRACTION,
+        )
+
         self.werewolf_serials: list[str] = []
         self.human_serials: list[str] = []
         self.revealed = False
@@ -128,7 +152,7 @@ class WerewolfGame(BaseGameMode):
             controllers: List of controller protobuf messages
         """
         num_players = len(controllers)
-        num_werewolves = max(1, int(num_players * 0.44))  # ~44% are werewolves, minimum 1
+        num_werewolves = max(1, int(num_players * self.werewolf_fraction))  # minimum 1
 
         # Randomly select werewolves
         serials = [c.serial for c in controllers]

--- a/services/game_coordinator/games/zombie.py
+++ b/services/game_coordinator/games/zombie.py
@@ -21,7 +21,7 @@ from opentelemetry import trace
 from opentelemetry.trace import Status, StatusCode
 
 from lib.colors import Colors
-from lib.feature_flags import read_object_flag
+from lib.feature_flags import read_float_flag, read_int_flag, read_object_flag
 from lib.types import Sound
 from proto import controller_manager_pb2
 from services.game_coordinator.games.base import (
@@ -31,6 +31,7 @@ from services.game_coordinator.games.base import (
     Player,
     Sensitivity,
     resolve_mode_thresholds,
+    resolve_non_negative_duration,
 )
 
 logger = logging.getLogger(__name__)
@@ -129,6 +130,27 @@ class ZombieGame(BaseGameMode):
             read_object_flag("game", "zombie.thresholds", {}), ZOMBIE_THRESHOLDS
         )
 
+        # #766 F2: initial zombie count and respawn delay window promoted to game
+        # flags. Read ONCE here (init-frozen); malformed values fall back to the
+        # module constants. ``initial_count`` must be a positive int; respawn
+        # bounds are non-negative and the min must not exceed the max (else both
+        # fall back together to preserve a sane window).
+        initial = read_int_flag("game", "zombie.initial_count", INITIAL_ZOMBIES)
+        self.initial_zombies = initial if isinstance(initial, int) and initial >= 1 else INITIAL_ZOMBIES
+
+        respawn_min = resolve_non_negative_duration(
+            read_float_flag("game", "zombie.respawn_min_seconds", ZOMBIE_RESPAWN_MIN),
+            ZOMBIE_RESPAWN_MIN,
+        )
+        respawn_max = resolve_non_negative_duration(
+            read_float_flag("game", "zombie.respawn_max_seconds", ZOMBIE_RESPAWN_MAX),
+            ZOMBIE_RESPAWN_MAX,
+        )
+        if respawn_min > respawn_max:
+            respawn_min, respawn_max = ZOMBIE_RESPAWN_MIN, ZOMBIE_RESPAWN_MAX
+        self.zombie_respawn_min = respawn_min
+        self.zombie_respawn_max = respawn_max
+
         self.zombie_serials: list[str] = []
         self.human_serials: list[str] = []
         self.game_duration: float = 180.0  # Will be calculated based on player count
@@ -153,7 +175,7 @@ class ZombieGame(BaseGameMode):
 
         # Randomly select initial zombies
         serials = [c.serial for c in controllers]
-        num_zombies = min(INITIAL_ZOMBIES, num_players - 1)  # At least 1 human
+        num_zombies = min(self.initial_zombies, num_players - 1)  # At least 1 human
         zombie_serials = set(random.sample(serials, num_zombies))
 
         for controller in controllers:
@@ -365,7 +387,7 @@ class ZombieGame(BaseGameMode):
         if zombie_player.is_zombie:
             # Zombie killed - set respawn timer
             zombie_player.alive = False
-            respawn_delay = random.uniform(ZOMBIE_RESPAWN_MIN, ZOMBIE_RESPAWN_MAX)
+            respawn_delay = random.uniform(self.zombie_respawn_min, self.zombie_respawn_max)
             zombie_player.respawn_until = time.time() + respawn_delay
 
             logger.info(f"Zombie {serial} killed, respawning in {respawn_delay:.1f}s")

--- a/services/game_coordinator/tests/test_duration_flags.py
+++ b/services/game_coordinator/tests/test_duration_flags.py
@@ -1,0 +1,432 @@
+"""
+Tests for #766 F2: durations, roles, and scoring promoted to game flags.
+
+Covers, per the issue's consistency rules:
+- Characterization: every game.json default reproduces the current hardcoded
+  behavior exactly (durations, role counts at various player counts, scoring).
+- Malformed/out-of-range flag values fall back to the module constants
+  (the source of truth) per flag.
+- Init-frozen: each mode reads its flags once at __init__; a mid-game flag
+  change has no effect on the already-resolved instance values.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+# Setup paths for imports
+test_dir = Path(__file__).parent
+service_dir = test_dir.parent
+project_root = service_dir.parent.parent
+sys.path.insert(0, str(project_root))
+sys.path.insert(0, str(test_dir))
+
+from conftest import EventCollector, async_noop
+
+from services.game_coordinator.games.base import (
+    DEATH_GRACE_PERIOD,
+    resolve_non_negative_duration,
+)
+from services.game_coordinator.games.ffa import FFAGame
+from services.game_coordinator.games.fight_club import ROUND_DURATION, FightClubGame
+from services.game_coordinator.games.nonstop_joust import (
+    RESPAWN_DURATION,
+    SCORE_BASE,
+    SCORE_DEATH_PENALTY,
+    SPAWN_PROTECTION_DURATION,
+    NonstopJoustGame,
+    resolve_scoring,
+)
+from services.game_coordinator.games.tournament import (
+    MATCH_DURATION,
+    TIME_BETWEEN_MATCHES,
+    TournamentGame,
+)
+from services.game_coordinator.games.traitor import (
+    DEFAULT_TRAITOR_COUNT_TIERS,
+    DEFAULT_TRAITOR_FALLBACK_DIVISOR,
+    TraitorGame,
+    resolve_count_tiers,
+)
+from services.game_coordinator.games.werewolf import (
+    WEREWOLF_FRACTION,
+    WerewolfGame,
+    resolve_fraction,
+)
+from services.game_coordinator.games.zombie import (
+    INITIAL_ZOMBIES,
+    ZOMBIE_RESPAWN_MAX,
+    ZOMBIE_RESPAWN_MIN,
+    ZombieGame,
+)
+
+# ========================================================================
+# Helpers
+# ========================================================================
+
+
+def _make_ffa():
+    return FFAGame(
+        controller_manager_client=None,
+        event_publisher=EventCollector().publish,
+        sensitivity=2,
+    )
+
+
+def _make_nonstop():
+    return NonstopJoustGame(
+        controller_manager_client=None,
+        event_publisher=async_noop,
+        sensitivity=2,
+    )
+
+
+def _make_fight_club():
+    return FightClubGame(
+        controller_manager_client=None,
+        event_publisher=async_noop,
+        sensitivity=2,
+    )
+
+
+def _make_tournament():
+    return TournamentGame(
+        controller_manager_client=None,
+        event_publisher=async_noop,
+        sensitivity=2,
+    )
+
+
+def _make_werewolf():
+    return WerewolfGame(
+        controller_manager_client=None,
+        event_publisher=async_noop,
+        sensitivity=2,
+    )
+
+
+def _make_traitor():
+    return TraitorGame(
+        controller_manager_client=None,
+        event_publisher=async_noop,
+        sensitivity=2,
+    )
+
+
+def _make_zombie():
+    return ZombieGame(
+        controller_manager_client=None,
+        event_publisher=async_noop,
+        sensitivity=2,
+    )
+
+
+# ========================================================================
+# resolve_non_negative_duration
+# ========================================================================
+
+
+def test_duration_valid_positive_and_zero():
+    assert resolve_non_negative_duration(3.0, 1.0) == 3.0
+    assert resolve_non_negative_duration(0, 1.0) == 0.0
+    assert resolve_non_negative_duration(7, 1.0) == 7.0
+
+
+def test_duration_rejects_negative_nonnumeric_bool_nan_inf():
+    assert resolve_non_negative_duration(-1.0, 1.0) == 1.0
+    assert resolve_non_negative_duration("x", 1.0) == 1.0
+    assert resolve_non_negative_duration(None, 1.0) == 1.0
+    assert resolve_non_negative_duration(True, 1.0) == 1.0
+    assert resolve_non_negative_duration(float("nan"), 1.0) == 1.0
+    assert resolve_non_negative_duration(float("inf"), 1.0) == 1.0
+
+
+# ========================================================================
+# death_grace_period (base.py)
+# ========================================================================
+
+
+def test_grace_default_reproduces_constant():
+    game = _make_ffa()
+    assert game.death_grace_period == DEATH_GRACE_PERIOD
+
+
+def test_grace_reads_flag_once_and_frozen():
+    with patch("services.game_coordinator.games.base.read_float_flag", return_value=0.25) as mock_read:
+        game = _make_ffa()
+    assert game.death_grace_period == 0.25
+    # exactly one read for the grace flag (init-frozen)
+    grace_calls = [c for c in mock_read.call_args_list if c.args[1] == "death_grace_period_seconds"]
+    assert len(grace_calls) == 1
+
+
+def test_grace_malformed_falls_back():
+    with patch("services.game_coordinator.games.base.read_float_flag", return_value=-5.0):
+        game = _make_ffa()
+    assert game.death_grace_period == DEATH_GRACE_PERIOD
+
+
+# ========================================================================
+# Nonstop: respawn / spawn-protection / scoring
+# ========================================================================
+
+
+def test_nonstop_defaults_reproduce_constants():
+    game = _make_nonstop()
+    assert game.respawn_duration == RESPAWN_DURATION
+    assert game.spawn_protection_duration == SPAWN_PROTECTION_DURATION
+    assert game.score_base == SCORE_BASE
+    assert game.score_death_penalty == SCORE_DEATH_PENALTY
+
+
+def test_nonstop_scoring_resolver_characterization():
+    # The game.json default object must reproduce the 100 - deaths*10 formula.
+    base, penalty = resolve_scoring({"base": 100, "death_penalty": 10}, SCORE_BASE, SCORE_DEATH_PENALTY)
+    assert base == 100
+    assert penalty == 10
+    for deaths in (0, 1, 3, 11, 20):
+        assert max(0, base - deaths * penalty) == max(0, 100 - deaths * 10)
+
+
+def test_nonstop_scoring_resolver_fallbacks():
+    # non-dict, negative, non-int, bool, missing keys -> default
+    assert resolve_scoring(None, 100, 10) == (100, 10)
+    assert resolve_scoring({"base": -5, "death_penalty": 10}, 100, 10) == (100, 10)
+    assert resolve_scoring({"base": 2.5, "death_penalty": 10}, 100, 10) == (100, 10)
+    assert resolve_scoring({"base": True, "death_penalty": 10}, 100, 10) == (100, 10)
+    assert resolve_scoring({"base": 50}, 100, 10) == (50, 10)  # missing penalty -> default
+
+
+def test_nonstop_reads_frozen_override():
+    with (
+        patch(
+            "services.game_coordinator.games.nonstop_joust.read_float_flag",
+            side_effect=[1.5, 4.0],  # respawn, spawn_protection
+        ),
+        patch(
+            "services.game_coordinator.games.nonstop_joust.read_object_flag",
+            return_value={"base": 200, "death_penalty": 25},
+        ),
+    ):
+        game = _make_nonstop()
+    assert game.respawn_duration == 1.5
+    assert game.spawn_protection_duration == 4.0
+    assert game.score_base == 200
+    assert game.score_death_penalty == 25
+
+
+def test_nonstop_malformed_durations_fall_back():
+    with (
+        patch(
+            "services.game_coordinator.games.nonstop_joust.read_float_flag",
+            side_effect=[-1.0, "bad"],
+        ),
+        patch(
+            "services.game_coordinator.games.nonstop_joust.read_object_flag",
+            return_value="not-a-dict",
+        ),
+    ):
+        game = _make_nonstop()
+    assert game.respawn_duration == RESPAWN_DURATION
+    assert game.spawn_protection_duration == SPAWN_PROTECTION_DURATION
+    assert game.score_base == SCORE_BASE
+    assert game.score_death_penalty == SCORE_DEATH_PENALTY
+
+
+# ========================================================================
+# Fight Club: round duration
+# ========================================================================
+
+
+def test_fight_club_default_round_duration():
+    game = _make_fight_club()
+    assert game._round_duration == ROUND_DURATION
+
+
+def test_fight_club_round_override_and_zero_fallback():
+    with patch("services.game_coordinator.games.fight_club.read_float_flag", return_value=30.0):
+        game = _make_fight_club()
+    assert game._round_duration == 30.0
+    # A 0s round would break play -> fall back to the constant.
+    with patch("services.game_coordinator.games.fight_club.read_float_flag", return_value=0.0):
+        game = _make_fight_club()
+    assert game._round_duration == ROUND_DURATION
+
+
+# ========================================================================
+# Tournament: match duration + inter-match pause
+# ========================================================================
+
+
+def test_tournament_defaults():
+    game = _make_tournament()
+    assert game._match_duration == MATCH_DURATION
+    assert game._time_between_matches == TIME_BETWEEN_MATCHES
+
+
+def test_tournament_overrides_and_fallbacks():
+    with patch(
+        "services.game_coordinator.games.tournament.read_float_flag",
+        side_effect=[18.0, 0.0],  # match=18s, pause=0s (0 pause allowed)
+    ):
+        game = _make_tournament()
+    assert game._match_duration == 18.0
+    assert game._time_between_matches == 0.0
+    # 0s match -> fall back; bad pause -> fall back
+    with patch(
+        "services.game_coordinator.games.tournament.read_float_flag",
+        side_effect=[0.0, "bad"],
+    ):
+        game = _make_tournament()
+    assert game._match_duration == MATCH_DURATION
+    assert game._time_between_matches == TIME_BETWEEN_MATCHES
+
+
+# ========================================================================
+# Werewolf: werewolf fraction
+# ========================================================================
+
+
+def test_fraction_resolver():
+    assert resolve_fraction(0.44, 0.44) == 0.44
+    assert resolve_fraction(0.5, 0.44) == 0.5
+    # boundaries (0 and 1) and out-of-range -> default
+    for bad in (0.0, 1.0, -0.1, 1.5, "x", None, True, float("nan")):
+        assert resolve_fraction(bad, 0.44) == 0.44
+
+
+def test_werewolf_fraction_default_characterization():
+    """Default 0.44 reproduces the original werewolf-count math at several sizes."""
+    game = _make_werewolf()
+    assert game.werewolf_fraction == WEREWOLF_FRACTION
+    for num_players in (2, 4, 5, 8, 13, 20):
+        expected = max(1, int(num_players * 0.44))
+        assert max(1, int(num_players * game.werewolf_fraction)) == expected
+
+
+def test_werewolf_fraction_override_and_fallback():
+    with patch("services.game_coordinator.games.werewolf.read_float_flag", return_value=0.5):
+        game = _make_werewolf()
+    assert game.werewolf_fraction == 0.5
+    with patch("services.game_coordinator.games.werewolf.read_float_flag", return_value=1.5):
+        game = _make_werewolf()
+    assert game.werewolf_fraction == WEREWOLF_FRACTION
+
+
+# ========================================================================
+# Traitor: count tiers
+# ========================================================================
+
+
+def test_count_tiers_resolver_default():
+    tiers, divisor = resolve_count_tiers(
+        {
+            "tiers": [
+                {"max_players": 5, "count": 1},
+                {"max_players": 8, "count": 2},
+                {"max_players": 11, "count": 3},
+            ],
+            "fallback_divisor": 3,
+        },
+        DEFAULT_TRAITOR_COUNT_TIERS,
+        DEFAULT_TRAITOR_FALLBACK_DIVISOR,
+    )
+    assert tiers == DEFAULT_TRAITOR_COUNT_TIERS
+    assert divisor == 3
+
+
+def test_count_tiers_resolver_fallbacks():
+    d = (DEFAULT_TRAITOR_COUNT_TIERS, DEFAULT_TRAITOR_FALLBACK_DIVISOR)
+    assert resolve_count_tiers(None, *d) == d
+    assert resolve_count_tiers({"tiers": [], "fallback_divisor": 3}, *d) == d
+    assert resolve_count_tiers({"tiers": [{"max_players": 5, "count": 1}], "fallback_divisor": 0}, *d) == d
+    # non-ascending max_players
+    bad_order = {
+        "tiers": [{"max_players": 8, "count": 1}, {"max_players": 5, "count": 2}],
+        "fallback_divisor": 3,
+    }
+    assert resolve_count_tiers(bad_order, *d) == d
+    # count < 1
+    bad_count = {"tiers": [{"max_players": 5, "count": 0}], "fallback_divisor": 3}
+    assert resolve_count_tiers(bad_count, *d) == d
+    # bool rejected
+    bad_bool = {"tiers": [{"max_players": True, "count": 1}], "fallback_divisor": 3}
+    assert resolve_count_tiers(bad_bool, *d) == d
+
+
+def test_traitor_count_default_characterization():
+    """Default tiers reproduce the original 1/2/3/(//3) traitor counts."""
+    game = _make_traitor()
+
+    def original(n):
+        if n <= 5:
+            return 1
+        if n <= 8:
+            return 2
+        if n <= 11:
+            return 3
+        return n // 3
+
+    for n in (1, 4, 5, 6, 8, 9, 11, 12, 15, 30):
+        assert game._get_traitor_count(n) == original(n)
+
+
+def test_traitor_count_override_frozen():
+    custom = {
+        "tiers": [{"max_players": 3, "count": 1}, {"max_players": 6, "count": 2}],
+        "fallback_divisor": 4,
+    }
+    with patch("services.game_coordinator.games.traitor.read_object_flag", return_value=custom):
+        game = _make_traitor()
+    assert game._get_traitor_count(3) == 1
+    assert game._get_traitor_count(6) == 2
+    assert game._get_traitor_count(12) == 3  # 12 // 4
+    # init-frozen: changing the flag after init has no effect
+    with patch("services.game_coordinator.games.traitor.read_object_flag", return_value={"tiers": []}):
+        assert game._get_traitor_count(3) == 1
+
+
+# ========================================================================
+# Zombie: initial count + respawn window
+# ========================================================================
+
+
+def test_zombie_defaults_reproduce_constants():
+    game = _make_zombie()
+    assert game.initial_zombies == INITIAL_ZOMBIES
+    assert game.zombie_respawn_min == ZOMBIE_RESPAWN_MIN
+    assert game.zombie_respawn_max == ZOMBIE_RESPAWN_MAX
+
+
+def test_zombie_reads_overrides():
+    with (
+        patch("services.game_coordinator.games.zombie.read_int_flag", return_value=3),
+        patch(
+            "services.game_coordinator.games.zombie.read_float_flag",
+            side_effect=[1.0, 6.0],  # respawn_min, respawn_max
+        ),
+    ):
+        game = _make_zombie()
+    assert game.initial_zombies == 3
+    assert game.zombie_respawn_min == 1.0
+    assert game.zombie_respawn_max == 6.0
+
+
+def test_zombie_initial_count_malformed_falls_back():
+    # non-positive int -> fall back to INITIAL_ZOMBIES
+    with patch("services.game_coordinator.games.zombie.read_int_flag", return_value=0):
+        game = _make_zombie()
+    assert game.initial_zombies == INITIAL_ZOMBIES
+
+
+def test_zombie_respawn_min_gt_max_falls_back_pair():
+    with (
+        patch("services.game_coordinator.games.zombie.read_int_flag", return_value=INITIAL_ZOMBIES),
+        patch(
+            "services.game_coordinator.games.zombie.read_float_flag",
+            side_effect=[12.0, 3.0],  # min > max -> both revert
+        ),
+    ):
+        game = _make_zombie()
+    assert game.zombie_respawn_min == ZOMBIE_RESPAWN_MIN
+    assert game.zombie_respawn_max == ZOMBIE_RESPAWN_MAX


### PR DESCRIPTION
Part of #766 (F2).

Originally **stacked on #769** (F1) — but #769 has already merged into `main`, so this PR now targets `main` directly (rebased onto current `main`, F1 content already present).

Refs #722 #725 #730.

## What

Promotes the audited calibration constants for **durations, role counts, and scoring** to the `game` flag domain (#722 §2b calibration surface). Every current value becomes the flag default, so the promotion is **behavior-neutral**.

New `services/flagd/game.json` flags (#725 naming — bare `snake_case`, dots only for genuine sub-structure):

| Flag | Default | Source constant |
|------|---------|-----------------|
| `death_grace_period_seconds` | 0.5 | `base.py` `DEATH_GRACE_PERIOD` |
| `nonstop.respawn_seconds` | 3.0 | `nonstop_joust.py` `RESPAWN_DURATION` |
| `nonstop.spawn_protection_seconds` | 2.0 | `SPAWN_PROTECTION_DURATION` |
| `nonstop.scoring` | `{base:100, death_penalty:10}` | `100 - deaths*10` formula |
| `fight_club.round_seconds` | 22.0 | `ROUND_DURATION` |
| `tournament.match_seconds` | 22.0 | `MATCH_DURATION` |
| `tournament.time_between_matches_seconds` | 5.0 | `TIME_BETWEEN_MATCHES` |
| `werewolf.werewolf_fraction` | 0.44 | `int(n * 0.44)` |
| `traitor.count_tiers` | tiers 5/8/11 + divisor 3 | `_get_traitor_count` |
| `zombie.initial_count` | 2 | `INITIAL_ZOMBIES` |
| `zombie.respawn_min_seconds` | 2.0 | `ZOMBIE_RESPAWN_MIN` |
| `zombie.respawn_max_seconds` | 10.0 | `ZOMBIE_RESPAWN_MAX` |

## How

- Each mode reads its flags **once at `__init__`** (init-frozen, like F1) — a mid-game flag change has no effect.
- **No proto changes**: calibration flags bypass `StartGameConfig` entirely.
- New scalar siblings of `read_object_flag` added to `lib/feature_flags.py`: **`read_float_flag`** and **`read_int_flag`**, same fail-safe / init-frozen semantics (lazy domain init, default on any error; bool rejected; `read_int_flag` rejects non-integral floats). **F3 can reuse these for music-window scalars.**
- Per-flag validation (positive/non-negative durations, fraction strictly in (0,1), well-formed ascending tiers, respawn `min <= max`, non-negative scoring ints) falls back to the hardcoded module/class constants, which **remain the source of truth**. Reusable validators: `resolve_non_negative_duration` (base.py), `resolve_scoring` (nonstop), `resolve_fraction` (werewolf), `resolve_count_tiers` (traitor).

## Test plan

- `cd services/game_coordinator && uv run --extra test pytest` → **809 passed** (existing suite unchanged + 25 new in `test_duration_flags.py`).
- `cd lib && uv run --extra test pytest tests/test_feature_flags.py` → **15 passed** (6 new for the scalar helpers).
- `make lint` clean. `game.json` parses; all default variants verified to equal the module constants.

New tests cover, per the issue's consistency rules:
- **Characterization** — defaults reproduce current durations, traitor/werewolf role counts at many player sizes, and the `100 - deaths*10` scoring.
- **Malformed fallback** — per flag (negative/NaN/inf duration, non-dict scoring, 0s round/match, out-of-range fraction, malformed/non-ascending tiers, respawn min>max, non-positive initial count).
- **Init-frozen** — flags read exactly once at init; post-init flag change is ignored.

## Out of scope (other #766 items)
No music windows (F3), no `docs/feature-flags.md` (F8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)