### PR TITLE
feat: promote music schedule windows to game flags with pacing presets (#766 F3)

### DIFF
--- a/services/flagd/game.json
+++ b/services/flagd/game.json
@@ -270,6 +270,42 @@
         }
       },
       "defaultVariant": "default"
+    },
+    "windows": {
+      "state": "ENABLED",
+      "variants": {
+        "default": {
+          "min_music_fast_time": 4,
+          "max_music_fast_time": 8,
+          "min_music_slow_time": 10,
+          "max_music_slow_time": 23,
+          "end_min_music_fast_time": 6,
+          "end_max_music_fast_time": 10,
+          "end_min_music_slow_time": 8,
+          "end_max_music_slow_time": 12
+        },
+        "calm": {
+          "min_music_fast_time": 3,
+          "max_music_fast_time": 6,
+          "min_music_slow_time": 13,
+          "max_music_slow_time": 30,
+          "end_min_music_fast_time": 4,
+          "end_max_music_fast_time": 7,
+          "end_min_music_slow_time": 10,
+          "end_max_music_slow_time": 16
+        },
+        "frantic": {
+          "min_music_fast_time": 6,
+          "max_music_fast_time": 11,
+          "min_music_slow_time": 6,
+          "max_music_slow_time": 14,
+          "end_min_music_fast_time": 8,
+          "end_max_music_fast_time": 14,
+          "end_min_music_slow_time": 5,
+          "end_max_music_slow_time": 8
+        }
+      },
+      "defaultVariant": "default"
     }
   }
 }

--- a/services/game_coordinator/games/base.py
+++ b/services/game_coordinator/games/base.py
@@ -217,6 +217,116 @@ def resolve_non_negative_duration(value, default: float) -> float:
     return float(value) if value >= 0 else default
 
 
