### PR TITLE
feat: global difficulty factor and pacing profile interventions (#766 F6)

### DIFF
--- a/lib/feature_flags.py
+++ b/lib/feature_flags.py
@@ -208,6 +208,36 @@ def read_object_flag(domain: str, flag_key: str, default: dict) -> dict:
         return default
 
 
+def read_object_flag_variant(domain: str, flag_key: str, targeting_key: str, default: dict) -> dict:
+    """
+    Read an object-typed flag selecting a named variant via flagd targeting.
+
+    Live sibling of :func:`read_object_flag` for selecting a *named* preset
+    (#766 F6 ``pacing_profile``): the flag's targeting rule maps
+    ``targetingKey == <name>`` to the matching variant, so passing
+    ``targeting_key`` resolves that preset's value. Unknown names fall through
+    to the flag's default variant (the flag's own targeting ``else``). On ANY
+    failure the supplied ``default`` is returned.
+
+    Args:
+        domain: OpenFeature domain / flagSetId (e.g. "game")
+        flag_key: Object flag key (e.g. "windows")
+        targeting_key: Preset/variant selector (e.g. "calm" / "frantic")
+        default: Fallback value returned on any error or missing flag
+
+    Returns:
+        The selected variant's object value, or ``default`` on failure.
+    """
+    try:
+        init_flag_domain(domain)
+        client = get_flag_client(domain)
+        value = client.get_object_value(flag_key, default, EvaluationContext(targeting_key=targeting_key))
+        return value if isinstance(value, dict) else default
+    except Exception as e:
+        logger.warning(f"read_object_flag_variant({domain!r}, {flag_key!r}, {targeting_key!r}) failed: {e}")
+        return default
+
+
 def read_float_flag(domain: str, flag_key: str, default: float) -> float:
     """
     Read a number-typed flag once at init time, with a hardcoded fallback.

--- a/services/agent/actions/testdata/interventions.json
+++ b/services/agent/actions/testdata/interventions.json
@@ -56,6 +56,27 @@
       },
       "defaultVariant": "none"
     },
+    "global_difficulty_factor": {
+      "state": "ENABLED",
+      "variants": {
+        "default": 1.0,
+        "easier": 0.5,
+        "easy": 0.75,
+        "hard": 1.5,
+        "harder": 2.0
+      },
+      "defaultVariant": "default"
+    },
+    "pacing_profile": {
+      "state": "ENABLED",
+      "variants": {
+        "none": "none",
+        "default": "default",
+        "calm": "calm",
+        "frantic": "frantic"
+      },
+      "defaultVariant": "none"
+    },
     "eliminate_player": {
       "state": "ENABLED",
       "variants": {

--- a/services/agent/actions/writer.go
+++ b/services/agent/actions/writer.go
@@ -41,6 +41,8 @@ const (
 	flagPlayerSensitivityFactor   = "player_sensitivity_factor"
 	flagShieldSeconds             = "shield_seconds"
 	flagVolumeOverride            = "volume_override"
+	flagGlobalDifficultyFactor    = "global_difficulty_factor" // #766 F6
+	flagPacingProfile             = "pacing_profile"           // #766 F6
 	flagEliminatePlayer           = "eliminate_player"
 	flagRevivePlayer              = "revive_player"
 	flagAudioCue                  = "audio_cue"
@@ -73,6 +75,8 @@ const (
 	defaultGlobalSensitivity = 2    // matches "medium"
 	defaultPlayerSensitivity = 1.5  // matches "handicap"
 	defaultShieldSeconds     = 5    // matches "default"
+	defaultGlobalDifficulty  = 1.5  // matches interventions.json "hard" (#766 F6)
+	defaultPacingProfile     = "frantic"
 )
 
 // Writer is the production ActionSink. It is safe for concurrent use; the agent
@@ -202,6 +206,8 @@ var stateNeutral = map[string]string{
 	flagMusicTempoOverride:        neutralNone,
 	flagGlobalSensitivityOverride: neutralNone,
 	flagVolumeOverride:            neutralNone,
+	flagGlobalDifficultyFactor:    neutralDefault, // #766 F6 (neutral = 1.0 "default")
+	flagPacingProfile:             neutralNone,    // #766 F6 (neutral = "none")
 }
 
 var targetedNeutral = map[string]string{
@@ -232,6 +238,10 @@ func (w *Writer) mutate(doc *orderedDoc, d decision.Decision) error {
 		return w.setState(doc, flagVolumeOverride, w.numOr(d.Value, defaultVolume))
 	case decision.InterventionAdjustGlobalSensitivity:
 		return w.setState(doc, flagGlobalSensitivityOverride, w.numOr(d.Value, defaultGlobalSensitivity))
+	case decision.InterventionAdjustGlobalDifficulty: // #766 F6
+		return w.setState(doc, flagGlobalDifficultyFactor, w.numOr(d.Value, defaultGlobalDifficulty))
+	case decision.InterventionSetPacingProfile: // #766 F6 (string state-shaped)
+		return w.setStateString(doc, flagPacingProfile, w.payloadOr(d.Value, defaultPacingProfile))
 
 	// Per-player state-shaped overrides (flagd targeting if-ladder).
 	case decision.InterventionAdjustPlayerSensitivity:
@@ -269,6 +279,23 @@ func (w *Writer) setEdge(doc *orderedDoc, flagKey, payload string) error {
 // setState writes a session-scoped state-shaped flag: overwrite the "active"
 // variant with the typed value and flip defaultVariant to it.
 func (w *Writer) setState(doc *orderedDoc, flagKey string, value float64) error {
+	f, err := doc.flag(flagKey)
+	if err != nil {
+		return err
+	}
+	if err := setVariant(f, activeVariant, value); err != nil {
+		return err
+	}
+	if err := f.set("defaultVariant", activeVariant); err != nil {
+		return err
+	}
+	return doc.putFlag(flagKey, f)
+}
+
+// setStateString writes a session-scoped STRING state-shaped flag (#766 F6
+// pacing_profile): overwrite the "active" variant with the string value and flip
+// defaultVariant to it. Mirrors setState but for string-typed flags.
+func (w *Writer) setStateString(doc *orderedDoc, flagKey, value string) error {
 	f, err := doc.flag(flagKey)
 	if err != nil {
 		return err

--- a/services/agent/actions/writer_test.go
+++ b/services/agent/actions/writer_test.go
@@ -156,6 +156,8 @@ func TestStateInterventions(t *testing.T) {
 		{"music tempo value", decision.Decision{Intervention: decision.InterventionAdjustMusicTempo, Value: "1.3"}, flagMusicTempoOverride, 1.3},
 		{"volume default", decision.Decision{Intervention: decision.InterventionAdjustVolume}, flagVolumeOverride, defaultVolume},
 		{"global sensitivity", decision.Decision{Intervention: decision.InterventionAdjustGlobalSensitivity, Value: "3"}, flagGlobalSensitivityOverride, 3},
+		{"global difficulty default", decision.Decision{Intervention: decision.InterventionAdjustGlobalDifficulty}, flagGlobalDifficultyFactor, defaultGlobalDifficulty},
+		{"global difficulty value", decision.Decision{Intervention: decision.InterventionAdjustGlobalDifficulty, Value: "0.5"}, flagGlobalDifficultyFactor, 0.5},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -173,6 +175,54 @@ func TestStateInterventions(t *testing.T) {
 			}
 			assertStructurallyValid(t, path)
 		})
+	}
+}
+
+// #766 F6: pacing_profile is a STRING state-shaped flag.
+func TestPacingProfileStateAndRevert(t *testing.T) {
+	w, path := newTestWriter(t)
+
+	// Default value.
+	if err := w.Apply(context.Background(), decision.Decision{Intervention: decision.InterventionSetPacingProfile}); err != nil {
+		t.Fatalf("apply default: %v", err)
+	}
+	flag := readFlag(t, path, flagPacingProfile)
+	if dv := flag["defaultVariant"]; dv != activeVariant {
+		t.Fatalf("defaultVariant = %v, want %q", dv, activeVariant)
+	}
+	if got := flag["variants"].(map[string]any)[activeVariant].(string); got != defaultPacingProfile {
+		t.Fatalf("active value = %q, want %q", got, defaultPacingProfile)
+	}
+
+	// Explicit value.
+	if err := w.Apply(context.Background(), decision.Decision{Intervention: decision.InterventionSetPacingProfile, Value: "calm"}); err != nil {
+		t.Fatalf("apply value: %v", err)
+	}
+	if got := readFlag(t, path, flagPacingProfile)["variants"].(map[string]any)[activeVariant].(string); got != "calm" {
+		t.Fatalf("active value = %q, want %q", got, "calm")
+	}
+
+	// Revert flips defaultVariant back to neutral "none".
+	if err := w.RevertState(flagPacingProfile); err != nil {
+		t.Fatalf("revert: %v", err)
+	}
+	if dv := readFlag(t, path, flagPacingProfile)["defaultVariant"]; dv != neutralNone {
+		t.Fatalf("post-revert defaultVariant = %v, want %q", dv, neutralNone)
+	}
+	assertStructurallyValid(t, path)
+}
+
+// #766 F6: global_difficulty_factor reverts to "default" (1.0), not "none".
+func TestGlobalDifficultyRevertNeutral(t *testing.T) {
+	w, path := newTestWriter(t)
+	if err := w.Apply(context.Background(), decision.Decision{Intervention: decision.InterventionAdjustGlobalDifficulty, Value: "1.5"}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if err := w.RevertState(flagGlobalDifficultyFactor); err != nil {
+		t.Fatalf("revert: %v", err)
+	}
+	if dv := readFlag(t, path, flagGlobalDifficultyFactor)["defaultVariant"]; dv != neutralDefault {
+		t.Fatalf("post-revert defaultVariant = %v, want %q", dv, neutralDefault)
 	}
 }
 

--- a/services/agent/decision/ratelimit.go
+++ b/services/agent/decision/ratelimit.go
@@ -38,6 +38,8 @@ const (
 	InterventionAdjustPlayerSensitivity = "adjust_player_sensitivity"
 	InterventionGrantShield             = "grant_shield"
 	InterventionAdjustGlobalSensitivity = "adjust_global_sensitivity"
+	InterventionAdjustGlobalDifficulty  = "adjust_global_difficulty"
+	InterventionSetPacingProfile        = "set_pacing_profile"
 	InterventionEliminatePlayer         = "eliminate_player"
 	InterventionRevivePlayer            = "revive_player"
 	InterventionEndGame                 = "end_game"
@@ -62,6 +64,8 @@ var interventionWeights = map[string]float64{
 	InterventionAdjustMusicTempo:        1,
 	InterventionAdjustPlayerSensitivity: 1,
 	InterventionGrantShield:             1,
+	InterventionAdjustGlobalDifficulty:  1, // #766 F6
+	InterventionSetPacingProfile:        1, // #766 F6
 	// Hard (2)
 	InterventionAdjustGlobalSensitivity: 2,
 	InterventionEliminatePlayer:         2,

--- a/services/flagd/agent.json
+++ b/services/flagd/agent.json
@@ -88,6 +88,7 @@
           "send_controller_effect",
           "adjust_volume",
           "adjust_music_tempo",
+          "set_pacing_profile",
           "adjust_player_sensitivity",
           "grant_shield"
         ],
@@ -96,9 +97,11 @@
           "send_controller_effect",
           "adjust_volume",
           "adjust_music_tempo",
+          "set_pacing_profile",
           "adjust_player_sensitivity",
           "grant_shield",
           "adjust_global_sensitivity",
+          "adjust_global_difficulty",
           "eliminate_player",
           "revive_player",
           "end_game"

--- a/services/flagd/game.json
+++ b/services/flagd/game.json
@@ -305,7 +305,20 @@
           "end_max_music_slow_time": 8
         }
       },
-      "defaultVariant": "default"
+      "defaultVariant": "default",
+      "targeting": {
+        "if": [
+          { "===": [{ "var": "targetingKey" }, "calm"] },
+          "calm",
+          {
+            "if": [
+              { "===": [{ "var": "targetingKey" }, "frantic"] },
+              "frantic",
+              "default"
+            ]
+          }
+        ]
+      }
     }
   }
 }

--- a/services/flagd/interventions.json
+++ b/services/flagd/interventions.json
@@ -56,6 +56,27 @@
       },
       "defaultVariant": "none"
     },
+    "global_difficulty_factor": {
+      "state": "ENABLED",
+      "variants": {
+        "default": 1.0,
+        "easier": 0.5,
+        "easy": 0.75,
+        "hard": 1.5,
+        "harder": 2.0
+      },
+      "defaultVariant": "default"
+    },
+    "pacing_profile": {
+      "state": "ENABLED",
+      "variants": {
+        "none": "none",
+        "default": "default",
+        "calm": "calm",
+        "frantic": "frantic"
+      },
+      "defaultVariant": "none"
+    },
     "eliminate_player": {
       "state": "ENABLED",
       "variants": {

--- a/services/game_coordinator/difficulty_handlers.py
+++ b/services/game_coordinator/difficulty_handlers.py
@@ -29,8 +29,10 @@ not conflict structurally.
 
 import logging
 
+from lib.feature_flags import read_object_flag_variant
 from lib.types import Sensitivity
 
+from .games.base import resolve_music_windows
 from .interventions import InterventionContext, InterventionManager
 
 logger = logging.getLogger(__name__)
@@ -39,6 +41,15 @@ logger = logging.getLogger(__name__)
 SENSITIVITY_FACTOR_MIN = 0.5
 SENSITIVITY_FACTOR_MAX = 2.0
 SENSITIVITY_FACTOR_DEFAULT = 1.0
+
+# Global difficulty factor clamp + neutral (#766 F6). Mirrors the combined-factor
+# clamp in base.py _compute_effective_thresholds.
+GLOBAL_DIFFICULTY_FACTOR_MIN = 0.5
+GLOBAL_DIFFICULTY_FACTOR_MAX = 2.0
+GLOBAL_DIFFICULTY_FACTOR_DEFAULT = 1.0
+
+# Profile names that mean "neutral / restore the game's init-resolved windows".
+_NEUTRAL_PACING_PROFILES = frozenset({"none", "default", ""})
 
 
 async def handle_music_tempo_override(ctx: InterventionContext) -> None:
@@ -125,6 +136,96 @@ async def handle_player_sensitivity_factor(ctx: InterventionContext, manager: In
         logger.info(f"player_sensitivity_factor: {serial} -> {clamped:.2f}")
 
 
+async def handle_global_difficulty_factor(ctx: InterventionContext) -> None:
+    """Apply / clear the live global difficulty factor on the running game (#766 F6).
+
+    State-shaped: ``ctx.value`` is the float factor (range 0.5-2.0). It is stored
+    on ``game.global_difficulty_factor`` and live-read every frame by
+    ``_compute_effective_thresholds``, where it is multiplied with each player's
+    own ``sensitivity_factor`` before the combined factor is clamped and divides
+    the thresholds. A value of 1.0 (the none-value) never reaches here (the
+    manager skips reverts-to-neutral) — the neutral revert restores 1.0 via
+    ``handle_global_difficulty_factor_revert``. Values are clamped to [0.5, 2.0].
+    """
+    game = ctx.game
+    if game is None:
+        logger.debug("global_difficulty_factor: no live game, ignoring")
+        return
+
+    factor = float(ctx.value)
+    clamped = max(GLOBAL_DIFFICULTY_FACTOR_MIN, min(GLOBAL_DIFFICULTY_FACTOR_MAX, factor))
+    game.global_difficulty_factor = clamped
+    logger.info(f"global_difficulty_factor: live factor -> {clamped:.2f}")
+
+
+async def handle_global_difficulty_factor_revert(ctx: InterventionContext) -> None:
+    """Restore the neutral global difficulty factor (1.0) on revert (#766 F6)."""
+    game = ctx.game
+    if game is None:
+        logger.debug("global_difficulty_factor: no live game on revert, ignoring")
+        return
+    game.global_difficulty_factor = GLOBAL_DIFFICULTY_FACTOR_DEFAULT
+    logger.info("global_difficulty_factor: reverted to neutral 1.0")
+
+
+async def handle_pacing_profile(ctx: InterventionContext) -> None:
+    """Swap the live music schedule windows to a named preset (#766 F6).
+
+    State-shaped: ``ctx.value`` is the profile name (``calm`` / ``frantic`` /
+    ``default``). The named preset is resolved from the ``game.windows`` flag's
+    variants (reusing F3's ``resolve_music_windows`` over the targeting-selected
+    variant) and assigned ATOMICALLY to ``game.music_windows`` (single store,
+    never mutated in place) so the music loop picks it up on its next tempo
+    change without tearing. The neutral profile (``none``/``default``) never
+    reaches here; reverting restores the init-resolved windows via
+    ``handle_pacing_profile_revert``. An unknown/malformed preset falls back to
+    the game's init windows (``resolve_music_windows`` validates; the flag's
+    targeting ``else`` resolves unknown names to ``default``).
+    """
+    game = ctx.game
+    if game is None:
+        logger.debug("pacing_profile: no live game, ignoring")
+        return
+
+    profile = str(ctx.value).strip().lower()
+    if profile in _NEUTRAL_PACING_PROFILES:
+        _restore_init_windows(game)
+        return
+
+    init_windows = getattr(game, "init_music_windows", game.music_windows)
+    variant = read_object_flag_variant("game", "windows", profile, {})
+    new_windows = resolve_music_windows(variant)
+    # resolve_music_windows falls back to module defaults (not the game's init
+    # windows) on malformed values; an unknown profile resolves to the flag's
+    # "default" variant. Either way the windows are well-formed; assign atomically.
+    game.music_windows = new_windows
+    logger.info(f"pacing_profile: swapped music windows to preset '{profile}'")
+    if new_windows == resolve_music_windows({}) and init_windows is not None:
+        # Unknown/malformed preset resolved to bare module defaults; if the game
+        # was started with custom windows, prefer its init windows over defaults.
+        game.music_windows = init_windows
+        logger.info("pacing_profile: unknown preset, restored init windows")
+
+
+async def handle_pacing_profile_revert(ctx: InterventionContext) -> None:
+    """Restore the game's init-resolved music windows on revert (#766 F6)."""
+    game = ctx.game
+    if game is None:
+        logger.debug("pacing_profile: no live game on revert, ignoring")
+        return
+    _restore_init_windows(game)
+
+
+def _restore_init_windows(game: object) -> None:
+    """Atomically restore the game's init-resolved music windows."""
+    init_windows = getattr(game, "init_music_windows", None)
+    if init_windows is None:
+        logger.debug("pacing_profile: no init windows recorded, leaving current windows")
+        return
+    game.music_windows = init_windows
+    logger.info("pacing_profile: restored init-resolved music windows")
+
+
 def register_difficulty_handlers(manager: InterventionManager) -> None:
     """Wire the difficulty handlers onto the manager (one line per flag).
 
@@ -139,3 +240,8 @@ def register_difficulty_handlers(manager: InterventionManager) -> None:
         "player_sensitivity_factor",
         lambda ctx: handle_player_sensitivity_factor(ctx, manager),
     )
+    # #766 F6: two new state-shaped levers. Both restore their baseline on revert.
+    manager.register_handler("global_difficulty_factor", handle_global_difficulty_factor)
+    manager._revert_handlers["global_difficulty_factor"] = handle_global_difficulty_factor_revert
+    manager.register_handler("pacing_profile", handle_pacing_profile)
+    manager._revert_handlers["pacing_profile"] = handle_pacing_profile_revert

--- a/services/game_coordinator/games/base.py
+++ b/services/game_coordinator/games/base.py
@@ -505,6 +505,17 @@ class BaseGameMode(ABC):
         # ``pacing_profile`` intervention that atomically swaps
         # ``self.music_windows`` mid-game — see MusicWindows for the seam.
         self.music_windows = resolve_music_windows(read_object_flag("game", "windows", {}))
+        # #766 F6: the init-resolved windows are retained so the LIVE
+        # ``pacing_profile`` intervention can restore them when it reverts to the
+        # neutral profile. Never reassigned after init (the live handler swaps
+        # ``self.music_windows`` only).
+        self.init_music_windows = self.music_windows
+        # #766 F6: live global difficulty factor (analogue of per-player
+        # ``sensitivity_factor``). Combined with the per-player factor in
+        # ``_compute_effective_thresholds``; 1.0 is neutral (baseline behavior).
+        # Set/cleared by the global_difficulty_factor intervention handler and
+        # live-read every frame.
+        self.global_difficulty_factor: float = 1.0
 
         # Phase 70: Music tempo control state
         self.music_track_id = None
@@ -1165,10 +1176,13 @@ class BaseGameMode(ABC):
         base_warn = self._lerp(self.slow_warning[sens_idx], self.fast_warning[sens_idx], speed_percent)
         base_death = self._lerp(self.slow_max[sens_idx], self.fast_max[sens_idx], speed_percent)
 
-        # Apply per-player sensitivity factor
-        # Clamp factor to [0.5, 2.0] for safety, then divide thresholds
-        # Higher factor = lower threshold = easier to die
-        clamped_factor = max(0.5, min(2.0, player.sensitivity_factor))
+        # Apply per-player sensitivity factor combined with the live global
+        # difficulty factor (#766 F6). Both are multiplied, then the COMBINED
+        # factor is clamped to [0.5, 2.0] for safety before dividing thresholds.
+        # Higher combined factor = lower threshold = easier to die. At the
+        # neutral 1.0/1.0 this preserves the prior behavior exactly.
+        combined_factor = player.sensitivity_factor * self.global_difficulty_factor
+        clamped_factor = max(0.5, min(2.0, combined_factor))
         return base_warn / clamped_factor, base_death / clamped_factor
 
     def _record_player_analytics(

--- a/services/game_coordinator/interventions.py
+++ b/services/game_coordinator/interventions.py
@@ -152,6 +152,27 @@ INTERVENTION_SPECS: tuple[InterventionSpec, ...] = (
         value_kind="float",
         none_value=-1,
     ),
+    # #766 F6 — two new state-shaped difficulty/pacing levers (weight Medium).
+    InterventionSpec(
+        flag_key="global_difficulty_factor",
+        type_id="adjust_global_difficulty",
+        weight=WEIGHT_MEDIUM,
+        edge_triggered=False,
+        player_targeted=False,
+        value_kind="float",
+        # 1.0 is the neutral default; a value != 1.0 is an intervention.
+        none_value=1.0,
+    ),
+    InterventionSpec(
+        flag_key="pacing_profile",
+        type_id="set_pacing_profile",
+        weight=WEIGHT_MEDIUM,
+        edge_triggered=False,
+        player_targeted=False,
+        value_kind="string",
+        # "none" (and "default") mean the neutral init-resolved windows.
+        none_value="none",
+    ),
     # --- Edge-triggered (one-shot) flags ---
     InterventionSpec(
         flag_key="eliminate_player",
@@ -198,11 +219,18 @@ INTERVENTION_SPECS: tuple[InterventionSpec, ...] = (
 # Only modes with a restriction appear. ``send_controller_effect`` is restricted
 # in hidden-role modes because LED effects can leak roles; ``revive_player`` is
 # gated where reviving breaks the mode; ``adjust_global_sensitivity`` is gated
-# where it interacts with per-role threshold overrides.
+# where it interacts with per-role threshold overrides. ``adjust_global_difficulty``
+# (#766 F6) inherits the ``adjust_global_sensitivity`` row (same role-threshold
+# interaction); ``set_pacing_profile`` inherits ``adjust_music_tempo`` (allowed
+# everywhere — no deny rows).
 MODE_CAPABILITY_DENY: dict[str, frozenset[str]] = {
     # Hidden-role modes: LED effects leak roles; revive breaks hidden roles.
-    "Werewolf": frozenset({"send_controller_effect", "revive_player", "adjust_global_sensitivity"}),
-    "Traitor": frozenset({"send_controller_effect", "revive_player", "adjust_global_sensitivity"}),
+    "Werewolf": frozenset(
+        {"send_controller_effect", "revive_player", "adjust_global_sensitivity", "adjust_global_difficulty"}
+    ),
+    "Traitor": frozenset(
+        {"send_controller_effect", "revive_player", "adjust_global_sensitivity", "adjust_global_difficulty"}
+    ),
     # Bracket / queue modes: revive breaks the bracket/queue.
     "Tournament": frozenset({"revive_player"}),
     "Fight Club": frozenset({"revive_player"}),
@@ -210,8 +238,8 @@ MODE_CAPABILITY_DENY: dict[str, frozenset[str]] = {
     "FFA": frozenset({"revive_player"}),
     "Teams": frozenset({"revive_player"}),
     "Random Teams": frozenset({"revive_player"}),
-    # Zombie role thresholds are asymmetric; global override interacts.
-    "Zombie": frozenset({"adjust_global_sensitivity"}),
+    # Zombie role thresholds are asymmetric; global override/difficulty interacts.
+    "Zombie": frozenset({"adjust_global_sensitivity", "adjust_global_difficulty"}),
     # Swapper: revive leaves team state ambiguous.
     "Swapper": frozenset({"revive_player"}),
 }
@@ -871,7 +899,10 @@ class InterventionManager:
             return client.get_integer_value(spec.flag_key, spec.none_value, ctx)
         if spec.value_kind == "float":
             return client.get_float_value(spec.flag_key, float(spec.none_value), ctx)
-        return client.get_string_value(spec.flag_key, "", ctx)
+        # State-shaped string flags carry a string none_value (e.g. pacing_profile
+        # "none"); edge-triggered flags leave none_value None and default to "".
+        string_default = spec.none_value if isinstance(spec.none_value, str) else ""
+        return client.get_string_value(spec.flag_key, string_default, ctx)
 
     def _state_target_serial(self, _spec: InterventionSpec) -> str | None:
         """Player-targeted state flags fan out across all active serials via
@@ -1045,7 +1076,8 @@ def _spec_default(spec: InterventionSpec) -> object:
         return ""
     if spec.value_kind in ("int", "float"):
         return spec.none_value
-    return ""
+    # State-shaped string flag: fall back to its string none_value (e.g. "none").
+    return spec.none_value if isinstance(spec.none_value, str) else ""
 
 
 def _active_player_serials(game: object) -> list[str]:

--- a/services/game_coordinator/tests/test_f6_intervention_levers.py
+++ b/services/game_coordinator/tests/test_f6_intervention_levers.py
@@ -1,0 +1,344 @@
+"""
+Unit tests for the #766 F6 intervention levers.
+
+Two new state-shaped interventions:
+
+- global_difficulty_factor (adjust_global_difficulty): combined with each
+  player's sensitivity_factor in the threshold division; live-read per frame;
+  revert restores the neutral 1.0.
+- pacing_profile (set_pacing_profile): atomically swaps the live music windows
+  to a named preset (resolved via F3's resolve_music_windows); revert restores
+  the game's init-resolved windows; unknown presets fall back safely.
+
+Also covers registry well-formedness, enforcement (weight Medium charged, mode
+gates inherited from adjust_global_sensitivity / adjust_music_tempo).
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+test_dir = Path(__file__).parent
+service_dir = test_dir.parent
+project_root = service_dir.parent.parent
+sys.path.insert(0, str(project_root))
+sys.path.insert(0, str(test_dir))
+
+from conftest import MockControllerManagerService, async_noop
+
+from services.game_coordinator import difficulty_handlers as dh
+from services.game_coordinator.difficulty_handlers import (
+    GLOBAL_DIFFICULTY_FACTOR_DEFAULT,
+    handle_global_difficulty_factor,
+    handle_global_difficulty_factor_revert,
+    handle_pacing_profile,
+    handle_pacing_profile_revert,
+    register_difficulty_handlers,
+)
+from services.game_coordinator.games.base import MusicWindows, Player, resolve_music_windows
+from services.game_coordinator.games.ffa import FFAGame
+from services.game_coordinator.interventions import (
+    INTERVENTION_SPECS,
+    MODE_CAPABILITY_DENY,
+    WEIGHT_MEDIUM,
+    InterventionContext,
+    InterventionManager,
+)
+
+# Preset window dicts mirroring services/flagd/game.json variants.
+_CALM = {
+    "min_music_fast_time": 3,
+    "max_music_fast_time": 6,
+    "min_music_slow_time": 13,
+    "max_music_slow_time": 30,
+    "end_min_music_fast_time": 4,
+    "end_max_music_fast_time": 7,
+    "end_min_music_slow_time": 10,
+    "end_max_music_slow_time": 16,
+}
+_FRANTIC = {
+    "min_music_fast_time": 6,
+    "max_music_fast_time": 11,
+    "min_music_slow_time": 6,
+    "max_music_slow_time": 14,
+    "end_min_music_fast_time": 8,
+    "end_max_music_fast_time": 14,
+    "end_min_music_slow_time": 5,
+    "end_max_music_slow_time": 8,
+}
+_PRESETS = {"calm": _CALM, "frantic": _FRANTIC}
+
+
+def make_game(sensitivity=2, num_players=2):
+    mock_cm = MockControllerManagerService(num_controllers=num_players)
+    game = FFAGame(
+        controller_manager_client=mock_cm,
+        event_publisher=async_noop,
+        audio_client=AsyncMock(),
+        game_id="test_f6",
+        sensitivity=sensitivity,
+    )
+    for i in range(num_players):
+        s = f"p{i + 1}"
+        game.players[s] = Player(serial=s, alive=True, color=(255, 0, 0))
+    return game
+
+
+def _spec(flag_key):
+    return next(s for s in INTERVENTION_SPECS if s.flag_key == flag_key)
+
+
+def make_ctx(flag_key, value, game):
+    return InterventionContext(
+        spec=_spec(flag_key),
+        value=value,
+        payload="",
+        target_serial=None,
+        game=game,
+        objective="balanced",
+    )
+
+
+def _patch_windows_resolution():
+    """Patch read_object_flag_variant to resolve presets like flagd targeting:
+    known name -> its preset dict; unknown -> the 'default' (empty -> defaults)."""
+
+    def fake(_domain, _flag, targeting_key, _default):
+        return _PRESETS.get(targeting_key, {})
+
+    return patch.object(dh, "read_object_flag_variant", side_effect=fake)
+
+
+# --------------------------------------------------------------------------- #
+# global_difficulty_factor
+# --------------------------------------------------------------------------- #
+class TestGlobalDifficultyFactor:
+    @pytest.mark.asyncio
+    async def test_neutral_one_preserves_baseline(self):
+        game = make_game()
+        player = game.players["p1"]
+        base_warn, base_death = game._compute_effective_thresholds(player)
+        # Applying 1.0 explicitly leaves thresholds unchanged.
+        await handle_global_difficulty_factor(make_ctx("global_difficulty_factor", 1.0, game))
+        w, d = game._compute_effective_thresholds(player)
+        assert w == pytest.approx(base_warn)
+        assert d == pytest.approx(base_death)
+
+    @pytest.mark.asyncio
+    async def test_factor_combines_with_player_factor(self):
+        game = make_game()
+        player = game.players["p1"]
+        player.sensitivity_factor = 1.0
+        base_warn, base_death = game._compute_effective_thresholds(player)
+
+        # 2.0 global -> thresholds divided by 2.0 (easier to die).
+        await handle_global_difficulty_factor(make_ctx("global_difficulty_factor", 2.0, game))
+        w, d = game._compute_effective_thresholds(player)
+        assert w == pytest.approx(base_warn / 2.0)
+        assert d == pytest.approx(base_death / 2.0)
+
+        # 0.5 global -> thresholds divided by 0.5 (harder to die).
+        await handle_global_difficulty_factor(make_ctx("global_difficulty_factor", 0.5, game))
+        w, d = game._compute_effective_thresholds(player)
+        assert w == pytest.approx(base_warn / 0.5)
+        assert d == pytest.approx(base_death / 0.5)
+
+    @pytest.mark.asyncio
+    async def test_combined_factor_is_clamped(self):
+        game = make_game()
+        player = game.players["p1"]
+        player.sensitivity_factor = 2.0  # already at max
+        base_warn, _ = game._compute_effective_thresholds(player)  # uses combined clamp
+        # Without global factor, combined = 2.0 (clamped to 2.0).
+        clamped_warn_no_global = base_warn
+
+        # global 2.0 -> combined 4.0 -> clamped back to 2.0: same thresholds.
+        await handle_global_difficulty_factor(make_ctx("global_difficulty_factor", 2.0, game))
+        w, _ = game._compute_effective_thresholds(player)
+        assert w == pytest.approx(clamped_warn_no_global)
+
+    @pytest.mark.asyncio
+    async def test_handler_clamps_stored_value(self):
+        game = make_game()
+        await handle_global_difficulty_factor(make_ctx("global_difficulty_factor", 5.0, game))
+        assert game.global_difficulty_factor == pytest.approx(2.0)
+        await handle_global_difficulty_factor(make_ctx("global_difficulty_factor", 0.1, game))
+        assert game.global_difficulty_factor == pytest.approx(0.5)
+
+    @pytest.mark.asyncio
+    async def test_revert_restores_neutral(self):
+        game = make_game()
+        game.global_difficulty_factor = 1.8
+        await handle_global_difficulty_factor_revert(make_ctx("global_difficulty_factor", 1.0, game))
+        assert game.global_difficulty_factor == pytest.approx(GLOBAL_DIFFICULTY_FACTOR_DEFAULT)
+
+    @pytest.mark.asyncio
+    async def test_no_live_game_is_noop(self):
+        await handle_global_difficulty_factor(make_ctx("global_difficulty_factor", 1.5, None))
+        await handle_global_difficulty_factor_revert(make_ctx("global_difficulty_factor", 1.0, None))
+
+
+# --------------------------------------------------------------------------- #
+# pacing_profile
+# --------------------------------------------------------------------------- #
+class TestPacingProfile:
+    @pytest.mark.asyncio
+    async def test_swap_is_atomic_and_correct(self):
+        game = make_game()
+        init = game.music_windows
+        with _patch_windows_resolution():
+            await handle_pacing_profile(make_ctx("pacing_profile", "frantic", game))
+        # New instance assigned (atomic store; original untouched).
+        assert game.music_windows is not init
+        assert game.music_windows == resolve_music_windows(_FRANTIC)
+        # init reference preserved unchanged.
+        assert game.init_music_windows == init
+
+    @pytest.mark.asyncio
+    async def test_revert_restores_init_windows(self):
+        game = make_game()
+        init = game.init_music_windows
+        with _patch_windows_resolution():
+            await handle_pacing_profile(make_ctx("pacing_profile", "calm", game))
+        assert game.music_windows != init
+        await handle_pacing_profile_revert(make_ctx("pacing_profile", "none", game))
+        assert game.music_windows is init
+
+    @pytest.mark.asyncio
+    async def test_neutral_profile_restores_init(self):
+        game = make_game()
+        init = game.init_music_windows
+        with _patch_windows_resolution():
+            await handle_pacing_profile(make_ctx("pacing_profile", "frantic", game))
+            assert game.music_windows != init
+            # "default"/"none"/"" all mean neutral.
+            await handle_pacing_profile(make_ctx("pacing_profile", "default", game))
+        assert game.music_windows is init
+
+    @pytest.mark.asyncio
+    async def test_unknown_preset_falls_back_to_init(self):
+        game = make_game()
+        # Start the game with non-default (custom) windows so fallback is observable.
+        custom = resolve_music_windows(_CALM)
+        game.music_windows = custom
+        game.init_music_windows = custom
+        with _patch_windows_resolution():
+            # 'bogus' resolves to {} -> resolve_music_windows -> module defaults;
+            # handler prefers the game's init windows over bare defaults.
+            await handle_pacing_profile(make_ctx("pacing_profile", "bogus", game))
+        assert game.music_windows is custom
+
+    @pytest.mark.asyncio
+    async def test_no_live_game_is_noop(self):
+        with _patch_windows_resolution():
+            await handle_pacing_profile(make_ctx("pacing_profile", "calm", None))
+        await handle_pacing_profile_revert(make_ctx("pacing_profile", "none", None))
+
+
+# --------------------------------------------------------------------------- #
+# Registry / policy wiring
+# --------------------------------------------------------------------------- #
+class TestRegistry:
+    def test_rows_well_formed(self):
+        diff = _spec("global_difficulty_factor")
+        assert diff.type_id == "adjust_global_difficulty"
+        assert diff.weight == WEIGHT_MEDIUM
+        assert diff.edge_triggered is False
+        assert diff.player_targeted is False
+        assert diff.value_kind == "float"
+        assert diff.none_value == pytest.approx(1.0)
+
+        pacing = _spec("pacing_profile")
+        assert pacing.type_id == "set_pacing_profile"
+        assert pacing.weight == WEIGHT_MEDIUM
+        assert pacing.edge_triggered is False
+        assert pacing.player_targeted is False
+        assert pacing.value_kind == "string"
+        assert pacing.none_value == "none"
+
+    def test_mode_gates_inherited(self):
+        # adjust_global_difficulty inherits the adjust_global_sensitivity deny
+        # rows (role-threshold modes); set_pacing_profile inherits adjust_music_tempo
+        # (allowed everywhere — never denied).
+        for mode, denied in MODE_CAPABILITY_DENY.items():
+            if "adjust_global_sensitivity" in denied:
+                assert "adjust_global_difficulty" in denied, mode
+            assert "set_pacing_profile" not in denied, mode
+        # Specifically: Werewolf/Traitor/Zombie deny global difficulty.
+        for mode in ("Werewolf", "Traitor", "Zombie"):
+            assert "adjust_global_difficulty" in MODE_CAPABILITY_DENY[mode]
+
+
+# --------------------------------------------------------------------------- #
+# Enforcement (weight charged, mode gate)
+# --------------------------------------------------------------------------- #
+def make_manager(game=None, allowed=None, budget=10):
+    events = []
+
+    async def publisher(event_type, data):
+        events.append((event_type, data))
+
+    mgr = InterventionManager(
+        event_publisher=publisher,
+        get_game=lambda: game,
+    )
+    mgr._agent_client = _AgentStub(allowed or [], budget)
+    mgr._rate_limiter.set_budget(budget)
+    return mgr, events
+
+
+class _AgentStub:
+    def __init__(self, allowed, budget):
+        self._allowed = allowed
+        self._budget = budget
+
+    def get_integer_value(self, key, default, _ctx=None):
+        if key == "policy.max_interventions_per_minute":
+            return self._budget
+        if key == "policy.battery_threshold":
+            return 20
+        return default
+
+    def get_object_value(self, key, default, _ctx=None):
+        if key == "interventions_allowed":
+            return self._allowed
+        return default
+
+
+class TestEnforcement:
+    @pytest.mark.asyncio
+    async def test_weight_medium_charged(self):
+        game = make_game()
+        mgr, _ = make_manager(game=game, allowed=["adjust_global_difficulty"], budget=10)
+        register_difficulty_handlers(mgr)
+        before = mgr._rate_limiter.current_weight()
+        await mgr._enforce_and_dispatch(_spec("global_difficulty_factor"), 1.5, "", None)
+        after = mgr._rate_limiter.current_weight()
+        assert after - before == pytest.approx(WEIGHT_MEDIUM)
+        assert game.global_difficulty_factor == pytest.approx(1.5)
+
+    @pytest.mark.asyncio
+    async def test_mode_gate_blocks_difficulty_in_werewolf(self):
+        game = make_game()
+        game.get_game_name = lambda: "Werewolf"
+        mgr, events = make_manager(game=game, allowed=["adjust_global_difficulty"], budget=10)
+        register_difficulty_handlers(mgr)
+        await mgr._enforce_and_dispatch(_spec("global_difficulty_factor"), 1.5, "", None)
+        # Blocked: factor never applied; a blocked event was published.
+        assert game.global_difficulty_factor == pytest.approx(1.0)
+        assert any(d["blocked"] == "true" and d["block_reason"] == "mode_unsupported" for _, d in events)
+
+    @pytest.mark.asyncio
+    async def test_pacing_allowed_everywhere(self):
+        game = make_game()
+        game.get_game_name = lambda: "Werewolf"
+        mgr, _ = make_manager(game=game, allowed=["set_pacing_profile"], budget=10)
+        register_difficulty_handlers(mgr)
+        init = game.init_music_windows
+        with _patch_windows_resolution():
+            await mgr._enforce_and_dispatch(_spec("pacing_profile"), "frantic", "", None)
+        # Not mode-gated; swap applied.
+        assert game.music_windows != init
+        assert isinstance(game.music_windows, MusicWindows)


### PR DESCRIPTION
Part of #766 (F6). Refs #722 #725 #730.

Adds the two new intervention levers from the calibration-surface follow-up plan:

## global_difficulty_factor
- New state-shaped flag in `interventions.json` (variants 0.5–2.0, default 1.0)
- Combines with the per-player factor in the effective-threshold division in `_compute_effective_thresholds` — live-read per frame; revert to 1.0 restores baseline
- Mode gates inherit the `adjust_global_sensitivity` row; weight **Medium**

## pacing_profile
- New state-shaped flag (`none`/`default`/`calm`/`frantic`)
- Handler resolves the named preset from the `game.windows` flag variants (F3) and atomically swaps `self.music_windows` per the F3 seam; revert restores the game's init-resolved windows
- Mode gates inherit the `adjust_music_tempo` row; weight **Medium**

## Wiring
- Both registered as state-shaped `InterventionSpec` rows with new `game_interventions_total` type ids
- Type ids added to `interventions_allowed` variants in `agent.json` (difficulty factor: full tier; pacing: standard tier, matching the rows they extend)
- Go action-sink mapping extended (`services/agent/actions/writer.go`) so the agent can dispatch both as session state flags; rate-limit weight table updated

## Notes
- The implementing background agent hit a session limit after completing the implementation; final lint fix, rebase onto current main, verification, and PR were completed by the coordinating session
- Docs follow in #786 (F8) — its table gains these two rows once this lands

## Test plan
- [x] `services/game_coordinator`: 862 passed (incl. 16 new in `test_f6_intervention_levers.py`)
- [x] `services/agent`: `go test -race ./...` all packages, `go vet`, `gofmt -l` clean
- [x] `make lint` clean; all flagd JSON parses
- [ ] Live verification on the Pi 5 (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
