### PR TITLE
feat(agent): infrastructure signal extraction from bluetooth health spans (#733)

### DIFF
--- a/services/agent/README.md
+++ b/services/agent/README.md
@@ -62,6 +62,58 @@ Sessions are not carried in every signal, so the Agent synthesizes them:
 | Player | Evicted after a **5 s** TTL with no fresh signal |
 | Session | Kept for a **15 s** grace period after it goes inactive, then evicted |
 
+## Infrastructure observe path (#733)
+
+Alongside the game `GameContext`, the Agent runs a **parallel infrastructure
+observe path** over the same OTLP trace receiver. It recognizes the periodic
+`controller.bluetooth_health` span emitted by controller-manager (PR #785),
+extracts the Bluetooth transport signals into a thread-safe `InfraContext`
+(`infracontext/`), and triggers an infrastructure evaluation loop.
+
+This PR is **OBSERVE only**: the loop is a logging stub
+(`decision.InfraLoop`, debug level, throttled to ~1/sec). Fitness, decisions, and
+remediation land in later stacked PRs behind the `decision.InfraEvaluator` seam.
+The telemetry constants those PRs converge on — span `agent.infrastructure.decision`
+and its attribute keys — are already declared in `decision/infra_telemetry.go`
+(no span is emitted yet).
+
+### Input span contract (`controller.bluetooth_health`)
+
+A ~1Hz root span; **absent when no controllers are connected**.
+
+| Span attribute | Type | Meaning |
+|----------------|------|---------|
+| `bluetooth.event_gap_ms` | float | window max inter-fresh-frame gap (ms) |
+| `bluetooth.dropped_events_pct` | float 0–1 | window drop ratio |
+| `bluetooth.movement_update_hz` | float | window min per-serial fresh rate |
+| `bluetooth.active_controllers` | int | active controller count |
+| `bluetooth.target_backend` | string | rollout target adapter_type (`""` when off) |
+| `bluetooth.rollout_count` | int | current rollout controller count (`0` when off) |
+
+One `bluetooth_controller_sample` **span event per active serial** carries the
+per-controller view: `controller.serial`, `bluetooth.movement_update_hz`,
+`bluetooth.dropped_events_pct`, `controller.adapter` (winning adapter_type, e.g.
+`python`/`rust`/`unstable`). Numeric attributes are read tolerant of both Int and
+Double encodings; any missing window attribute simply stays `nil` (the extractor
+sets a pointer only for present attributes).
+
+### InfraContext lifecycle
+
+- **Window signals** are replaced **wholesale** on each health span — an absent
+  attribute next window drops back to `nil`, never a stale carry-over.
+- **Per-controller** records accumulate keyed on serial; each appearance stamps
+  `LastUpdate`.
+- **Eviction**: a controller absent from health spans past a **5 s** TTL (≈ five
+  missed 1Hz windows) is dropped, on the same eviction ticker as the game store.
+- `Snapshot()` deep-copies the controllers map, so the stub loop reads an
+  isolated view (the per-span pointer-replacement invariant means later spans
+  never mutate an already-handed-out snapshot).
+
+The same **self-ingestion skip** as the game path applies: any resource whose
+`service.name` equals the agent's own `OTEL_SERVICE_NAME` is ignored on the infra
+path too. A mixed batch (game spans + health spans) feeds both stores
+independently with no cross-contamination.
+
 ## Gating & decisions
 
 After each context update the Agent evaluates `should_evaluate`. When the gate
@@ -477,6 +529,7 @@ services/agent/
 ├── otel.go         # OTLP/self-telemetry setup
 ├── receiver.go     # OTLP span/metric ingestion + extraction into GameContext
 ├── gamecontext/    # GameContext accumulation, session identity, eviction
+├── infracontext/   # InfraContext: controller.bluetooth_health observe path (#733)
 ├── gate/           # should_evaluate gating logic
 ├── flags/          # OpenFeature/flagd four-layer control flags (existence, objective, capability, permission)
 ├── actions/        # Action sink (#730): rewrites the flagd interventions file in place

--- a/services/agent/decision/infra_loop.go
+++ b/services/agent/decision/infra_loop.go
@@ -1,0 +1,71 @@
+package decision
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/joustmania/agent/infracontext"
+)
+
+// InfraEvaluator is the seam the infrastructure observe path triggers when the
+// Bluetooth-health context updates. PR E plugs the real fitness + remediation
+// loop in behind this interface; this PR ships only the logging stub below.
+//
+// OnInfraEvaluate receives the inbound gRPC context (for trace propagation in
+// PR E) and an isolated InfraContext snapshot.
+type InfraEvaluator interface {
+	OnInfraEvaluate(ctx context.Context, snap infracontext.InfraContext)
+}
+
+// InfraLoop is the OBSERVE-only infrastructure evaluation stub (#733, M3 PR C).
+// It logs the observed Bluetooth-health snapshot at debug level, throttled to at
+// most one line per throttle interval so the ~1Hz health-span stream does not
+// flood the log. The real fitness/decision/remediation loop lands in PR E,
+// plugging in behind the InfraEvaluator seam.
+type InfraLoop struct {
+	log      *slog.Logger
+	throttle time.Duration
+
+	mu      sync.Mutex
+	lastLog time.Time
+	now     func() time.Time
+}
+
+// NewInfraLoop builds the observe-only stub. log may be nil (slog.Default() is
+// used). A non-positive throttle falls back to DefaultThrottleInterval.
+func NewInfraLoop(log *slog.Logger, throttle time.Duration) *InfraLoop {
+	if log == nil {
+		log = slog.Default()
+	}
+	if throttle <= 0 {
+		throttle = DefaultThrottleInterval
+	}
+	return &InfraLoop{
+		log:      log,
+		throttle: throttle,
+		now:      time.Now,
+	}
+}
+
+// OnInfraEvaluate logs the current Bluetooth-health snapshot, throttled. It is
+// safe for concurrent use: the trace Export handler invokes it from its own
+// goroutine.
+func (l *InfraLoop) OnInfraEvaluate(_ context.Context, snap infracontext.InfraContext) {
+	l.mu.Lock()
+	now := l.now()
+	if !l.lastLog.IsZero() && now.Sub(l.lastLog) < l.throttle {
+		l.mu.Unlock()
+		return
+	}
+	l.lastLog = now
+	l.mu.Unlock()
+
+	l.log.Debug("infrastructure observe (#733 stub)",
+		"active_controllers", snap.Window.ActiveControllers,
+		"target_backend", snap.Window.TargetBackend,
+		"rollout_count", snap.Window.RolloutCount,
+		"controllers", len(snap.Controllers),
+	)
+}

--- a/services/agent/decision/infra_telemetry.go
+++ b/services/agent/decision/infra_telemetry.go
@@ -1,0 +1,43 @@
+package decision
+
+// Infrastructure-domain decision telemetry constants (#733, M3). The agent runs
+// a parallel OBSERVE path over the controller.bluetooth_health span: it tracks
+// Bluetooth transport health and (in later stacked PRs D/E/F) evaluates fitness
+// and emits a remediation decision span.
+//
+// This file declares the span name + attribute keys ONLY — NO span is emitted in
+// this PR. They live here, alongside the game decision schema (telemetry.go), so
+// PR D/E/F import a single converged vocabulary rather than redefining keys.
+const (
+	// SpanInfraDecision is the infrastructure remediation decision span, the
+	// infra-domain parallel to SpanDecision (agent.decision). Emitted by PR E/F.
+	SpanInfraDecision = "agent.infrastructure.decision"
+)
+
+// Custom attribute keys of the infrastructure-decision span schema. The rollout
+// and fitness/remediation keys are the infra-domain decision attribution; the
+// bluetooth.* keys mirror the controller.bluetooth_health span contract so the
+// signals that drove a decision can be lifted onto its span verbatim.
+const (
+	// AttrRolloutTarget is the rollout target adapter_type in effect
+	// (bluetooth.target_backend), "" when rollout is off.
+	AttrRolloutTarget = "rollout.target"
+	// AttrFitnessPassing is whether the infrastructure fitness check passed (#733
+	// fitness lands in PR D).
+	AttrFitnessPassing = "fitness.passing"
+	// AttrFitnessViolations lists the failing fitness checks for this decision.
+	AttrFitnessViolations = "fitness.violations"
+	// AttrRemediationAction is the remediation the decision selected (e.g. roll
+	// back the rollout); the infra-domain parallel to AttrDecisionAction.
+	AttrRemediationAction = "remediation.action"
+
+	// Bluetooth signal attribute keys (controller.bluetooth_health contract).
+	// Re-declared here, decoupled from the infracontext extractor constants, so
+	// the decision package has no dependency on infracontext for span emission.
+	AttrBluetoothEventGapMs        = "bluetooth.event_gap_ms"
+	AttrBluetoothDroppedEventsPct  = "bluetooth.dropped_events_pct"
+	AttrBluetoothMovementUpdateHz  = "bluetooth.movement_update_hz"
+	AttrBluetoothActiveControllers = "bluetooth.active_controllers"
+	AttrBluetoothTargetBackend     = "bluetooth.target_backend"
+	AttrBluetoothRolloutCount      = "bluetooth.rollout_count"
+)

--- a/services/agent/infracontext/extract_spans.go
+++ b/services/agent/infracontext/extract_spans.go
@@ -1,0 +1,164 @@
+package infracontext
+
+import (
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+)
+
+// Span name, event name, and attribute keys of the controller.bluetooth_health
+// span contract (controller-manager, PR #785). Consumed VERBATIM — do not rename
+// without coordinating with the producer.
+const (
+	// SpanBluetoothHealth is the ~1Hz root span carrying window-level Bluetooth
+	// transport health. Absent when no controllers are connected.
+	SpanBluetoothHealth = "controller.bluetooth_health"
+
+	// EventControllerSample is the per-active-serial span event carrying
+	// per-controller Bluetooth signals.
+	EventControllerSample = "bluetooth_controller_sample"
+
+	// Window-level span attributes.
+	AttrEventGapMs        = "bluetooth.event_gap_ms"
+	AttrDroppedEventsPct  = "bluetooth.dropped_events_pct"
+	AttrMovementUpdateHz  = "bluetooth.movement_update_hz"
+	AttrActiveControllers = "bluetooth.active_controllers"
+	AttrTargetBackend     = "bluetooth.target_backend"
+	AttrRolloutCount      = "bluetooth.rollout_count"
+
+	// Per-sample event attributes. AttrDroppedEventsPct and AttrMovementUpdateHz
+	// are reused at the per-serial scope.
+	AttrControllerSerial  = "controller.serial"
+	AttrControllerAdapter = "controller.adapter"
+
+	// resourceAttrServiceName mirrors semconv service.name, used for the
+	// own-telemetry skip.
+	resourceAttrServiceName = "service.name"
+)
+
+// ApplySpans applies trace data to the store, recognizing
+// controller.bluetooth_health spans and extracting their window + per-serial
+// signals. Spans of any other name are ignored (the game path consumes them
+// separately). It returns true if at least one health span was applied.
+func (s *Store) ApplySpans(td ptrace.Traces) bool {
+	updated := false
+	rss := td.ResourceSpans()
+	for i := 0; i < rss.Len(); i++ {
+		if s.isOwnResource(rss.At(i).Resource()) {
+			continue
+		}
+		sss := rss.At(i).ScopeSpans()
+		for j := 0; j < sss.Len(); j++ {
+			spans := sss.At(j).Spans()
+			for k := 0; k < spans.Len(); k++ {
+				span := spans.At(k)
+				if span.Name() != SpanBluetoothHealth {
+					continue
+				}
+				if s.applyHealthSpan(span) {
+					updated = true
+				}
+			}
+		}
+	}
+	return updated
+}
+
+// applyHealthSpan extracts one controller.bluetooth_health span: the window
+// signals from the span attributes and the per-serial samples from its
+// bluetooth_controller_sample events.
+func (s *Store) applyHealthSpan(span ptrace.Span) bool {
+	w := windowFromAttrs(span.Attributes())
+
+	s.mu.Lock()
+	s.setWindow(w)
+	events := span.Events()
+	for e := 0; e < events.Len(); e++ {
+		ev := events.At(e)
+		if ev.Name() != EventControllerSample {
+			continue
+		}
+		if sample, ok := controllerFromAttrs(ev.Attributes()); ok {
+			s.setController(sample)
+		}
+	}
+	s.mu.Unlock()
+	return true
+}
+
+// windowFromAttrs reads the six window-level attributes, setting a pointer only
+// for attributes that are present. Numeric attributes tolerate both Int and
+// Double pvalue encodings.
+func windowFromAttrs(attrs pcommon.Map) WindowSignals {
+	var w WindowSignals
+	if v, ok := floatAttr(attrs, AttrEventGapMs); ok {
+		w.EventGapMs = ptr(v)
+	}
+	if v, ok := floatAttr(attrs, AttrDroppedEventsPct); ok {
+		w.DroppedEventsPct = ptr(v)
+	}
+	if v, ok := floatAttr(attrs, AttrMovementUpdateHz); ok {
+		w.MovementUpdateHz = ptr(v)
+	}
+	if v, ok := intAttr(attrs, AttrActiveControllers); ok {
+		w.ActiveControllers = ptr(v)
+	}
+	if v, ok := attrs.Get(AttrTargetBackend); ok {
+		w.TargetBackend = v.AsString()
+	}
+	if v, ok := intAttr(attrs, AttrRolloutCount); ok {
+		w.RolloutCount = v
+	}
+	return w
+}
+
+// controllerFromAttrs reads one per-serial sample. It returns ok=false when the
+// sample carries no serial (nothing to key on).
+func controllerFromAttrs(attrs pcommon.Map) (ControllerHealth, bool) {
+	sv, ok := attrs.Get(AttrControllerSerial)
+	if !ok {
+		return ControllerHealth{}, false
+	}
+	serial := sv.AsString()
+	if serial == "" {
+		return ControllerHealth{}, false
+	}
+	c := ControllerHealth{Serial: serial}
+	if v, ok := floatAttr(attrs, AttrMovementUpdateHz); ok {
+		c.MovementUpdateHz = ptr(v)
+	}
+	if v, ok := floatAttr(attrs, AttrDroppedEventsPct); ok {
+		c.DroppedEventsPct = ptr(v)
+	}
+	if v, ok := attrs.Get(AttrControllerAdapter); ok {
+		c.Adapter = v.AsString()
+	}
+	return c, true
+}
+
+// floatAttr reads a numeric attribute as float64, tolerating both Int and Double
+// pvalue encodings (mirrors gamecontext.numberValue). Returns ok=false when the
+// attribute is absent or not numeric.
+func floatAttr(attrs pcommon.Map, key string) (float64, bool) {
+	v, ok := attrs.Get(key)
+	if !ok {
+		return 0, false
+	}
+	switch v.Type() {
+	case pcommon.ValueTypeInt:
+		return float64(v.Int()), true
+	case pcommon.ValueTypeDouble:
+		return v.Double(), true
+	default:
+		return 0, false
+	}
+}
+
+// intAttr reads a numeric attribute as int, tolerating both Int and Double
+// pvalue encodings. Returns ok=false when the attribute is absent or not numeric.
+func intAttr(attrs pcommon.Map, key string) (int, bool) {
+	v, ok := floatAttr(attrs, key)
+	if !ok {
+		return 0, false
+	}
+	return int(v), true
+}

--- a/services/agent/infracontext/extract_spans_test.go
+++ b/services/agent/infracontext/extract_spans_test.go
@@ -1,0 +1,209 @@
+package infracontext
+
+import (
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/collector/pdata/ptrace"
+)
+
+// newTestStore makes a Store with a generous TTL and a fixed clock for tests.
+func newTestStore() *Store {
+	return NewStore(time.Hour, func() time.Time {
+		return time.Unix(1000, 0)
+	})
+}
+
+// sampleEvent describes a per-serial bluetooth_controller_sample event.
+type sampleEvent struct {
+	serial     string
+	hz         float64
+	droppedPct float64
+	adapter    string
+}
+
+// healthSpan builds a controller.bluetooth_health span with the given window
+// attributes and per-serial sample events. Window attrs are applied as Doubles
+// (active/rollout as Ints) — useInt re-encodes the numeric window attrs as Ints
+// to exercise the Int-vs-Double tolerance.
+func healthSpan(name string, win map[string]float64, target string, samples []sampleEvent, useInt bool) ptrace.Traces {
+	td := ptrace.NewTraces()
+	span := td.ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+	span.SetName(name)
+	attrs := span.Attributes()
+	for k, v := range win {
+		if useInt {
+			attrs.PutInt(k, int64(v))
+		} else {
+			attrs.PutDouble(k, v)
+		}
+	}
+	if target != "" {
+		attrs.PutStr(AttrTargetBackend, target)
+	}
+	for _, s := range samples {
+		ev := span.Events().AppendEmpty()
+		ev.SetName(EventControllerSample)
+		ev.Attributes().PutStr(AttrControllerSerial, s.serial)
+		ev.Attributes().PutDouble(AttrMovementUpdateHz, s.hz)
+		ev.Attributes().PutDouble(AttrDroppedEventsPct, s.droppedPct)
+		ev.Attributes().PutStr(AttrControllerAdapter, s.adapter)
+	}
+	return td
+}
+
+func TestApplySpans_FullHealthSpan(t *testing.T) {
+	s := newTestStore()
+	td := healthSpan(SpanBluetoothHealth, map[string]float64{
+		AttrEventGapMs:        42.5,
+		AttrDroppedEventsPct:  0.1,
+		AttrMovementUpdateHz:  58.0,
+		AttrActiveControllers: 2,
+		AttrRolloutCount:      2,
+	}, "rust", []sampleEvent{
+		{serial: "A", hz: 60, droppedPct: 0.0, adapter: "python"},
+		{serial: "B", hz: 55, droppedPct: 0.2, adapter: "rust"},
+	}, false)
+
+	if !s.ApplySpans(td) {
+		t.Fatal("expected health span to be recognized")
+	}
+	snap := s.Snapshot()
+
+	if snap.Window.EventGapMs == nil || *snap.Window.EventGapMs != 42.5 {
+		t.Fatalf("event_gap_ms = %v, want 42.5", snap.Window.EventGapMs)
+	}
+	if snap.Window.DroppedEventsPct == nil || *snap.Window.DroppedEventsPct != 0.1 {
+		t.Fatalf("window dropped_events_pct = %v, want 0.1", snap.Window.DroppedEventsPct)
+	}
+	if snap.Window.MovementUpdateHz == nil || *snap.Window.MovementUpdateHz != 58.0 {
+		t.Fatalf("window movement_update_hz = %v, want 58.0", snap.Window.MovementUpdateHz)
+	}
+	if snap.Window.ActiveControllers == nil || *snap.Window.ActiveControllers != 2 {
+		t.Fatalf("active_controllers = %v, want 2", snap.Window.ActiveControllers)
+	}
+	if snap.Window.TargetBackend != "rust" {
+		t.Fatalf("target_backend = %q, want rust", snap.Window.TargetBackend)
+	}
+	if snap.Window.RolloutCount != 2 {
+		t.Fatalf("rollout_count = %d, want 2", snap.Window.RolloutCount)
+	}
+
+	if len(snap.Controllers) != 2 {
+		t.Fatalf("controllers = %d, want 2", len(snap.Controllers))
+	}
+	a := snap.Controllers["A"]
+	if a == nil || a.MovementUpdateHz == nil || *a.MovementUpdateHz != 60 || a.Adapter != "python" {
+		t.Fatalf("controller A = %+v, want hz=60 adapter=python", a)
+	}
+	b := snap.Controllers["B"]
+	if b == nil || b.DroppedEventsPct == nil || *b.DroppedEventsPct != 0.2 || b.Adapter != "rust" {
+		t.Fatalf("controller B = %+v, want dropped=0.2 adapter=rust", b)
+	}
+}
+
+func TestApplySpans_PartialAttrs(t *testing.T) {
+	s := newTestStore()
+	// Only event_gap_ms present; the rest must stay nil. No samples.
+	td := healthSpan(SpanBluetoothHealth, map[string]float64{
+		AttrEventGapMs: 12.0,
+	}, "", nil, false)
+
+	if !s.ApplySpans(td) {
+		t.Fatal("expected partial health span to be recognized")
+	}
+	snap := s.Snapshot()
+	if snap.Window.EventGapMs == nil || *snap.Window.EventGapMs != 12.0 {
+		t.Fatalf("event_gap_ms = %v, want 12.0", snap.Window.EventGapMs)
+	}
+	if snap.Window.DroppedEventsPct != nil {
+		t.Fatalf("dropped_events_pct = %v, want nil (absent)", snap.Window.DroppedEventsPct)
+	}
+	if snap.Window.MovementUpdateHz != nil {
+		t.Fatalf("movement_update_hz = %v, want nil (absent)", snap.Window.MovementUpdateHz)
+	}
+	if snap.Window.ActiveControllers != nil {
+		t.Fatalf("active_controllers = %v, want nil (absent)", snap.Window.ActiveControllers)
+	}
+	if snap.Window.TargetBackend != "" {
+		t.Fatalf("target_backend = %q, want empty", snap.Window.TargetBackend)
+	}
+	if snap.Window.RolloutCount != 0 {
+		t.Fatalf("rollout_count = %d, want 0", snap.Window.RolloutCount)
+	}
+	if len(snap.Controllers) != 0 {
+		t.Fatalf("controllers = %d, want 0", len(snap.Controllers))
+	}
+}
+
+func TestApplySpans_WrongSpanNameIgnored(t *testing.T) {
+	s := newTestStore()
+	td := healthSpan("player_lifecycle", map[string]float64{
+		AttrEventGapMs: 99.0,
+	}, "rust", []sampleEvent{{serial: "A", hz: 60, adapter: "python"}}, false)
+
+	if s.ApplySpans(td) {
+		t.Fatal("non-health span must not be recognized")
+	}
+	snap := s.Snapshot()
+	if snap.Window.EventGapMs != nil {
+		t.Fatal("non-health span must not populate window signals")
+	}
+	if len(snap.Controllers) != 0 {
+		t.Fatal("non-health span must not create controllers")
+	}
+}
+
+func TestApplySpans_IntVsDoubleTolerance(t *testing.T) {
+	s := newTestStore()
+	// All numeric window attrs encoded as Int pvalues.
+	td := healthSpan(SpanBluetoothHealth, map[string]float64{
+		AttrEventGapMs:        40,
+		AttrDroppedEventsPct:  0, // 0 as Int
+		AttrMovementUpdateHz:  58,
+		AttrActiveControllers: 3,
+		AttrRolloutCount:      3,
+	}, "unstable", nil, true)
+
+	if !s.ApplySpans(td) {
+		t.Fatal("expected Int-encoded health span to be recognized")
+	}
+	snap := s.Snapshot()
+	if snap.Window.EventGapMs == nil || *snap.Window.EventGapMs != 40 {
+		t.Fatalf("event_gap_ms (Int) = %v, want 40", snap.Window.EventGapMs)
+	}
+	if snap.Window.DroppedEventsPct == nil || *snap.Window.DroppedEventsPct != 0 {
+		t.Fatalf("dropped_events_pct (Int 0) = %v, want 0", snap.Window.DroppedEventsPct)
+	}
+	if snap.Window.MovementUpdateHz == nil || *snap.Window.MovementUpdateHz != 58 {
+		t.Fatalf("movement_update_hz (Int) = %v, want 58", snap.Window.MovementUpdateHz)
+	}
+	if snap.Window.ActiveControllers == nil || *snap.Window.ActiveControllers != 3 {
+		t.Fatalf("active_controllers (Int) = %v, want 3", snap.Window.ActiveControllers)
+	}
+	if snap.Window.RolloutCount != 3 {
+		t.Fatalf("rollout_count (Int) = %d, want 3", snap.Window.RolloutCount)
+	}
+}
+
+func TestApplySpans_SkipsOwnService(t *testing.T) {
+	s := newTestStore()
+	s.SetOwnService("agent")
+
+	td := healthSpan(SpanBluetoothHealth, map[string]float64{AttrEventGapMs: 10},
+		"rust", []sampleEvent{{serial: "A", hz: 60, adapter: "python"}}, false)
+	td.ResourceSpans().At(0).Resource().Attributes().PutStr("service.name", "agent")
+	if s.ApplySpans(td) {
+		t.Fatal("own-service health spans must be skipped (self-ingestion defense)")
+	}
+	if s.Snapshot().Window.EventGapMs != nil {
+		t.Fatal("own-service span must not populate window signals")
+	}
+
+	// Other services still apply.
+	td = healthSpan(SpanBluetoothHealth, map[string]float64{AttrEventGapMs: 10}, "", nil, false)
+	td.ResourceSpans().At(0).Resource().Attributes().PutStr("service.name", "controller-manager")
+	if !s.ApplySpans(td) {
+		t.Fatal("non-own service health spans must still apply")
+	}
+}

--- a/services/agent/infracontext/model.go
+++ b/services/agent/infracontext/model.go
@@ -1,0 +1,74 @@
+// Package infracontext holds the accumulated, denormalized view of the Bluetooth
+// transport health the agent builds up from the periodic
+// controller.bluetooth_health span emitted by controller-manager (PR #785).
+//
+// It is the infrastructure-domain parallel to gamecontext: an OBSERVE-only store
+// today (M3 PR C, #733). Fitness/decisions/remediation land in later stacked PRs;
+// this package only recognizes the health span, extracts its signals, and exposes
+// a thread-safe snapshot for the (initially stub) infrastructure evaluation loop.
+//
+// Pointer fields distinguish "never observed" (nil) from a genuine zero value
+// (e.g. a 0.0 drop ratio): the producer may omit any window attribute, and the
+// extractor sets a pointer only for attributes actually present.
+package infracontext
+
+import "time"
+
+// ControllerHealth is the per-controller (per-serial) Bluetooth view, derived
+// from the bluetooth_controller_sample span events on the health span.
+type ControllerHealth struct {
+	// Serial is the controller serial (controller.serial event attribute).
+	Serial string
+
+	// MovementUpdateHz is the per-serial fresh movement-frame rate.
+	// Source: bluetooth.movement_update_hz (per-sample event attribute).
+	MovementUpdateHz *float64
+
+	// DroppedEventsPct is the per-serial drop ratio (0-1).
+	// Source: bluetooth.dropped_events_pct (per-sample event attribute).
+	DroppedEventsPct *float64
+
+	// Adapter is the winning adapter_type for this controller
+	// (e.g. "python"/"rust"/"unstable").
+	// Source: controller.adapter (per-sample event attribute).
+	Adapter string
+
+	// LastUpdate is the last time this controller appeared in a health span.
+	LastUpdate time.Time
+}
+
+// WindowSignals is the aggregate, window-level view carried on the
+// controller.bluetooth_health span attributes (~1Hz window).
+type WindowSignals struct {
+	// EventGapMs is the window max inter-fresh-frame gap in milliseconds.
+	// Source: bluetooth.event_gap_ms.
+	EventGapMs *float64
+
+	// DroppedEventsPct is the window drop ratio (0-1).
+	// Source: bluetooth.dropped_events_pct.
+	DroppedEventsPct *float64
+
+	// MovementUpdateHz is the window min per-serial fresh rate.
+	// Source: bluetooth.movement_update_hz.
+	MovementUpdateHz *float64
+
+	// ActiveControllers is the number of active controllers this window.
+	// Source: bluetooth.active_controllers.
+	ActiveControllers *int
+
+	// TargetBackend is the rollout target adapter_type, "" when rollout is off.
+	// Source: bluetooth.target_backend.
+	TargetBackend string
+
+	// RolloutCount is the current_controller_count under rollout, 0 when off.
+	// Source: bluetooth.rollout_count.
+	RolloutCount int
+}
+
+// InfraContext is the full accumulated infrastructure view: the latest window
+// signals plus the live set of per-controller health records.
+type InfraContext struct {
+	Window      WindowSignals
+	Controllers map[string]*ControllerHealth
+	UpdatedAt   time.Time
+}

--- a/services/agent/infracontext/store.go
+++ b/services/agent/infracontext/store.go
@@ -1,0 +1,132 @@
+package infracontext
+
+import (
+	"sync"
+	"time"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+)
+
+// Store accumulates InfraContext state from the controller.bluetooth_health span.
+// It is safe for concurrent use; all access is guarded by a single mutex.
+//
+// Invariant (mirrors gamecontext.Store): setters always REPLACE pointer fields
+// with fresh pointers and never mutate through an existing pointer. This lets
+// Snapshot() shallow-copy each ControllerHealth struct (and thus share the
+// pointers) without a later span mutating data already handed out in a snapshot.
+type Store struct {
+	mu  sync.Mutex
+	ctx InfraContext
+
+	// controllerTTL bounds how long a controller is retained after it stops
+	// appearing in health spans. Health spans arrive at ~1Hz, so a controller
+	// absent for several windows is considered gone.
+	controllerTTL time.Duration
+	now           func() time.Time
+
+	// ownService is this agent's own OTEL service name. Telemetry from this
+	// service is skipped by ApplySpans: the collector fans the agent's own spans
+	// back to it (otlp/agent exporter), so the skip is defense-in-depth against a
+	// self-ingestion feedback loop. Set once before serving; not mutex-guarded.
+	ownService string
+}
+
+// NewStore constructs a Store. controllerTTL bounds how long a silent controller
+// is retained. now is injectable for tests; nil uses time.Now.
+func NewStore(controllerTTL time.Duration, now func() time.Time) *Store {
+	if now == nil {
+		now = time.Now
+	}
+	return &Store{
+		ctx: InfraContext{
+			Controllers: make(map[string]*ControllerHealth),
+		},
+		controllerTTL: controllerTTL,
+		now:           now,
+	}
+}
+
+// SetOwnService records the agent's own OTEL service name so ApplySpans can skip
+// the agent's own telemetry. Must be called before the store starts receiving
+// ApplySpans calls.
+func (s *Store) SetOwnService(name string) {
+	s.ownService = name
+}
+
+// isOwnResource reports whether a resource belongs to this agent itself
+// (service.name matches ownService) — its telemetry is skipped to break the
+// otlp/agent fan-out feedback loop.
+func (s *Store) isOwnResource(res pcommon.Resource) bool {
+	if s.ownService == "" {
+		return false
+	}
+	v, ok := res.Attributes().Get(resourceAttrServiceName)
+	return ok && v.AsString() == s.ownService
+}
+
+// controller returns the ControllerHealth for serial, creating it if missing.
+// Caller must hold s.mu.
+func (s *Store) controller(serial string) *ControllerHealth {
+	c := s.ctx.Controllers[serial]
+	if c == nil {
+		c = &ControllerHealth{Serial: serial}
+		s.ctx.Controllers[serial] = c
+	}
+	return c
+}
+
+func ptr[T any](v T) *T { return &v }
+
+// setWindow replaces the window signals wholesale (the producer sends a fresh
+// aggregate window each health span). Caller must hold s.mu.
+func (s *Store) setWindow(w WindowSignals) {
+	s.ctx.Window = w
+	s.ctx.UpdatedAt = s.now()
+}
+
+// setController applies one per-serial sample, replacing only the present
+// pointer fields and stamping LastUpdate. Caller must hold s.mu.
+func (s *Store) setController(sample ControllerHealth) {
+	c := s.controller(sample.Serial)
+	if sample.MovementUpdateHz != nil {
+		c.MovementUpdateHz = sample.MovementUpdateHz
+	}
+	if sample.DroppedEventsPct != nil {
+		c.DroppedEventsPct = sample.DroppedEventsPct
+	}
+	if sample.Adapter != "" {
+		c.Adapter = sample.Adapter
+	}
+	t := s.now()
+	c.LastUpdate = t
+	s.ctx.UpdatedAt = t
+}
+
+// Snapshot returns a deep-enough copy of the context: a fresh Controllers map
+// with copied structs. Safe to read after later store mutations because setters
+// never mutate through shared pointers.
+func (s *Store) Snapshot() InfraContext {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	out := s.ctx
+	out.Controllers = make(map[string]*ControllerHealth, len(s.ctx.Controllers))
+	for serial, c := range s.ctx.Controllers {
+		cp := *c
+		out.Controllers[serial] = &cp
+	}
+	return out
+}
+
+// EvictStale removes controllers that have stopped appearing in health spans
+// past the TTL.
+func (s *Store) EvictStale() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := s.now()
+	for serial, c := range s.ctx.Controllers {
+		if now.Sub(c.LastUpdate) > s.controllerTTL {
+			delete(s.ctx.Controllers, serial)
+		}
+	}
+}

