### PR TITLE
docs: F6 intervention levers in flag tables + stale action-sink claim (#766)

### DIFF
--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -427,6 +427,8 @@ design rationale behind this control plane.
 |------|------|-----------|-------------|
 | `music_tempo_override` | object/number | — | Override music tempo |
 | `global_sensitivity_override` | object/number | — | Override death-detection sensitivity globally |
+| `global_difficulty_factor` | object/number | — | Continuous difficulty scale 0.5–2.0 (default 1.0); combines with the per-player factor in the effective-threshold division (#766 F6) |
+| `pacing_profile` | object/string | — | Live-swap the active music windows to a named preset (`default`/`calm`/`frantic`) from the `game.windows` flag variants; revert restores the game's init-resolved windows (#766 F6) |
 | `player_sensitivity_factor` | object/number | per-serial | Per-player sensitivity multiplier |
 | `shield_seconds` | object/number | per-serial | Grant per-player shield duration |
 | `volume_override` | object/number | — | Override audio volume |

--- a/services/agent/README.md
+++ b/services/agent/README.md
@@ -128,7 +128,10 @@ The two decision hooks:
 - **Rules engine** (#726) — `ObjectiveRules`, the objective-weighted decision
   logic below. Active by default; its objectives are driven live by the flag.
 - **Action sink** (#730) — applies permitted intents via OpenFeature/flagd.
-  **Still a no-op**: decisions are traced, nothing is applied yet.
+  **No-op by default**: with `AGENT_INTERVENTIONS_ENABLED=true` the real
+  `actions.Writer` is wired in and dispatched decisions are written to the
+  flagd `interventions` domain (see **Action sink** below); otherwise decisions
+  are traced and discarded.
 
 The flags wrapper lives in [`flags/`](flags/) and uses the OpenFeature Go SDK
 with the flagd **RPC** resolver against flagd's gRPC evaluation port. Flag keys


### PR DESCRIPTION
Part of #766 (F8 follow-up). Two documentation gaps found by the M2 completeness audit:

1. **`docs/feature-flags.md`**: #786 (F8) merged before #787 (F6) was open, so the two new intervention levers were undocumented. Adds `global_difficulty_factor` and `pacing_profile` rows to the state-shaped interventions table.
2. **`services/agent/README.md`**: the decision-hooks overview still claimed the action sink is "Still a no-op", contradicting the merged #762 writer (and the README's own Action sink section). Now correctly states: no-op by default, real `actions.Writer` with `AGENT_INTERVENTIONS_ENABLED=true`.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)