### PR TITLE
feat: bluetooth health span and signal metrics (#732)

### DIFF
--- a/services/controller_manager/discovery_loop.py
+++ b/services/controller_manager/discovery_loop.py
@@ -170,6 +170,27 @@ class DiscoveryLoop:
         self._poll_drops: dict[str, int] = {}
         self._poll_errors: dict[str, int] = {}
 
+        # Bluetooth-health window accumulation (#732 M3). The window is the
+        # ~1s span-emission interval, decoupled from the 100Hz discovery cadence.
+        # The 100Hz path only increments cheap counters; gap/ratio/hz are derived
+        # once per window at emission time.
+        self._health_interval = 1.0  # seconds between health spans/metrics
+        # Emit gate uses monotonic (immune to wall-clock jumps); window/gap math
+        # uses wall-clock time.time() to match the poll loop's current_time.
+        self._last_health_emit = time.monotonic()
+        self._window_start = time.time()
+        # Per-serial counters reset every window.
+        self._hw_polls: dict[str, int] = {}  # polls attempted
+        self._hw_fresh: dict[str, int] = {}  # polls returning a genuinely-new frame
+        self._hw_drops: dict[str, int] = {}  # polls returning None
+        self._hw_max_gap_ms: dict[str, float] = {}  # max gap between fresh frames
+        self._hw_last_fresh_ts: dict[str, float] = {}  # monotonic ts of last fresh frame
+        # Identity of the last poll object per serial — distinguishes a stale
+        # replay (same object, e.g. UnstableAdapter throttle window) from a fresh
+        # frame. The poll dict carries no sequence/timestamp, so identity is the
+        # cheapest reliable freshness signal.
+        self._hw_last_obj_id: dict[str, int] = {}
+
         # Gameplay disconnect events: accumulated between stream frames, drained by servicer (#580)
         self._gameplay_disconnects: list[str] = []
 
@@ -270,6 +291,13 @@ class DiscoveryLoop:
                 # Update controller states from backend
                 await self._update_controller_states()
 
+                # Bluetooth health: emit a ~1Hz span + metrics from accumulated
+                # window counters. Decoupled from discovery cadence (#732 M3).
+                now_mono = time.monotonic()
+                if now_mono - self._last_health_emit >= self._health_interval:
+                    self._emit_bluetooth_health(time.time())
+                    self._last_health_emit = now_mono
+
                 # Check battery levels every 30 seconds (Phase 39 - Task 4, Phase 70)
                 # Note: Battery display/warnings moved to menu service (Phase 70)
                 if current_time - self.monitoring.last_battery_check >= 30.0:
@@ -365,6 +393,17 @@ class DiscoveryLoop:
                 self._accel_gauges.pop(serial, None)
                 self._poll_drops.pop(serial, None)
                 self._poll_errors.pop(serial, None)
+                # Bluetooth-health window counters
+                self._hw_polls.pop(serial, None)
+                self._hw_fresh.pop(serial, None)
+                self._hw_drops.pop(serial, None)
+                self._hw_max_gap_ms.pop(serial, None)
+                self._hw_last_fresh_ts.pop(serial, None)
+                self._hw_last_obj_id.pop(serial, None)
+                # Clear per-serial health metric labels so disconnected
+                # controllers don't linger in dashboards.
+                metrics.controller_bluetooth_dropped_events_ratio.remove(serial)
+                metrics.controller_bluetooth_movement_update_hz.remove(serial)
                 # Publish disconnect event to button event stream subscribers —
                 # but never announce reserved controllers to the menu (#777).
                 if not reserved:
@@ -498,17 +537,36 @@ class DiscoveryLoop:
                 if serial not in self.tracked_controllers:
                     continue
 
+                # Bluetooth-health: every processed serial counts as one attempt.
+                self._hw_polls[serial] = self._hw_polls.get(serial, 0) + 1
+
                 # Handle exceptions from individual controller reads
                 if isinstance(state, Exception):
                     logger.debug(f"Error updating state for {serial}: {state}")
                     self._poll_errors[serial] = self._poll_errors.get(serial, 0) + 1
                     metrics.controller_poll_errors_total.labels(serial=serial).inc()
+                    # An exception yields no fresh frame — count as a drop for health.
+                    self._hw_drops[serial] = self._hw_drops.get(serial, 0) + 1
                     continue
 
                 if not state:
                     self._poll_drops[serial] = self._poll_drops.get(serial, 0) + 1
                     metrics.controller_poll_drops_total.labels(serial=serial).inc()
+                    self._hw_drops[serial] = self._hw_drops.get(serial, 0) + 1
                     continue
+
+                # Truthy dict: fresh frame only if the poll returned a *different*
+                # object than last time. A stale replay (same object, e.g. an
+                # UnstableAdapter throttle window) is NOT a new movement update.
+                obj_id = id(state)
+                if self._hw_last_obj_id.get(serial) != obj_id:
+                    self._hw_last_obj_id[serial] = obj_id
+                    self._record_fresh_frame(serial, current_time)
+                else:
+                    # Stale replay: no new frame, but not a hardware drop either.
+                    # Counts against the update rate via _hw_polls without bumping
+                    # _hw_fresh, so movement_update_hz reflects the degradation.
+                    pass
 
                 # Update stored state
                 self.controller_states[serial] = state
@@ -582,6 +640,151 @@ class DiscoveryLoop:
         # Update last activity time if activity detected
         if activity_detected:
             self._last_activity_time[serial] = current_time
+
+    def _record_fresh_frame(self, serial: str, now: float) -> None:
+        """Record a genuinely-new frame for the bluetooth-health window.
+
+        Tracks the fresh-frame count and the max inter-event gap (ms) between
+        consecutive fresh frames. Cheap — runs on the 100Hz path. ``now`` is a
+        wall-clock timestamp (seconds); only deltas are used so the clock source
+        just needs to be monotone within a window.
+        """
+        self._hw_fresh[serial] = self._hw_fresh.get(serial, 0) + 1
+        last_ts = self._hw_last_fresh_ts.get(serial)
+        if last_ts is not None:
+            gap_ms = (now - last_ts) * 1000.0
+            if gap_ms > self._hw_max_gap_ms.get(serial, 0.0):
+                self._hw_max_gap_ms[serial] = gap_ms
+        self._hw_last_fresh_ts[serial] = now
+
+    def _compute_health_window(self, window_seconds: float) -> dict:
+        """Derive per-serial and window-aggregate health signals.
+
+        Called once per window at emission time. Returns a dict with:
+          * ``per_serial``: {serial: {update_hz, dropped_pct, max_gap_ms}}
+          * window aggregates: ``event_gap_ms`` (max), ``dropped_events_pct``
+            (total drops / total polls), ``movement_update_hz`` (min across
+            serials), ``active_controllers`` (count of serials polled).
+
+        ``window_seconds`` guards against a zero/negative interval (clamped to a
+        small positive value) so rate math never divides by zero.
+        """
+        duration = max(window_seconds, 1e-6)
+        per_serial: dict[str, dict] = {}
+        serials = list(self._hw_polls.keys())
+
+        total_events = 0  # event-bearing cycles: fresh + dropped
+        total_drops = 0
+        max_gap_ms = 0.0
+        min_hz: float | None = None
+
+        for serial in serials:
+            fresh = self._hw_fresh.get(serial, 0)
+            drops = self._hw_drops.get(serial, 0)
+            gap_ms = self._hw_max_gap_ms.get(serial, 0.0)
+
+            update_hz = fresh / duration
+            # Dropped-event ratio: drops as a fraction of event-bearing poll
+            # cycles (fresh frames + drops). Stale replays are excluded — they
+            # are the *absence* of an event, not a dropped event, so they must
+            # not dilute the denominator. This matches the UnstableAdapter
+            # design (every Nth *fresh* frame dropped) so the ratio reflects the
+            # genuine event-loss rate rather than washing out across 100Hz polls.
+            events = fresh + drops
+            dropped_pct = (drops / events) if events else 0.0
+
+            per_serial[serial] = {
+                "update_hz": update_hz,
+                "dropped_pct": dropped_pct,
+                "max_gap_ms": gap_ms,
+            }
+
+            total_events += events
+            total_drops += drops
+            if gap_ms > max_gap_ms:
+                max_gap_ms = gap_ms
+            if min_hz is None or update_hz < min_hz:
+                min_hz = update_hz
+
+        return {
+            "per_serial": per_serial,
+            "event_gap_ms": max_gap_ms,
+            "dropped_events_pct": (total_drops / total_events) if total_events else 0.0,
+            "movement_update_hz": min_hz if min_hz is not None else 0.0,
+            "active_controllers": len(serials),
+        }
+
+    def _reset_health_window(self, now: float) -> None:
+        """Clear per-serial window counters and start a new window at ``now``."""
+        self._hw_polls.clear()
+        self._hw_fresh.clear()
+        self._hw_drops.clear()
+        self._hw_max_gap_ms.clear()
+        # Keep _hw_last_fresh_ts / _hw_last_obj_id across windows so the first
+        # fresh frame of the next window measures its gap from the real previous
+        # frame, and stale replays spanning the boundary are still detected.
+        self._window_start = now
+
+    def _emit_bluetooth_health(self, now: float) -> None:
+        """Emit the ~1Hz controller.bluetooth_health span + health metrics.
+
+        Decoupled from discovery cadence via ``_last_health_emit``. Skips
+        emission entirely when no controllers were polled this window — an idle
+        lobby with no controllers produces no health heartbeat (the agent's
+        OBSERVE step treats absence-of-span as "nothing to perceive").
+        """
+        window_seconds = now - self._window_start
+        signals = self._compute_health_window(window_seconds)
+
+        # Skip-when-empty: no point spamming empty health spans with no controllers.
+        if signals["active_controllers"] == 0:
+            self._reset_health_window(now)
+            return
+
+        # Window-level rollout summary (target backend + cohort size).
+        target_backend = ""
+        rollout_count = 0
+        if hasattr(self.backend, "_rollout_router"):
+            try:
+                target_backend, rollout_count = self.backend._rollout_router.current_target()
+            except Exception:
+                logger.debug("Failed to read rollout summary for health span", exc_info=True)
+
+        # --- Span: periodic root span, like controller.discover ---------------
+        with tracer.start_as_current_span("controller.bluetooth_health") as span:
+            span.set_attribute("bluetooth.event_gap_ms", float(signals["event_gap_ms"]))
+            span.set_attribute("bluetooth.dropped_events_pct", float(signals["dropped_events_pct"]))
+            span.set_attribute("bluetooth.movement_update_hz", float(signals["movement_update_hz"]))
+            span.set_attribute("bluetooth.active_controllers", int(signals["active_controllers"]))
+            span.set_attribute("bluetooth.target_backend", target_backend)
+            span.set_attribute("bluetooth.rollout_count", int(rollout_count))
+
+            # One event per active serial with per-serial signals.
+            for serial, s in signals["per_serial"].items():
+                adapter_type = ""
+                if hasattr(self.backend, "get_adapter_type"):
+                    adapter_type = self.backend.get_adapter_type(serial)
+                span.add_event(
+                    "bluetooth_controller_sample",
+                    {
+                        "controller.serial": serial,
+                        "bluetooth.movement_update_hz": float(s["update_hz"]),
+                        "bluetooth.dropped_events_pct": float(s["dropped_pct"]),
+                        "controller.adapter": adapter_type,
+                    },
+                )
+
+        # --- Metrics ----------------------------------------------------------
+        # Window-max gap in SECONDS (repo convention for *_seconds histograms).
+        metrics.controller_bluetooth_event_gap_seconds.observe(signals["event_gap_ms"] / 1000.0)
+        metrics.controller_bluetooth_dropped_events_ratio_window.set(signals["dropped_events_pct"])
+        for serial, s in signals["per_serial"].items():
+            metrics.controller_bluetooth_dropped_events_ratio.labels(serial=serial).set(s["dropped_pct"])
+            metrics.controller_bluetooth_movement_update_hz.labels(serial=serial).set(s["update_hz"])
+            # Populate the previously-unset generic update-rate gauge too.
+            metrics.controller_state_update_hz.labels(serial=serial).set(s["update_hz"])
+
+        self._reset_health_window(now)
 
     def drain_health_counters(self, serial: str) -> tuple[int, int, int]:
         """Drain and reset health counters for a controller.

--- a/services/controller_manager/discovery_loop.py
+++ b/services/controller_manager/discovery_loop.py
@@ -744,9 +744,10 @@ class DiscoveryLoop:
         # Window-level rollout summary (target backend + cohort size).
         target_backend = ""
         rollout_count = 0
-        if hasattr(self.backend, "_rollout_router"):
+        rollout_summary = getattr(self.backend, "rollout_summary", None)
+        if rollout_summary is not None:
             try:
-                target_backend, rollout_count = self.backend._rollout_router.current_target()
+                target_backend, rollout_count = rollout_summary()
             except Exception:
                 logger.debug("Failed to read rollout summary for health span", exc_info=True)
 

--- a/services/controller_manager/metrics.py
+++ b/services/controller_manager/metrics.py
@@ -317,3 +317,39 @@ chaos_faults_injected_total = Counter(
     "Total chaos faults injected by ChaosAdapter",
     ["fault", "serial"],
 )
+
+# Bluetooth health metrics (#732 M3). Emitted once per ~1s health window
+# alongside the controller.bluetooth_health span. These feed dashboards; the
+# agent's OBSERVE input is the span, not these metrics.
+#
+# Histogram of the window-max inter-event gap (in SECONDS — repo convention is
+# *_seconds for durations). The span carries the same value in ms.
+controller_bluetooth_event_gap_seconds = Histogram(
+    "controller_bluetooth_event_gap_seconds",
+    "Worst-case inter-event gap across controllers per health window (seconds)",
+    buckets=[0.010, 0.025, 0.050, 0.075, 0.100, 0.150, 0.200, 0.350, 0.500, 1.0],
+)
+
+# Per-serial dropped-event ratio (0-1) over the window, plus an unlabeled
+# window aggregate (the worst-case across serials). The Gauge family supports a
+# no-label observation only when the metric has no label keys, so we declare two
+# separate gauges (mirroring the prom_*/labeled split used elsewhere).
+controller_bluetooth_dropped_events_ratio = Gauge(
+    "controller_bluetooth_dropped_events_ratio",
+    "Fraction of polls returning no fresh frame per controller over the window (0-1)",
+    ["serial"],
+)
+
+controller_bluetooth_dropped_events_ratio_window = Gauge(
+    "controller_bluetooth_dropped_events_ratio_window",
+    "Window-aggregate dropped-event ratio across all controllers (0-1)",
+)
+
+# Per-serial movement update rate: genuinely-new frames per second over the
+# window. Stale replays (identical poll objects) are NOT counted as fresh, so a
+# throttled/degraded backend shows a depressed rate here.
+controller_bluetooth_movement_update_hz = Gauge(
+    "controller_bluetooth_movement_update_hz",
+    "Genuinely-new frame rate per controller over the health window (Hz)",
+    ["serial"],
+)

--- a/services/controller_manager/multiplexer/multiplexer_backend.py
+++ b/services/controller_manager/multiplexer/multiplexer_backend.py
@@ -306,6 +306,14 @@ class MultiplexerBackend(ControllerBackend):
             return adapter.get_metadata(serial)
         return None
 
+    def rollout_summary(self) -> tuple[str, int]:
+        """Window-level rollout summary ``(target_backend, cohort_count)``.
+
+        Public seam for telemetry (the bluetooth-health span); delegates to the
+        RolloutRouter, which degrades to ``("", 0)`` on any flag error.
+        """
+        return self._rollout_router.current_target()
+
     def _cleanup_stale_state(self, seen: dict[str, ControllerIOAdapter]) -> None:
         """Remove centralized state for controllers no longer present."""
         stale = set(self._led_colors.keys()) - set(seen.keys())

--- a/services/controller_manager/multiplexer/rollout_router.py
+++ b/services/controller_manager/multiplexer/rollout_router.py
@@ -33,6 +33,43 @@ _DOMAIN = "rollout"
 class RolloutRouter:
     """Evaluates the ``rollout`` domain to pick a target backend per serial."""
 
+    def current_target(self) -> tuple[str, int]:
+        """Return the window-level rollout summary ``(target_backend, count)``.
+
+        Used by the bluetooth-health span to report which backend the rollout is
+        steering toward and how many controllers are in the cohort. Returns
+        ``("", 0)`` when the strategy is "off" or on any evaluation error, so a
+        flagd outage never breaks span emission.
+
+        For ``immediate`` the cohort is effectively the whole fleet, but the
+        ``current_controller_count`` flag is only meaningful for ``progressive``;
+        callers treat a 0 count as "not a bounded cohort".
+        """
+        try:
+            from openfeature.evaluation_context import EvaluationContext
+
+            from lib.feature_flags import get_flag_client
+
+            client = get_flag_client(_DOMAIN)
+
+            strategy = client.get_string_value("strategy", "off", EvaluationContext())
+            if strategy == "off":
+                return "", 0
+
+            target = client.get_string_value("target_backend", "", EvaluationContext())
+            if not target:
+                return "", 0
+
+            count = client.get_integer_value(
+                "current_controller_count",
+                0,
+                EvaluationContext(),
+            )
+            return target, max(0, int(count))
+        except Exception:
+            logger.debug("RolloutRouter.current_target failed; reporting off", exc_info=True)
+            return "", 0
+
     def target_for(self, serial: str, all_serials: list[str]) -> str | None:
         """Return the rollout target adapter_type for ``serial``, or None.
 

--- a/services/controller_manager/tests/test_bluetooth_health.py
+++ b/services/controller_manager/tests/test_bluetooth_health.py
@@ -185,7 +185,7 @@ class TestSpanEmission:
     def test_span_attributes_and_events(self, _hz, _gap, _ratio_w, _ratio, _mhz):
         backend = MagicMock()
         backend.get_adapter_type.return_value = "unstable"
-        backend._rollout_router.current_target.return_value = ("unstable", 3)
+        backend.rollout_summary.return_value = ("unstable", 3)
         loop = _make_loop(backend)
         loop._window_start = 0.0
         _feed(loop, "AA", [{"n": i} if i % 5 != 0 else None for i in range(10)], dt=0.01)

--- a/services/controller_manager/tests/test_bluetooth_health.py
+++ b/services/controller_manager/tests/test_bluetooth_health.py
@@ -1,0 +1,349 @@
+"""
+Unit tests for the bluetooth-health window accumulator and span emission (#732 M3).
+
+Drives synthetic poll sequences (fresh / None / stale-replay patterns) through the
+DiscoveryLoop window accumulator with an injected wall clock, then asserts the
+computed gap / dropped-ratio / movement-hz signals, the controller.bluetooth_health
+span attributes, and the per-serial bluetooth_controller_sample events.
+
+A stale replay is detected by object identity: UnstableAdapter returns the *same*
+dict object within a throttle window, so the discovery loop counts it as a poll
+attempt but NOT a fresh movement update. The end-to-end degradation test wraps a
+fake inner through a real UnstableAdapter and asserts all three fitness thresholds
+are violated (gap > 50 ms, drops > 0.02, hz < 10).
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+test_dir = Path(__file__).parent
+service_dir = test_dir.parent
+project_root = service_dir.parent.parent
+sys.path.insert(0, str(project_root))
+
+
+class FakeSpan:
+    """Records attributes and events set on a span for assertions."""
+
+    def __init__(self):
+        self.attributes: dict = {}
+        self.events: list[tuple[str, dict]] = []
+
+    def set_attribute(self, key, value):
+        self.attributes[key] = value
+
+    def add_event(self, name, attrs=None):
+        self.events.append((name, dict(attrs or {})))
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+class FakeTracer:
+    """Captures spans created via start_as_current_span by name."""
+
+    def __init__(self):
+        self.spans: dict[str, FakeSpan] = {}
+
+    def start_as_current_span(self, name):
+        span = FakeSpan()
+        self.spans[name] = span
+        return span
+
+
+def _make_loop(backend=None):
+    from services.controller_manager.discovery_loop import DiscoveryLoop
+
+    return DiscoveryLoop(
+        backend=backend or MagicMock(),
+        tracked_controllers={},
+        controller_states={},
+        button_detector=MagicMock(),
+        state_cache_manager=MagicMock(),
+        feedback_manager=MagicMock(),
+        monitoring=MagicMock(),
+        rescan_timer=MagicMock(),
+        paired_serials=[],
+        base_colors={},
+        event_publisher=MagicMock(),
+    )
+
+
+def _feed(loop, serial, sequence, t0=0.0, dt=0.01):
+    """Feed a sequence of poll outcomes into the window accumulator.
+
+    Each element is either a dict (a frame — fresh if a new object, stale if the
+    same object as the previous element) or None (a drop). ``dt`` is the spacing
+    between consecutive polls in seconds.
+    """
+    t = t0
+    for item in sequence:
+        loop._hw_polls[serial] = loop._hw_polls.get(serial, 0) + 1
+        if item is None:
+            loop._hw_drops[serial] = loop._hw_drops.get(serial, 0) + 1
+        else:
+            obj_id = id(item)
+            if loop._hw_last_obj_id.get(serial) != obj_id:
+                loop._hw_last_obj_id[serial] = obj_id
+                loop._record_fresh_frame(serial, t)
+        t += dt
+    return t
+
+
+class TestWindowComputation:
+    def test_all_fresh_counts_every_poll(self):
+        loop = _make_loop()
+        frames = [{"n": i} for i in range(10)]  # 10 distinct objects
+        _feed(loop, "AA", frames, dt=0.01)
+        sig = loop._compute_health_window(window_seconds=0.1)
+        per = sig["per_serial"]["AA"]
+        assert per["update_hz"] == 100.0  # 10 fresh / 0.1s
+        assert per["dropped_pct"] == 0.0
+        # Consecutive frames 10ms apart -> max gap 10ms.
+        assert abs(per["max_gap_ms"] - 10.0) < 1e-6
+
+    def test_none_drops_count_as_drops_not_fresh(self):
+        loop = _make_loop()
+        # 8 fresh, 2 drops out of 10 polls.
+        seq = [{"n": i} if i % 5 != 0 else None for i in range(10)]
+        _feed(loop, "AA", seq, dt=0.01)
+        sig = loop._compute_health_window(window_seconds=0.1)
+        per = sig["per_serial"]["AA"]
+        assert per["dropped_pct"] == 0.2  # 2/10
+        assert per["update_hz"] == 80.0  # 8 fresh / 0.1s
+
+    def test_stale_replay_not_counted_as_fresh(self):
+        loop = _make_loop()
+        same = {"n": 1}
+        # 1 fresh frame then 9 replays of the SAME object.
+        seq = [same] * 10
+        _feed(loop, "AA", seq, dt=0.01)
+        sig = loop._compute_health_window(window_seconds=0.1)
+        per = sig["per_serial"]["AA"]
+        # Only one genuinely-new frame in the window.
+        assert per["update_hz"] == 10.0  # 1 fresh / 0.1s
+        assert per["dropped_pct"] == 0.0  # replays are not drops
+
+    def test_max_gap_is_largest_inter_fresh_gap(self):
+        loop = _make_loop()
+        a, b, c = {"n": 1}, {"n": 2}, {"n": 3}
+        # fresh @0, stale*5 (50ms), fresh @60ms, fresh @70ms
+        loop._hw_last_obj_id["AA"] = None
+        for item, t in [(a, 0.0), (a, 0.01), (a, 0.02), (a, 0.03), (a, 0.04), (a, 0.05), (b, 0.06), (c, 0.07)]:
+            loop._hw_polls["AA"] = loop._hw_polls.get("AA", 0) + 1
+            oid = id(item)
+            if loop._hw_last_obj_id.get("AA") != oid:
+                loop._hw_last_obj_id["AA"] = oid
+                loop._record_fresh_frame("AA", t)
+        # Gaps between fresh frames: a@0 -> b@60ms = 60ms, b@60 -> c@70 = 10ms.
+        assert abs(loop._hw_max_gap_ms["AA"] - 60.0) < 1e-6
+
+    def test_window_aggregates_worst_case_across_serials(self):
+        loop = _make_loop()
+        # Serial AA: healthy (10 fresh, no drops, 10ms gaps).
+        _feed(loop, "AA", [{"n": i} for i in range(10)], dt=0.01)
+        # Serial BB: degraded (2 fresh spaced 60ms, plus 2 drops).
+        bb = [{"n": 100}, None, {"n": 101}, None]
+        _feed(loop, "BB", bb, dt=0.06)
+        sig = loop._compute_health_window(window_seconds=0.24)
+        # event_gap = worst (max) across serials -> BB's 60ms.
+        assert sig["event_gap_ms"] >= 60.0
+        # movement_update_hz = min across serials -> BB's lower rate.
+        bb_hz = sig["per_serial"]["BB"]["update_hz"]
+        aa_hz = sig["per_serial"]["AA"]["update_hz"]
+        assert sig["movement_update_hz"] == min(aa_hz, bb_hz)
+        assert sig["active_controllers"] == 2
+
+    def test_empty_window_zero_signals(self):
+        loop = _make_loop()
+        sig = loop._compute_health_window(window_seconds=1.0)
+        assert sig["active_controllers"] == 0
+        assert sig["event_gap_ms"] == 0.0
+        assert sig["dropped_events_pct"] == 0.0
+        assert sig["movement_update_hz"] == 0.0
+
+    def test_zero_duration_does_not_divide_by_zero(self):
+        loop = _make_loop()
+        _feed(loop, "AA", [{"n": i} for i in range(3)], dt=0.0)
+        sig = loop._compute_health_window(window_seconds=0.0)
+        # Should not raise; rate is finite (huge but finite).
+        assert sig["per_serial"]["AA"]["update_hz"] > 0
+
+
+class TestSpanEmission:
+    @patch("services.controller_manager.metrics.controller_bluetooth_movement_update_hz")
+    @patch("services.controller_manager.metrics.controller_bluetooth_dropped_events_ratio")
+    @patch("services.controller_manager.metrics.controller_bluetooth_dropped_events_ratio_window")
+    @patch("services.controller_manager.metrics.controller_bluetooth_event_gap_seconds")
+    @patch("services.controller_manager.metrics.controller_state_update_hz")
+    def test_span_attributes_and_events(self, _hz, _gap, _ratio_w, _ratio, _mhz):
+        backend = MagicMock()
+        backend.get_adapter_type.return_value = "unstable"
+        backend._rollout_router.current_target.return_value = ("unstable", 3)
+        loop = _make_loop(backend)
+        loop._window_start = 0.0
+        _feed(loop, "AA", [{"n": i} if i % 5 != 0 else None for i in range(10)], dt=0.01)
+
+        fake = FakeTracer()
+        with patch("services.controller_manager.discovery_loop.tracer", fake):
+            loop._emit_bluetooth_health(now=1.0)
+
+        assert "controller.bluetooth_health" in fake.spans
+        span = fake.spans["controller.bluetooth_health"]
+        a = span.attributes
+        assert a["bluetooth.active_controllers"] == 1
+        assert a["bluetooth.dropped_events_pct"] == 0.2
+        assert a["bluetooth.target_backend"] == "unstable"
+        assert a["bluetooth.rollout_count"] == 3
+        assert isinstance(a["bluetooth.event_gap_ms"], float)
+        assert isinstance(a["bluetooth.movement_update_hz"], float)
+
+        # One event per serial.
+        sample_events = [e for e in span.events if e[0] == "bluetooth_controller_sample"]
+        assert len(sample_events) == 1
+        ev_attrs = sample_events[0][1]
+        assert ev_attrs["controller.serial"] == "AA"
+        assert ev_attrs["controller.adapter"] == "unstable"
+        assert ev_attrs["bluetooth.dropped_events_pct"] == 0.2
+        assert "bluetooth.movement_update_hz" in ev_attrs
+
+    @patch("services.controller_manager.metrics.controller_bluetooth_event_gap_seconds")
+    def test_skip_when_no_controllers(self, gap):
+        loop = _make_loop()
+        loop._window_start = 0.0
+        fake = FakeTracer()
+        with patch("services.controller_manager.discovery_loop.tracer", fake):
+            loop._emit_bluetooth_health(now=1.0)
+        # No span, no metric observation when the window had no controllers.
+        assert "controller.bluetooth_health" not in fake.spans
+        gap.observe.assert_not_called()
+
+    @patch("services.controller_manager.metrics.controller_bluetooth_movement_update_hz")
+    @patch("services.controller_manager.metrics.controller_bluetooth_dropped_events_ratio")
+    @patch("services.controller_manager.metrics.controller_bluetooth_dropped_events_ratio_window")
+    @patch("services.controller_manager.metrics.controller_bluetooth_event_gap_seconds")
+    @patch("services.controller_manager.metrics.controller_state_update_hz")
+    def test_metrics_emitted_in_seconds(self, _hz, gap, ratio_w, ratio, mhz):
+        loop = _make_loop(MagicMock())
+        loop._window_start = 0.0
+        # One serial, two fresh frames 60ms apart -> max gap 60ms.
+        loop._hw_polls["AA"] = 2
+        loop._record_fresh_frame("AA", 0.0)
+        loop._record_fresh_frame("AA", 0.06)
+        fake = FakeTracer()
+        with patch("services.controller_manager.discovery_loop.tracer", fake):
+            loop._emit_bluetooth_health(now=1.0)
+        # Gap observed in SECONDS (0.06), not ms.
+        observed = gap.observe.call_args[0][0]
+        assert abs(observed - 0.06) < 1e-6
+
+    @patch("services.controller_manager.metrics.controller_bluetooth_movement_update_hz")
+    @patch("services.controller_manager.metrics.controller_bluetooth_dropped_events_ratio")
+    @patch("services.controller_manager.metrics.controller_bluetooth_dropped_events_ratio_window")
+    @patch("services.controller_manager.metrics.controller_bluetooth_event_gap_seconds")
+    @patch("services.controller_manager.metrics.controller_state_update_hz")
+    def test_window_resets_after_emit(self, _hz, _gap, _rw, _r, _mhz):
+        loop = _make_loop(MagicMock())
+        loop._window_start = 0.0
+        _feed(loop, "AA", [{"n": i} for i in range(5)], dt=0.01)
+        fake = FakeTracer()
+        with patch("services.controller_manager.discovery_loop.tracer", fake):
+            loop._emit_bluetooth_health(now=1.0)
+        assert loop._hw_polls == {}
+        assert loop._hw_fresh == {}
+        assert loop._window_start == 1.0
+
+
+class TestUpdateControllerStatesWiring:
+    """Verify _update_controller_states wires poll outcomes into the window."""
+
+    @pytest.mark.asyncio
+    async def test_fresh_stale_none_accumulated_via_real_path(self):
+        loop = _make_loop()
+        loop.backend_initialized = True
+        loop.tracked_controllers = {"AA": {}}
+        loop.controller_states = {}
+        loop._cached_serials = ["AA"]
+        loop.button_detector = MagicMock()
+
+        fresh1 = {"serial": "AA", "accel": {"x": 0.0, "y": 0.0, "z": 1.0}}
+        stale = fresh1  # same object -> stale replay
+        fresh2 = {"serial": "AA", "accel": {"x": 0.0, "y": 0.0, "z": 1.0}}
+        # Sequence: fresh, stale (same obj), None, fresh2.
+        loop.backend.get_controller_state = AsyncMock(side_effect=[fresh1, stale, None, fresh2])
+
+        for _ in range(4):
+            await loop._update_controller_states()
+
+        assert loop._hw_polls["AA"] == 4
+        assert loop._hw_fresh["AA"] == 2  # fresh1 + fresh2 (stale replay excluded)
+        assert loop._hw_drops["AA"] == 1  # the None
+
+
+class TestUnstableAdapterDegradationEndToEnd:
+    """Drive a real UnstableAdapter through the accumulator; all 3 thresholds break."""
+
+    def test_unstable_routed_serial_violates_all_thresholds(self):
+        from services.controller_manager.multiplexer.unstable_adapter import UnstableAdapter
+
+        class FakeClock:
+            def __init__(self):
+                self.t = 0.0
+
+            def __call__(self):
+                return self.t
+
+        clock = FakeClock()
+        inner = MagicMock()
+        inner.adapter_type = "python"
+        inner.inner = None
+        # Inner always returns a NEW fresh object so identity-dedup is exercised
+        # purely by the UnstableAdapter's stale replays.
+        inner.poll = MagicMock(side_effect=lambda s: {"serial": s, "seq": inner.poll.call_count})
+
+        adapter = UnstableAdapter(inner, throttle_seconds=0.12, drop_every=10, time_source=clock)
+
+        loop = _make_loop()
+        serial = "AA:AA"
+
+        # Simulate a multi-second run at 100Hz: poll every 10ms through the
+        # adapter, feeding outcomes into the window accumulator exactly as the
+        # loop does. The window must span enough fresh frames (>= drop_every) for
+        # at least one deterministic drop to land, so the drop ratio is non-zero.
+        # ~3s -> ~25 fresh frames -> >= 2 drops at drop_every=10.
+        loop._window_start = 0.0
+        wall = 0.0
+        n_polls = 300  # 3 seconds at 100Hz
+        for _ in range(n_polls):
+            result = adapter.poll(serial)
+            loop._hw_polls[serial] = loop._hw_polls.get(serial, 0) + 1
+            if result is None:
+                loop._hw_drops[serial] = loop._hw_drops.get(serial, 0) + 1
+            else:
+                oid = id(result)
+                if loop._hw_last_obj_id.get(serial) != oid:
+                    loop._hw_last_obj_id[serial] = oid
+                    loop._record_fresh_frame(serial, wall)
+            clock.t += 0.01
+            wall += 0.01
+
+        sig = loop._compute_health_window(window_seconds=wall)
+        per = sig["per_serial"][serial]
+
+        # Threshold 1: movement update rate < 10 Hz (throttle ~8.3Hz, minus drops).
+        assert per["update_hz"] < 10.0, per["update_hz"]
+        assert sig["movement_update_hz"] < 10.0
+        # Threshold 2: dropped-event ratio > 2%. drop_every=10 drops every 10th
+        # fresh frame -> ~10% of event-bearing cycles. Stale replays are excluded
+        # from the denominator, so the ratio reflects genuine event loss.
+        assert per["dropped_pct"] > 0.02, per["dropped_pct"]
+        assert sig["dropped_events_pct"] > 0.02
+        # Threshold 3: event gap > 50 ms (throttle window is 120ms between fresh).
+        assert per["max_gap_ms"] > 50.0, per["max_gap_ms"]
+        assert sig["event_gap_ms"] > 50.0

--- a/services/controller_manager/tests/test_rollout_router.py
+++ b/services/controller_manager/tests/test_rollout_router.py
@@ -104,3 +104,33 @@ class TestDefensive:
         client.get_string_value = MagicMock(side_effect=ValueError("boom"))
         with patch("lib.feature_flags.get_flag_client", return_value=client):
             assert router.target_for("A", ALL) is None
+
+
+def _current(**kw):
+    router = RolloutRouter()
+    with patch("lib.feature_flags.get_flag_client", return_value=_client(**kw)):
+        return router.current_target()
+
+
+class TestCurrentTarget:
+    """Window-level rollout summary used by the bluetooth-health span (#732 M3)."""
+
+    def test_off_reports_empty(self):
+        assert _current(strategy="off", count=99) == ("", 0)
+
+    def test_immediate_reports_target_and_count(self):
+        assert _current(strategy="immediate", target="unstable", count=0) == ("unstable", 0)
+
+    def test_progressive_reports_target_and_count(self):
+        assert _current(strategy="progressive", target="unstable", count=3) == ("unstable", 3)
+
+    def test_empty_target_reports_off(self):
+        assert _current(strategy="immediate", target="", count=5) == ("", 0)
+
+    def test_negative_count_clamped_to_zero(self):
+        assert _current(strategy="progressive", target="unstable", count=-4) == ("unstable", 0)
+
+    def test_flag_client_error_reports_off(self):
+        router = RolloutRouter()
+        with patch("lib.feature_flags.get_flag_client", side_effect=RuntimeError("flagd down")):
+            assert router.current_target() == ("", 0)


### PR DESCRIPTION
## Summary

Part 2 of 2 for #732 (M3 Infrastructure Agent), stacked on #783. Controller-manager now emits the Bluetooth health observability that becomes the agent's OBSERVE input in M3.

- **`controller.bluetooth_health` span** (~1Hz, root span, skipped when no controllers): window attributes `bluetooth.event_gap_ms` (window max), `bluetooth.dropped_events_pct` (0–1), `bluetooth.movement_update_hz` (window min), `bluetooth.active_controllers`, `bluetooth.target_backend`, `bluetooth.rollout_count` — plus one `bluetooth_controller_sample` event per serial (`controller.serial`, per-serial hz/drop ratio, `controller.adapter`). Units match the `fitness.bluetooth.*` flag thresholds verbatim (no conversion on the agent side).
- **Freshness via object identity**: a stale replay (same poll dict object — UnstableAdapter throttle windows, python-hid stale reads) is not a new movement update. The previous dict stays referenced in `controller_states`, so id reuse can't false-positive. The poll dict carries no sequence/timestamp, making identity the cheapest reliable signal; also populates the previously-dead `controller_state_update_hz` gauge.
- **Drop ratio semantics**: `drops / (fresh + drops)` — stale replays are the *absence* of an event, not a dropped one, so they don't dilute the ratio (UnstableAdapter shows ~10% > 2% threshold instead of washing out across 100Hz polls).
- **Metrics** (dashboards; the agent reads the span): `controller_bluetooth_event_gap_seconds` (histogram, seconds per convention), `controller_bluetooth_dropped_events_ratio[serial]` + `_window` aggregate, `controller_bluetooth_movement_update_hz[serial]`. Reuses `active_controllers_total`.
- 100Hz path stays cheap: counters only; rates/ratios derived once per window. Public `rollout_summary()` seam on MultiplexerBackend for the span's rollout attributes.

## Test plan

- [x] 627 unit tests pass (`cd services/controller_manager && uv run pytest`)
- [x] `make lint` clean
- [x] New `test_bluetooth_health.py` (13): window math with injected clock, span attributes + per-serial events, skip-when-empty, degradation story (UnstableAdapter-shaped sequences violate all three fitness thresholds)

Closes #732 (together with #783).

🤖 Generated with [Claude Code](https://claude.com/claude-code)