--- a/services/agent/infracontext/store_test.go
+++ b/services/agent/infracontext/store_test.go
@@ -1,0 +1,121 @@
+package infracontext
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// clock is a mutable injected time source for deterministic tests.
+type clock struct {
+	mu sync.Mutex
+	t  time.Time
+}
+
+func (c *clock) now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.t
+}
+
+func (c *clock) advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.t = c.t.Add(d)
+}
+
+func TestStore_SnapshotIsolation(t *testing.T) {
+	s := newTestStore()
+	s.ApplySpans(healthSpan(SpanBluetoothHealth, map[string]float64{AttrEventGapMs: 10},
+		"rust", []sampleEvent{{serial: "A", hz: 60, adapter: "python"}}, false))
+	snap := s.Snapshot()
+
+	// Mutate the store after snapshotting (new window + new controller signal).
+	s.ApplySpans(healthSpan(SpanBluetoothHealth, map[string]float64{AttrEventGapMs: 99},
+		"unstable", []sampleEvent{{serial: "A", hz: 5, adapter: "rust"}}, false))
+
+	if snap.Window.EventGapMs == nil || *snap.Window.EventGapMs != 10 {
+		t.Fatalf("snapshot window mutated: got %v, want 10", snap.Window.EventGapMs)
+	}
+	if snap.Window.TargetBackend != "rust" {
+		t.Fatalf("snapshot target mutated: got %q, want rust", snap.Window.TargetBackend)
+	}
+	a := snap.Controllers["A"]
+	if a == nil || a.MovementUpdateHz == nil || *a.MovementUpdateHz != 60 || a.Adapter != "python" {
+		t.Fatalf("snapshot controller mutated: %+v, want hz=60 adapter=python", a)
+	}
+}
+
+func TestStore_WindowReplacedPerSpan(t *testing.T) {
+	s := newTestStore()
+	// First span sets dropped_events_pct; second span omits it entirely.
+	s.ApplySpans(healthSpan(SpanBluetoothHealth, map[string]float64{
+		AttrEventGapMs:       10,
+		AttrDroppedEventsPct: 0.5,
+	}, "", nil, false))
+	if got := s.Snapshot().Window.DroppedEventsPct; got == nil || *got != 0.5 {
+		t.Fatalf("dropped_events_pct = %v, want 0.5", got)
+	}
+
+	s.ApplySpans(healthSpan(SpanBluetoothHealth, map[string]float64{
+		AttrEventGapMs: 20,
+	}, "", nil, false))
+	snap := s.Snapshot()
+	if snap.Window.EventGapMs == nil || *snap.Window.EventGapMs != 20 {
+		t.Fatalf("event_gap_ms = %v, want 20 (replaced)", snap.Window.EventGapMs)
+	}
+	// Window is replaced wholesale, so the absent attr drops back to nil.
+	if snap.Window.DroppedEventsPct != nil {
+		t.Fatalf("dropped_events_pct = %v, want nil (window replaced, attr absent)", snap.Window.DroppedEventsPct)
+	}
+}
+
+func TestStore_EvictStaleControllers(t *testing.T) {
+	clk := &clock{t: time.Unix(0, 0)}
+	s := NewStore(5*time.Second, clk.now)
+
+	s.ApplySpans(healthSpan(SpanBluetoothHealth, map[string]float64{AttrEventGapMs: 10},
+		"", []sampleEvent{
+			{serial: "A", hz: 60, adapter: "python"},
+			{serial: "B", hz: 55, adapter: "rust"},
+		}, false))
+
+	// A keeps reporting; B goes silent.
+	clk.advance(3 * time.Second)
+	s.ApplySpans(healthSpan(SpanBluetoothHealth, map[string]float64{AttrEventGapMs: 11},
+		"", []sampleEvent{{serial: "A", hz: 60, adapter: "python"}}, false))
+
+	clk.advance(3 * time.Second) // B now 6s silent (> 5s TTL), A only 3s
+	s.EvictStale()
+
+	snap := s.Snapshot()
+	if _, ok := snap.Controllers["A"]; !ok {
+		t.Fatal("fresh controller A must be retained")
+	}
+	if _, ok := snap.Controllers["B"]; ok {
+		t.Fatal("silent controller B must be evicted past TTL")
+	}
+}
+
+func TestStore_ConcurrencySmoke(t *testing.T) {
+	s := NewStore(time.Hour, nil)
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			for j := 0; j < 200; j++ {
+				s.ApplySpans(healthSpan(SpanBluetoothHealth, map[string]float64{
+					AttrEventGapMs:        float64(j),
+					AttrActiveControllers: 2,
+				}, "rust", []sampleEvent{
+					{serial: "A", hz: float64(j), droppedPct: 0.1, adapter: "python"},
+					{serial: "B", hz: float64(j % 30), droppedPct: 0.2, adapter: "rust"},
+				}, j%2 == 0))
+				_ = s.Snapshot()
+				s.EvictStale()
+			}
+		}(i)
+	}
+	wg.Wait()
+}

