### PR TITLE
ci: sync flagd CI configs with calibration flags + drift guard (#801)

### DIFF
--- a/lib/tests/test_flagd_ci_drift.py
+++ b/lib/tests/test_flagd_ci_drift.py
@@ -1,0 +1,81 @@
+"""Drift guard for flagd CI override configs (issue #801).
+
+`docker-compose.ci.yml` mounts a `<domain>.ci.json` over each base
+`<domain>.json` for the domains it overrides. The CI variant is allowed to
+change flag *defaults* (e.g. `play_audio=off`, `backend=mock`), but it must
+define the *same set of flag keys* as its base file. If a base file gains a new
+flag and the CI override is not updated, that flag resolves to FLAG_NOT_FOUND in
+CI and integration tests silently fall back to the code default -- so a flag-key
+typo or a non-default variant can never be exercised.
+
+This test fails loudly whenever a base flagd config carries a flag key that its
+corresponding `.ci.json` is missing.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+# lib/tests/ -> lib/ -> repo root
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+FLAGD_DIR = REPO_ROOT / "services" / "flagd"
+
+
+def _flag_keys(path: Path) -> set[str]:
+    return set(json.loads(path.read_text())["flags"].keys())
+
+
+def _ci_override_pairs() -> list[tuple[Path, Path]]:
+    """Find every base flagd config that has a sibling `.ci.json` override.
+
+    Discovery is automatic so new domains are guarded without editing this test.
+    Partial/special overrides (e.g. `controller.ci-rust.json`, which is a
+    single-flag canary override and is not mounted as a full base replacement)
+    are intentionally excluded -- only the canonical `<domain>.ci.json` form is
+    treated as a full override that must mirror its base key set.
+    """
+    pairs = []
+    for ci_path in sorted(FLAGD_DIR.glob("*.ci.json")):
+        base_path = FLAGD_DIR / f"{ci_path.name[: -len('.ci.json')]}.json"
+        if base_path.exists():
+            pairs.append((base_path, ci_path))
+    return pairs
+
+
+PAIRS = _ci_override_pairs()
+
+
+def test_ci_override_pairs_discovered():
+    """Sanity check: we actually found the expected CI override files."""
+    ci_names = {ci.name for _, ci in PAIRS}
+    expected = {
+        "controller.ci.json",
+        "game.ci.json",
+        "observability.ci.json",
+        "system.ci.json",
+        "user.ci.json",
+    }
+    assert expected <= ci_names, f"Expected CI override files not discovered: {expected - ci_names}"
+
+
+@pytest.mark.parametrize("base_path,ci_path", PAIRS, ids=[ci.name for _, ci in PAIRS])
+def test_ci_config_has_no_missing_flags(base_path: Path, ci_path: Path):
+    """Every flag key in the base config must exist in its CI override."""
+    base_keys = _flag_keys(base_path)
+    ci_keys = _flag_keys(ci_path)
+
+    missing = sorted(base_keys - ci_keys)
+    assert not missing, (
+        f"{ci_path.name} is missing flag(s) present in {base_path.name}: "
+        f"{missing}. Add the new flag(s) to {ci_path.name} "
+        f"(defaults matching {base_path.name}); CI mounts {ci_path.name} over "
+        f"{base_path.name}, so missing keys resolve to FLAG_NOT_FOUND in CI."
+    )
+
+    # A CI override should not invent flags that don't exist in the base config.
+    unknown = sorted(ci_keys - base_keys)
+    assert not unknown, (
+        f"{ci_path.name} defines flag(s) not present in {base_path.name}: "
+        f"{unknown}. Remove them or add them to {base_path.name}."
+    )

--- a/services/flagd/controller.ci.json
+++ b/services/flagd/controller.ci.json
@@ -47,6 +47,51 @@
       },
       "defaultVariant": "none",
       "targeting": {}
+    },
+    "effect.warning_flash_ms": {
+      "state": "ENABLED",
+      "variants": {
+        "short": 100,
+        "default": 200,
+        "long": 400
+      },
+      "defaultVariant": "default"
+    },
+    "effect.warning_vibration_ms": {
+      "state": "ENABLED",
+      "variants": {
+        "short": 100,
+        "default": 200,
+        "long": 400
+      },
+      "defaultVariant": "default"
+    },
+    "effect.death_rumble_ms": {
+      "state": "ENABLED",
+      "variants": {
+        "short": 100,
+        "default": 150,
+        "long": 250
+      },
+      "defaultVariant": "default"
+    },
+    "effect.death_red_hold_ms": {
+      "state": "ENABLED",
+      "variants": {
+        "short": 150,
+        "default": 300,
+        "long": 500
+      },
+      "defaultVariant": "default"
+    },
+    "effect.death_fade_ms": {
+      "state": "ENABLED",
+      "variants": {
+        "short": 400,
+        "default": 700,
+        "long": 1200
+      },
+      "defaultVariant": "default"
     }
   }
 }

--- a/services/flagd/game.ci.json
+++ b/services/flagd/game.ci.json
@@ -123,6 +123,273 @@
         "long": 5000
       },
       "defaultVariant": "short"
+    },
+    "death_grace_period_seconds": {
+      "state": "ENABLED",
+      "variants": {
+        "default": 0.5,
+        "none": 0.0,
+        "short": 0.25,
+        "long": 1.0
+      },
+      "defaultVariant": "default"
+    },
+    "nonstop.respawn_seconds": {
+      "state": "ENABLED",
+      "variants": {
+        "default": 3.0,
+        "fast": 1.5,
+        "slow": 5.0
+      },
+      "defaultVariant": "default"
+    },
+    "nonstop.spawn_protection_seconds": {
+      "state": "ENABLED",
+      "variants": {
+        "default": 2.0,
+        "none": 0.0,
+        "long": 4.0
+      },
+      "defaultVariant": "default"
+    },
+    "nonstop.scoring": {
+      "state": "ENABLED",
+      "variants": {
+        "default": {
+          "base": 100,
+          "death_penalty": 10
+        }
+      },
+      "defaultVariant": "default"
+    },
+    "fight_club.round_seconds": {
+      "state": "ENABLED",
+      "variants": {
+        "default": 22.0,
+        "short": 15.0,
+        "long": 30.0
+      },
+      "defaultVariant": "default"
+    },
+    "tournament.match_seconds": {
+      "state": "ENABLED",
+      "variants": {
+        "default": 22.0,
+        "short": 15.0,
+        "long": 30.0
+      },
+      "defaultVariant": "default"
+    },
+    "tournament.time_between_matches_seconds": {
+      "state": "ENABLED",
+      "variants": {
+        "default": 5.0,
+        "short": 3.0,
+        "long": 8.0
+      },
+      "defaultVariant": "default"
+    },
+    "werewolf.werewolf_fraction": {
+      "state": "ENABLED",
+      "variants": {
+        "default": 0.44,
+        "third": 0.33,
+        "half": 0.5
+      },
+      "defaultVariant": "default"
+    },
+    "traitor.count_tiers": {
+      "state": "ENABLED",
+      "variants": {
+        "default": {
+          "tiers": [
+            {
+              "max_players": 5,
+              "count": 1
+            },
+            {
+              "max_players": 8,
+              "count": 2
+            },
+            {
+              "max_players": 11,
+              "count": 3
+            }
+          ],
+          "fallback_divisor": 3
+        }
+      },
+      "defaultVariant": "default"
+    },
+    "zombie.initial_count": {
+      "state": "ENABLED",
+      "variants": {
+        "default": 2,
+        "one": 1,
+        "three": 3
+      },
+      "defaultVariant": "default"
+    },
+    "zombie.respawn_min_seconds": {
+      "state": "ENABLED",
+      "variants": {
+        "default": 2.0,
+        "fast": 1.0,
+        "slow": 4.0
+      },
+      "defaultVariant": "default"
+    },
+    "zombie.respawn_max_seconds": {
+      "state": "ENABLED",
+      "variants": {
+        "default": 10.0,
+        "fast": 6.0,
+        "slow": 15.0
+      },
+      "defaultVariant": "default"
+    },
+    "thresholds": {
+      "state": "ENABLED",
+      "variants": {
+        "default": {
+          "slow_warning": [
+            1.2,
+            1.3,
+            1.6,
+            2.0,
+            2.5
+          ],
+          "slow_max": [
+            1.3,
+            1.5,
+            1.8,
+            2.5,
+            3.2
+          ],
+          "fast_warning": [
+            1.4,
+            1.6,
+            1.9,
+            2.7,
+            2.8
+          ],
+          "fast_max": [
+            1.6,
+            1.8,
+            2.8,
+            3.2,
+            3.5
+          ]
+        }
+      },
+      "defaultVariant": "default"
+    },
+    "zombie.thresholds": {
+      "state": "ENABLED",
+      "variants": {
+        "default": {
+          "warning": [
+            1.4,
+            1.7,
+            2.1,
+            2.9,
+            3.5
+          ],
+          "max": [
+            1.6,
+            1.9,
+            2.6,
+            3.9,
+            4.5
+          ]
+        }
+      },
+      "defaultVariant": "default"
+    },
+    "werewolf.thresholds": {
+      "state": "ENABLED",
+      "variants": {
+        "default": {
+          "warning": [
+            1.4,
+            1.7,
+            2.1,
+            2.9,
+            3.5
+          ],
+          "max": [
+            1.6,
+            1.9,
+            2.6,
+            3.9,
+            4.5
+          ]
+        }
+      },
+      "defaultVariant": "default"
+    },
+    "windows": {
+      "state": "ENABLED",
+      "variants": {
+        "default": {
+          "min_music_fast_time": 4,
+          "max_music_fast_time": 8,
+          "min_music_slow_time": 10,
+          "max_music_slow_time": 23,
+          "end_min_music_fast_time": 6,
+          "end_max_music_fast_time": 10,
+          "end_min_music_slow_time": 8,
+          "end_max_music_slow_time": 12
+        },
+        "calm": {
+          "min_music_fast_time": 3,
+          "max_music_fast_time": 6,
+          "min_music_slow_time": 13,
+          "max_music_slow_time": 30,
+          "end_min_music_fast_time": 4,
+          "end_max_music_fast_time": 7,
+          "end_min_music_slow_time": 10,
+          "end_max_music_slow_time": 16
+        },
+        "frantic": {
+          "min_music_fast_time": 6,
+          "max_music_fast_time": 11,
+          "min_music_slow_time": 6,
+          "max_music_slow_time": 14,
+          "end_min_music_fast_time": 8,
+          "end_max_music_fast_time": 14,
+          "end_min_music_slow_time": 5,
+          "end_max_music_slow_time": 8
+        }
+      },
+      "defaultVariant": "default",
+      "targeting": {
+        "if": [
+          {
+            "===": [
+              {
+                "var": "targetingKey"
+              },
+              "calm"
+            ]
+          },
+          "calm",
+          {
+            "if": [
+              {
+                "===": [
+                  {
+                    "var": "targetingKey"
+                  },
+                  "frantic"
+                ]
+              },
+              "frantic",
+              "default"
+            ]
+          }
+        ]
+      }
     }
   }
 }

--- a/services/flagd/system.ci.json
+++ b/services/flagd/system.ci.json
@@ -66,6 +66,51 @@
         "slow": 15
       },
       "defaultVariant": "normal"
+    },
+    "sentinel.update_hz": {
+      "state": "ENABLED",
+      "variants": {
+        "slow": 5,
+        "default": 10,
+        "fast": 20
+      },
+      "defaultVariant": "default"
+    },
+    "sentinel.min_brightness": {
+      "state": "ENABLED",
+      "variants": {
+        "dim": 0.05,
+        "default": 0.09,
+        "bright": 0.15
+      },
+      "defaultVariant": "default"
+    },
+    "sentinel.max_brightness": {
+      "state": "ENABLED",
+      "variants": {
+        "dim": 0.2,
+        "default": 0.3,
+        "bright": 0.5
+      },
+      "defaultVariant": "default"
+    },
+    "sentinel.breath_period_seconds": {
+      "state": "ENABLED",
+      "variants": {
+        "fast": 2.0,
+        "default": 4.0,
+        "slow": 8.0
+      },
+      "defaultVariant": "default"
+    },
+    "sentinel.hue_period_seconds": {
+      "state": "ENABLED",
+      "variants": {
+        "fast": 15.0,
+        "default": 30.0,
+        "slow": 60.0
+      },
+      "defaultVariant": "default"
     }
   }
 }

--- a/services/flagd/user.ci.json
+++ b/services/flagd/user.ci.json
@@ -42,6 +42,59 @@
         "off": false
       },
       "defaultVariant": "on"
+    },
+    "menu_auto_start": {
+      "state": "ENABLED",
+      "variants": {
+        "on": true,
+        "off": false
+      },
+      "defaultVariant": "on"
+    },
+    "audio_volume.game": {
+      "state": "ENABLED",
+      "variants": {
+        "quiet": 0.5,
+        "default": 0.7,
+        "loud": 0.9
+      },
+      "defaultVariant": "default"
+    },
+    "audio_volume.countdown_music": {
+      "state": "ENABLED",
+      "variants": {
+        "silent": 0.0,
+        "default": 0.15,
+        "loud": 0.3
+      },
+      "defaultVariant": "default"
+    },
+    "audio_volume.lobby_music": {
+      "state": "ENABLED",
+      "variants": {
+        "quiet": 0.2,
+        "default": 0.4,
+        "loud": 0.6
+      },
+      "defaultVariant": "default"
+    },
+    "audio_volume.menu_sound": {
+      "state": "ENABLED",
+      "variants": {
+        "quiet": 0.6,
+        "default": 0.8,
+        "loud": 1.0
+      },
+      "defaultVariant": "default"
+    },
+    "audio_volume.menu_voice": {
+      "state": "ENABLED",
+      "variants": {
+        "quiet": 0.7,
+        "default": 0.9,
+        "loud": 1.0
+      },
+      "defaultVariant": "default"
     }
   }
 }


### PR DESCRIPTION
Closes #801

## Problem
`docker-compose.ci.yml` mounts `<domain>.ci.json` over each base `<domain>.json` for the domains it overrides. These CI overrides had drifted: `game.ci.json` was missing the #766 F1–F3 calibration flags, so in CI they resolved to `FLAG_NOT_FOUND` and integration tests silently fell back to code defaults — unable to catch a flag-key typo or exercise a non-default variant. A sweep of the other CI overrides found the same gap in `controller`, `system`, and `user`.

## Changes
Added the missing flag definitions (verbatim base defaults; existing CI-deliberate overrides like `play_audio=off` and `backend=mock` preserved):

| File | Keys added |
|------|-----------|
| `game.ci.json` | `thresholds`, `windows`, `death_grace_period_seconds`, `fight_club.round_seconds`, `nonstop.respawn_seconds`, `nonstop.spawn_protection_seconds`, `nonstop.scoring`, `tournament.match_seconds`, `tournament.time_between_matches_seconds`, `werewolf.werewolf_fraction`, `werewolf.thresholds`, `zombie.thresholds`, `zombie.initial_count`, `zombie.respawn_min_seconds`, `zombie.respawn_max_seconds`, `traitor.count_tiers` (16) |
| `controller.ci.json` | `effect.warning_flash_ms`, `effect.warning_vibration_ms`, `effect.death_rumble_ms`, `effect.death_red_hold_ms`, `effect.death_fade_ms` (5) |
| `system.ci.json` | `sentinel.update_hz`, `sentinel.min_brightness`, `sentinel.max_brightness`, `sentinel.breath_period_seconds`, `sentinel.hue_period_seconds` (5) |
| `user.ci.json` | `menu_auto_start`, `audio_volume.game`, `audio_volume.countdown_music`, `audio_volume.lobby_music`, `audio_volume.menu_sound`, `audio_volume.menu_voice` (6) |

`observability.ci.json` was already in parity.

## Drift guard
`lib/tests/test_flagd_ci_drift.py` auto-discovers every `<domain>.ci.json` that has a base `<domain>.json` and asserts exact flag-key parity, with an actionable failure message (`add the new flag to <domain>.ci.json …`). It runs in the always-on **lib-tests** CI job (`cd lib && uv run pytest tests/`), so new domains are guarded automatically with no test edits.

`controller.ci-rust.json` is intentionally excluded: it is a single-flag canary override (`bluetooth_backend=rust`), not a full base replacement, and is not mounted by any compose file.

## agent / interventions / rollout — no CI override (intentional)
`docker-compose.ci.yml` only remounts `system`, `controller`, `observability`, `game`, `user`. `agent.json`, `interventions.json`, and `rollout.json` have **no `.ci.json`**, so their full base files load unchanged in CI. Confirmed in `docker-compose.yml` (8 sources) vs `docker-compose.ci.yml` (5 overrides). The drift guard skips them since they have no ci variant.

## Test plan
- `cd lib && uv run pytest tests/test_flagd_ci_drift.py -v` → 6 passed
- Negative check: temporarily deleting a key from `game.ci.json` makes the guard fail with the actionable message (verified locally, then restored)
- `cd lib && uv run pytest tests/` → 347 passed
- All `services/flagd/*.json` parse
- `make lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)