### PR TITLE
docs: agent ACT-path runbook + dispatchable probe mode (#799)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -697,6 +697,12 @@ services:
       # the scaffold stays inert.
       - AGENT_INTERVENTIONS_ENABLED=${AGENT_INTERVENTIONS_ENABLED:-false}
       - INTERVENTIONS_FLAG_PATH=/etc/flagd/interventions.json
+      # Demo/verification only: emit a synthetic `noop` decision (full audit
+      # trace) every ~5s. Off by default; never for production sessions. With the
+      # default interventions_allowed variant probe decisions are blocked
+      # (not_allowed) — flip that flag to the `probe` variant to dispatch. See
+      # docs/agent-act-runbook.md.
+      - AGENT_PROBE_DECISIONS=${AGENT_PROBE_DECISIONS:-}
       - LOG_LEVEL=${LOG_LEVEL:-info}
       - OTEL_SERVICE_NAME=agent
       - OTEL_SERVICE_NAMESPACE=infrastructure

--- a/docs/agent-act-runbook.md
+++ b/docs/agent-act-runbook.md
@@ -1,0 +1,280 @@
+# Agent ACT-Path Runbook — enabling the agent to act live
+
+This runbook takes a **stock deployment** (agent observes and traces, but
+dispatches nothing) to an agent that **acts on the live game**, and back. It is
+the demo script for the agentic control stack (issues #722–#730).
+
+For the design behind each flag and span, see the
+[agent README](../services/agent/README.md) and
+[feature-flags guide](feature-flags.md). For where to look in Jaeger/Grafana/Prometheus,
+see the observability section of `.claude/rules/development.md`.
+
+---
+
+## TL;DR
+
+A stock deployment dispatches **nothing**, by design. Two **independent gates**
+must both be open for an intervention to reach the game:
+
+| Gate | Where | Stock value | Act value | Restart? |
+|------|-------|-------------|-----------|----------|
+| **1. Sink** `AGENT_INTERVENTIONS_ENABLED` | compose env on the `agent` container | `false` (NoopActions — discards) | `true` (real `actions.Writer`) | **Yes** — restart `agent` |
+| **2. Kill switch** `enabled` | `services/flagd/agent.json` flag domain | `off` | `on` | **No** — flagd hot-reload (<100 ms) |
+
+Both gates are also the **safe defaults** when their backing config is missing
+(flagd unreachable → `enabled=false`; env unset → NoopActions), so the agent
+always comes up **inert**.
+
+The kill switch is a **flag flip** — instant, no restart. That is the demo
+panic button.
+
+---
+
+## Stock deployment behavior (the two-gate baseline)
+
+With `docker compose up`, the agent:
+
+- **Observes**: ingests spans + metrics over OTLP (`agent:4317`), accumulates a
+  `GameContext`, gates on whether a game is live with fresh data.
+- **Decides**: runs the objective-weighted rules engine each gated cycle,
+  evaluating all four flag layers from flagd live.
+- **Traces**: emits the `agent.span_received → agent.decision → agent.action`
+  audit trace whenever the engine returns ≥ 1 decision (idle cycles cost no
+  spans).
+- **Dispatches nothing**: the action sink is `NoopActions`
+  (`AGENT_INTERVENTIONS_ENABLED` unset), so even a permitted, fitting decision is
+  discarded. And `enabled=off` short-circuits the loop before any rule runs,
+  emitting only a throttled `agent.disabled` kill-switch trace.
+
+So the **whole OBSERVE/DECIDE/trace pipeline runs**, visible end to end in
+Jaeger, while no intervention ever reaches the game. That is intentional — and
+the reason this runbook exists.
+
+---
+
+## Going live — open both gates
+
+### Step 1 — Swap in the real action sink (env, requires restart)
+
+`AGENT_INTERVENTIONS_ENABLED=true` swaps `NoopActions` for `actions.Writer`,
+which applies decisions by rewriting `services/flagd/interventions.json` in place
+(the game coordinator watches that file and converges on its contents — there is
+no gRPC from the agent to the game services). This env is read **once at
+startup**, so it requires an agent restart:
+
+```bash
+AGENT_INTERVENTIONS_ENABLED=true docker compose up -d agent
+# or set it in your .env / compose override, then:
+docker compose up -d --no-deps agent
+```
+
+Confirm from the agent log:
+
+```
+Agent intervention writes enabled (#730) path=/etc/flagd/interventions.json
+```
+
+> The sink alone changes nothing yet — gate 2 (`enabled`) still short-circuits
+> the loop. Both must be open.
+
+### Step 2 — Flip the kill switch on (flag, no restart)
+
+Edit `enabled` in `services/flagd/agent.json` — change its `defaultVariant` from
+`off` to `on`:
+
+```json
+"enabled": {
+  "state": "ENABLED",
+  "variants": { "on": true, "off": false },
+  "defaultVariant": "on"
+}
+```
+
+Save. flagd's file-watch fires within **~100 ms–1 s**; no restart. The agent's
+next cycle runs the rules engine instead of emitting `agent.disabled`. This is
+the same mechanism documented in
+[feature-flags.md → Edit Flag Values](feature-flags.md#3-edit-flag-values), and
+mirrors the admin-mode `defaultVariant` rewrite in `lib/flag_config_writer.py`.
+
+### Step 3 — Open the permission surface
+
+Even with both gates open, the **permission layer** still bounds what dispatches.
+The stock `interventions_allowed` variant is `ambient` (audio cue, controller
+effect, volume only). To allow more, flip its `defaultVariant` in `agent.json`:
+
+| Variant | Allows |
+|---------|--------|
+| `none` | nothing (empty allow-list) |
+| `ambient` (stock) | `play_audio_cue`, `send_controller_effect`, `adjust_volume` |
+| `standard` | + tempo, pacing, player sensitivity, shield |
+| `full` | + global sensitivity/difficulty, eliminate, revive, end_game |
+| `probe` | `noop` only — for [probe mode](#probe-mode-full-path-without-touching-the-game) |
+
+An intervention not on the active list is **blocked** (`decision.blocked=true`,
+`decision.block_reason=not_allowed`) — traced, never silently dropped.
+
+---
+
+## Kill-switch path back (instant, no restart)
+
+Flip `enabled` back to `off` in `services/flagd/agent.json`. The next cycle
+short-circuits before any rule runs; only the throttled `agent.disabled` trace is
+emitted (`agent.enabled=false` visible in Jaeger). This is the **demo panic
+button** — a single flag flip, hot-reloaded in <100 ms, no container restart.
+
+(Setting `interventions_allowed` to `none` is a softer brake: the loop still runs
+and traces, but every decision is blocked `not_allowed`.)
+
+---
+
+## Demo flow — drive behavior live and watch the trace change
+
+Each step changes one flag live (no restart) and shows up on the **next**
+`agent.decision` span in Jaeger. The decision span carries the cycle's entire
+`LayerState` (#729), so a single trace answers *which flags were in effect, which
+objective was served, why this action, and was it permitted*.
+
+### A. Flip the objective → `decision.objective_served` changes
+
+Edit `objectives.defaultVariant` in `agent.json` (e.g. `balanced_focused` →
+`accelerate_focused`). On the next cycle the rules engine re-weights candidates;
+the selected winner's **`decision.objective_served`** attribute on `agent.decision`
+flips toward the now-dominant objective (e.g. `accelerate`). The cycle-level
+`agent.objectives` attribute shows the new weight map.
+
+### B. Change a `fitness.*` flag → `fitness.evaluated` changes
+
+Edit e.g. `fitness.endurance.min_session_seconds` (`default` 120 → `short` 60) or
+`fitness.accelerate.target_session_seconds` in `agent.json`. Fitness is evaluated
+**every cycle** against the live `GameContext`, so the next decision span's
+**`fitness.evaluated`** attribute shows the new threshold and recomputed progress
+(e.g. `endurance.min_session_seconds=60 endurance.session_progress=…`). A failing
+fitness amplifies the candidates serving that objective and can flip the selected
+winner — without blocking anything outright.
+
+### C. Observe an **applied** intervention → `game_interventions_total`
+
+With both gates open and a permitting `interventions_allowed`, run a live game
+(or push synthetic metrics — see the agent README *Local smoke test*). When the
+engine selects a permitted, fitting decision:
+
+1. `agent.action` span completes (no `decision.blocked`), and the agent rewrites
+   `services/flagd/interventions.json`.
+2. The **game coordinator** reads the changed file and applies the intervention,
+   incrementing the Prometheus counter
+   **`game_interventions_total{type, objective, blocked="false"}`**.
+
+In Grafana/Prometheus:
+
+```promql
+sum by (type) (rate(game_interventions_total{blocked="false"}[1m]))
+```
+
+### D. Observe a **blocked** one → `decision.blocked=true`
+
+Tighten a gate and watch a block. Two easy demos:
+
+- **Allow-list block**: set `interventions_allowed` to `none` (or a variant
+  excluding the rule's intervention). The next selected decision spans carry
+  `decision.blocked=true`, `decision.block_reason=not_allowed`; `agent.action` is
+  **not** dispatched (recorded `blocked` on the span), and
+  `game_interventions_total{blocked="true"}` increments on the game side.
+- **Rate-limit block**: lower `policy.max_interventions_per_minute` to
+  `conservative` (1). Once the weighted trailing-minute budget is spent, further
+  decisions block with `decision.block_reason=rate_limit`.
+
+---
+
+## Probe mode — full path without touching the game
+
+`AGENT_PROBE_DECISIONS=true` emits a synthetic `noop` decision every ~5 s, so you
+can verify the trace pipeline without a live game. See the agent README →
+[Probe mode](../services/agent/README.md#probe-mode-agent_probe_decisions).
+
+- **Default variant**: `noop` is in no standard allow-list, so probe decisions
+  are **blocked by design** (`decision.block_reason=not_allowed`). The
+  `agent.span_received → agent.decision` spans still emit — OBSERVE→DECIDE and the
+  span schema are fully exercised; only `agent.action` is withheld.
+- **Full path**: flip `interventions_allowed` to the **`probe`** variant
+  (`["noop"]`) in `agent.json`, plus `AGENT_INTERVENTIONS_ENABLED=true` and
+  `enabled=on`. `noop` is a harmless no-op in the `Writer` (returns success
+  without writing any flag), so the decision flows through every gate, reaches
+  the real sink, and completes the `agent.action` span — all without changing the
+  game.
+
+---
+
+## Where to look
+
+| Tool | Path | Use |
+|------|------|-----|
+| **Jaeger** | `http://localhost:8080/jaeger/` | Decision audit traces: `agent.span_received → agent.decision → agent.action`, and `agent.disabled` kill-switch traces. Service: `agent` |
+| **Grafana** | `http://localhost:8080/grafana/` | Dashboards in `services/grafana/dashboards/` |
+| **Prometheus** | `http://localhost:8080/prometheus/` | `game_interventions_total`, agent process metrics |
+| **agent logs** | `docker compose logs -f agent` | Sink-enabled warning, flag evaluation, block reasons |
+
+### Span attributes to watch (see the agent README for the full table)
+
+| Attribute | On | Meaning |
+|-----------|----|---------|
+| `agent.enabled` | every span | gate 2 (`false` = kill switch on) |
+| `agent.objectives` | `agent.decision` | live objective weight map |
+| `interventions.allowed` | `agent.decision` | active allow-list (`none` / `a,b,c`) |
+| `decision.objective_served` | `agent.decision` | objective the selected rule served |
+| `decision.action` / `decision.reason` | `agent.decision` | the chosen intervention + why |
+| `decision.blocked` / `decision.block_reason` | `agent.decision` | `not_allowed` / `battery_threshold` / `rate_limit` |
+| `fitness.evaluated` | `agent.decision` | per-objective thresholds + computed progress |
+
+Cross-reference: [agent README → Span schema (#724)](../services/agent/README.md#span-schema-724--the-trace-is-the-audit-log).
+
+---
+
+## Troubleshooting
+
+### "The agent decides, but nothing happens in the game"
+
+Walk the two gates plus the permission layer, in order:
+
+1. **Sink gate** — is `AGENT_INTERVENTIONS_ENABLED=true` on the `agent`
+   container, and was the container **restarted** since? The startup log must
+   show `Agent intervention writes enabled (#730)`. Without it the sink is
+   `NoopActions` and discards everything (no error, no write).
+2. **Kill switch** — is `enabled` `on` in `agent.json`? If `off`, the loop
+   short-circuits and you'll see `agent.disabled` traces (`agent.enabled=false`),
+   not `agent.decision`.
+3. **Allow-list** — is the rule's intervention in the active
+   `interventions_allowed` variant? Look for `decision.block_reason=not_allowed`.
+4. **Battery gate** — a player-targeted decision is blocked when the target's
+   battery is below `policy.battery_threshold` (`block_reason=battery_threshold`).
+5. **Rate limit** — `block_reason=rate_limit` means the weighted per-minute
+   budget (`policy.max_interventions_per_minute`) is spent; it replenishes over
+   the trailing minute.
+6. **File path** — `INTERVENTIONS_FLAG_PATH` must point at the bind-mounted file
+   flagd watches (`/etc/flagd/interventions.json`). The agent is the sole writer.
+
+### flagd unreachable → safe defaults
+
+If flagd is down or not yet reachable at startup, **every flag evaluation falls
+back to its safe default**: `enabled=false` (agent inert), and the lifecycle/
+throttle flags fall back to their former hardcoded constants. The agent still
+starts; it just does nothing until flagd is back. (The provider connects in the
+background, so recovery needs no restart — except the read-at-startup lifecycle
+flags, see the agent README → *Lifecycle flags*.)
+
+### Rate-limit budget exhausted
+
+Decisions blocking with `rate_limit` while the game looks quiet usually means the
+budget is too low for the demo. Raise `policy.max_interventions_per_minute` to
+`aggressive` (4), or recall that **hard** interventions cost 2, **medium** 1, and
+**soft** 0.5 against the trailing-minute budget (see the agent README →
+*Rules engine* weight table). Blocked decisions do **not** draw down the budget.
+
+---
+
+## See also
+
+- [Agent README](../services/agent/README.md) — four-layer model, span schema, action sink
+- [Feature flags guide](feature-flags.md) — flagd, domains, editing flag values
+- [Intervention surface research](research/722-intervention-surface.md) — the intervention vocabulary and weights
+</content>
+</invoke>

--- a/services/agent/README.md
+++ b/services/agent/README.md
@@ -437,12 +437,44 @@ All configuration is via environment variables:
 | `LOG_LEVEL` | `info` | Log verbosity |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | set in compose | Self-telemetry export (decision audit traces → collector → Jaeger); no-op when unset |
 | `OTEL_SERVICE_NAME` | `agent` | Service identity; also drives the self-ingestion skip |
-| `AGENT_PROBE_DECISIONS` | _unset_ | `true` enables the demo/verification probe: a synthetic `noop` decision (and thus a full audit trace) at most every 5 s. Never for production sessions |
+| `AGENT_PROBE_DECISIONS` | _unset_ | `true` enables the demo/verification probe: a synthetic `noop` decision (and thus a full audit trace) at most every 5 s. Never for production sessions. See [Probe mode](#probe-mode-agent_probe_decisions) |
 | `AGENT_INTERVENTIONS_ENABLED` | `false` | `true` swaps the no-op action sink for the real intervention **Writer** (#730). Default off keeps the scaffold inert |
 | `INTERVENTIONS_FLAG_PATH` | `/etc/flagd/interventions.json` | Path of the flagd interventions file the Writer rewrites (must be the bind-mounted file flagd watches) |
 
 > The Go agent uses the flagd **RPC** resolver (gRPC evaluation port `8013`),
 > not the in-process sync port `8015` that the Python services use.
+
+### Probe mode (`AGENT_PROBE_DECISIONS`)
+
+`AGENT_PROBE_DECISIONS=true` swaps the rules engine for `ProbeRules`, which emits
+one synthetic `noop` decision at most every 5 s. Its only purpose is to drive a
+**full audit trace** (`agent.span_received → agent.decision → agent.action`)
+without waiting for a live game to trigger the real rules — invaluable for
+verifying the trace pipeline end to end.
+
+**With the default `interventions_allowed` variant, probe decisions are blocked
+by design.** `noop` is not in the `ambient`/`standard`/`full` allow-lists, so the
+permission layer blocks every probe decision with `decision.blocked=true`,
+`decision.block_reason=not_allowed`. This is still useful: the
+`agent.span_received → agent.decision` spans are emitted (a blocked decision is
+traced, not dropped), so the OBSERVE→DECIDE path and the span schema are fully
+exercised — only the `agent.action` dispatch is withheld.
+
+**To make probe decisions dispatch** (exercise the *whole* path including
+`agent.action`), flip `interventions_allowed` to the dedicated **`probe`**
+variant (`["noop"]`) in [`services/flagd/agent.json`](../flagd/agent.json):
+
+```json
+"interventions_allowed": { "defaultVariant": "probe" }
+```
+
+`noop` is a **harmless no-op in the action sink**: the `Writer` recognizes it and
+returns success **without writing any flag** (`actions/writer.go`,
+`InterventionNoop`). So with the `probe` variant + `AGENT_INTERVENTIONS_ENABLED=true`
++ `enabled=on`, a probe decision flows through allow-list, battery, and rate-limit
+gates, reaches the real `Writer`, and completes the `agent.action` span — all
+without touching the game. Revert by flipping `interventions_allowed` back to
+`ambient` (or `none`).
 
 ### Lifecycle flags — read at startup (#766 F5)
 

--- a/services/agent/actions/writer.go
+++ b/services/agent/actions/writer.go
@@ -249,6 +249,13 @@ func (w *Writer) mutate(doc *orderedDoc, d decision.Decision) error {
 	case decision.InterventionGrantShield:
 		return w.setTargeted(doc, flagShieldSeconds, neutralNone, d.TargetSerial, w.numOr(d.Value, defaultShieldSeconds))
 
+	// Probe-mode synthetic intervention: no game effect, but a dispatched success
+	// so probe mode (AGENT_PROBE_DECISIONS + the `probe` interventions_allowed
+	// variant) exercises the full ACT path, including the agent.action span,
+	// without rewriting any flag.
+	case decision.InterventionNoop:
+		return nil
+
 	default:
 		return fmt.Errorf("unknown intervention %q", d.Intervention)
 	}

--- a/services/agent/actions/writer_test.go
+++ b/services/agent/actions/writer_test.go
@@ -310,6 +310,26 @@ func TestUnknownIntervention(t *testing.T) {
 	}
 }
 
+// TestNoopDispatchIsByteStableSuccess asserts that dispatching the probe-mode
+// `noop` intervention succeeds (it is NOT an unknown-intervention error) and
+// writes nothing — every flag round-trips byte-for-byte. Probe mode can thus
+// exercise the full ACT path harmlessly.
+func TestNoopDispatchIsByteStableSuccess(t *testing.T) {
+	w, path := newTestWriter(t)
+	before := readAllFlagsRaw(t, path)
+
+	if err := w.Apply(context.Background(), decision.Decision{Intervention: decision.InterventionNoop}); err != nil {
+		t.Fatalf("noop dispatch must succeed, got: %v", err)
+	}
+
+	after := readAllFlagsRaw(t, path)
+	for key, rawBefore := range before {
+		if string(after[key]) != string(rawBefore) {
+			t.Fatalf("noop must not mutate flag %q:\n before=%s\n after =%s", key, rawBefore, after[key])
+		}
+	}
+}
+
 // TestPreservesUnrelatedFlags asserts that flags the agent does not touch are
 // byte-identical before and after a write, and that touched flags are the only
 // difference.

--- a/services/agent/decision/probe.go
+++ b/services/agent/decision/probe.go
@@ -42,7 +42,7 @@ func (p *ProbeRules) Evaluate(context.Context, gamecontext.GameContext) []Decisi
 	}
 	p.last = t
 	return []Decision{{
-		Intervention: "noop",
+		Intervention: InterventionNoop,
 		Reason:       "probe decision for trace pipeline verification",
 	}}
 }

--- a/services/agent/decision/ratelimit.go
+++ b/services/agent/decision/ratelimit.go
@@ -43,6 +43,13 @@ const (
 	InterventionEliminatePlayer         = "eliminate_player"
 	InterventionRevivePlayer            = "revive_player"
 	InterventionEndGame                 = "end_game"
+
+	// InterventionNoop is the probe-mode synthetic intervention (ProbeRules). It
+	// carries no game effect: when dispatched through the action sink it is a
+	// no-op success, so probe mode exercises the full OBSERVE→DECIDE→ACT path
+	// (including the action span) harmlessly. It is allow-listed only via the
+	// `probe` variant of interventions_allowed (services/flagd/agent.json).
+	InterventionNoop = "noop"
 )
 
 // interventionWeights is the cost of each intervention against the per-minute

--- a/services/flagd/agent.json
+++ b/services/flagd/agent.json
@@ -78,6 +78,9 @@
       "state": "ENABLED",
       "variants": {
         "none": [],
+        "probe": [
+          "noop"
+        ],
         "ambient": [
           "play_audio_cue",
           "send_controller_effect",


### PR DESCRIPTION
Closes #799

## What

Two operator-experience gaps from the M2 completeness audit.

### 1. ACT-path runbook (`docs/agent-act-runbook.md`)
A stock deployment dispatches **nothing** by design — two independent gates must both be open:
- `AGENT_INTERVENTIONS_ENABLED=true` (compose env, swaps NoopActions → real `actions.Writer`; **requires agent restart**)
- `enabled=on` (flagd `agent` domain kill switch; **flag flip, hot-reloaded <100 ms, no restart**)

The runbook documents: the two-gate baseline, step-by-step go-live (env + flag flips + permission surface), the instant kill-switch path back, the demo flow (flip `objectives` → `decision.objective_served` changes; change `fitness.*` → `fitness.evaluated` changes; applied intervention → `game_interventions_total`; blocked one → `decision.blocked=true`), where to look (Jaeger/Grafana/Prometheus + span-attribute table), and gate-checklist troubleshooting (decides-but-nothing-happens, flagd unreachable safe defaults, rate-limit budget).

### 2. Dispatchable probe mode
`AGENT_PROBE_DECISIONS` emits intervention `noop`, which was in **zero** `interventions_allowed` variants → every probe decision blocked `not_allowed`, and a *dispatched* noop would have errored in the Writer (`unknown intervention "noop"`).

Fix:
- Added a **`probe` variant** (`["noop"]`) to `interventions_allowed` in `services/flagd/agent.json` (defaultVariant unchanged, so default behavior is identical).
- Added `decision.InterventionNoop` constant; `probe.go` now uses it.
- The action sink (`actions/writer.go`) now treats `noop` as a **byte-stable no-op success** — returns without writing any flag — so probe mode exercises the full OBSERVE→DECIDE→ACT path (including the `agent.action` span) harmlessly when the `probe` variant is active.
- Documented in the agent README probe section: default variant blocks probe by design (still verifies the trace pipeline), and how to enable dispatch.
- Exposed `AGENT_PROBE_DECISIONS` in `docker-compose.yml`.

## Test plan
- `go test -race ./...` from `services/agent` — all packages pass; new `TestNoopDispatchIsByteStableSuccess` asserts noop dispatch succeeds and mutates no flag.
- `gofmt -l` clean, `go vet ./...` clean.
- `python3 -c "import json; json.load(...)"` on `agent.json` and `yaml.safe_load` on `docker-compose.yml` — both parse.
- `make lint` — all checks passed.
- Claims in the runbook verified against code (gate semantics in `main.go`, block reasons in `decision.go`, `game_interventions_total{type,objective,blocked}` in game-coordinator `metrics.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)