--- a/services/agent/main.go
+++ b/services/agent/main.go
@@ -32,10 +32,17 @@ import (
 	"github.com/joustmania/agent/decision"
 	"github.com/joustmania/agent/flags"
 	"github.com/joustmania/agent/gamecontext"
+	"github.com/joustmania/agent/infracontext"
 )
 
 // probeInterval rate-limits the AGENT_PROBE_DECISIONS demo probe.
 const probeInterval = 5 * time.Second
+
+// infraControllerTTL bounds how long a controller is retained in the
+// infrastructure observe path (#733) after it stops appearing in
+// controller.bluetooth_health spans. Health spans arrive at ~1Hz, so 5s ≈ five
+// missed windows before a controller is considered gone.
+const infraControllerTTL = 5 * time.Second
 
 // defaultServiceName is the agent's OTEL service name default. It MUST stay
 // identical everywhere it is used: the exported resource (otel.go) and the
@@ -168,7 +175,15 @@ func main() {
 		slog.Warn("Probe decisions enabled (demo/verification mode)",
 			"interval", probeInterval)
 	}
-	pipe := newPipeline(store, loop, lifecycle.PlayerTTL)
+	// Infrastructure observe path (#733, M3 PR C): a parallel store fed by the
+	// controller.bluetooth_health span on the same OTLP trace receiver. It honors
+	// the same self-ingestion skip as the game store. The InfraLoop is an
+	// OBSERVE-only logging stub for this PR; the real fitness/remediation loop
+	// plugs in behind the decision.InfraEvaluator seam in PR E.
+	infraStore := infracontext.NewStore(infraControllerTTL, nil)
+	infraStore.SetOwnService(resolveServiceName())
+	infraLoop := decision.NewInfraLoop(logger, lifecycle.DecisionThrottle)
+	pipe := newPipeline(store, loop, lifecycle.PlayerTTL).withInfra(infraStore, infraLoop)
 
 	grpcServer := grpc.NewServer()
 	ptraceotlp.RegisterGRPCServer(grpcServer, &traceReceiver{pipe: pipe})
