### PR TITLE
feat: unstable backend + rollout-driven adapter routing (#732)

### DIFF
--- a/services/controller_manager/backend_factory.py
+++ b/services/controller_manager/backend_factory.py
@@ -158,5 +158,28 @@ def create_backend() -> ControllerBackend:
 
     adapters = [_create_adapter_by_name(n) for n in names]
     adapters = _maybe_wrap_chaos(adapters)
+    routing_only = _build_routing_only_adapters(adapters)
     logger.info(f"MultiplexerBackend with adapters: {names}")
-    return MultiplexerBackend(adapters=adapters)
+    return MultiplexerBackend(adapters=adapters, routing_only_adapters=routing_only)
+
+
+def _build_routing_only_adapters(
+    adapters: list[ControllerIOAdapter],
+) -> list[ControllerIOAdapter]:
+    """Build routing-only adapters (selectable by targeting/rollout, not by default).
+
+    Whenever a python adapter is loaded, an :class:`UnstableAdapter` wrapping the
+    *same* python instance is registered so the ``unstable`` backend is routable
+    via explicit ``bluetooth_backend`` targeting or the rollout domain. It shares
+    the inner python adapter (see UnstableAdapter docstring for why a second
+    independent instance is unsafe), so it must NOT be added as an independent
+    discoverer and is never chosen as a default/fallback winner.
+    """
+    from services.controller_manager.multiplexer.unstable_adapter import UnstableAdapter
+
+    routing_only: list[ControllerIOAdapter] = []
+    for adapter in adapters:
+        if adapter.adapter_type == "python":
+            routing_only.append(UnstableAdapter(adapter))
+            logger.info("Registered UnstableAdapter (shared inner python) as routing-only target")
+    return routing_only

--- a/services/controller_manager/metrics.py
+++ b/services/controller_manager/metrics.py
@@ -90,7 +90,7 @@ controller_disconnect_total = Counter(
 controller_routing_decisions_total = Counter(
     "controller_routing_decisions_total",
     "Adapter routing decisions",
-    ["serial", "adapter", "method"],  # method: targeted, fallback, default
+    ["serial", "adapter", "method"],  # method: targeted, rollout, fallback, default
 )
 
 controller_reconnect_total = Counter("controller_reconnect_total", "Total number of controller reconnects", ["serial"])

--- a/services/controller_manager/multiplexer/multiplexer_backend.py
+++ b/services/controller_manager/multiplexer/multiplexer_backend.py
@@ -21,8 +21,21 @@ import time
 from services.controller_manager import metrics
 from services.controller_manager.backend import ControllerBackend
 from services.controller_manager.multiplexer.adapter import ControllerIOAdapter
+from services.controller_manager.multiplexer.rollout_router import RolloutRouter
 
 logger = logging.getLogger(__name__)
+
+
+def _adapter_owner(adapter: ControllerIOAdapter) -> ControllerIOAdapter:
+    """Return the underlying device-owning adapter.
+
+    Decorators that share a single inner adapter (e.g. UnstableAdapter) expose
+    it via ``.inner``. Routing uses owner identity to avoid closing the shared
+    device when a serial switches between a plain adapter and a decorator that
+    wraps the same inner.
+    """
+    inner = getattr(adapter, "inner", None)
+    return inner if inner is not None else adapter
 
 
 class MultiplexerBackend(ControllerBackend):
@@ -36,11 +49,18 @@ class MultiplexerBackend(ControllerBackend):
     def __init__(
         self,
         adapters: list[ControllerIOAdapter],
+        routing_only_adapters: list[ControllerIOAdapter] | None = None,
     ):
         if not adapters:
             raise ValueError("MultiplexerBackend requires at least one adapter")
 
         self._adapters = adapters
+
+        # Routing-only adapters (e.g. UnstableAdapter) are valid targeting/rollout
+        # destinations but do NOT discover independently — they share an inner
+        # adapter that is already a discoverer. They are reachable only when
+        # explicit targeting or rollout selects their adapter_type.
+        self._routing_only_adapters = routing_only_adapters or []
 
         # Adapter-based routing
         self._serial_to_adapter: dict[str, ControllerIOAdapter] = {}
@@ -53,10 +73,15 @@ class MultiplexerBackend(ControllerBackend):
         self._effect_active: set[str] = set()
         self._led_lock = threading.Lock()
 
-        # Build adapter_type -> adapter lookup for targeting resolution
+        # Build adapter_type -> adapter lookup for targeting resolution.
+        # Routing-only adapters are registered too, but added last so they never
+        # shadow a discoverer of the same type.
         self._adapter_by_type: dict[str, ControllerIOAdapter] = {}
-        for adapter in self._adapters:
+        for adapter in (*self._routing_only_adapters, *self._adapters):
             self._adapter_by_type[adapter.adapter_type] = adapter
+
+        # Rollout routing (rollout flagd domain). Evaluated per cycle.
+        self._rollout_router = RolloutRouter()
 
         # Discovery throttle: only run full enumeration every N seconds
         self._last_full_discovery: float = 0.0
@@ -144,6 +169,7 @@ class MultiplexerBackend(ControllerBackend):
                 candidates.setdefault(serial, []).append(adapter)
 
         # Phase 2: route — pick winner for each serial
+        candidate_serials = list(candidates.keys())
         seen: dict[str, ControllerIOAdapter] = {}
         for serial, adapters in candidates.items():
             # Mock-only → skip targeting
@@ -156,33 +182,40 @@ class MultiplexerBackend(ControllerBackend):
                 ).inc()
                 continue
 
-            preferred = self._resolve_adapter_for_serial(serial)
+            preferred, preferred_method = self._resolve_adapter_for_serial(serial, candidate_serials)
             winner = None
             method = "default"
 
             if preferred and preferred in adapters:
                 winner = preferred
-                method = "targeted"
+                method = preferred_method
             elif preferred:
-                # Preferred adapter didn't discover it — try open on demand
+                # Preferred adapter didn't discover it — try open on demand.
+                # Routing-only adapters (e.g. unstable) share an inner that IS a
+                # discoverer, so their open() reaches the already-open device.
                 if preferred.open(serial):
                     winner = preferred
-                    method = "targeted"
+                    method = preferred_method
                 else:
                     method = "fallback"
 
             if winner is None:
-                # Pick first non-mock, or first overall
+                # Pick first non-mock (excluding routing-only types like
+                # "unstable", which must never be a default/fallback winner),
+                # or first overall.
                 winner = next(
-                    (a for a in adapters if a.adapter_type != "mock"),
+                    (a for a in adapters if a.adapter_type not in ("mock", "unstable")),
                     adapters[0],
                 )
 
             seen[serial] = winner
+            winner_owner = _adapter_owner(winner)
 
-            # Close handles on non-winning adapters
+            # Close handles on non-winning adapters. Skip any loser that shares
+            # the winner's underlying device owner (shared-inner case), else we
+            # would tear down the device the winner is using.
             for adapter in adapters:
-                if adapter is not winner:
+                if adapter is not winner and _adapter_owner(adapter) is not winner_owner:
                     adapter.close(serial)
 
             metrics.controller_routing_decisions_total.labels(
@@ -193,34 +226,69 @@ class MultiplexerBackend(ControllerBackend):
 
             # Detect dynamic switch from previous cycle
             old = self._serial_to_adapter.get(serial)
-            if old and old is not winner and old not in adapters:
+            if old and old is not winner and old not in adapters and _adapter_owner(old) is not winner_owner:
                 old.close(serial)
                 logger.info(f"Switched {serial}: {old.adapter_type} -> {winner.adapter_type}")
 
         return seen
 
-    def _resolve_adapter_for_serial(self, serial: str) -> ControllerIOAdapter | None:
-        """Evaluate the bluetooth_backend flag for a serial.
+    def _resolve_adapter_for_serial(
+        self,
+        serial: str,
+        candidate_serials: list[str] | None = None,
+    ) -> tuple[ControllerIOAdapter | None, str]:
+        """Resolve the preferred adapter for a serial via three-way precedence.
 
-        Returns the matching adapter instance, or None if targeting is
-        unavailable, errors, or the result doesn't match any adapter.
+        Precedence (highest to lowest):
+          1. Explicit per-serial ``bluetooth_backend`` targeting — honored only
+             when the evaluation reason is ``TARGETING_MATCH`` (an actual rule
+             match, not the flag's default variant).
+          2. Rollout-driven — :meth:`RolloutRouter.target_for` over the full
+             candidate serial set.
+          3. Default — the flag's resolved value (default variant / fallback).
+
+        Returns ``(adapter, method)`` where ``method`` is one of
+        ``"targeted"`` / ``"rollout"`` / ``"default"``. ``adapter`` is ``None``
+        when nothing resolves (targeting unavailable, error, or no matching
+        adapter), in which case ``method`` is ``"default"``.
         """
         try:
             from openfeature.evaluation_context import EvaluationContext
+            from openfeature.flag_evaluation import Reason
 
             from lib.feature_flags import get_flag_client
 
             client = get_flag_client("controller")
-            adapter_type = client.get_string_value(
+
+            # 1. Explicit per-serial targeting wins outright.
+            details = client.get_string_details(
                 "bluetooth_backend",
                 "",
                 EvaluationContext(targeting_key=serial),
             )
-            if adapter_type:
-                return self._adapter_by_type.get(adapter_type)
+            if details.value and str(details.reason) == Reason.TARGETING_MATCH.value:
+                adapter = self._adapter_by_type.get(details.value)
+                if adapter is not None:
+                    return adapter, "targeted"
+
+            # 2. Rollout-driven selection.
+            rollout_target = self._rollout_router.target_for(
+                serial,
+                candidate_serials or [serial],
+            )
+            if rollout_target:
+                adapter = self._adapter_by_type.get(rollout_target)
+                if adapter is not None:
+                    return adapter, "rollout"
+
+            # 3. Default: the flag's resolved value (e.g. default variant).
+            if details.value:
+                adapter = self._adapter_by_type.get(details.value)
+                if adapter is not None:
+                    return adapter, "default"
         except Exception:
-            logger.debug(f"Failed to evaluate bluetooth_backend for {serial}", exc_info=True)
-        return None
+            logger.debug(f"Failed to resolve adapter for {serial}", exc_info=True)
+        return None, "default"
 
     def get_adapter_type(self, serial: str) -> str:
         """Return the adapter_type string for a tracked serial."""
@@ -356,7 +424,7 @@ class MultiplexerBackend(ControllerBackend):
 
     async def connect_controller(self, address: str) -> bool:
         # Try targeted adapter first
-        preferred = self._resolve_adapter_for_serial(address)
+        preferred, _method = self._resolve_adapter_for_serial(address, [address])
         if preferred:
             try:
                 if preferred.open(address):

--- a/services/controller_manager/multiplexer/rollout_router.py
+++ b/services/controller_manager/multiplexer/rollout_router.py
@@ -1,0 +1,83 @@
+"""
+RolloutRouter — consumes the ``rollout`` flagd domain to drive progressive
+backend rollout across the controller fleet.
+
+The ``rollout`` domain defines:
+  * ``strategy``               — "off" | "immediate" | "progressive"
+  * ``target_backend``         — the adapter_type to roll toward (e.g. "unstable")
+  * ``current_controller_count`` — int cohort size for "progressive" (0/1/3/6/99)
+
+``target_for(serial, all_serials)`` returns the target adapter_type for a serial,
+or ``None`` when the rollout does not apply to it:
+
+  * strategy "off"          -> None for every serial
+  * strategy "immediate"    -> target_backend for every serial
+  * strategy "progressive"  -> target_backend if the serial is in the first
+    ``current_controller_count`` serials by sorted order, else None
+
+Flags are evaluated cheaply per routing cycle via the in-process resolver,
+mirroring how ``bluetooth_backend`` is evaluated per cycle in the multiplexer —
+no caching layer is needed. Any flag/evaluation error degrades to ``None`` so a
+flagd outage can never break controller routing.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+_DOMAIN = "rollout"
+
+
+class RolloutRouter:
+    """Evaluates the ``rollout`` domain to pick a target backend per serial."""
+
+    def target_for(self, serial: str, all_serials: list[str]) -> str | None:
+        """Return the rollout target adapter_type for ``serial``, or None.
+
+        Defensive: any failure to read the rollout flags returns None so that
+        routing always falls back to the explicit-targeting / default path.
+        """
+        try:
+            from openfeature.evaluation_context import EvaluationContext
+
+            from lib.feature_flags import get_flag_client
+
+            client = get_flag_client(_DOMAIN)
+
+            strategy = client.get_string_value("strategy", "off", EvaluationContext())
+            if strategy == "off":
+                return None
+
+            target = client.get_string_value(
+                "target_backend",
+                "",
+                EvaluationContext(targeting_key=serial),
+            )
+            if not target:
+                return None
+
+            if strategy == "immediate":
+                return target
+
+            if strategy == "progressive":
+                count = client.get_integer_value(
+                    "current_controller_count",
+                    0,
+                    EvaluationContext(),
+                )
+                if count <= 0:
+                    return None
+                cohort = sorted(all_serials)[:count]
+                return target if serial in cohort else None
+
+            # Unknown strategy -> behave like "off".
+            return None
+        except Exception:
+            logger.debug(
+                "RolloutRouter.target_for failed for %s; falling back to None",
+                serial,
+                exc_info=True,
+            )
+            return None

--- a/services/controller_manager/multiplexer/unstable_adapter.py
+++ b/services/controller_manager/multiplexer/unstable_adapter.py
@@ -1,0 +1,188 @@
+"""
+UnstableAdapter — a deliberately-degraded ControllerIOAdapter decorator.
+
+This adapter exists to give M3 a *routable* backend that reliably violates the
+perception fitness thresholds (movement update rate, dropped-event ratio, event
+gap). It is selected only via explicit ``bluetooth_backend`` targeting or via the
+``rollout`` domain — never as a default/fallback winner.
+
+Unlike :class:`ChaosAdapter`, whose ``adapter_type`` is *transparent* (it returns
+the inner adapter's type so routing treats a chaos-wrapped python adapter as
+"python"), ``UnstableAdapter.adapter_type`` returns ``"unstable"`` so the
+multiplexer can route specific serials to it while other serials continue to use
+the plain inner adapter.
+
+Degradation is fully DETERMINISTIC (no ``random``) so tests can assert exact
+threshold violations:
+
+  * Update rate < 10 Hz — ``poll()`` serves a *fresh* inner result at most once
+    every ``throttle_seconds`` (default 0.12 s ≈ 8.3 Hz). Between throttle windows
+    it replays the last served frame (a stale repeat), so the perceived rate of
+    genuinely-new frames stays under 10 Hz.
+  * Event gap > 50 ms — a direct consequence of the 120 ms throttle window: the
+    time between two fresh frames is always ≥ 120 ms > 50 ms.
+  * Dropped-event ratio > 2% — every ``drop_every``-th fresh frame (default 10,
+    i.e. 10%) is dropped by returning ``None`` instead of the inner result.
+
+``poll()`` MUST NOT sleep or block: it runs inside the shared poll batch.
+Degradation is achieved purely by throttling/dropping using a monotonic clock —
+never by blocking.
+
+Shared-inner design (the simultaneous-routability question)
+-----------------------------------------------------------
+During a progressive rollout, "python" and "unstable" must be routable
+*simultaneously* for different serials. ``UnstableAdapter`` therefore wraps the
+**same** :class:`PythonHidAdapter` instance that the plain "python" route uses
+rather than opening a second, independent one. Evidence this is the only safe
+option:
+
+  * ``PythonHidAdapter.open``/``close`` are unary RPCs against *global* device
+    state in the shared python-hid service. Two independent ``PythonHidAdapter``
+    instances both connect to that one service, so a ``Close`` issued by one
+    tears the device down for the other. The multiplexer routinely closes the
+    *losing* adapter for a serial, which would tear down the device the winner
+    is actively using.
+  * ``PythonHidAdapter.poll`` is destructive (it ``pop``\\s ``_latest_data``),
+    so two clients would duplicate-and-compete over the same stream.
+  * The multiplexer guarantees exactly one winner per serial, so with a shared
+    inner only the winner's ``open``/``poll``/``set_output`` reach the device —
+    there is no contention.
+
+Because the inner is shared, ``UnstableAdapter`` is registered ONLY in the
+multiplexer's ``_adapter_by_type`` map (as a routing target); it is *not* added
+as an independent discoverer. ``discover``/``open``/``close``/``close_all`` are
+intentionally pass-throughs to the shared inner so the discoverer (the plain
+python adapter) and the unstable wrapper agree on device lifecycle. To keep the
+multiplexer from closing the shared device when a serial switches between the
+plain and unstable routes, the wrapper exposes :pyattr:`inner` and the
+multiplexer skips closing any losing adapter that shares the winner's inner.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Callable
+from typing import Any
+
+from services.controller_manager.multiplexer.adapter import ControllerIOAdapter
+
+logger = logging.getLogger(__name__)
+
+# Defaults chosen so the M3 fitness thresholds are reliably violated:
+#   throttle 0.12 s -> ~8.3 Hz fresh frames (< 10 Hz) and 120 ms gaps (> 50 ms)
+#   drop every 10th fresh frame -> 10% drop ratio (> 2%)
+DEFAULT_THROTTLE_SECONDS = 0.12
+DEFAULT_DROP_EVERY = 10
+
+
+class UnstableAdapter(ControllerIOAdapter):
+    """Deterministically-degraded decorator around a shared inner adapter.
+
+    Args:
+        inner: The adapter to delegate to (shared with the plain route).
+        throttle_seconds: Minimum spacing between *fresh* inner polls.
+        drop_every: Every Nth fresh poll is dropped (returns None). Must be >= 2
+            to keep the drop ratio finite and above the 2% threshold.
+        time_source: Monotonic clock injection point for tests.
+    """
+
+    def __init__(
+        self,
+        inner: ControllerIOAdapter,
+        throttle_seconds: float = DEFAULT_THROTTLE_SECONDS,
+        drop_every: int = DEFAULT_DROP_EVERY,
+        time_source: Callable[[], float] = time.monotonic,
+    ):
+        if drop_every < 2:
+            raise ValueError("drop_every must be >= 2")
+        self._inner = inner
+        self._throttle_seconds = throttle_seconds
+        self._drop_every = drop_every
+        self._now = time_source
+
+        # Per-serial throttle bookkeeping.
+        self._last_fresh_time: dict[str, float] = {}
+        self._last_result: dict[str, dict | None] = {}
+        self._fresh_count: dict[str, int] = {}
+
+    @property
+    def adapter_type(self) -> str:
+        # NOT transparent (unlike ChaosAdapter): routing must see "unstable".
+        return "unstable"
+
+    @property
+    def inner(self) -> ControllerIOAdapter:
+        """The shared inner adapter (used by the multiplexer for dedup safety)."""
+        return self._inner
+
+    # -- Lifecycle: pass straight through to the shared inner -----------------
+
+    def discover(
+        self,
+        force: bool = False,
+        verify_only: bool = False,
+        exclude_serials: list[str] | None = None,
+    ) -> list[str]:
+        return self._inner.discover(
+            force=force,
+            verify_only=verify_only,
+            exclude_serials=exclude_serials,
+        )
+
+    def open(self, serial: str) -> bool:
+        return self._inner.open(serial)
+
+    def set_output(self, serial: str, r: int, g: int, b: int, rumble: int) -> bool:
+        return self._inner.set_output(serial, r, g, b, rumble)
+
+    def get_adapter_for_serial(self, serial: str) -> str | None:
+        return self._inner.get_adapter_for_serial(serial)
+
+    def close(self, serial: str) -> None:
+        self._inner.close(serial)
+        self._last_fresh_time.pop(serial, None)
+        self._last_result.pop(serial, None)
+        self._fresh_count.pop(serial, None)
+
+    def close_all(self) -> None:
+        self._inner.close_all()
+        self._last_fresh_time.clear()
+        self._last_result.clear()
+        self._fresh_count.clear()
+
+    # -- Degraded poll --------------------------------------------------------
+
+    def poll(self, serial: str) -> dict | None:
+        """Throttle + deterministically drop. Never blocks.
+
+        Within a throttle window the last served frame is replayed (a stale
+        repeat) so the rate of *fresh* frames stays under 10 Hz and the gap
+        between fresh frames stays above 50 ms. Every ``drop_every``-th fresh
+        frame is dropped (returns None) to push the drop ratio above 2%.
+        """
+        now = self._now()
+        last_fresh = self._last_fresh_time.get(serial)
+
+        if last_fresh is not None and (now - last_fresh) < self._throttle_seconds:
+            # Inside the throttle window: replay the last served frame unchanged.
+            return self._last_result.get(serial)
+
+        # Throttle window elapsed -> serve a fresh frame.
+        self._last_fresh_time[serial] = now
+        count = self._fresh_count.get(serial, 0) + 1
+        self._fresh_count[serial] = count
+
+        result = self._inner.poll(serial)
+
+        # Deterministic drop: every Nth fresh frame is dropped.
+        if count % self._drop_every == 0:
+            self._last_result[serial] = None
+            return None
+
+        self._last_result[serial] = result
+        return result
+
+    def __getattr__(self, name: str) -> Any:
+        """Delegate unknown attributes to the inner adapter (mirrors ChaosAdapter)."""
+        return getattr(self._inner, name)

--- a/services/controller_manager/server.py
+++ b/services/controller_manager/server.py
@@ -50,11 +50,17 @@ async def serve(port=50052):
     init_flag_domain("system")
     # controller domain: backend, bluetooth_backend, chaos_fault_type, poll_drop_threshold
     init_flag_domain("controller")
-    # Wait for both domains to be ready: create_backend() evaluates the
-    # controller domain, the frequency listener evaluates the system domain.
+    # rollout domain: strategy, target_backend, current_controller_count
+    # (consumed by RolloutRouter during per-cycle adapter routing).
+    init_flag_domain("rollout")
+    # Wait for all domains to be ready before backend creation: create_backend()
+    # evaluates the controller domain, the frequency listener evaluates the
+    # system domain, and the multiplexer's RolloutRouter evaluates the rollout
+    # domain on the first routing cycle.
     # Deadline must be shorter than the Docker HEALTHCHECK window (start_period + retries * interval).
     await wait_for_provider_ready("system", deadline_seconds=5.0)
     await wait_for_provider_ready("controller", deadline_seconds=5.0)
+    await wait_for_provider_ready("rollout", deadline_seconds=5.0)
 
     # Initialize OTEL push metrics
     # Export interval read from flagd with per-service targeting (Issue #479)

--- a/services/controller_manager/tests/test_backend_factory.py
+++ b/services/controller_manager/tests/test_backend_factory.py
@@ -165,6 +165,57 @@ class TestMultiAdapterCreation:
         assert "mock" in call_names
         assert "python" in call_names
 
+    def test_python_registers_unstable_routing_only_adapter(self):
+        """When python is loaded, an UnstableAdapter sharing it is registered
+        as a routing-only target (not as a discoverer)."""
+        mock_client = MagicMock()
+        mock_client.get_string_details.return_value = _mock_details("python")
+
+        with (
+            patch("lib.feature_flags.get_flag_client", return_value=mock_client),
+            patch("services.controller_manager.backend_factory._create_adapter_by_name") as mock_create,
+        ):
+            python_adapter = MagicMock()
+            python_adapter.adapter_type = "python"
+            python_adapter.inner = None
+            mock_adapter = MagicMock()
+            mock_adapter.adapter_type = "mock"
+            mock_adapter.inner = None
+            mock_create.side_effect = [python_adapter, mock_adapter]
+
+            backend = create_backend()
+
+        # Unstable is routable by type but not an independent discoverer.
+        unstable = backend._adapter_by_type.get("unstable")
+        assert unstable is not None
+        assert unstable.adapter_type == "unstable"
+        # It shares the same python-typed adapter instance the plain route uses
+        # (which may be chaos-wrapped, but stays type "python").
+        python_route = backend._adapter_by_type["python"]
+        assert unstable.inner is python_route
+        assert unstable not in backend.adapters
+
+    def test_no_python_means_no_unstable_adapter(self):
+        """rust-only -> no unstable routing-only adapter registered."""
+        mock_client = MagicMock()
+        mock_client.get_string_details.return_value = _mock_details("rust")
+
+        with (
+            patch("lib.feature_flags.get_flag_client", return_value=mock_client),
+            patch("services.controller_manager.backend_factory._create_adapter_by_name") as mock_create,
+        ):
+            rust_adapter = MagicMock()
+            rust_adapter.adapter_type = "rust"
+            rust_adapter.inner = None
+            mock_adapter = MagicMock()
+            mock_adapter.adapter_type = "mock"
+            mock_adapter.inner = None
+            mock_create.side_effect = [rust_adapter, mock_adapter]
+
+            backend = create_backend()
+
+        assert "unstable" not in backend._adapter_by_type
+
     def test_single_name_creates_adapter(self):
         """flag='mock' -> MultiplexerBackend with 1 adapter."""
         mock_client = MagicMock()

--- a/services/controller_manager/tests/test_multiplexer_backend.py
+++ b/services/controller_manager/tests/test_multiplexer_backend.py
@@ -29,6 +29,8 @@ def _make_adapter(adapter_type="mock", serials=None):
     adapter.close = MagicMock()
     adapter.close_all = MagicMock()
     adapter.get_adapter_for_serial = MagicMock(return_value=None)
+    # Plain adapters are their own device owner — no shared inner.
+    adapter.inner = None
     return adapter
 
 
@@ -110,7 +112,7 @@ class TestMultiplexerGetConnectedControllers:
         a2 = _make_adapter("python", serials=["AA:AA"])
         mux = MultiplexerBackend(adapters=[a1, a2])
 
-        with patch.object(mux, "_resolve_adapter_for_serial", return_value=None):
+        with patch.object(mux, "_resolve_adapter_for_serial", return_value=(None, "default")):
             result = mux.get_connected_controllers()
 
         assert result == ["AA:AA"]
@@ -484,7 +486,7 @@ class TestRouteControllers:
         a2 = _make_adapter("python", serials=["AA:AA"])
         mux = MultiplexerBackend(adapters=[a1, a2])
 
-        with patch.object(mux, "_resolve_adapter_for_serial", return_value=a2):
+        with patch.object(mux, "_resolve_adapter_for_serial", return_value=(a2, "targeted")):
             result = mux.get_connected_controllers()
 
         assert result == ["AA:AA"]
@@ -501,7 +503,7 @@ class TestRouteControllers:
         a2.open.return_value = False
         mux = MultiplexerBackend(adapters=[a1, a2])
 
-        with patch.object(mux, "_resolve_adapter_for_serial", return_value=a2):
+        with patch.object(mux, "_resolve_adapter_for_serial", return_value=(a2, "targeted")):
             result = mux.get_connected_controllers()
 
         assert result == ["AA:AA"]
@@ -516,7 +518,7 @@ class TestRouteControllers:
         a2.open.return_value = True
         mux = MultiplexerBackend(adapters=[a1, a2])
 
-        with patch.object(mux, "_resolve_adapter_for_serial", return_value=a2):
+        with patch.object(mux, "_resolve_adapter_for_serial", return_value=(a2, "targeted")):
             result = mux.get_connected_controllers()
 
         assert result == ["AA:AA"]
@@ -553,7 +555,7 @@ class TestRouteControllers:
         mux = MultiplexerBackend(adapters=[a1, a2])
 
         # First discovery: a1 discovers, gets routed
-        with patch.object(mux, "_resolve_adapter_for_serial", return_value=a1):
+        with patch.object(mux, "_resolve_adapter_for_serial", return_value=(a1, "targeted")):
             mux.get_connected_controllers()
 
         assert mux._serial_to_adapter["AA:AA"] is a1
@@ -561,7 +563,7 @@ class TestRouteControllers:
         # Second discovery: only a2 discovers the serial now
         a1.discover.return_value = []
         a2.discover.return_value = ["AA:AA"]
-        with patch.object(mux, "_resolve_adapter_for_serial", return_value=a2):
+        with patch.object(mux, "_resolve_adapter_for_serial", return_value=(a2, "targeted")):
             mux.get_connected_controllers()
 
         assert mux._serial_to_adapter["AA:AA"] is a2
@@ -575,7 +577,7 @@ class TestRouteControllers:
         mux = MultiplexerBackend(adapters=[a1, a2])
 
         # First discovery: targeting picks a1
-        with patch.object(mux, "_resolve_adapter_for_serial", return_value=a1):
+        with patch.object(mux, "_resolve_adapter_for_serial", return_value=(a1, "targeted")):
             mux.get_connected_controllers()
 
         assert mux._serial_to_adapter["AA:AA"] is a1
@@ -584,7 +586,7 @@ class TestRouteControllers:
         a2.close.reset_mock()
 
         # Second discovery: targeting switches to a2
-        with patch.object(mux, "_resolve_adapter_for_serial", return_value=a2):
+        with patch.object(mux, "_resolve_adapter_for_serial", return_value=(a2, "targeted")):
             mux.get_connected_controllers()
 
         # Old adapter (a1) should have been closed via dynamic switch
@@ -597,8 +599,8 @@ class TestRouteControllers:
         a2 = _make_adapter("python", serials=["AA:AA", "BB:BB"])
         mux = MultiplexerBackend(adapters=[a1, a2])
 
-        def route(serial):
-            return a2 if serial == "AA:AA" else a1
+        def route(serial, _candidate_serials=None):
+            return (a2, "targeted") if serial == "AA:AA" else (a1, "targeted")
 
         with patch.object(mux, "_resolve_adapter_for_serial", side_effect=route):
             mux.get_connected_controllers()
@@ -615,7 +617,7 @@ class TestRouteControllers:
         mux = MultiplexerBackend(adapters=[a1, a2])
 
         # _resolve returns None — but only one real adapter found it
-        with patch.object(mux, "_resolve_adapter_for_serial", return_value=None):
+        with patch.object(mux, "_resolve_adapter_for_serial", return_value=(None, "default")):
             mux.get_connected_controllers()
 
         assert mux._serial_to_adapter["AA:AA"] is a1
@@ -627,7 +629,7 @@ class TestRouteControllers:
         a2 = _make_adapter("python", serials=["AA:AA"])
         mux = MultiplexerBackend(adapters=[a1, a2])
 
-        with patch.object(mux, "_resolve_adapter_for_serial", return_value=a2):
+        with patch.object(mux, "_resolve_adapter_for_serial", return_value=(a2, "targeted")):
             mux.get_connected_controllers()
 
         mock_metrics.controller_routing_decisions_total.labels.assert_any_call(
@@ -635,6 +637,83 @@ class TestRouteControllers:
             adapter="python",
             method="targeted",
         )
+
+    @patch("services.controller_manager.multiplexer.multiplexer_backend.metrics")
+    def test_rollout_method_label_recorded(self, mock_metrics):
+        """A rollout-driven winner records the 'rollout' method label."""
+        a1 = _make_adapter("python", serials=["AA:AA"])
+        mux = MultiplexerBackend(adapters=[a1])
+
+        with patch.object(mux, "_resolve_adapter_for_serial", return_value=(a1, "rollout")):
+            mux.get_connected_controllers()
+
+        mock_metrics.controller_routing_decisions_total.labels.assert_any_call(
+            serial="AA:AA",
+            adapter="python",
+            method="rollout",
+        )
+
+
+class TestUnstableRoutingOnly:
+    """Routing-only adapters (unstable) must never win by default/fallback."""
+
+    @patch("services.controller_manager.multiplexer.multiplexer_backend.metrics")
+    def test_unstable_registered_for_targeting_not_discovery(self, mock_metrics):
+        a_py = _make_adapter("python")
+        a_un = _make_adapter("unstable")
+        mux = MultiplexerBackend(adapters=[a_py], routing_only_adapters=[a_un])
+
+        # Reachable as a targeting/rollout destination
+        assert mux._adapter_by_type["unstable"] is a_un
+        # But not an independent discoverer
+        assert a_un not in mux.adapters
+
+    @patch("services.controller_manager.multiplexer.multiplexer_backend.metrics")
+    def test_unstable_excluded_from_fallback_selection(self, mock_metrics):
+        """When two non-mock adapters discover a serial and one is unstable,
+        the fallback path must pick the non-unstable adapter."""
+        a_py = _make_adapter("python", serials=["AA:AA"])
+        a_un = _make_adapter("unstable", serials=["AA:AA"])
+        # Put unstable FIRST so a naive 'first non-mock' would wrongly pick it.
+        mux = MultiplexerBackend(adapters=[a_un, a_py])
+
+        # No targeting/rollout resolves -> fallback selection
+        with patch.object(mux, "_resolve_adapter_for_serial", return_value=(None, "default")):
+            mux.get_connected_controllers()
+
+        assert mux._serial_to_adapter["AA:AA"] is a_py
+
+    @patch("services.controller_manager.multiplexer.multiplexer_backend.metrics")
+    def test_unstable_only_falls_back_to_itself(self, mock_metrics):
+        """If unstable is the ONLY discoverer, adapters[0] fallback still uses it."""
+        a_un = _make_adapter("unstable", serials=["AA:AA"])
+        mux = MultiplexerBackend(adapters=[a_un])
+
+        with patch.object(mux, "_resolve_adapter_for_serial", return_value=(None, "default")):
+            mux.get_connected_controllers()
+
+        assert mux._serial_to_adapter["AA:AA"] is a_un
+
+
+class TestSharedInnerNotClosed:
+    """Switching between a plain adapter and a decorator sharing its inner
+    must not close the shared device."""
+
+    @patch("services.controller_manager.multiplexer.multiplexer_backend.metrics")
+    def test_loser_sharing_inner_not_closed(self, mock_metrics):
+        from services.controller_manager.multiplexer.unstable_adapter import UnstableAdapter
+
+        a_py = _make_adapter("python", serials=["AA:AA"])
+        a_un = UnstableAdapter(a_py)  # shares a_py as inner
+        mux = MultiplexerBackend(adapters=[a_py], routing_only_adapters=[a_un])
+
+        # Route the serial to the unstable wrapper; python is the discoverer/loser.
+        with patch.object(mux, "_resolve_adapter_for_serial", return_value=(a_un, "targeted")):
+            mux.get_connected_controllers()
+
+        assert mux._serial_to_adapter["AA:AA"] is a_un
+        # Shared inner must NOT have been closed by the losing python discoverer
+        a_py.close.assert_not_called()
 
 
 class TestIndependentDiscovery:
@@ -659,7 +738,7 @@ class TestIndependentDiscovery:
         a2 = _make_adapter("python", serials=["AA:AA"])
         mux = MultiplexerBackend(adapters=[a1, a2])
 
-        with patch.object(mux, "_resolve_adapter_for_serial", return_value=None):
+        with patch.object(mux, "_resolve_adapter_for_serial", return_value=(None, "default")):
             mux.get_connected_controllers()
 
         assert mux._serial_to_adapter["AA:AA"] is a2
@@ -672,7 +751,7 @@ class TestIndependentDiscovery:
         mux = MultiplexerBackend(adapters=[a1, a2])
 
         # Targeting picks a1 as winner
-        with patch.object(mux, "_resolve_adapter_for_serial", return_value=a1):
+        with patch.object(mux, "_resolve_adapter_for_serial", return_value=(a1, "targeted")):
             mux.get_connected_controllers()
 
         assert mux._serial_to_adapter["AA:AA"] is a1
@@ -680,66 +759,141 @@ class TestIndependentDiscovery:
         a2.close.assert_called_with("AA:AA")
 
 
-class TestResolveAdapterForSerial:
-    """Tests for flag evaluation in _resolve_adapter_for_serial."""
+def _details(value, reason):
+    """Build a fake FlagEvaluationDetails-like object for get_string_details."""
+    d = MagicMock()
+    d.value = value
+    d.reason = reason
+    return d
 
-    def test_returns_matching_adapter(self):
+
+class TestResolveAdapterForSerial:
+    """Tests for three-way precedence in _resolve_adapter_for_serial."""
+
+    def test_explicit_targeting_match_wins(self):
+        """A TARGETING_MATCH on bluetooth_backend routes to that adapter."""
         a1 = _make_adapter("python")
-        a2 = _make_adapter("python")
+        a2 = _make_adapter("rust")
         mux = MultiplexerBackend(adapters=[a1, a2])
 
         mock_client = MagicMock()
-        mock_client.get_string_value.return_value = "python"
+        mock_client.get_string_details.return_value = _details("rust", "TARGETING_MATCH")
 
         with patch("lib.feature_flags.get_flag_client", return_value=mock_client):
-            result = mux._resolve_adapter_for_serial("AA:AA")
+            adapter, method = mux._resolve_adapter_for_serial("AA:AA", ["AA:AA"])
 
-        assert result is a2
+        assert adapter is a2
+        assert method == "targeted"
+
+    def test_default_variant_is_method_default_not_targeted(self):
+        """A non-TARGETING_MATCH reason (default variant) routes as 'default'."""
+        a1 = _make_adapter("python")
+        mux = MultiplexerBackend(adapters=[a1])
+
+        mock_client = MagicMock()
+        mock_client.get_string_details.return_value = _details("python", "DEFAULT")
+        # No rollout in play
+        with (
+            patch("lib.feature_flags.get_flag_client", return_value=mock_client),
+            patch.object(mux._rollout_router, "target_for", return_value=None),
+        ):
+            adapter, method = mux._resolve_adapter_for_serial("AA:AA", ["AA:AA"])
+
+        assert adapter is a1
+        assert method == "default"
+
+    def test_rollout_beats_default_when_no_explicit_targeting(self):
+        """Rollout target wins over the flag default variant."""
+        a_py = _make_adapter("python")
+        a_un = _make_adapter("unstable")
+        mux = MultiplexerBackend(adapters=[a_py], routing_only_adapters=[a_un])
+
+        mock_client = MagicMock()
+        # bluetooth_backend resolves to default variant (no TARGETING_MATCH)
+        mock_client.get_string_details.return_value = _details("python", "DEFAULT")
+
+        with (
+            patch("lib.feature_flags.get_flag_client", return_value=mock_client),
+            patch.object(mux._rollout_router, "target_for", return_value="unstable"),
+        ):
+            adapter, method = mux._resolve_adapter_for_serial("AA:AA", ["AA:AA"])
+
+        assert adapter is a_un
+        assert method == "rollout"
+
+    def test_explicit_targeting_beats_rollout(self):
+        """Explicit TARGETING_MATCH takes precedence over an active rollout."""
+        a_py = _make_adapter("python")
+        a_un = _make_adapter("unstable")
+        mux = MultiplexerBackend(adapters=[a_py], routing_only_adapters=[a_un])
+
+        mock_client = MagicMock()
+        mock_client.get_string_details.return_value = _details("python", "TARGETING_MATCH")
+
+        with (
+            patch("lib.feature_flags.get_flag_client", return_value=mock_client),
+            patch.object(mux._rollout_router, "target_for", return_value="unstable") as rollout,
+        ):
+            adapter, method = mux._resolve_adapter_for_serial("AA:AA", ["AA:AA"])
+
+        assert adapter is a_py
+        assert method == "targeted"
+        # Explicit match short-circuits before rollout is consulted
+        rollout.assert_not_called()
 
     def test_returns_none_when_no_match(self):
         a1 = _make_adapter("python")
         mux = MultiplexerBackend(adapters=[a1])
 
         mock_client = MagicMock()
-        mock_client.get_string_value.return_value = "nonexistent"
+        mock_client.get_string_details.return_value = _details("nonexistent", "DEFAULT")
 
-        with patch("lib.feature_flags.get_flag_client", return_value=mock_client):
-            result = mux._resolve_adapter_for_serial("AA:AA")
+        with (
+            patch("lib.feature_flags.get_flag_client", return_value=mock_client),
+            patch.object(mux._rollout_router, "target_for", return_value=None),
+        ):
+            adapter, method = mux._resolve_adapter_for_serial("AA:AA", ["AA:AA"])
 
-        assert result is None
+        assert adapter is None
+        assert method == "default"
 
     def test_returns_none_when_empty_value(self):
         a1 = _make_adapter("python")
         mux = MultiplexerBackend(adapters=[a1])
 
         mock_client = MagicMock()
-        mock_client.get_string_value.return_value = ""
+        mock_client.get_string_details.return_value = _details("", "DEFAULT")
 
-        with patch("lib.feature_flags.get_flag_client", return_value=mock_client):
-            result = mux._resolve_adapter_for_serial("AA:AA")
+        with (
+            patch("lib.feature_flags.get_flag_client", return_value=mock_client),
+            patch.object(mux._rollout_router, "target_for", return_value=None),
+        ):
+            adapter, method = mux._resolve_adapter_for_serial("AA:AA", ["AA:AA"])
 
-        assert result is None
+        assert adapter is None
+        assert method == "default"
 
     def test_returns_none_on_exception(self):
         a1 = _make_adapter("python")
         mux = MultiplexerBackend(adapters=[a1])
 
         with patch("lib.feature_flags.get_flag_client", side_effect=RuntimeError("flagd down")):
-            result = mux._resolve_adapter_for_serial("AA:AA")
+            adapter, method = mux._resolve_adapter_for_serial("AA:AA", ["AA:AA"])
 
-        assert result is None
+        assert adapter is None
+        assert method == "default"
 
     def test_passes_serial_as_targeting_key(self):
         a1 = _make_adapter("python")
         mux = MultiplexerBackend(adapters=[a1])
 
         mock_client = MagicMock()
-        mock_client.get_string_value.return_value = "python"
+        mock_client.get_string_details.return_value = _details("python", "TARGETING_MATCH")
 
         with patch("lib.feature_flags.get_flag_client", return_value=mock_client):
-            mux._resolve_adapter_for_serial("E0AE5EE111AB")
+            mux._resolve_adapter_for_serial("E0AE5EE111AB", ["E0AE5EE111AB"])
 
-        call_args = mock_client.get_string_value.call_args
+        call_args = mock_client.get_string_details.call_args
         ctx = call_args[0][2]  # Third positional arg is the EvaluationContext
         assert ctx.targeting_key == "E0AE5EE111AB"
 

--- a/services/controller_manager/tests/test_rollout_router.py
+++ b/services/controller_manager/tests/test_rollout_router.py
@@ -1,0 +1,106 @@
+"""
+Unit tests for RolloutRouter — consumes the rollout flagd domain to drive
+progressive backend rollout.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+test_dir = Path(__file__).parent
+service_dir = test_dir.parent
+project_root = service_dir.parent.parent
+sys.path.insert(0, str(project_root))
+
+from services.controller_manager.multiplexer.rollout_router import RolloutRouter
+
+ALL = ["C", "A", "F", "B", "E", "D"]  # unsorted on purpose
+SORTED = ["A", "B", "C", "D", "E", "F"]
+
+
+def _client(strategy="off", target="unstable", count=0):
+    client = MagicMock()
+
+    def get_string(key, default, _ctx):
+        if key == "strategy":
+            return strategy
+        if key == "target_backend":
+            return target
+        return default
+
+    def get_int(key, default, _ctx):
+        if key == "current_controller_count":
+            return count
+        return default
+
+    client.get_string_value = MagicMock(side_effect=get_string)
+    client.get_integer_value = MagicMock(side_effect=get_int)
+    return client
+
+
+def _run(serial, all_serials, **kw):
+    router = RolloutRouter()
+    with patch("lib.feature_flags.get_flag_client", return_value=_client(**kw)):
+        return router.target_for(serial, all_serials)
+
+
+class TestStrategyOff:
+    def test_off_returns_none(self):
+        assert _run("A", ALL, strategy="off", count=99) is None
+
+
+class TestStrategyImmediate:
+    def test_immediate_targets_every_serial(self):
+        assert _run("A", ALL, strategy="immediate", target="unstable") == "unstable"
+        assert _run("F", ALL, strategy="immediate", target="unstable") == "unstable"
+
+    def test_immediate_empty_target_returns_none(self):
+        assert _run("A", ALL, strategy="immediate", target="") is None
+
+
+class TestStrategyProgressive:
+    def test_count_zero_returns_none(self):
+        assert _run("A", ALL, strategy="progressive", count=0) is None
+
+    def test_count_one_first_serial_only(self):
+        # sorted -> A is first
+        assert _run("A", ALL, strategy="progressive", count=1) == "unstable"
+        assert _run("B", ALL, strategy="progressive", count=1) is None
+
+    def test_count_three_boundary(self):
+        # sorted[:3] = A, B, C
+        assert _run("C", ALL, strategy="progressive", count=3) == "unstable"
+        assert _run("D", ALL, strategy="progressive", count=3) is None
+
+    def test_count_six_includes_all_present(self):
+        for s in SORTED:
+            assert _run(s, ALL, strategy="progressive", count=6) == "unstable"
+
+    def test_count_all_99_includes_everyone(self):
+        for s in SORTED:
+            assert _run(s, ALL, strategy="progressive", count=99) == "unstable"
+
+    def test_uses_sorted_order_not_input_order(self):
+        # Input order has C first, but sorted-first is A.
+        assert _run("C", ALL, strategy="progressive", count=1) is None
+        assert _run("A", ALL, strategy="progressive", count=1) == "unstable"
+
+    def test_serial_not_in_all_serials_returns_none(self):
+        assert _run("Z", ALL, strategy="progressive", count=99) is None
+
+
+class TestDefensive:
+    def test_flag_client_error_returns_none(self):
+        router = RolloutRouter()
+        with patch("lib.feature_flags.get_flag_client", side_effect=RuntimeError("flagd down")):
+            assert router.target_for("A", ALL) is None
+
+    def test_unknown_strategy_returns_none(self):
+        assert _run("A", ALL, strategy="bogus", count=99) is None
+
+    def test_string_eval_error_returns_none(self):
+        router = RolloutRouter()
+        client = MagicMock()
+        client.get_string_value = MagicMock(side_effect=ValueError("boom"))
+        with patch("lib.feature_flags.get_flag_client", return_value=client):
+            assert router.target_for("A", ALL) is None

--- a/services/controller_manager/tests/test_unstable_adapter.py
+++ b/services/controller_manager/tests/test_unstable_adapter.py
@@ -1,0 +1,206 @@
+"""
+Unit tests for UnstableAdapter — a deterministically-degraded decorator.
+
+Verifies the M3 fitness thresholds are reliably violated:
+  * fresh-frame update rate < 10 Hz
+  * dropped-event ratio > 2%
+  * gap between fresh frames > 50 ms
+plus lifecycle delegation and the routable adapter_type.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+test_dir = Path(__file__).parent
+service_dir = test_dir.parent
+project_root = service_dir.parent.parent
+sys.path.insert(0, str(project_root))
+
+from services.controller_manager.multiplexer.unstable_adapter import UnstableAdapter
+
+
+class FakeClock:
+    """Injectable monotonic clock for deterministic throttle tests."""
+
+    def __init__(self):
+        self.t = 0.0
+
+    def __call__(self) -> float:
+        return self.t
+
+    def advance(self, dt: float) -> None:
+        self.t += dt
+
+
+def _inner(poll_returns=None):
+    inner = MagicMock()
+    inner.adapter_type = "python"
+    inner.inner = None
+    if poll_returns is None:
+        inner.poll = MagicMock(side_effect=lambda s: {"serial": s, "seq": inner.poll.call_count})
+    else:
+        inner.poll = MagicMock(return_value=poll_returns)
+    inner.discover = MagicMock(return_value=["AA:AA"])
+    inner.open = MagicMock(return_value=True)
+    inner.set_output = MagicMock(return_value=True)
+    inner.close = MagicMock()
+    inner.close_all = MagicMock()
+    inner.get_adapter_for_serial = MagicMock(return_value="hci0")
+    return inner
+
+
+class TestAdapterType:
+    def test_adapter_type_is_unstable_not_transparent(self):
+        adapter = UnstableAdapter(_inner())
+        # Unlike ChaosAdapter, this is NOT transparent — routing must see it.
+        assert adapter.adapter_type == "unstable"
+
+    def test_exposes_inner(self):
+        inner = _inner()
+        adapter = UnstableAdapter(inner)
+        assert adapter.inner is inner
+
+    def test_rejects_drop_every_below_two(self):
+        with pytest.raises(ValueError, match="drop_every"):
+            UnstableAdapter(_inner(), drop_every=1)
+
+
+class TestDegradation:
+    def test_fresh_update_rate_below_10hz(self):
+        """Driving poll() at 100 Hz wall-clock yields < 10 fresh frames/sec."""
+        clock = FakeClock()
+        inner = _inner()
+        adapter = UnstableAdapter(inner, throttle_seconds=0.12, drop_every=10, time_source=clock)
+
+        fresh = 0
+        # Simulate 1 second at 100 Hz (10 ms steps).
+        for _ in range(100):
+            inner.poll.reset_mock()
+            adapter.poll("AA:AA")
+            if inner.poll.called:  # a fresh inner poll happened this tick
+                fresh += 1
+            clock.advance(0.010)
+
+        # 1 s / 0.12 s window -> at most ~9 fresh frames, strictly < 10 Hz.
+        assert fresh < 10
+
+    def test_gap_between_fresh_frames_exceeds_50ms(self):
+        """Time between consecutive fresh inner polls is always > 50 ms."""
+        clock = FakeClock()
+        inner = _inner()
+        adapter = UnstableAdapter(inner, throttle_seconds=0.12, drop_every=10, time_source=clock)
+
+        fresh_times = []
+        for _ in range(200):
+            inner.poll.reset_mock()
+            adapter.poll("AA:AA")
+            if inner.poll.called:
+                fresh_times.append(clock.t)
+            clock.advance(0.005)  # 5 ms steps
+
+        gaps = [b - a for a, b in zip(fresh_times, fresh_times[1:], strict=False)]
+        assert gaps  # we observed multiple fresh frames
+        assert all(g > 0.050 for g in gaps), gaps
+
+    def test_drop_ratio_above_2_percent(self):
+        """Across fresh polls, the dropped (None) ratio exceeds 2%."""
+        clock = FakeClock()
+        inner = _inner()
+        adapter = UnstableAdapter(inner, throttle_seconds=0.12, drop_every=10, time_source=clock)
+
+        fresh = 0
+        drops = 0
+        for _ in range(500):
+            inner.poll.reset_mock()
+            result = adapter.poll("AA:AA")
+            if inner.poll.called:
+                fresh += 1
+                if result is None:
+                    drops += 1
+            clock.advance(0.130)  # always past the throttle window -> every poll is fresh
+
+        assert fresh > 0
+        ratio = drops / fresh
+        assert ratio > 0.02, ratio
+        # drop_every=10 -> exactly 10%
+        assert abs(ratio - 0.10) < 0.001, ratio
+
+    def test_stale_replay_within_throttle_window(self):
+        """Within a throttle window, the last served frame is replayed."""
+        clock = FakeClock()
+        inner = _inner()
+        adapter = UnstableAdapter(inner, throttle_seconds=0.12, time_source=clock)
+
+        first = adapter.poll("AA:AA")
+        inner.poll.reset_mock()
+        # Advance less than the throttle window.
+        clock.advance(0.05)
+        replay = adapter.poll("AA:AA")
+
+        inner.poll.assert_not_called()  # no fresh inner poll
+        assert replay == first
+
+    def test_poll_never_blocks(self):
+        """poll() must not call sleep — degradation is throttle/drop only."""
+        import time as time_module
+
+        clock = FakeClock()
+        adapter = UnstableAdapter(_inner(), time_source=clock)
+        start = time_module.perf_counter()
+        for _ in range(50):
+            adapter.poll("AA:AA")
+            clock.advance(0.2)
+        elapsed = time_module.perf_counter() - start
+        assert elapsed < 0.5  # generous; real impl is microseconds
+
+
+class TestDelegation:
+    def test_discover_delegates(self):
+        inner = _inner()
+        adapter = UnstableAdapter(inner)
+        assert adapter.discover(force=True, exclude_serials=["X"]) == ["AA:AA"]
+        inner.discover.assert_called_once_with(force=True, verify_only=False, exclude_serials=["X"])
+
+    def test_open_delegates(self):
+        inner = _inner()
+        adapter = UnstableAdapter(inner)
+        assert adapter.open("AA:AA") is True
+        inner.open.assert_called_once_with("AA:AA")
+
+    def test_set_output_delegates(self):
+        inner = _inner()
+        adapter = UnstableAdapter(inner)
+        assert adapter.set_output("AA:AA", 1, 2, 3, 4) is True
+        inner.set_output.assert_called_once_with("AA:AA", 1, 2, 3, 4)
+
+    def test_get_adapter_for_serial_delegates(self):
+        inner = _inner()
+        adapter = UnstableAdapter(inner)
+        assert adapter.get_adapter_for_serial("AA:AA") == "hci0"
+
+    def test_close_delegates_and_clears_state(self):
+        clock = FakeClock()
+        inner = _inner()
+        adapter = UnstableAdapter(inner, time_source=clock)
+        adapter.poll("AA:AA")  # seed throttle state
+        adapter.close("AA:AA")
+        inner.close.assert_called_once_with("AA:AA")
+        assert "AA:AA" not in adapter._last_fresh_time
+
+    def test_close_all_delegates_and_clears_state(self):
+        clock = FakeClock()
+        inner = _inner()
+        adapter = UnstableAdapter(inner, time_source=clock)
+        adapter.poll("AA:AA")
+        adapter.close_all()
+        inner.close_all.assert_called_once()
+        assert adapter._last_fresh_time == {}
+
+    def test_unknown_attr_delegates_to_inner(self):
+        inner = _inner()
+        inner.some_extra = "value"
+        adapter = UnstableAdapter(inner)
+        assert adapter.some_extra == "value"

--- a/services/flagd/rollout.json
+++ b/services/flagd/rollout.json
@@ -7,7 +7,8 @@
       "state": "ENABLED",
       "variants": {
         "python": "python",
-        "rust": "rust"
+        "rust": "rust",
+        "unstable": "unstable"
       },
       "defaultVariant": "python"
     },


### PR DESCRIPTION
## Summary

Part 1 of 2 for #732 (M3 Infrastructure Agent): makes the Bluetooth backend selectable per controller via flags, including a deliberately degraded `unstable` backend, and wires the previously unconsumed `rollout` flagd domain into adapter routing.

- **`UnstableAdapter`** (new): routable decorator with `adapter_type="unstable"` around the python adapter. Deterministic degradation (no randomness): fresh frames throttled to ~8.3 Hz (<10 Hz), every 10th fresh frame dropped (10% > 2%), inter-frame gap ≥120 ms (>50 ms) — reliably violates the `fitness.bluetooth.*` thresholds for the M3 rollback demo. Never blocks inside the shared poll batch.
- **Shared-inner design**: the wrapper shares the *same* python adapter instance as the plain route — python-hid `open`/`close` are global device state and `poll` is destructive, so a second independent client would tear down or compete over devices. The multiplexer skips closing losers that share the winner's device owner.
- **`RolloutRouter`** (new): consumes `rollout.strategy` / `target_backend` / `current_controller_count`; progressive = first N serials by lexicographic sort. Defensive: any flag error → no rollout routing.
- **Three-way routing precedence** in `_resolve_adapter_for_serial`: explicit per-serial `bluetooth_backend` targeting (`TARGETING_MATCH` only) → rollout cohort → flag default. New `rollout` value for the `controller_routing_decisions_total` method label; `unstable` excluded from default/fallback selection.
- `rollout.json`: add `unstable` variant to `target_backend`; `server.py`: init + readiness-wait the `rollout` domain.

## Test plan

- [x] 608 unit tests pass (`cd services/controller_manager && uv run pytest`)
- [x] `make lint` clean
- [x] New: `test_unstable_adapter.py` (15 — throttle/drop/gap with injected clock, delegation), `test_rollout_router.py` (subset math, strategies, error fallback), multiplexer precedence + shared-inner close-skip tests, backend factory routing-only registration

Part 2 (`controller.bluetooth_health` span + bluetooth signal metrics) follows stacked on this branch.

Closes nothing yet — #732 closes with part 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)