+@dataclass
+class MusicWindows:
+    """Tempo-change scheduling windows (seconds) for the music loop.
+
+    Each field is the min/max delay before the next tempo change in a given
+    phase. The loop draws a uniform delay in ``[min, max]`` (lerping between the
+    early-game and end-game pairs as players are eliminated). #766 F3 promoted
+    these from the module constants to the ``game.windows`` object flag.
+
+    #766 F6 seam (LIVE ``pacing_profile`` intervention): the resolved windows
+    live on ``self.music_windows`` (one ``MusicWindows`` instance). F6's live
+    handler must build a new ``MusicWindows`` from the chosen preset and assign
+    it atomically — ``self.music_windows = new_windows`` — so the music loop,
+    which reads ``self.music_windows`` fresh on each ``_get_music_change_time``
+    call, picks up the swap on the next tempo change without tearing (the field
+    reference flips in a single bytecode store; never mutate the fields in
+    place). Init reads it once (init-frozen calibration); F6 owns the live path.
+    """
+
+    fast_min: float
+    fast_max: float
+    slow_min: float
+    slow_max: float
+    end_fast_min: float
+    end_fast_max: float
+    end_slow_min: float
+    end_slow_max: float
+
+    @classmethod
+    def defaults(cls) -> "MusicWindows":
+        """Build a MusicWindows from the hardcoded module constants."""
+        return cls(
+            fast_min=MIN_MUSIC_FAST_TIME,
+            fast_max=MAX_MUSIC_FAST_TIME,
+            slow_min=MIN_MUSIC_SLOW_TIME,
+            slow_max=MAX_MUSIC_SLOW_TIME,
+            end_fast_min=END_MIN_MUSIC_FAST_TIME,
+            end_fast_max=END_MAX_MUSIC_FAST_TIME,
+            end_slow_min=END_MIN_MUSIC_SLOW_TIME,
+            end_slow_max=END_MAX_MUSIC_SLOW_TIME,
+        )
+
+
+# Maps each MusicWindows field to its game.windows flag key (snake_case after
+# the module constants) and the constant used as the per-field fallback.
+_MUSIC_WINDOW_FIELDS = (
+    ("fast_min", "min_music_fast_time", MIN_MUSIC_FAST_TIME),
+    ("fast_max", "max_music_fast_time", MAX_MUSIC_FAST_TIME),
+    ("slow_min", "min_music_slow_time", MIN_MUSIC_SLOW_TIME),
+    ("slow_max", "max_music_slow_time", MAX_MUSIC_SLOW_TIME),
+    ("end_fast_min", "end_min_music_fast_time", END_MIN_MUSIC_FAST_TIME),
+    ("end_fast_max", "end_max_music_fast_time", END_MAX_MUSIC_FAST_TIME),
+    ("end_slow_min", "end_min_music_slow_time", END_MIN_MUSIC_SLOW_TIME),
+    ("end_slow_max", "end_max_music_slow_time", END_MAX_MUSIC_SLOW_TIME),
+)
+
+# (min_field, max_field) pairs that must satisfy min <= max for the windows to
+# be usable. If any pair is violated after resolution we discard the whole flag
+# value and fall back to the defaults (keeping promotion behavior-neutral).
+_MUSIC_WINDOW_PAIRS = (
+    ("fast_min", "fast_max"),
+    ("slow_min", "slow_max"),
+    ("end_fast_min", "end_fast_max"),
+    ("end_slow_min", "end_slow_max"),
+)
+
+
+def _positive_number(value) -> bool:
+    """A music window must be a finite, strictly-positive (>0) number, not bool."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return False
+    if value != value or value in (float("inf"), float("-inf")):  # NaN / inf
+        return False
+    return value > 0
+
+
+def resolve_music_windows(flag_value: dict) -> MusicWindows:
+    """
+    Validate the ``game.windows`` object flag and resolve a :class:`MusicWindows`.
+
+    Each of the eight window values must be a finite, strictly-positive number,
+    and every (min, max) pair must satisfy ``min <= max``. On ANY malformed
+    value or violated ordering the ENTIRE flag value is rejected in favour of
+    the module-constant defaults, keeping the promotion behavior-neutral (a
+    half-applied window set could distort the fast/slow rhythm unexpectedly).
+
+    Args:
+        flag_value: Object value from the ``windows`` flag (may be partial/invalid)
+
+    Returns:
+        A validated :class:`MusicWindows` (defaults on any failure).
+    """
+    defaults = MusicWindows.defaults()
+    if not isinstance(flag_value, dict):
+        return defaults
+
+    resolved: dict[str, float] = {}
+    for field, key, _fallback in _MUSIC_WINDOW_FIELDS:
+        candidate = flag_value.get(key)
+        if not _positive_number(candidate):
+            return defaults  # any malformed value -> whole-set fallback
+        resolved[field] = float(candidate)
+
+    for min_field, max_field in _MUSIC_WINDOW_PAIRS:
+        if resolved[min_field] > resolved[max_field]:
+            return defaults  # any inverted window -> whole-set fallback
+
+    return MusicWindows(**resolved)
+
+
 # Warning feedback duration (seconds) - flash + rumble time
 # This is purely visual feedback, NOT protection (player can still die during warning)
 WARNING_DURATION = 0.5
@@ -387,6 +497,14 @@ class BaseGameMode(ABC):
             read_float_flag("game", "death_grace_period_seconds", DEATH_GRACE_PERIOD),
             DEATH_GRACE_PERIOD,
         )
+
+        # #766 F3: music tempo-change scheduling windows promoted to the
+        # ``game.windows`` object flag (the ``pacing_profile`` presets live as
+        # named variants). Read ONCE here (init-frozen calibration); malformed
+        # values fall back to the module constants. F6 will add a LIVE
+        # ``pacing_profile`` intervention that atomically swaps
+        # ``self.music_windows`` mid-game — see MusicWindows for the seam.
+        self.music_windows = resolve_music_windows(read_object_flag("game", "windows", {}))
 
         # Phase 70: Music tempo control state
         self.music_track_id = None
@@ -2099,15 +2217,18 @@ class BaseGameMode(ABC):
             min_moves = 1
         game_percent = min(1.0, self.dead_count / min_moves)
 
-        # Interpolate between normal and end-game timing
+        # Interpolate between normal and end-game timing using the (init-frozen,
+        # F6-swappable) per-instance windows. Read once into a local so a
+        # concurrent F6 pacing_profile swap can't tear within a single change.
+        windows = self.music_windows
         if self.speed_up:
             # Currently slow, will speed up - use slow timing
-            min_t = self._lerp(MIN_MUSIC_SLOW_TIME, END_MIN_MUSIC_SLOW_TIME, game_percent)
-            max_t = self._lerp(MAX_MUSIC_SLOW_TIME, END_MAX_MUSIC_SLOW_TIME, game_percent)
+            min_t = self._lerp(windows.slow_min, windows.end_slow_min, game_percent)
+            max_t = self._lerp(windows.slow_max, windows.end_slow_max, game_percent)
         else:
             # Currently fast, will slow down - use fast timing
-            min_t = self._lerp(MIN_MUSIC_FAST_TIME, END_MIN_MUSIC_FAST_TIME, game_percent)
-            max_t = self._lerp(MAX_MUSIC_FAST_TIME, END_MAX_MUSIC_FAST_TIME, game_percent)
+            min_t = self._lerp(windows.fast_min, windows.end_fast_min, game_percent)
+            max_t = self._lerp(windows.fast_max, windows.end_fast_max, game_percent)
 
         delay = random.uniform(min_t, max_t)
         return time.time() + delay

--- a/services/game_coordinator/tests/test_music_window_flags.py
+++ b/services/game_coordinator/tests/test_music_window_flags.py
@@ -1,0 +1,300 @@
+"""
+Tests for #766 F3: music schedule windows promoted to game flags + pacing presets.
+
+Covers, per the issue's consistency rules:
+- Characterization: the ``game.windows`` default variant reproduces the current
+  hardcoded scheduling exactly (the music loop draws delays within the same
+  ranges as the module constants).
+- Malformed flag values fall back (as a whole set) to the module constants.
+- min <= max ordering: any inverted window pair reverts the whole set.
+- Preset variants (calm/default/frantic) in game.json are well-formed: each
+  parses through ``resolve_music_windows`` without falling back to defaults.
+- Init-frozen: the windows are read once at __init__; the resolved
+  ``self.music_windows`` is the F6-swappable seam.
+"""
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+# Setup paths for imports
+test_dir = Path(__file__).parent
+service_dir = test_dir.parent
+project_root = service_dir.parent.parent
+sys.path.insert(0, str(project_root))
+sys.path.insert(0, str(test_dir))
+
+from conftest import EventCollector
+
+from services.game_coordinator.games.base import (
+    END_MAX_MUSIC_FAST_TIME,
+    END_MAX_MUSIC_SLOW_TIME,
+    END_MIN_MUSIC_FAST_TIME,
+    END_MIN_MUSIC_SLOW_TIME,
+    MAX_MUSIC_FAST_TIME,
+    MAX_MUSIC_SLOW_TIME,
+    MIN_MUSIC_FAST_TIME,
+    MIN_MUSIC_SLOW_TIME,
+    MusicWindows,
+    resolve_music_windows,
+)
+from services.game_coordinator.games.ffa import FFAGame
+
+GAME_JSON = project_root / "services" / "flagd" / "game.json"
+
+
+def _make_ffa():
+    return FFAGame(
+        controller_manager_client=None,
+        event_publisher=EventCollector().publish,
+        sensitivity=2,
+    )
+
+
+def _default_flag_dict() -> dict:
+    """The exact game.windows default object (snake_case after the constants)."""
+    return {
+        "min_music_fast_time": MIN_MUSIC_FAST_TIME,
+        "max_music_fast_time": MAX_MUSIC_FAST_TIME,
+        "min_music_slow_time": MIN_MUSIC_SLOW_TIME,
+        "max_music_slow_time": MAX_MUSIC_SLOW_TIME,
+        "end_min_music_fast_time": END_MIN_MUSIC_FAST_TIME,
+        "end_max_music_fast_time": END_MAX_MUSIC_FAST_TIME,
+        "end_min_music_slow_time": END_MIN_MUSIC_SLOW_TIME,
+        "end_max_music_slow_time": END_MAX_MUSIC_SLOW_TIME,
+    }
+
+
+# ========================================================================
+# resolve_music_windows
+# ========================================================================
+
+
+def test_default_flag_reproduces_constants():
+    """The default object resolves to exactly the module-constant windows."""
+    windows = resolve_music_windows(_default_flag_dict())
+    assert windows == MusicWindows.defaults()
+    assert windows.fast_min == MIN_MUSIC_FAST_TIME
+    assert windows.fast_max == MAX_MUSIC_FAST_TIME
+    assert windows.slow_min == MIN_MUSIC_SLOW_TIME
+    assert windows.slow_max == MAX_MUSIC_SLOW_TIME
+    assert windows.end_fast_min == END_MIN_MUSIC_FAST_TIME
+    assert windows.end_fast_max == END_MAX_MUSIC_FAST_TIME
+    assert windows.end_slow_min == END_MIN_MUSIC_SLOW_TIME
+    assert windows.end_slow_max == END_MAX_MUSIC_SLOW_TIME
+
+
+def test_non_dict_falls_back():
+    for bad in (None, "x", 5, [], True):
+        assert resolve_music_windows(bad) == MusicWindows.defaults()
+
+
+def test_missing_key_falls_back_whole_set():
+    partial = _default_flag_dict()
+    del partial["min_music_fast_time"]
+    assert resolve_music_windows(partial) == MusicWindows.defaults()
+
+
+def test_malformed_value_falls_back_whole_set():
+    for bad in (0, -1, "fast", None, True, float("nan"), float("inf")):
+        flag = _default_flag_dict()
+        flag["max_music_slow_time"] = bad
+        assert resolve_music_windows(flag) == MusicWindows.defaults()
+
+
+def test_min_gt_max_falls_back_whole_set():
+    # invert each window pair in turn -> whole-set fallback
+    for min_key, max_key in (
+        ("min_music_fast_time", "max_music_fast_time"),
+        ("min_music_slow_time", "max_music_slow_time"),
+        ("end_min_music_fast_time", "end_max_music_fast_time"),
+        ("end_min_music_slow_time", "end_max_music_slow_time"),
+    ):
+        flag = _default_flag_dict()
+        flag[min_key], flag[max_key] = flag[max_key], flag[min_key]
+        # only invert if they actually differ (all defaults do)
+        assert resolve_music_windows(flag) == MusicWindows.defaults()
+
+
+def test_min_eq_max_is_accepted():
+    flag = _default_flag_dict()
+    flag["min_music_fast_time"] = flag["max_music_fast_time"]
+    windows = resolve_music_windows(flag)
+    assert windows.fast_min == windows.fast_max == MAX_MUSIC_FAST_TIME
+
+
+def test_valid_custom_windows_resolve():
+    flag = {
+        "min_music_fast_time": 3,
+        "max_music_fast_time": 6,
+        "min_music_slow_time": 13,
+        "max_music_slow_time": 30,
+        "end_min_music_fast_time": 4,
+        "end_max_music_fast_time": 7,
+        "end_min_music_slow_time": 10,
+        "end_max_music_slow_time": 16,
+    }
+    windows = resolve_music_windows(flag)
+    assert windows.slow_max == 30.0
+    assert windows.fast_min == 3.0
+
+
+# ========================================================================
+# Characterization: music loop draws delays within the same ranges
+# ========================================================================
+
+
+def test_default_instance_reproduces_scheduling_ranges():
+    """With default windows, _get_music_change_time stays within constant ranges."""
+    game = _make_ffa()
+    assert game.music_windows == MusicWindows.defaults()
+
+    # Two players -> game_percent = 0 at start (early-game windows in effect).
+    game.players = {"a": object(), "b": object()}
+    game.dead_count = 0
+
+    import time as _time
+
+    # speed_up=True -> slow windows; speed_up=False -> fast windows.
+    for speed_up, lo, hi in (
+        (True, MIN_MUSIC_SLOW_TIME, MAX_MUSIC_SLOW_TIME),
+        (False, MIN_MUSIC_FAST_TIME, MAX_MUSIC_FAST_TIME),
+    ):
+        game.speed_up = speed_up
+        for _ in range(200):
+            now = _time.time()
+            delay = game._get_music_change_time() - now
+            assert lo - 0.001 <= delay <= hi + 0.001
+
+
+def test_end_game_windows_used_when_all_dead():
+    """game_percent=1.0 -> end-game windows bound the delay."""
+    game = _make_ffa()
+    game.players = {"a": object(), "b": object(), "c": object()}
+    game.dead_count = len(game.players)  # forces game_percent -> 1.0
+
+    import time as _time
+
+    for speed_up, lo, hi in (
+        (True, END_MIN_MUSIC_SLOW_TIME, END_MAX_MUSIC_SLOW_TIME),
+        (False, END_MIN_MUSIC_FAST_TIME, END_MAX_MUSIC_FAST_TIME),
+    ):
+        game.speed_up = speed_up
+        for _ in range(200):
+            now = _time.time()
+            delay = game._get_music_change_time() - now
+            assert lo - 0.001 <= delay <= hi + 0.001
+
+
+# ========================================================================
+# Init-frozen read + F6 swap seam
+# ========================================================================
+
+
+def test_windows_read_once_and_frozen():
+    custom = {
+        "min_music_fast_time": 2,
+        "max_music_fast_time": 5,
+        "min_music_slow_time": 8,
+        "max_music_slow_time": 20,
+        "end_min_music_fast_time": 3,
+        "end_max_music_fast_time": 6,
+        "end_min_music_slow_time": 6,
+        "end_max_music_slow_time": 10,
+    }
+    with patch(
+        "services.game_coordinator.games.base.read_object_flag",
+        side_effect=lambda _domain, key, default: custom if key == "windows" else default,
+    ) as mock_read:
+        game = _make_ffa()
+    assert game.music_windows.fast_min == 2.0
+    assert game.music_windows.slow_max == 20.0
+    windows_calls = [c for c in mock_read.call_args_list if c.args[1] == "windows"]
+    assert len(windows_calls) == 1
+
+
+def test_malformed_flag_instance_falls_back():
+    with patch(
+        "services.game_coordinator.games.base.read_object_flag",
+        side_effect=lambda _domain, key, default: "garbage" if key == "windows" else default,
+    ):
+        game = _make_ffa()
+    assert game.music_windows == MusicWindows.defaults()
+
+
+def test_f6_atomic_swap_seam():
+    """F6 swaps self.music_windows atomically; the loop picks up the new windows."""
+    game = _make_ffa()
+    game.players = {"a": object(), "b": object()}
+    game.dead_count = 0
+    game.speed_up = False  # fast windows
+
+    import time as _time
+
+    # Swap to the frantic-ish profile (longer fast windows).
+    frantic = MusicWindows(
+        fast_min=6,
+        fast_max=11,
+        slow_min=6,
+        slow_max=14,
+        end_fast_min=8,
+        end_fast_max=14,
+        end_slow_min=5,
+        end_slow_max=8,
+    )
+    game.music_windows = frantic  # the atomic single-store swap F6 uses
+
+    for _ in range(200):
+        delay = game._get_music_change_time() - _time.time()
+        assert 6 - 0.001 <= delay <= 11 + 0.001
+
+
+# ========================================================================
+# Preset variants in game.json are well-formed
+# ========================================================================
+
+
+def test_game_json_window_presets_well_formed():
+    data = json.loads(GAME_JSON.read_text())
+    flag = data["flags"]["windows"]
+    variants = flag["variants"]
+
+    # All three presets present, default is the default variant.
+    assert set(variants) >= {"calm", "default", "frantic"}
+    assert flag["defaultVariant"] == "default"
+
+    # default variant must reproduce the module constants exactly.
+    assert resolve_music_windows(variants["default"]) == MusicWindows.defaults()
+
+    # every preset parses without falling back to defaults (i.e. is well-formed:
+    # all positive, every min <= max).
+    defaults = MusicWindows.defaults()
+    for name, value in variants.items():
+        resolved = resolve_music_windows(value)
+        if name == "default":
+            assert resolved == defaults
+        else:
+            # well-formed: did NOT silently revert to defaults
+            assert resolved != defaults, f"preset {name} reverted to defaults (malformed)"
+        # explicit pair ordering sanity
+        assert resolved.fast_min <= resolved.fast_max
+        assert resolved.slow_min <= resolved.slow_max
+        assert resolved.end_fast_min <= resolved.end_fast_max
+        assert resolved.end_slow_min <= resolved.end_slow_max
+
+
+def test_preset_pacing_directions():
+    """calm = slower pacing (longer slow / shorter fast); frantic = the reverse."""
+    data = json.loads(GAME_JSON.read_text())
+    variants = data["flags"]["windows"]["variants"]
+    calm = resolve_music_windows(variants["calm"])
+    default = resolve_music_windows(variants["default"])
+    frantic = resolve_music_windows(variants["frantic"])
+
+    # calm dwells longer in slow, shorter in fast than default.
+    assert calm.slow_max >= default.slow_max
+    assert calm.fast_max <= default.fast_max
+    # frantic dwells shorter in slow, longer in fast than default.
+    assert frantic.slow_max <= default.slow_max
+    assert frantic.fast_max >= default.fast_max

--- a/services/game_coordinator/tests/test_threshold_flags.py
+++ b/services/game_coordinator/tests/test_threshold_flags.py
@@ -211,11 +211,16 @@ def test_base_init_stores_instance_tables_from_defaults():
 
 
 def test_base_init_reads_flag_once():
-    """The threshold flag is read exactly once at init (init-frozen)."""
+    """The threshold flag is read exactly once at init (init-frozen).
+
+    Base init reads several game-domain object flags (thresholds, F3 windows,
+    ...); assert specifically that ``thresholds`` is read exactly once.
+    """
     with patch("services.game_coordinator.games.base.read_object_flag", return_value={}) as mock_read:
         _make_ffa()
-    assert mock_read.call_count == 1
-    assert mock_read.call_args.args == ("game", "thresholds", {})
+    threshold_calls = [c for c in mock_read.call_args_list if c.args[1] == "thresholds"]
+    assert len(threshold_calls) == 1
+    assert threshold_calls[0].args == ("game", "thresholds", {})
 
 
 def test_base_init_applies_flag_override():


### PR DESCRIPTION
Part of #766 (F3).

**Stacked on #773** (`feat/766-f2-duration-flags`) — this PR targets that branch, not `main`. Shared files (`services/flagd/game.json`, `services/game_coordinator/games/base.py`) build on F2. Refs #722 #725.

## What

Promotes the eight music tempo-change scheduling windows (`MIN/MAX_MUSIC_FAST/SLOW_TIME` + end-game variants, `base.py:72-81`) to the `game.windows` object flag and defines `pacing_profile` presets.

- **`game.json`**: new `windows` object flag. Default variant carries all current constants in snake_case (behavior-neutral). Adds `calm` (longer slow / shorter fast) and `frantic` (shorter slow / longer fast) presets as named variants, sensible multiples of the defaults.
- **`base.py`**: new `MusicWindows` dataclass + `resolve_music_windows()` validator. `BaseGameMode.__init__` reads `game.windows` once (init-frozen calibration) into `self.music_windows`. `_get_music_change_time()` consumes `self.music_windows` instead of the module constants (constants remain the per-field fallback).
- **Validation**: all eight values must be finite and strictly positive; each `(min, max)` pair must satisfy `min <= max`. Any malformed or inverted value reverts the whole set to the module-constant defaults.

## F6 seam (LIVE `pacing_profile` swap)

The resolved windows live on `self.music_windows` (a single `MusicWindows` instance). F6's live handler builds a new `MusicWindows` from the chosen preset and assigns it atomically:

```python
self.music_windows = new_windows   # single bytecode store; never mutate fields in place
```

`_get_music_change_time` reads `self.music_windows` fresh into a local on each call, so the swap is picked up on the next tempo change without tearing. Documented in the `MusicWindows` docstring. This PR does **not** touch `interventions.json` (F6) or `docs/feature-flags.md` (F8).

## Test plan

`cd services/game_coordinator && uv run --extra test python -m pytest` → **823 passed** (809 baseline + 14 new in `test_music_window_flags.py`).

- Characterization: default windows keep `_get_music_change_time` within the same ranges as the constants (early- and end-game).
- Malformed / non-dict / missing-key / `min > max` → whole-set fallback to defaults.
- Init-frozen: `game.windows` read exactly once.
- F6 atomic-swap seam behaves as documented.
- `game.json` preset variants parse well-formed with correct pacing directions.
- Updated the F2 threshold init-read test to filter by flag key (base init now reads multiple object flags).

`make lint` clean; `game.json` parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)