@@ -208,6 +223,7 @@ func main() {
 				return
 			case <-ticker.C:
 				store.EvictStale()
+				infraStore.EvictStale()
 			}
 		}
 	}()

--- a/services/agent/receiver.go
+++ b/services/agent/receiver.go
@@ -10,6 +10,7 @@ import (
 	"github.com/joustmania/agent/decision"
 	"github.com/joustmania/agent/gamecontext"
 	"github.com/joustmania/agent/gate"
+	"github.com/joustmania/agent/infracontext"
 )
 
 // Full OTLP gRPC service names, recorded as rpc.service (semconv) on the
@@ -19,13 +20,22 @@ const (
 	otlpMetricsService = "opentelemetry.proto.collector.metrics.v1.MetricsService"
 )
 
-// pipeline ties the context store and decision loop together. On each signal
-// update it snapshots the store and, if the gate allows, runs the loop.
+// pipeline ties the context stores and decision loops together. On each signal
+// update it snapshots the relevant store and, if the gate allows, runs the loop.
+//
+// There are two parallel observe paths sharing the one OTLP trace receiver:
+//   - the game path (store + loop): the existing GameContext + decision loop.
+//   - the infrastructure path (infraStore + infraLoop): the #733 Bluetooth-health
+//     observe path. infraLoop may be nil, in which case the infra path is inert.
 type pipeline struct {
 	store     *gamecontext.Store
 	loop      *decision.Loop
 	playerTTL time.Duration
-	now       func() time.Time
+
+	infraStore *infracontext.Store
+	infraLoop  decision.InfraEvaluator
+
+	now func() time.Time
 }
 
 func newPipeline(store *gamecontext.Store, loop *decision.Loop, playerTTL time.Duration) *pipeline {
@@ -35,6 +45,24 @@ func newPipeline(store *gamecontext.Store, loop *decision.Loop, playerTTL time.D
 		playerTTL: playerTTL,
 		now:       time.Now,
 	}
+}
+
+// withInfra attaches the infrastructure observe path. Returns the pipeline for
+// chaining at construction.
+func (p *pipeline) withInfra(infraStore *infracontext.Store, infraLoop decision.InfraEvaluator) *pipeline {
+	p.infraStore = infraStore
+	p.infraLoop = infraLoop
+	return p
+}
+
+// infraUpdated is called after the Bluetooth-health context mutates. It snapshots
+// the infra store and triggers the (stub) infrastructure evaluation loop. Parallel
+// to signalUpdated for the game path; no gate yet (the real gate lands in PR E).
+func (p *pipeline) infraUpdated(ctx context.Context) {
+	if p.infraStore == nil || p.infraLoop == nil {
+		return
+	}
+	p.infraLoop.OnInfraEvaluate(ctx, p.infraStore.Snapshot())
 }
 
 // signalUpdated is called after any received signal mutates the store. The
