### PR TITLE
feat: reserved mock controllers hidden from button-stream consumers (#777)

### DIFF
--- a/lib/controller_constants.py
+++ b/lib/controller_constants.py
@@ -73,6 +73,10 @@ class ControllerInfoKey(StrEnum):
     NAME = "name"
     PAIRED = "paired"
     ADAPTER = "adapter"  # Which adapter handles this controller (psmove, hidapi, mock)
+    # Reserved controllers are hidden from button-stream consumers (the menu):
+    # no connect/disconnect announcements, excluded from connected_serials.
+    RESERVED = "reserved"
+    TAG = "tag"  # Identifies the owning agent/game (orphan cleanup, debugging)
 
 
 class LobbyState(StrEnum):

--- a/proto/controller_manager_mock.proto
+++ b/proto/controller_manager_mock.proto
@@ -104,9 +104,19 @@ message ResetResponse {
 
 message ListRequest {}
 
+// Per-controller info for ListMockControllers. Lets tests/agents enumerate
+// their reserved controllers and sweep orphans by tag.
+message MockControllerInfo {
+    string serial = 1;
+    bool reserved = 2;
+    string tag = 3;
+}
+
 message ListResponse {
     repeated string serials = 1;
     int32 count = 2;
+    // Detailed per-controller info including reserved/tag.
+    repeated MockControllerInfo controllers = 3;
 }
 
 message AutoGameEndRequest {
@@ -172,6 +182,13 @@ message ConnectionEvent {
 // AddController - add a single mock controller dynamically
 message AddControllerRequest {
     string serial = 1;  // Optional: auto-generated if empty
+    // When true, the controller is hidden from button-stream consumers (the
+    // menu): no connect/disconnect announcements, excluded from the
+    // connected_serials roster. It stays fully usable via gameplay-data
+    // streams and explicit-serial LED/feedback commands.
+    bool reserved = 2;
+    // Identifies the owning agent/game — aids orphan cleanup and debugging.
+    string tag = 3;
 }
 
 message AddControllerResponse {
@@ -193,6 +210,11 @@ message RemoveControllerResponse {
 // AddControllers - add multiple mock controllers at once
 message AddControllersRequest {
     int32 count = 1;
+    // When true, all added controllers are reserved (hidden from the menu).
+    // See AddControllerRequest.reserved.
+    bool reserved = 2;
+    // Identifies the owning agent/game — applied to all added controllers.
+    string tag = 3;
 }
 
 message AddControllersResponse {

--- a/proto/controller_manager_mock_pb2.py
+++ b/proto/controller_manager_mock_pb2.py
@@ -24,7 +24,7 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x1d\x63ontroller_manager_mock.proto\x12\x17\x63ontroller_manager_mock\"T\n\x0fMovementRequest\x12\x0e\n\x06serial\x18\x01 \x01(\t\x12\x0f\n\x07\x61\x63\x63\x65l_x\x18\x02 \x01(\x02\x12\x0f\n\x07\x61\x63\x63\x65l_y\x18\x03 \x01(\x02\x12\x0f\n\x07\x61\x63\x63\x65l_z\x18\x04 \x01(\x02\"2\n\x10MovementResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\r\n\x05\x65rror\x18\x02 \x01(\t\"\x1e\n\x0c\x44\x65\x61thRequest\x12\x0e\n\x06serial\x18\x01 \x01(\t\"9\n\rDeathResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\x17\n\x0f\x61\x63\x63\x65l_magnitude\x18\x02 \x01(\x02\"\xa7\x01\n\rButtonRequest\x12\x0e\n\x06serial\x18\x01 \x01(\t\x12=\n\x06\x62utton\x18\x02 \x01(\x0e\x32-.controller_manager_mock.ButtonRequest.Button\x12\x0f\n\x07pressed\x18\x03 \x01(\x08\"6\n\x06\x42utton\x12\x0b\n\x07TRIGGER\x10\x00\x12\x08\n\x04MOVE\x10\x01\x12\n\n\x06SELECT\x10\x02\x12\t\n\x05START\x10\x03\"0\n\x0e\x42uttonResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\r\n\x05\x65rror\x18\x02 \x01(\t\"?\n\x0c\x43olorRequest\x12\x0e\n\x06serial\x18\x01 \x01(\t\x12\t\n\x01r\x18\x02 \x01(\x05\x12\t\n\x01g\x18\x03 \x01(\x05\x12\t\n\x01\x62\x18\x04 \x01(\x05\"/\n\rColorResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\r\n\x05\x65rror\x18\x02 \x01(\t\"\x1e\n\x0cResetRequest\x12\x0e\n\x06serial\x18\x01 \x01(\t\"/\n\rResetResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\r\n\x05\x65rror\x18\x02 \x01(\t\"\r\n\x0bListRequest\".\n\x0cListResponse\x12\x0f\n\x07serials\x18\x01 \x03(\t\x12\r\n\x05\x63ount\x18\x02 \x01(\x05\"?\n\x12\x41utoGameEndRequest\x12\x18\n\x10\x64uration_seconds\x18\x01 \x01(\x02\x12\x0f\n\x07\x65nabled\x18\x02 \x01(\x08\"5\n\x13\x41utoGameEndResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\r\n\x05\x65rror\x18\x02 \x01(\t\"!\n\x0fGetColorRequest\x12\x0e\n\x06serial\x18\x01 \x01(\t\"S\n\x10GetColorResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\r\n\x05\x65rror\x18\x02 \x01(\t\x12\t\n\x01r\x18\x03 \x01(\x05\x12\t\n\x01g\x18\x04 \x01(\x05\x12\t\n\x01\x62\x18\x05 \x01(\x05\"\x16\n\x14ObservabilityRequest\"\xcc\x02\n\x12ObservabilityEvent\x12\x14\n\x0ctimestamp_ms\x18\x01 \x01(\x03\x12\x0e\n\x06serial\x18\x02 \x01(\t\x12=\n\nled_change\x18\n \x01(\x0b\x32\'.controller_manager_mock.LedChangeEventH\x00\x12\x43\n\rrumble_change\x18\x0b \x01(\x0b\x32*.controller_manager_mock.RumbleChangeEventH\x00\x12\x43\n\rbutton_change\x18\x0c \x01(\x0b\x32*.controller_manager_mock.ButtonChangeEventH\x00\x12>\n\nconnection\x18\r \x01(\x0b\x32(.controller_manager_mock.ConnectionEventH\x00\x42\x07\n\x05\x65vent\"A\n\x0eLedChangeEvent\x12\t\n\x01r\x18\x01 \x01(\x05\x12\t\n\x01g\x18\x02 \x01(\x05\x12\t\n\x01\x62\x18\x03 \x01(\x05\x12\x0e\n\x06source\x18\x04 \x01(\t\"&\n\x11RumbleChangeEvent\x12\x11\n\tintensity\x18\x01 \x01(\x05\"4\n\x11\x42uttonChangeEvent\x12\x0e\n\x06\x62utton\x18\x01 \x01(\t\x12\x0f\n\x07pressed\x18\x02 \x01(\x08\"$\n\x0f\x43onnectionEvent\x12\x11\n\tconnected\x18\x01 \x01(\x08\"&\n\x14\x41\x64\x64\x43ontrollerRequest\x12\x0e\n\x06serial\x18\x01 \x01(\t\"G\n\x15\x41\x64\x64\x43ontrollerResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\r\n\x05\x65rror\x18\x02 \x01(\t\x12\x0e\n\x06serial\x18\x03 \x01(\t\")\n\x17RemoveControllerRequest\x12\x0e\n\x06serial\x18\x01 \x01(\t\":\n\x18RemoveControllerResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\r\n\x05\x65rror\x18\x02 \x01(\t\"&\n\x15\x41\x64\x64\x43ontrollersRequest\x12\r\n\x05\x63ount\x18\x01 \x01(\x05\"I\n\x16\x41\x64\x64\x43ontrollersResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\r\n\x05\x65rror\x18\x02 \x01(\t\x12\x0f\n\x07serials\x18\x03 \x03(\t2\x83\n\n\x15MockControllerService\x12g\n\x10SimulateMovement\x12(.controller_manager_mock.MovementRequest\x1a).controller_manager_mock.MovementResponse\x12^\n\rSimulateDeath\x12%.controller_manager_mock.DeathRequest\x1a&.controller_manager_mock.DeathResponse\x12\x61\n\x0eSimulateButton\x12&.controller_manager_mock.ButtonRequest\x1a\'.controller_manager_mock.ButtonResponse\x12Y\n\x08SetColor\x12%.controller_manager_mock.ColorRequest\x1a&.controller_manager_mock.ColorResponse\x12`\n\x0fResetController\x12%.controller_manager_mock.ResetRequest\x1a&.controller_manager_mock.ResetResponse\x12\x62\n\x13ListMockControllers\x12$.controller_manager_mock.ListRequest\x1a%.controller_manager_mock.ListResponse\x12k\n\x0eSetAutoGameEnd\x12+.controller_manager_mock.AutoGameEndRequest\x1a,.controller_manager_mock.AutoGameEndResponse\x12_\n\x08GetColor\x12(.controller_manager_mock.GetColorRequest\x1a).controller_manager_mock.GetColorResponse\x12s\n\x13StreamObservability\x12-.controller_manager_mock.ObservabilityRequest\x1a+.controller_manager_mock.ObservabilityEvent0\x01\x12n\n\rAddController\x12-.controller_manager_mock.AddControllerRequest\x1a..controller_manager_mock.AddControllerResponse\x12w\n\x10RemoveController\x12\x30.controller_manager_mock.RemoveControllerRequest\x1a\x31.controller_manager_mock.RemoveControllerResponse\x12q\n\x0e\x41\x64\x64\x43ontrollers\x12..controller_manager_mock.AddControllersRequest\x1a/.controller_manager_mock.AddControllersResponseBAZ?github.com/joustmania/connect-proxy/gen/controller_manager_mockb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x1d\x63ontroller_manager_mock.proto\x12\x17\x63ontroller_manager_mock\"T\n\x0fMovementRequest\x12\x0e\n\x06serial\x18\x01 \x01(\t\x12\x0f\n\x07\x61\x63\x63\x65l_x\x18\x02 \x01(\x02\x12\x0f\n\x07\x61\x63\x63\x65l_y\x18\x03 \x01(\x02\x12\x0f\n\x07\x61\x63\x63\x65l_z\x18\x04 \x01(\x02\"2\n\x10MovementResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\r\n\x05\x65rror\x18\x02 \x01(\t\"\x1e\n\x0c\x44\x65\x61thRequest\x12\x0e\n\x06serial\x18\x01 \x01(\t\"9\n\rDeathResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\x17\n\x0f\x61\x63\x63\x65l_magnitude\x18\x02 \x01(\x02\"\xa7\x01\n\rButtonRequest\x12\x0e\n\x06serial\x18\x01 \x01(\t\x12=\n\x06\x62utton\x18\x02 \x01(\x0e\x32-.controller_manager_mock.ButtonRequest.Button\x12\x0f\n\x07pressed\x18\x03 \x01(\x08\"6\n\x06\x42utton\x12\x0b\n\x07TRIGGER\x10\x00\x12\x08\n\x04MOVE\x10\x01\x12\n\n\x06SELECT\x10\x02\x12\t\n\x05START\x10\x03\"0\n\x0e\x42uttonResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\r\n\x05\x65rror\x18\x02 \x01(\t\"?\n\x0c\x43olorRequest\x12\x0e\n\x06serial\x18\x01 \x01(\t\x12\t\n\x01r\x18\x02 \x01(\x05\x12\t\n\x01g\x18\x03 \x01(\x05\x12\t\n\x01\x62\x18\x04 \x01(\x05\"/\n\rColorResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\r\n\x05\x65rror\x18\x02 \x01(\t\"\x1e\n\x0cResetRequest\x12\x0e\n\x06serial\x18\x01 \x01(\t\"/\n\rResetResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\r\n\x05\x65rror\x18\x02 \x01(\t\"\r\n\x0bListRequest\"C\n\x12MockControllerInfo\x12\x0e\n\x06serial\x18\x01 \x01(\t\x12\x10\n\x08reserved\x18\x02 \x01(\x08\x12\x0b\n\x03tag\x18\x03 \x01(\t\"p\n\x0cListResponse\x12\x0f\n\x07serials\x18\x01 \x03(\t\x12\r\n\x05\x63ount\x18\x02 \x01(\x05\x12@\n\x0b\x63ontrollers\x18\x03 \x03(\x0b\x32+.controller_manager_mock.MockControllerInfo\"?\n\x12\x41utoGameEndRequest\x12\x18\n\x10\x64uration_seconds\x18\x01 \x01(\x02\x12\x0f\n\x07\x65nabled\x18\x02 \x01(\x08\"5\n\x13\x41utoGameEndResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\r\n\x05\x65rror\x18\x02 \x01(\t\"!\n\x0fGetColorRequest\x12\x0e\n\x06serial\x18\x01 \x01(\t\"S\n\x10GetColorResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\r\n\x05\x65rror\x18\x02 \x01(\t\x12\t\n\x01r\x18\x03 \x01(\x05\x12\t\n\x01g\x18\x04 \x01(\x05\x12\t\n\x01\x62\x18\x05 \x01(\x05\"\x16\n\x14ObservabilityRequest\"\xcc\x02\n\x12ObservabilityEvent\x12\x14\n\x0ctimestamp_ms\x18\x01 \x01(\x03\x12\x0e\n\x06serial\x18\x02 \x01(\t\x12=\n\nled_change\x18\n \x01(\x0b\x32\'.controller_manager_mock.LedChangeEventH\x00\x12\x43\n\rrumble_change\x18\x0b \x01(\x0b\x32*.controller_manager_mock.RumbleChangeEventH\x00\x12\x43\n\rbutton_change\x18\x0c \x01(\x0b\x32*.controller_manager_mock.ButtonChangeEventH\x00\x12>\n\nconnection\x18\r \x01(\x0b\x32(.controller_manager_mock.ConnectionEventH\x00\x42\x07\n\x05\x65vent\"A\n\x0eLedChangeEvent\x12\t\n\x01r\x18\x01 \x01(\x05\x12\t\n\x01g\x18\x02 \x01(\x05\x12\t\n\x01\x62\x18\x03 \x01(\x05\x12\x0e\n\x06source\x18\x04 \x01(\t\"&\n\x11RumbleChangeEvent\x12\x11\n\tintensity\x18\x01 \x01(\x05\"4\n\x11\x42uttonChangeEvent\x12\x0e\n\x06\x62utton\x18\x01 \x01(\t\x12\x0f\n\x07pressed\x18\x02 \x01(\x08\"$\n\x0f\x43onnectionEvent\x12\x11\n\tconnected\x18\x01 \x01(\x08\"E\n\x14\x41\x64\x64\x43ontrollerRequest\x12\x0e\n\x06serial\x18\x01 \x01(\t\x12\x10\n\x08reserved\x18\x02 \x01(\x08\x12\x0b\n\x03tag\x18\x03 \x01(\t\"G\n\x15\x41\x64\x64\x43ontrollerResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\r\n\x05\x65rror\x18\x02 \x01(\t\x12\x0e\n\x06serial\x18\x03 \x01(\t\")\n\x17RemoveControllerRequest\x12\x0e\n\x06serial\x18\x01 \x01(\t\":\n\x18RemoveControllerResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\r\n\x05\x65rror\x18\x02 \x01(\t\"E\n\x15\x41\x64\x64\x43ontrollersRequest\x12\r\n\x05\x63ount\x18\x01 \x01(\x05\x12\x10\n\x08reserved\x18\x02 \x01(\x08\x12\x0b\n\x03tag\x18\x03 \x01(\t\"I\n\x16\x41\x64\x64\x43ontrollersResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\r\n\x05\x65rror\x18\x02 \x01(\t\x12\x0f\n\x07serials\x18\x03 \x03(\t2\x83\n\n\x15MockControllerService\x12g\n\x10SimulateMovement\x12(.controller_manager_mock.MovementRequest\x1a).controller_manager_mock.MovementResponse\x12^\n\rSimulateDeath\x12%.controller_manager_mock.DeathRequest\x1a&.controller_manager_mock.DeathResponse\x12\x61\n\x0eSimulateButton\x12&.controller_manager_mock.ButtonRequest\x1a\'.controller_manager_mock.ButtonResponse\x12Y\n\x08SetColor\x12%.controller_manager_mock.ColorRequest\x1a&.controller_manager_mock.ColorResponse\x12`\n\x0fResetController\x12%.controller_manager_mock.ResetRequest\x1a&.controller_manager_mock.ResetResponse\x12\x62\n\x13ListMockControllers\x12$.controller_manager_mock.ListRequest\x1a%.controller_manager_mock.ListResponse\x12k\n\x0eSetAutoGameEnd\x12+.controller_manager_mock.AutoGameEndRequest\x1a,.controller_manager_mock.AutoGameEndResponse\x12_\n\x08GetColor\x12(.controller_manager_mock.GetColorRequest\x1a).controller_manager_mock.GetColorResponse\x12s\n\x13StreamObservability\x12-.controller_manager_mock.ObservabilityRequest\x1a+.controller_manager_mock.ObservabilityEvent0\x01\x12n\n\rAddController\x12-.controller_manager_mock.AddControllerRequest\x1a..controller_manager_mock.AddControllerResponse\x12w\n\x10RemoveController\x12\x30.controller_manager_mock.RemoveControllerRequest\x1a\x31.controller_manager_mock.RemoveControllerResponse\x12q\n\x0e\x41\x64\x64\x43ontrollers\x12..controller_manager_mock.AddControllersRequest\x1a/.controller_manager_mock.AddControllersResponseBAZ?github.com/joustmania/connect-proxy/gen/controller_manager_mockb\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -56,40 +56,42 @@ if not _descriptor._USE_C_DESCRIPTORS:
   _globals['_RESETRESPONSE']._serialized_end=700
   _globals['_LISTREQUEST']._serialized_start=702
   _globals['_LISTREQUEST']._serialized_end=715
-  _globals['_LISTRESPONSE']._serialized_start=717
-  _globals['_LISTRESPONSE']._serialized_end=763
-  _globals['_AUTOGAMEENDREQUEST']._serialized_start=765
-  _globals['_AUTOGAMEENDREQUEST']._serialized_end=828
-  _globals['_AUTOGAMEENDRESPONSE']._serialized_start=830
-  _globals['_AUTOGAMEENDRESPONSE']._serialized_end=883
-  _globals['_GETCOLORREQUEST']._serialized_start=885
-  _globals['_GETCOLORREQUEST']._serialized_end=918
-  _globals['_GETCOLORRESPONSE']._serialized_start=920
-  _globals['_GETCOLORRESPONSE']._serialized_end=1003
-  _globals['_OBSERVABILITYREQUEST']._serialized_start=1005
-  _globals['_OBSERVABILITYREQUEST']._serialized_end=1027
-  _globals['_OBSERVABILITYEVENT']._serialized_start=1030
-  _globals['_OBSERVABILITYEVENT']._serialized_end=1362
-  _globals['_LEDCHANGEEVENT']._serialized_start=1364
-  _globals['_LEDCHANGEEVENT']._serialized_end=1429
-  _globals['_RUMBLECHANGEEVENT']._serialized_start=1431
-  _globals['_RUMBLECHANGEEVENT']._serialized_end=1469
-  _globals['_BUTTONCHANGEEVENT']._serialized_start=1471
-  _globals['_BUTTONCHANGEEVENT']._serialized_end=1523
-  _globals['_CONNECTIONEVENT']._serialized_start=1525
-  _globals['_CONNECTIONEVENT']._serialized_end=1561
-  _globals['_ADDCONTROLLERREQUEST']._serialized_start=1563
-  _globals['_ADDCONTROLLERREQUEST']._serialized_end=1601
-  _globals['_ADDCONTROLLERRESPONSE']._serialized_start=1603
-  _globals['_ADDCONTROLLERRESPONSE']._serialized_end=1674
-  _globals['_REMOVECONTROLLERREQUEST']._serialized_start=1676
-  _globals['_REMOVECONTROLLERREQUEST']._serialized_end=1717
-  _globals['_REMOVECONTROLLERRESPONSE']._serialized_start=1719
-  _globals['_REMOVECONTROLLERRESPONSE']._serialized_end=1777
-  _globals['_ADDCONTROLLERSREQUEST']._serialized_start=1779
-  _globals['_ADDCONTROLLERSREQUEST']._serialized_end=1817
-  _globals['_ADDCONTROLLERSRESPONSE']._serialized_start=1819
-  _globals['_ADDCONTROLLERSRESPONSE']._serialized_end=1892
-  _globals['_MOCKCONTROLLERSERVICE']._serialized_start=1895
-  _globals['_MOCKCONTROLLERSERVICE']._serialized_end=3178
+  _globals['_MOCKCONTROLLERINFO']._serialized_start=717
+  _globals['_MOCKCONTROLLERINFO']._serialized_end=784
+  _globals['_LISTRESPONSE']._serialized_start=786
+  _globals['_LISTRESPONSE']._serialized_end=898
+  _globals['_AUTOGAMEENDREQUEST']._serialized_start=900
+  _globals['_AUTOGAMEENDREQUEST']._serialized_end=963
+  _globals['_AUTOGAMEENDRESPONSE']._serialized_start=965
+  _globals['_AUTOGAMEENDRESPONSE']._serialized_end=1018
+  _globals['_GETCOLORREQUEST']._serialized_start=1020
+  _globals['_GETCOLORREQUEST']._serialized_end=1053
+  _globals['_GETCOLORRESPONSE']._serialized_start=1055
+  _globals['_GETCOLORRESPONSE']._serialized_end=1138
+  _globals['_OBSERVABILITYREQUEST']._serialized_start=1140
+  _globals['_OBSERVABILITYREQUEST']._serialized_end=1162
+  _globals['_OBSERVABILITYEVENT']._serialized_start=1165
+  _globals['_OBSERVABILITYEVENT']._serialized_end=1497
+  _globals['_LEDCHANGEEVENT']._serialized_start=1499
+  _globals['_LEDCHANGEEVENT']._serialized_end=1564
+  _globals['_RUMBLECHANGEEVENT']._serialized_start=1566
+  _globals['_RUMBLECHANGEEVENT']._serialized_end=1604
+  _globals['_BUTTONCHANGEEVENT']._serialized_start=1606
+  _globals['_BUTTONCHANGEEVENT']._serialized_end=1658
+  _globals['_CONNECTIONEVENT']._serialized_start=1660
+  _globals['_CONNECTIONEVENT']._serialized_end=1696
+  _globals['_ADDCONTROLLERREQUEST']._serialized_start=1698
+  _globals['_ADDCONTROLLERREQUEST']._serialized_end=1767
+  _globals['_ADDCONTROLLERRESPONSE']._serialized_start=1769
+  _globals['_ADDCONTROLLERRESPONSE']._serialized_end=1840
+  _globals['_REMOVECONTROLLERREQUEST']._serialized_start=1842
+  _globals['_REMOVECONTROLLERREQUEST']._serialized_end=1883
+  _globals['_REMOVECONTROLLERRESPONSE']._serialized_start=1885
+  _globals['_REMOVECONTROLLERRESPONSE']._serialized_end=1943
+  _globals['_ADDCONTROLLERSREQUEST']._serialized_start=1945
+  _globals['_ADDCONTROLLERSREQUEST']._serialized_end=2014
+  _globals['_ADDCONTROLLERSRESPONSE']._serialized_start=2016
+  _globals['_ADDCONTROLLERSRESPONSE']._serialized_end=2089
+  _globals['_MOCKCONTROLLERSERVICE']._serialized_start=2092
+  _globals['_MOCKCONTROLLERSERVICE']._serialized_end=3375
 # @@protoc_insertion_point(module_scope)

--- a/services/controller_manager/discovery_loop.py
+++ b/services/controller_manager/discovery_loop.py
@@ -48,6 +48,16 @@ logger = logging.getLogger(__name__)
 # Lazy telemetry initialization - defers OTLP setup until first span
 tracer = get_tracer(__name__)
 
+
+def visible_serials(tracked_controllers: dict[str, dict]) -> list[str]:
+    """Return serials that button-stream consumers (the menu) may learn about.
+
+    Reserved controllers (#777) are excluded — they are never announced via
+    connect/disconnect events nor included in the connected_serials roster.
+    """
+    return [serial for serial, info in tracked_controllers.items() if not info.get(ControllerInfoKey.RESERVED, False)]
+
+
 # Button keys checked every poll cycle — tuple to avoid per-call list allocation
 _BUTTON_KEYS = (
     ButtonKey.MOVE,
@@ -337,10 +347,12 @@ class DiscoveryLoop:
                 logger.info(f"Controller {serial} disconnected - cleaning up server tracking")
                 # Invalidate cached serial list
                 self._cached_serials = None
-                # Capture name before removing from tracked_controllers
+                # Capture name + reservation before removing from tracked_controllers
                 name = ""
+                reserved = False
                 if serial in self.tracked_controllers:
                     name = self.tracked_controllers[serial].get(ControllerInfoKey.NAME, "")
+                    reserved = self.tracked_controllers[serial].get(ControllerInfoKey.RESERVED, False)
                     del self.tracked_controllers[serial]
                 if serial in self.controller_states:
                     del self.controller_states[serial]
@@ -353,13 +365,15 @@ class DiscoveryLoop:
                 self._accel_gauges.pop(serial, None)
                 self._poll_drops.pop(serial, None)
                 self._poll_errors.pop(serial, None)
-                # Publish disconnect event to button event stream subscribers
-                self.button_detector.publish_connection_event(
-                    serial,
-                    is_connect=False,
-                    name=name,
-                    connected_serials=list(self.tracked_controllers.keys()),
-                )
+                # Publish disconnect event to button event stream subscribers —
+                # but never announce reserved controllers to the menu (#777).
+                if not reserved:
+                    self.button_detector.publish_connection_event(
+                        serial,
+                        is_connect=False,
+                        name=name,
+                        connected_serials=visible_serials(self.tracked_controllers),
+                    )
                 # Queue disconnect for gameplay stream subscribers (#580)
                 self._gameplay_disconnects.append(serial)
                 metrics.controller_disconnect_total.labels(serial=serial).inc()
@@ -382,17 +396,19 @@ class DiscoveryLoop:
                             spawn_span.set_attribute(SpanAttr.CONTROLLER_SERIAL, serial)
                             await self._spawn_controller_process(serial)
 
-                        # Publish connect event to button event stream subscribers
+                        # Publish connect event to button event stream subscribers —
+                        # but never announce reserved controllers to the menu (#777).
                         info = self.tracked_controllers.get(serial, {})
                         battery = info.get(ControllerInfoKey.BATTERY, 0)
                         name = info.get(ControllerInfoKey.NAME, "")
-                        self.button_detector.publish_connection_event(
-                            serial,
-                            is_connect=True,
-                            battery=battery,
-                            name=name,
-                            connected_serials=list(self.tracked_controllers.keys()),
-                        )
+                        if not info.get(ControllerInfoKey.RESERVED, False):
+                            self.button_detector.publish_connection_event(
+                                serial,
+                                is_connect=True,
+                                battery=battery,
+                                name=name,
+                                connected_serials=visible_serials(self.tracked_controllers),
+                            )
 
                         # Restore base color if we had one before (reconnection case)
                         if serial in self.base_colors:
@@ -636,6 +652,18 @@ class DiscoveryLoop:
             if hasattr(self.backend, "get_adapter_type"):
                 adapter_type = self.backend.get_adapter_type(serial)
 
+            # Resolve reservation metadata if backend supports it. Reserved
+            # controllers are hidden from button-stream consumers (the menu)
+            # but stay fully usable via gameplay-data streams and explicit-serial
+            # LED/feedback commands (#777).
+            reserved = False
+            tag = ""
+            if hasattr(self.backend, "get_controller_metadata"):
+                metadata = self.backend.get_controller_metadata(serial)
+                if metadata:
+                    reserved = metadata.get(ControllerInfoKey.RESERVED, False)
+                    tag = metadata.get(ControllerInfoKey.TAG, "")
+
             # Track controller
             self.tracked_controllers[serial] = {
                 ControllerInfoKey.SERIAL: serial,
@@ -644,6 +672,8 @@ class DiscoveryLoop:
                 ControllerInfoKey.CONNECTED_AT: time.time(),
                 ControllerInfoKey.NAME: name,
                 ControllerInfoKey.ADAPTER: adapter_type,
+                ControllerInfoKey.RESERVED: reserved,
+                ControllerInfoKey.TAG: tag,
             }
 
             # Store initial state

--- a/services/controller_manager/mock_control_service.py
+++ b/services/controller_manager/mock_control_service.py
@@ -172,10 +172,23 @@ class MockControllerService(controller_manager_mock_pb2_grpc.MockControllerServi
             return controller_manager_mock_pb2.ResetResponse(success=False, error=str(e))
 
     def ListMockControllers(self, _request, _context):
-        """List all mock controller serials."""
+        """List all mock controllers with reserved/tag metadata.
+
+        The repeated ``controllers`` field lets tests/agents enumerate their
+        reserved controllers and sweep orphans by tag. The legacy ``serials``
+        field is kept for backward compatibility.
+        """
         try:
             serials = list(self.backend.controllers.keys())
-            return controller_manager_mock_pb2.ListResponse(serials=serials, count=len(serials))
+            infos = [
+                controller_manager_mock_pb2.MockControllerInfo(
+                    serial=serial,
+                    reserved=state.get("reserved", False),
+                    tag=state.get("tag", ""),
+                )
+                for serial, state in self.backend.controllers.items()
+            ]
+            return controller_manager_mock_pb2.ListResponse(serials=serials, count=len(serials), controllers=infos)
 
         except Exception as e:
             logger.error(f"ListMockControllers error: {e}")
@@ -263,11 +276,15 @@ class MockControllerService(controller_manager_mock_pb2_grpc.MockControllerServi
             return controller_manager_mock_pb2.GetColorResponse(success=False, error=str(e))
 
     def AddController(self, request, _context):
-        """Add a single mock controller dynamically."""
+        """Add a single mock controller dynamically.
+
+        When request.reserved is set, the controller is hidden from
+        button-stream consumers (the menu); request.tag identifies the owner.
+        """
         try:
             serial = request.serial if request.serial else None
-            added_serial = self.backend.add_controller(serial)
-            logger.info(f"Mock: Added controller {added_serial}")
+            added_serial = self.backend.add_controller(serial, reserved=request.reserved, tag=request.tag)
+            logger.info(f"Mock: Added controller {added_serial} (reserved={request.reserved}, tag={request.tag!r})")
             return controller_manager_mock_pb2.AddControllerResponse(success=True, serial=added_serial)
         except Exception as e:
             logger.error(f"AddController error: {e}")
@@ -289,13 +306,18 @@ class MockControllerService(controller_manager_mock_pb2_grpc.MockControllerServi
             return controller_manager_mock_pb2.RemoveControllerResponse(success=False, error=str(e))
 
     def AddControllers(self, request, _context):
-        """Add multiple mock controllers at once."""
+        """Add multiple mock controllers at once.
+
+        request.reserved/request.tag apply to every added controller.
+        """
         try:
             serials = []
             for _ in range(request.count):
-                serial = self.backend.add_controller()
+                serial = self.backend.add_controller(reserved=request.reserved, tag=request.tag)
                 serials.append(serial)
-            logger.info(f"Mock: Added {request.count} controllers: {serials}")
+            logger.info(
+                f"Mock: Added {request.count} controllers: {serials} (reserved={request.reserved}, tag={request.tag!r})"
+            )
             return controller_manager_mock_pb2.AddControllersResponse(success=True, serials=serials)
         except Exception as e:
             logger.error(f"AddControllers error: {e}")

--- a/services/controller_manager/multiplexer/mock_adapter.py
+++ b/services/controller_manager/multiplexer/mock_adapter.py
@@ -20,10 +20,20 @@ from services.controller_manager.multiplexer.adapter import ControllerIOAdapter
 logger = logging.getLogger(__name__)
 
 
-def _create_controller_state(serial: str) -> dict:
-    """Create a new controller state dict with default values."""
+def _create_controller_state(serial: str, reserved: bool = False, tag: str = "") -> dict:
+    """Create a new controller state dict with default values.
+
+    Args:
+        serial: Controller serial number.
+        reserved: When True, the controller is hidden from button-stream
+            consumers (the menu). It stays fully usable via gameplay-data
+            streams and explicit-serial LED/feedback commands.
+        tag: Identifies the owning agent/game (orphan cleanup, debugging).
+    """
     return {
         StateKey.SERIAL: serial,
+        "reserved": reserved,
+        "tag": tag,
         StateKey.BATTERY: 100,
         StateKey.TRIGGER: 0,
         ButtonKey.MOVE: False,
@@ -194,16 +204,33 @@ class MockAdapter(ControllerIOAdapter):
 
     # -- Extra methods for MockControllerService --
 
-    def add_controller(self, serial: str | None = None) -> str:
-        """Add a new mock controller dynamically."""
+    def add_controller(self, serial: str | None = None, reserved: bool = False, tag: str = "") -> str:
+        """Add a new mock controller dynamically.
+
+        Args:
+            serial: Controller serial; auto-generated if None.
+            reserved: When True, hide the controller from button-stream
+                consumers (the menu). See _create_controller_state.
+            tag: Identifies the owning agent/game (orphan cleanup, debugging).
+        """
         if serial is None:
             serial = f"MOCK{len(self.controllers):04d}"
         if serial in self.controllers:
             logger.warning(f"Mock: Controller {serial} already exists")
             return serial
-        self.controllers[serial] = _create_controller_state(serial)
-        logger.info(f"Mock: Added controller {serial}")
+        self.controllers[serial] = _create_controller_state(serial, reserved=reserved, tag=tag)
+        logger.info(f"Mock: Added controller {serial} (reserved={reserved}, tag={tag!r})")
         return serial
+
+    def get_metadata(self, serial: str) -> dict | None:
+        """Return reserved/tag metadata for a controller, or None if unknown."""
+        controller = self.controllers.get(serial)
+        if not controller:
+            return None
+        return {
+            "reserved": controller.get("reserved", False),
+            "tag": controller.get("tag", ""),
+        }
 
     def remove_controller(self, serial: str) -> bool:
         """Remove a mock controller."""

--- a/services/controller_manager/multiplexer/multiplexer_backend.py
+++ b/services/controller_manager/multiplexer/multiplexer_backend.py
@@ -227,6 +227,17 @@ class MultiplexerBackend(ControllerBackend):
         adapter = self._serial_to_adapter.get(serial)
         return adapter.adapter_type if adapter else "unknown"
 
+    def get_controller_metadata(self, serial: str) -> dict | None:
+        """Return adapter-supplied metadata (e.g. reserved/tag) for a serial.
+
+        Delegates to the owning adapter's get_metadata() if it provides one
+        (the MockAdapter does). Returns None when unavailable.
+        """
+        adapter = self._serial_to_adapter.get(serial)
+        if adapter is not None and hasattr(adapter, "get_metadata"):
+            return adapter.get_metadata(serial)
+        return None
+
     def _cleanup_stale_state(self, seen: dict[str, ControllerIOAdapter]) -> None:
         """Remove centralized state for controllers no longer present."""
         stale = set(self._led_colors.keys()) - set(seen.keys())

--- a/services/controller_manager/servicer.py
+++ b/services/controller_manager/servicer.py
@@ -28,7 +28,7 @@ from services.controller_manager import metrics
 from services.controller_manager.backend_factory import create_backend
 from services.controller_manager.button_detector import ButtonDetector
 from services.controller_manager.discovery import PeriodicRescanTimer
-from services.controller_manager.discovery_loop import DiscoveryLoop
+from services.controller_manager.discovery_loop import DiscoveryLoop, visible_serials
 from services.controller_manager.effects_base import ControllerEffectsBase
 from services.controller_manager.event_publisher import EventPublisher as EventPublisherHelper
 from services.controller_manager.feedback_manager import FeedbackManager
@@ -159,8 +159,13 @@ class ControllerManagerServicer(controller_manager_pb2_grpc.ControllerManagerSer
         """
         # Snapshot to avoid RuntimeError if dict changes at await points
         tracked_snapshot = dict(self.tracked_controllers)
-        all_serials = list(tracked_snapshot.keys())
+        # Reserved controllers (#777) are never announced to button-stream
+        # consumers (the menu): skip their connect events and exclude them
+        # from the connected_serials roster.
+        all_serials = visible_serials(tracked_snapshot)
         for serial, info in tracked_snapshot.items():
+            if info.get(ControllerInfoKey.RESERVED, False):
+                continue
             battery = info.get(ControllerInfoKey.BATTERY, 0)
             name = info.get(ControllerInfoKey.NAME, "")
             connect_event = controller_manager_pb2.ButtonEvent(
@@ -177,7 +182,7 @@ class ControllerManagerServicer(controller_manager_pb2_grpc.ControllerManagerSer
             except asyncio.QueueFull:
                 logger.warning(f"[{subscriber_id}] Queue full, skipping initial event for {serial}")
 
-        logger.info(f"[{subscriber_id}] Sent initial connection events for {len(self.tracked_controllers)} controllers")
+        logger.info(f"[{subscriber_id}] Sent initial connection events for {len(all_serials)} controllers")
 
     async def _process_base_color_command(self, cmd, subscriber_id: str, stream_label: str) -> None:
         """Process a base_color command from either stream type.

--- a/services/controller_manager/tests/test_reserved_controllers.py
+++ b/services/controller_manager/tests/test_reserved_controllers.py
@@ -1,0 +1,343 @@
+"""
+Unit tests for reserved mock controllers (#777).
+
+Reserved controllers are hidden from button-stream consumers (the menu) at
+both leak paths:
+  1. connect/disconnect ButtonEvents (initial snapshot AND live discovery path)
+  2. the connected_serials roster inside every ButtonEvent
+
+They stay fully usable via gameplay-data streams (per-serial filter) and
+explicit-serial LED/feedback commands — suppression is ONLY about
+button-stream announcements.
+"""
+
+import asyncio
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# Setup paths for imports
+test_dir = Path(__file__).parent
+service_dir = test_dir.parent
+project_root = service_dir.parent.parent
+sys.path.insert(0, str(project_root))
+
+from lib.controller_constants import ControllerInfoKey
+from proto import controller_manager_mock_pb2, controller_manager_pb2
+from services.controller_manager.discovery_loop import visible_serials
+from services.controller_manager.mock_control_service import MockControllerService
+from services.controller_manager.multiplexer.mock_adapter import MockAdapter
+from services.controller_manager.multiplexer.multiplexer_backend import MultiplexerBackend
+
+
+def _make_service() -> tuple[MockControllerService, MockAdapter]:
+    adapter = MockAdapter(num_controllers=0)
+    adapter.discover()
+    return MockControllerService(adapter), adapter
+
+
+# --------------------------------------------------------------------------
+# Mock adapter + control service: reserved/tag storage and plumbing
+# --------------------------------------------------------------------------
+
+
+class TestMockAdapterReservation:
+    def test_add_controller_defaults_unreserved(self):
+        """Backward compat: add_controller without new args is unreserved."""
+        adapter = MockAdapter(num_controllers=0)
+        serial = adapter.add_controller("C1")
+        meta = adapter.get_metadata(serial)
+        assert meta == {"reserved": False, "tag": ""}
+
+    def test_add_controller_reserved_with_tag(self):
+        adapter = MockAdapter(num_controllers=0)
+        serial = adapter.add_controller("C1", reserved=True, tag="agent-7")
+        meta = adapter.get_metadata(serial)
+        assert meta == {"reserved": True, "tag": "agent-7"}
+
+    def test_get_metadata_unknown_returns_none(self):
+        adapter = MockAdapter(num_controllers=0)
+        assert adapter.get_metadata("NOPE") is None
+
+
+class TestAddControllerRpcReservation:
+    def test_add_controller_reserved_flag_plumbed(self):
+        service, adapter = _make_service()
+        req = controller_manager_mock_pb2.AddControllerRequest(serial="R1", reserved=True, tag="shadow")
+        resp = service.AddController(req, None)
+        assert resp.success
+        assert adapter.get_metadata("R1") == {"reserved": True, "tag": "shadow"}
+
+    def test_add_controller_backward_compat(self):
+        """AddController without reserved/tag behaves exactly as before."""
+        service, adapter = _make_service()
+        req = controller_manager_mock_pb2.AddControllerRequest(serial="U1")
+        resp = service.AddController(req, None)
+        assert resp.success
+        assert resp.serial == "U1"
+        assert adapter.get_metadata("U1") == {"reserved": False, "tag": ""}
+
+    def test_add_controllers_reserved_applied_to_all(self):
+        service, adapter = _make_service()
+        req = controller_manager_mock_pb2.AddControllersRequest(count=3, reserved=True, tag="batch")
+        resp = service.AddControllers(req, None)
+        assert resp.success
+        assert len(resp.serials) == 3
+        for serial in resp.serials:
+            assert adapter.get_metadata(serial) == {"reserved": True, "tag": "batch"}
+
+    def test_add_controllers_backward_compat(self):
+        service, adapter = _make_service()
+        req = controller_manager_mock_pb2.AddControllersRequest(count=2)
+        resp = service.AddControllers(req, None)
+        assert resp.success
+        for serial in resp.serials:
+            assert adapter.get_metadata(serial) == {"reserved": False, "tag": ""}
+
+
+class TestListMockControllers:
+    def test_reports_reserved_and_tag(self):
+        service, _ = _make_service()
+        service.AddController(controller_manager_mock_pb2.AddControllerRequest(serial="U1"), None)
+        service.AddController(
+            controller_manager_mock_pb2.AddControllerRequest(serial="R1", reserved=True, tag="agent-1"), None
+        )
+
+        resp = service.ListMockControllers(controller_manager_mock_pb2.ListRequest(), None)
+
+        # Legacy fields preserved
+        assert set(resp.serials) == {"U1", "R1"}
+        assert resp.count == 2
+
+        by_serial = {info.serial: info for info in resp.controllers}
+        assert by_serial["U1"].reserved is False
+        assert by_serial["U1"].tag == ""
+        assert by_serial["R1"].reserved is True
+        assert by_serial["R1"].tag == "agent-1"
+
+
+# --------------------------------------------------------------------------
+# visible_serials helper
+# --------------------------------------------------------------------------
+
+
+class TestVisibleSerials:
+    def test_excludes_reserved(self):
+        tracked = {
+            "U1": {ControllerInfoKey.RESERVED: False},
+            "R1": {ControllerInfoKey.RESERVED: True},
+            "U2": {},  # missing key defaults to not-reserved
+        }
+        assert set(visible_serials(tracked)) == {"U1", "U2"}
+
+    def test_empty(self):
+        assert visible_serials({}) == []
+
+
+# --------------------------------------------------------------------------
+# Reserved controllers stay usable: gameplay stream filter + LED by serial
+# --------------------------------------------------------------------------
+
+
+class TestReservedRemainsUsable:
+    @pytest.mark.asyncio
+    async def test_reserved_motion_streams_with_filter(self):
+        """A reserved controller still polls motion via the backend (used by
+        StreamGameplayData when included in the per-serial filter)."""
+        adapter = MockAdapter(num_controllers=0)
+        backend = MultiplexerBackend([adapter])
+        await backend.initialize()
+        adapter.add_controller("R1", reserved=True, tag="shadow")
+        # Make the new controller routable
+        backend.get_connected_controllers(force_rescan=True)
+
+        state = await backend.get_controller_state("R1")
+        assert state is not None
+        assert state["serial"] == "R1"
+        # Metadata still flags it reserved
+        assert backend.get_controller_metadata("R1") == {"reserved": True, "tag": "shadow"}
+
+    @pytest.mark.asyncio
+    async def test_reserved_led_set_by_serial(self):
+        """Explicit-serial LED write works on a reserved controller and
+        GetColor reflects it."""
+        service, adapter = _make_service()
+        adapter.add_controller("R1", reserved=True, tag="shadow")
+
+        backend = MultiplexerBackend([adapter])
+        await backend.initialize()
+        backend.get_connected_controllers(force_rescan=True)
+
+        ok = await backend.set_led_color("R1", 10, 20, 30)
+        assert ok
+
+        # Mock GetColor reflects the write
+        resp = service.GetColor(controller_manager_mock_pb2.GetColorRequest(serial="R1"), None)
+        assert resp.success
+        assert (resp.r, resp.g, resp.b) == (10, 20, 30)
+
+
+# --------------------------------------------------------------------------
+# Servicer suppression: initial connection events + roster
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture
+def servicer():
+    """Create a servicer with a mocked backend and discovery loop."""
+    from services.controller_manager.tests.test_servicer import MockBackend
+
+    with (
+        patch("services.controller_manager.servicer.create_backend") as mock_create_backend,
+        patch("services.controller_manager.servicer.DiscoveryLoop") as mock_discovery_loop,
+    ):
+        mock_create_backend.return_value = MockBackend()
+        mock_loop = MagicMock()
+        mock_loop.start = MagicMock()
+        mock_loop.stop = MagicMock()
+        mock_loop.wait_stopped = AsyncMock()
+        mock_discovery_loop.return_value = mock_loop
+
+        from services.controller_manager.servicer import ControllerManagerServicer
+
+        yield ControllerManagerServicer()
+
+
+class TestInitialConnectionSuppression:
+    @pytest.mark.asyncio
+    async def test_only_unreserved_announced_and_in_roster(self, servicer):
+        """2 reserved + 2 unreserved: subscriber gets connect events for only
+        the 2 unreserved, and every roster contains only unreserved serials."""
+        servicer.tracked_controllers["U1"] = {
+            ControllerInfoKey.BATTERY: 50,
+            ControllerInfoKey.NAME: "P1",
+            ControllerInfoKey.RESERVED: False,
+        }
+        servicer.tracked_controllers["U2"] = {
+            ControllerInfoKey.BATTERY: 60,
+            ControllerInfoKey.NAME: "P2",
+            ControllerInfoKey.RESERVED: False,
+        }
+        servicer.tracked_controllers["R1"] = {
+            ControllerInfoKey.BATTERY: 70,
+            ControllerInfoKey.NAME: "S1",
+            ControllerInfoKey.RESERVED: True,
+        }
+        servicer.tracked_controllers["R2"] = {
+            ControllerInfoKey.BATTERY: 80,
+            ControllerInfoKey.NAME: "S2",
+            ControllerInfoKey.RESERVED: True,
+        }
+
+        queue: asyncio.Queue = asyncio.Queue(maxsize=100)
+        await servicer._send_initial_connection_events("sub_1", queue)
+
+        events = []
+        while not queue.empty():
+            events.append(queue.get_nowait())
+
+        announced = {e.serial for e in events}
+        assert announced == {"U1", "U2"}
+
+        for event in events:
+            assert event.event_type == controller_manager_pb2.EVENT_CONNECT
+            assert set(event.connected_serials) == {"U1", "U2"}
+
+    @pytest.mark.asyncio
+    async def test_all_reserved_announces_nothing(self, servicer):
+        servicer.tracked_controllers["R1"] = {ControllerInfoKey.RESERVED: True}
+        servicer.tracked_controllers["R2"] = {ControllerInfoKey.RESERVED: True}
+
+        queue: asyncio.Queue = asyncio.Queue(maxsize=100)
+        await servicer._send_initial_connection_events("sub_1", queue)
+
+        assert queue.qsize() == 0
+
+
+# --------------------------------------------------------------------------
+# Discovery loop live connect/disconnect suppression
+# --------------------------------------------------------------------------
+
+
+def _make_discovery_loop(tracked, backend, button_detector):
+    """Build a DiscoveryLoop with minimal collaborators for connect/disconnect
+    publish-path testing against the real _check_for_new_controllers."""
+    from services.controller_manager.discovery_loop import DiscoveryLoop
+
+    loop = DiscoveryLoop(
+        backend=backend,
+        tracked_controllers=tracked,
+        controller_states={},
+        button_detector=button_detector,
+        state_cache_manager=MagicMock(),
+        feedback_manager=MagicMock(),
+        monitoring=MagicMock(),
+        rescan_timer=MagicMock(should_force_rescan=MagicMock(return_value=False)),
+        paired_serials=[],
+        base_colors={},
+        event_publisher=MagicMock(),
+    )
+    loop.backend_initialized = True
+    return loop
+
+
+class TestLiveDisconnectSuppression:
+    @pytest.mark.asyncio
+    async def test_reserved_disconnect_not_published(self):
+        """When a reserved controller disconnects, no disconnect ButtonEvent is
+        published; the unreserved one is, with a reserved-free roster."""
+        button_detector = MagicMock()
+        tracked = {
+            "U1": {ControllerInfoKey.NAME: "P1", ControllerInfoKey.RESERVED: False},
+            "U2": {ControllerInfoKey.NAME: "P2", ControllerInfoKey.RESERVED: False},
+            "R1": {ControllerInfoKey.NAME: "S1", ControllerInfoKey.RESERVED: True},
+        }
+        # Backend reports U2 still connected; U1 and R1 dropped.
+        backend = MagicMock()
+        backend.get_connected_controllers = MagicMock(return_value=["U2"])
+        loop = _make_discovery_loop(tracked, backend, button_detector)
+
+        await loop._check_for_new_controllers()
+
+        # Only the unreserved U1 disconnect was published (R1 suppressed).
+        assert button_detector.publish_connection_event.call_count == 1
+        call = button_detector.publish_connection_event.call_args
+        assert call.args[0] == "U1"
+        assert call.kwargs["is_connect"] is False
+        assert "R1" not in call.kwargs["connected_serials"]
+        assert set(call.kwargs["connected_serials"]) == {"U2"}
+
+    @pytest.mark.asyncio
+    async def test_reserved_connect_not_published(self):
+        """When a reserved controller appears, no connect ButtonEvent is
+        published; an unreserved newcomer is."""
+        button_detector = MagicMock()
+        tracked: dict = {}
+        backend = MagicMock()
+        backend.get_connected_controllers = MagicMock(return_value=["U1", "R1"])
+        # Adapter type + metadata used by _spawn_controller_process
+        backend.get_adapter_type = MagicMock(return_value="mock")
+        backend.get_controller_metadata = MagicMock(
+            side_effect=lambda s: {
+                "reserved": s == "R1",
+                "tag": "shadow" if s == "R1" else "",
+            }
+        )
+        backend.get_controller_state = AsyncMock(return_value={"battery": 100})
+
+        loop = _make_discovery_loop(tracked, backend, button_detector)
+        loop.feedback_manager.set_controller_color = AsyncMock()
+
+        await loop._check_for_new_controllers()
+
+        # Both tracked, but only U1 announced.
+        assert set(loop.tracked_controllers.keys()) == {"U1", "R1"}
+        assert loop.tracked_controllers["R1"][ControllerInfoKey.RESERVED] is True
+        announced = {
+            c.args[0]
+            for c in button_detector.publish_connection_event.call_args_list
+            if c.kwargs.get("is_connect") is True
+        }
+        assert announced == {"U1"}


### PR DESCRIPTION
Part of #774 (shadow games), Phase 3. Lets an agent/test add mock controllers marked `reserved` that the menu never learns about, while keeping them fully usable via the gameplay-data stream and explicit-serial LED/feedback commands.

## Two leak paths closed

The menu learns about controllers exclusively via the button-event stream. Reserved controllers are now suppressed at both:

1. **Initial snapshot** (`servicer._send_initial_connection_events`): reserved controllers are skipped when emitting per-controller `EVENT_CONNECT` events, and excluded from the `connected_serials` roster.
2. **Live discovery connect/disconnect path** (`discovery_loop._check_for_new_controllers`): `EVENT_CONNECT` / `EVENT_DISCONNECT` ButtonEvents are suppressed for reserved controllers, and the `connected_serials` roster on every published ButtonEvent excludes reserved serials.

A shared `visible_serials()` helper computes the reserved-free roster used everywhere a `connected_serials` list is built.

## What reserved controllers can still do

Reserved controllers stay in `tracked_controllers` / `controller_states`, so:
- gameplay-data streaming works (when included in the stream's per-serial filter),
- explicit-serial LED / feedback commands work,
- the mock RPCs (`SimulateMovement`, `SetColor`, `GetColor`, etc.) work.

Suppression is **only** about button-stream announcements.

## Changes

- **proto** (`controller_manager_mock.proto`): `bool reserved` + `string tag` on `AddControllerRequest` and `AddControllersRequest`; new `MockControllerInfo` message and `repeated MockControllerInfo controllers` on `ListResponse` so tests/agents can enumerate reserved controllers and sweep orphans by `tag`. Backward compatible (defaults false/empty). Generated `_pb2.py` regenerated via the CI proto container.
- **mock_adapter.py**: stores `reserved`/`tag` per controller; `add_controller(serial, reserved, tag)`; new `get_metadata(serial)`.
- **multiplexer_backend.py**: `get_controller_metadata(serial)` delegating to the owning adapter.
- **discovery_loop.py**: `_spawn_controller_process` records `RESERVED`/`TAG` in `tracked_controllers`; connect/disconnect publish paths suppress reserved; `visible_serials()` helper.
- **mock_control_service.py**: plumbs `reserved`/`tag` from `AddController(s)`; reports them in `ListMockControllers`.
- **servicer.py**: initial-snapshot suppression + reserved-free roster.

## Tests

New `tests/test_reserved_controllers.py` (16 tests): both leak paths (initial + live), reserved motion still streams, LED-by-serial + GetColor on a reserved controller, `ListMockControllers` reserved/tag reporting, and backward-compat defaults.

- `cd services/controller_manager && uv run pytest`: **586 passed** (16 new).
- `make lint`: clean.
- `make ci-validate-protos`: generated code in sync.

Scope limited to controller_manager + the mock proto + generated files. No menu / game_coordinator / integration-test changes (those are #779).

🤖 Generated with [Claude Code](https://claude.com/claude-code)