@@ -57,15 +85,23 @@ type traceReceiver struct {
 	pipe *pipeline
 }
 
-// Export ingests a batch of traces.
+// Export ingests a batch of traces. A single batch may carry both game spans
+// (player_lifecycle etc.) and controller.bluetooth_health spans; each store sees
+// the whole batch and recognizes only its own span kinds, so both observe paths
+// fire independently with no cross-contamination. Both stores honor the same
+// own-service self-ingestion skip internally.
 func (r *traceReceiver) Export(ctx context.Context, req ptraceotlp.ExportRequest) (ptraceotlp.ExportResponse, error) {
 	t0 := time.Now()
-	if r.pipe.store.ApplySpans(req.Traces()) {
+	td := req.Traces()
+	if r.pipe.store.ApplySpans(td) {
 		r.pipe.signalUpdated(ctx, decision.EvalTrigger{
 			Signal:     "traces",
 			RPCService: otlpTraceService,
 			T0:         t0,
 		})
+	}
+	if r.pipe.infraStore != nil && r.pipe.infraStore.ApplySpans(td) {
+		r.pipe.infraUpdated(ctx)
 	}
 	return ptraceotlp.NewExportResponse(), nil
 }

--- a/services/agent/receiver_test.go
+++ b/services/agent/receiver_test.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.opentelemetry.io/collector/pdata/ptrace/ptraceotlp"
+
+	"github.com/joustmania/agent/decision"
+	"github.com/joustmania/agent/gamecontext"
+	"github.com/joustmania/agent/infracontext"
+)
+
+// recordingInfraLoop counts OnInfraEvaluate calls and captures the last snapshot.
+type recordingInfraLoop struct {
+	calls atomic.Int32
+	last  infracontext.InfraContext
+}
+
+func (r *recordingInfraLoop) OnInfraEvaluate(_ context.Context, snap infracontext.InfraContext) {
+	r.calls.Add(1)
+	r.last = snap
+}
+
+// fixedClock returns a stable time so gating/eviction are deterministic.
+func fixedClock() func() time.Time { return func() time.Time { return time.Unix(1000, 0) } }
+
+// gameSpan appends a player_lifecycle span (game path) to td.
+func gameSpan(td ptrace.Traces, serial string) {
+	span := td.ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+	span.SetName("player_lifecycle")
+	span.Attributes().PutStr("player.serial", serial)
+}
+
+// healthSpanInto appends a controller.bluetooth_health span (infra path) to td.
+func healthSpanInto(td ptrace.Traces, gapMs float64, serial, adapter string) {
+	span := td.ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+	span.SetName(infracontext.SpanBluetoothHealth)
+	span.Attributes().PutDouble(infracontext.AttrEventGapMs, gapMs)
+	span.Attributes().PutInt(infracontext.AttrActiveControllers, 1)
+	ev := span.Events().AppendEmpty()
+	ev.SetName(infracontext.EventControllerSample)
+	ev.Attributes().PutStr(infracontext.AttrControllerSerial, serial)
+	ev.Attributes().PutDouble(infracontext.AttrMovementUpdateHz, 60)
+	ev.Attributes().PutStr(infracontext.AttrControllerAdapter, adapter)
+}
+
+func newTestReceiver(t *testing.T) (*traceReceiver, *gamecontext.Store, *infracontext.Store, *recordingInfraLoop) {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	store := gamecontext.NewStore(time.Hour, time.Hour, fixedClock())
+	loop := decision.NewLoop(nil, logger) // nil flags => disabled, no decisions
+	infraStore := infracontext.NewStore(time.Hour, fixedClock())
+	infraLoop := &recordingInfraLoop{}
+	pipe := newPipeline(store, loop, time.Hour).withInfra(infraStore, infraLoop)
+	return &traceReceiver{pipe: pipe}, store, infraStore, infraLoop
+}
+
+func TestReceiver_RoutesMixedBatchToBothStores(t *testing.T) {
+	r, store, infraStore, infraLoop := newTestReceiver(t)
+
+	td := ptrace.NewTraces()
+	gameSpan(td, "A")
+	healthSpanInto(td, 42, "A", "python")
+
+	if _, err := r.Export(context.Background(), ptraceotlp.NewExportRequestFromTraces(td)); err != nil {
+		t.Fatalf("Export error: %v", err)
+	}
+
+	// Game path: player identity enriched.
+	if store.Snapshot().Players["A"] == nil {
+		t.Fatal("game span must enrich the game store")
+	}
+	// Infra path: window + controller populated.
+	infra := infraStore.Snapshot()
+	if infra.Window.EventGapMs == nil || *infra.Window.EventGapMs != 42 {
+		t.Fatalf("infra window not populated: %v", infra.Window.EventGapMs)
+	}
+	if c := infra.Controllers["A"]; c == nil || c.Adapter != "python" {
+		t.Fatalf("infra controller A not populated: %+v", c)
+	}
+	if got := infraLoop.calls.Load(); got != 1 {
+		t.Fatalf("infra loop calls = %d, want 1", got)
+	}
+}
+
+func TestReceiver_GameOnlyBatchDoesNotTriggerInfra(t *testing.T) {
+	r, store, infraStore, infraLoop := newTestReceiver(t)
+
+	td := ptrace.NewTraces()
+	gameSpan(td, "A")
+
+	if _, err := r.Export(context.Background(), ptraceotlp.NewExportRequestFromTraces(td)); err != nil {
+		t.Fatalf("Export error: %v", err)
+	}
+	if store.Snapshot().Players["A"] == nil {
+		t.Fatal("game span must enrich the game store")
+	}
+	if got := infraLoop.calls.Load(); got != 0 {
+		t.Fatalf("infra loop calls = %d, want 0 (no health span, no cross-contamination)", got)
+	}
+	if infraStore.Snapshot().Window.EventGapMs != nil {
+		t.Fatal("game-only batch must not populate infra window")
+	}
+}
+
+func TestReceiver_HealthOnlyBatchDoesNotCreatePlayers(t *testing.T) {
+	r, store, infraStore, infraLoop := newTestReceiver(t)
+
+	td := ptrace.NewTraces()
+	healthSpanInto(td, 7, "A", "rust")
+
+	if _, err := r.Export(context.Background(), ptraceotlp.NewExportRequestFromTraces(td)); err != nil {
+		t.Fatalf("Export error: %v", err)
+	}
+	if len(store.Snapshot().Players) != 0 {
+		t.Fatal("health span must not create game players (no cross-contamination)")
+	}
+	if got := infraLoop.calls.Load(); got != 1 {
+		t.Fatalf("infra loop calls = %d, want 1", got)
+	}
+	if infraStore.Snapshot().Controllers["A"] == nil {
+		t.Fatal("health span must populate infra controller")
+	}
+}
+
+func TestReceiver_SkipsOwnServiceForBothPaths(t *testing.T) {
+	r, store, infraStore, infraLoop := newTestReceiver(t)
+	store.SetOwnService("agent")
+	infraStore.SetOwnService("agent")
+
+	td := ptrace.NewTraces()
+	gameSpan(td, "A")
+	healthSpanInto(td, 42, "A", "python")
+	// Tag every resource as the agent's own service.
+	rss := td.ResourceSpans()
+	for i := 0; i < rss.Len(); i++ {
+		rss.At(i).Resource().Attributes().PutStr("service.name", "agent")
+	}
+
+	if _, err := r.Export(context.Background(), ptraceotlp.NewExportRequestFromTraces(td)); err != nil {
+		t.Fatalf("Export error: %v", err)
+	}
+	if len(store.Snapshot().Players) != 0 {
+		t.Fatal("own-service spans must not enrich the game store")
+	}
+	if infraStore.Snapshot().Window.EventGapMs != nil {
+		t.Fatal("own-service spans must not populate the infra store")
+	}
+	if got := infraLoop.calls.Load(); got != 0 {
+		t.Fatalf("infra loop calls = %d, want 0 (own-service skipped)", got)
+	}
+}


### PR DESCRIPTION
## Summary

M3 Infrastructure Agent, agent-side OBSERVE path (#733). The agent now recognizes the ~1Hz `controller.bluetooth_health` span (emitted by controller-manager, #785) on its existing OTLP receiver and extracts the Bluetooth signals into a new thread-safe `infracontext` store — the input for infrastructure fitness/rollout/remediation in the stacked follow-ups (#735/#734/#736).

- **`infracontext` package** (mirrors `gamecontext` conventions): `InfraContext{Window, Controllers}` with pointer fields (absent ≠ zero), deep-copy `Snapshot()`, 5s controller TTL eviction (≈5 missed health windows), injectable clock.
- **Span extraction**: window attrs (`bluetooth.event_gap_ms`, `dropped_events_pct`, `movement_update_hz`, `active_controllers`, `target_backend`, `rollout_count`) + per-serial `bluetooth_controller_sample` events; Int/Double attribute tolerance; all names exported constants.
- **Receiver routing**: the trace `Export` feeds the same batch to both stores; each recognizes only its own span kinds (game path byte-for-byte unchanged, infra block nil-guarded). Both honor the own-service self-ingestion skip.
- **Seams for the stack**: `decision.InfraEvaluator` interface with a throttled observe-only `InfraLoop` stub (real loop in the #734 PR); `agent.infrastructure.decision` span + attribute constants (`rollout.target`, `fitness.passing`, `fitness.violations`, `remediation.action`) — constants only, no emission yet.

Based on `main` (consumes #785's span schema as a data contract only — no code dependency, agent simply sees no health spans until #785 ships).

## Test plan

- [x] `go test -race ./...` green (9 new infracontext tests, 4 receiver routing tests: mixed batches, no cross-contamination, self-ingestion skip)
- [x] `go vet ./...`, `gofmt -l` clean (matches the agent-tests CI job)

Closes #733.

🤖 Generated with [Claude Code](https://claude.com/claude-code)