### PR TITLE
feat(agent): progressive rollout expansion via rollout.json writes (#734)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -703,6 +703,12 @@ services:
       # (not_allowed) — flip that flag to the `probe` variant to dispatch. See
       # docs/agent-act-runbook.md.
       - AGENT_PROBE_DECISIONS=${AGENT_PROBE_DECISIONS:-}
+      # Progressive rollout expansion (#734): when enabled the agent advances the
+      # Bluetooth backend rollout controller-by-controller by rewriting the flagd
+      # rollout file in place (current_controller_count). Default off → the loop
+      # decides and spans expansions but does not apply them (dry-run).
+      - AGENT_ROLLOUT_ENABLED=${AGENT_ROLLOUT_ENABLED:-false}
+      - ROLLOUT_FLAG_PATH=/etc/flagd/rollout.json
       - LOG_LEVEL=${LOG_LEVEL:-info}
       - OTEL_SERVICE_NAME=agent
       - OTEL_SERVICE_NAMESPACE=infrastructure

--- a/services/agent/README.md
+++ b/services/agent/README.md
@@ -120,8 +120,9 @@ independently with no cross-contamination.
 Bluetooth transport against three **flag-sourced** thresholds and returns a
 structured `InfraFitnessResult` (`Evaluated` / `Passing` / `Violations` /
 `Values`). This is the infra-domain parallel to the game fitness functions
-(#731); it makes no rollout decision — rollout **expansion** (#734) and
-**rollback** (#736) consume the result in stacked follow-ups.
+(#731); it makes no rollout decision itself — rollout **expansion** (#734,
+[below](#progressive-rollout-expansion-734)) consumes the result, and
+**rollback** (#736) plugs into the same loop.
 
 | Fitness function | Flag key (default) | Violated when |
 |------------------|--------------------|---------------|
@@ -134,8 +135,8 @@ structured `InfraFitnessResult` (`Evaluated` / `Passing` / `Violations` /
 (`decision.LiveBluetoothFitness`, seeded with the flagd-schema defaults), so a
 threshold change on stage takes effect on the next evaluation with no restart.
 This source is **separate** from the game-objective `FitnessSource` — distinct
-flags, distinct concerns. (Until PR E wires the consumer, the observe-loop stub
-only logs the thresholds in effect.)
+flags, distinct concerns. The rollout-expansion loop (#734) reads these
+thresholds through it every cycle.
 
 **Missing signals are skipped, not failed** (mirroring game fitness): a `nil`
 window signal contributes no violation, and a context with *no* window signals at
@@ -151,6 +152,70 @@ attribute — `"<signal>[<serial>] <observed><cmp><threshold>"`, joined by `"; "
 ```
 event_gap_ms 87.5>50; movement_update_hz[AA:BB] 8.3<10
 ```
+
+### Progressive rollout expansion (#734)
+
+`decision.InfraLoop` consumes the infra fitness result to **expand the Bluetooth
+backend rollout controller-by-controller**. When fitness passes it advances
+`rollout.current_controller_count` one stage up a fixed ladder by rewriting
+`services/flagd/rollout.json` (the controller-manager watches the file and
+converges on it). The agent is the **sole writer** of `rollout.json`, via the
+same order-preserving in-place RMW as the interventions writer
+(`actions.RolloutWriter`); untouched flags round-trip byte-for-byte.
+
+**Stage ladder** (`current_controller_count` variants):
+
+| Variant | `none` | `one` | `three` | `six` | `all` |
+|---------|--------|-------|---------|-------|-------|
+| Value   | 0      | 1     | 3       | 6     | 99    |
+
+flagd flips by **variant name**, not value, so the loop maps the observed count
+(a number, read from the `controller.bluetooth_health` span's
+`bluetooth.rollout_count`) to the next variant via `actions.NextStage` /
+`actions.StageVariantForValue`. `all` (99) is terminal.
+
+**Decision matrix** (per observe cycle; observed state comes from the health
+span, **not** a flag re-read):
+
+| Rollout state | Fitness | Dwell elapsed & not held | Action | `remediation.action` | Span? |
+|---------------|---------|--------------------------|--------|----------------------|-------|
+| inactive (`target_backend==""`) | — | — | nothing | — | **no span** |
+| active, stage `< all` | passing | yes | flip to next variant | `expand` | yes |
+| active, stage `< all` | passing | no (dwell / hold) | nothing | `none` | yes |
+| active, stage `== all` | passing | — | nothing (terminal) | `none` | yes |
+| active | **failing** | — | **nothing** (no write — rollback is PR F) | `none` | yes |
+| active | write error | — | attempted, failed | `expand` (+ span error/status) | yes |
+
+**Dwell:** after each expansion the loop waits `AGENT_ROLLOUT_DWELL_SECONDS`
+(default **15s**) before expanding again, so fitness has time to observe the
+newly-added controllers at the current stage. The first expansion (no prior
+`lastExpansion`) is not delayed. A failed write does **not** advance the dwell
+clock, so the next passing cycle retries.
+
+**Fitness-failing branch (observe-only in this PR):** PR E records but never
+rolls back — a failing cycle emits the span with `remediation.action="none"` and
+the populated `fitness.violations`. **Rollback (PR F)** plugs into the
+`holdExpansion` hook (`InfraLoop.SetHoldExpansion`, always false here) for its
+post-rollback cooldown, and adds the rollback write (reset toward `none`).
+
+**Freshness gate** (`gate.ShouldEvaluateInfra`): the loop only evaluates when
+≥1 controller reported fresh `controller.bluetooth_health` within the controller
+TTL (5s). It is **game-state-independent** — controllers connect and stream in
+the lobby, and the rollout is driven by transport health alone.
+
+**Span** — `agent.infrastructure.decision`, emitted on **every active-rollout
+cycle**, carries `rollout.target`, `fitness.passing`, `fitness.violations`
+(empty when passing), `remediation.action`, the observed `bluetooth.*` signals,
+and `rollout.controller_count` (the new stage value) when expanding. A write
+failure sets the span status to error and records the error.
+
+**Env gates:**
+
+| Env | Default | Effect |
+|-----|---------|--------|
+| `AGENT_ROLLOUT_ENABLED` | `false` | `true` → real `RolloutWriter` applies flips. `false` → **dry-run**: the loop still decides and spans expansions (`remediation.action="expand"`, `rollout.controller_count` set) but does **not** write `rollout.json` (decided-but-not-applied; logged `agent.rollout_dry_run`). |
+| `ROLLOUT_FLAG_PATH` | `/etc/flagd/rollout.json` | rollout flag file path |
+| `AGENT_ROLLOUT_DWELL_SECONDS` | `15` | per-stage dwell before re-expansion |
 
 ## Gating & decisions
 

--- a/services/agent/actions/rollout_writer.go
+++ b/services/agent/actions/rollout_writer.go
@@ -1,0 +1,241 @@
+package actions
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"sync"
+)
+
+// RolloutWriter is the agent's writer for the flagd `rollout` flag file
+// (services/flagd/rollout.json). It is the infrastructure-domain parallel to
+// Writer: the progressive-rollout controller (#734) expands the Bluetooth
+// backend controller-by-controller by flipping current_controller_count's
+// defaultVariant along the stage ladder, and PR F rolls it back the same way.
+//
+// It reuses the same order-preserving read-modify-write-in-place machinery as
+// Writer (document.go / writeInPlace): untouched flags round-trip byte-for-byte,
+// and the write avoids temp+rename so it does not hit EBUSY on the flagd bind
+// mount. It carries its OWN mutex (separate file from interventions.json → a
+// separate lock); the agent is the sole writer of rollout.json.
+type RolloutWriter struct {
+	path string
+	log  *slog.Logger
+
+	mu sync.Mutex
+}
+
+// flagCurrentControllerCount is the rollout flag whose defaultVariant the agent
+// flips to advance/retreat the rollout stage.
+const flagCurrentControllerCount = "current_controller_count"
+
+// DefaultRolloutPath is the in-container rollout flag file path. Override with
+// ROLLOUT_FLAG_PATH.
+const DefaultRolloutPath = "/etc/flagd/rollout.json"
+
+// Rollout stage variant names and their controller-count values. These mirror
+// the current_controller_count variants in services/flagd/rollout.json. flagd
+// flips by VARIANT NAME (not value), so the agent must map the ladder value it
+// reasons about back to the variant name before writing — this mapping is the
+// sharp edge the loop depends on.
+const (
+	StageNoneVariant  = "none"
+	StageOneVariant   = "one"
+	StageThreeVariant = "three"
+	StageSixVariant   = "six"
+	StageAllVariant   = "all"
+
+	StageNoneValue  = 0
+	StageOneValue   = 1
+	StageThreeValue = 3
+	StageSixValue   = 6
+	StageAllValue   = 99
+)
+
+// rolloutLadder is the ordered expansion ladder: none(0) → one(1) → three(3) →
+// six(6) → all(99). It is the single source of truth for both NextStage and
+// StageVariantForValue, so the value↔variant mapping can never drift.
+var rolloutLadder = []struct {
+	variant string
+	value   int
+}{
+	{StageNoneVariant, StageNoneValue},
+	{StageOneVariant, StageOneValue},
+	{StageThreeVariant, StageThreeValue},
+	{StageSixVariant, StageSixValue},
+	{StageAllVariant, StageAllValue},
+}
+
+// NewRolloutWriter builds a RolloutWriter for the rollout flag file at path.
+// path "" uses DefaultRolloutPath. log nil uses slog.Default().
+func NewRolloutWriter(path string, log *slog.Logger) *RolloutWriter {
+	if path == "" {
+		path = DefaultRolloutPath
+	}
+	if log == nil {
+		log = slog.Default()
+	}
+	return &RolloutWriter{path: path, log: log}
+}
+
+// NewRolloutWriterFromEnv builds a RolloutWriter using ROLLOUT_FLAG_PATH (default
+// DefaultRolloutPath), mirroring NewWriterFromEnv.
+func NewRolloutWriterFromEnv(log *slog.Logger) *RolloutWriter {
+	return NewRolloutWriter(os.Getenv("ROLLOUT_FLAG_PATH"), log)
+}
+
+// SetControllerCount flips current_controller_count's defaultVariant to the
+// named variant. The variant MUST already exist in the document's variants map
+// (the agent never invents variants — the schema file ships them all); an
+// unknown variant is an error and the file is left untouched. Safe for
+// concurrent use.
+func (w *RolloutWriter) SetControllerCount(variant string) error {
+	if err := w.edit(func(doc *orderedDoc) error {
+		f, err := doc.flag(flagCurrentControllerCount)
+		if err != nil {
+			return err
+		}
+		// Validate the variant exists before flipping, so a typo never points
+		// defaultVariant at a missing variant (flagd would then serve no value).
+		variants := map[string]any{}
+		if ok, err := f.get("variants", &variants); err != nil {
+			return err
+		} else if !ok {
+			return fmt.Errorf("flag %q has no variants object", flagCurrentControllerCount)
+		}
+		if _, ok := variants[variant]; !ok {
+			return fmt.Errorf("variant %q not present in flag %q", variant, flagCurrentControllerCount)
+		}
+		if err := f.set("defaultVariant", variant); err != nil {
+			return err
+		}
+		return doc.putFlag(flagCurrentControllerCount, f)
+	}); err != nil {
+		return err
+	}
+	w.log.Debug("agent.rollout_written",
+		"flag", flagCurrentControllerCount,
+		"variant", variant,
+		"path", w.path)
+	return nil
+}
+
+// edit runs one read-modify-write cycle under the writer's mutex: read the file,
+// apply fn to the order-preserving document, and write it back in place. Mirrors
+// Writer.edit but over a separate file and lock.
+func (w *RolloutWriter) edit(fn func(*orderedDoc) error) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	raw, err := os.ReadFile(w.path)
+	if err != nil {
+		return fmt.Errorf("read rollout file %q: %w", w.path, err)
+	}
+	doc, err := parseDoc(raw)
+	if err != nil {
+		return err
+	}
+	if err := fn(doc); err != nil {
+		return err
+	}
+	out, err := doc.marshal()
+	if err != nil {
+		return err
+	}
+	return w.writeInPlace(out)
+}
+
+// writeInPlace overwrites the rollout file at the same path WITHOUT temp+rename
+// (same EBUSY-avoidance reasoning as Writer.writeInPlace).
+func (w *RolloutWriter) writeInPlace(data []byte) error {
+	f, err := os.OpenFile(w.path, os.O_WRONLY|os.O_TRUNC|os.O_CREATE, 0o644)
+	if err != nil {
+		return fmt.Errorf("open rollout file for write: %w", err)
+	}
+	if _, err := f.Write(data); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("write rollout file: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("close rollout file: %w", err)
+	}
+	return nil
+}
+
+// NextStage returns the next stage up the expansion ladder from the given
+// current controller-count VALUE: the next variant name, its value, and ok=true.
+// ok is false at or above the terminal stage (all/99), and also when current
+// does not sit on a known ladder value (a malformed/unknown observed count never
+// advances). It is the loop's "where do we expand to next?" helper, and pairs
+// with StageVariantForValue so the loop always flips by the correct variant
+// name.
+func NextStage(current int) (variant string, value int, ok bool) {
+	for i, stage := range rolloutLadder {
+		if stage.value == current {
+			if i+1 < len(rolloutLadder) {
+				next := rolloutLadder[i+1]
+				return next.variant, next.value, true
+			}
+			return "", 0, false // already at terminal stage (all)
+		}
+	}
+	return "", 0, false // unknown current value: do not advance
+}
+
+// StageVariantForValue maps a controller-count VALUE to its ladder variant name
+// (e.g. 3 → "three"). ok is false for any value not on the ladder. The loop uses
+// it to translate the observed rollout count (a number) into the variant flagd
+// flips by.
+func StageVariantForValue(value int) (string, bool) {
+	for _, stage := range rolloutLadder {
+		if stage.value == value {
+			return stage.variant, true
+		}
+	}
+	return "", false
+}
+
+// NextStage / StageVariantForValue are also exposed as methods so a
+// RolloutWriter can satisfy the decision package's actuator seam without that
+// package depending on these free functions (actions imports decision, so the
+// dependency cannot go the other way). They delegate to the package functions.
+func (w *RolloutWriter) NextStage(current int) (variant string, value int, ok bool) {
+	return NextStage(current)
+}
+
+func (w *RolloutWriter) StageVariantForValue(value int) (string, bool) {
+	return StageVariantForValue(value)
+}
+
+// DryRunRolloutWriter satisfies the same actuator seam as RolloutWriter but
+// NEVER writes the rollout file: SetControllerCount logs the would-be flip and
+// returns nil. It is the disabled-mode (AGENT_ROLLOUT_ENABLED=false) actuator —
+// the loop still decides and spans the expansion (remediation.action="expand"),
+// it just is not applied. The ladder helpers delegate to the real package
+// functions, so the value↔variant mapping stays single-sourced.
+type DryRunRolloutWriter struct {
+	log *slog.Logger
+}
+
+// NewDryRunRolloutWriter builds the no-op actuator. log nil → slog.Default().
+func NewDryRunRolloutWriter(log *slog.Logger) *DryRunRolloutWriter {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &DryRunRolloutWriter{log: log}
+}
+
+// SetControllerCount logs the intended flip and returns nil without writing.
+func (w *DryRunRolloutWriter) SetControllerCount(variant string) error {
+	w.log.Info("agent.rollout_dry_run",
+		"flag", flagCurrentControllerCount, "would_set_variant", variant)
+	return nil
+}
+
+func (w *DryRunRolloutWriter) NextStage(current int) (variant string, value int, ok bool) {
+	return NextStage(current)
+}
+
+func (w *DryRunRolloutWriter) StageVariantForValue(value int) (string, bool) {
+	return StageVariantForValue(value)
+}

--- a/services/agent/actions/rollout_writer_test.go
+++ b/services/agent/actions/rollout_writer_test.go
@@ -1,0 +1,210 @@
+package actions
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+// newTestRolloutWriter copies the real rollout.json fixture into a temp file and
+// returns a RolloutWriter over it plus the temp path.
+func newTestRolloutWriter(t *testing.T) (*RolloutWriter, string) {
+	t.Helper()
+	src, err := os.ReadFile(filepath.Join("testdata", "rollout.json"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "rollout.json")
+	if err := os.WriteFile(path, src, 0o644); err != nil {
+		t.Fatalf("write temp fixture: %v", err)
+	}
+	return NewRolloutWriter(path, discardLogger()), path
+}
+
+func defaultVariantOf(t *testing.T, path, flagKey string) string {
+	t.Helper()
+	flag := readFlag(t, path, flagKey)
+	dv, _ := flag["defaultVariant"].(string)
+	return dv
+}
+
+func TestSetControllerCount_FlipsDefaultVariant(t *testing.T) {
+	w, path := newTestRolloutWriter(t)
+
+	if got := defaultVariantOf(t, path, flagCurrentControllerCount); got != "none" {
+		t.Fatalf("fixture defaultVariant = %q, want none", got)
+	}
+	for _, variant := range []string{"one", "three", "six", "all"} {
+		if err := w.SetControllerCount(variant); err != nil {
+			t.Fatalf("SetControllerCount(%q): %v", variant, err)
+		}
+		if got := defaultVariantOf(t, path, flagCurrentControllerCount); got != variant {
+			t.Fatalf("after SetControllerCount(%q): defaultVariant = %q", variant, got)
+		}
+	}
+}
+
+// TestSetControllerCount_UntouchedFlagsByteStable asserts the order-preserving
+// RMW leaves every flag other than current_controller_count byte-for-byte intact.
+func TestSetControllerCount_UntouchedFlagsByteStable(t *testing.T) {
+	w, path := newTestRolloutWriter(t)
+
+	rawBefore := flagBytes(t, path)
+	if err := w.SetControllerCount("six"); err != nil {
+		t.Fatalf("SetControllerCount: %v", err)
+	}
+	rawAfter := flagBytes(t, path)
+
+	for _, key := range []string{"target_backend", "strategy", "remediation_allowed"} {
+		if string(rawBefore[key]) != string(rawAfter[key]) {
+			t.Errorf("flag %q changed:\n before: %s\n  after: %s", key, rawBefore[key], rawAfter[key])
+		}
+	}
+	// And the touched flag's variants map is untouched (only defaultVariant moved).
+	flag := readFlag(t, path, flagCurrentControllerCount)
+	variants, _ := flag["variants"].(map[string]any)
+	for _, name := range []string{"none", "one", "three", "six", "all"} {
+		if _, ok := variants[name]; !ok {
+			t.Errorf("variant %q lost after flip", name)
+		}
+	}
+}
+
+// flagBytes returns the raw JSON bytes of each flag in the document.
+func flagBytes(t *testing.T, path string) map[string]json.RawMessage {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	var doc struct {
+		Flags map[string]json.RawMessage `json:"flags"`
+	}
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("unmarshal doc: %v", err)
+	}
+	return doc.Flags
+}
+
+func TestSetControllerCount_UnknownVariantErrors(t *testing.T) {
+	w, path := newTestRolloutWriter(t)
+
+	if err := w.SetControllerCount("seven"); err == nil {
+		t.Fatal("SetControllerCount(unknown) returned nil error, want error")
+	}
+	// File must be left untouched on error.
+	if got := defaultVariantOf(t, path, flagCurrentControllerCount); got != "none" {
+		t.Errorf("defaultVariant changed on failed write: %q", got)
+	}
+}
+
+func TestNextStage_Ladder(t *testing.T) {
+	cases := []struct {
+		current     int
+		wantVariant string
+		wantValue   int
+		wantOK      bool
+	}{
+		{0, "one", 1, true},
+		{1, "three", 3, true},
+		{3, "six", 6, true},
+		{6, "all", 99, true},
+		{99, "", 0, false}, // terminal stage
+		{2, "", 0, false},  // unknown value: do not advance
+		{-1, "", 0, false},
+		{100, "", 0, false},
+	}
+	for _, tc := range cases {
+		gotVar, gotVal, gotOK := NextStage(tc.current)
+		if gotVar != tc.wantVariant || gotVal != tc.wantValue || gotOK != tc.wantOK {
+			t.Errorf("NextStage(%d) = (%q,%d,%v), want (%q,%d,%v)",
+				tc.current, gotVar, gotVal, gotOK, tc.wantVariant, tc.wantValue, tc.wantOK)
+		}
+	}
+}
+
+func TestStageVariantForValue(t *testing.T) {
+	cases := []struct {
+		value  int
+		want   string
+		wantOK bool
+	}{
+		{0, "none", true},
+		{1, "one", true},
+		{3, "three", true},
+		{6, "six", true},
+		{99, "all", true},
+		{2, "", false},
+		{-5, "", false},
+	}
+	for _, tc := range cases {
+		got, ok := StageVariantForValue(tc.value)
+		if got != tc.want || ok != tc.wantOK {
+			t.Errorf("StageVariantForValue(%d) = (%q,%v), want (%q,%v)", tc.value, got, ok, tc.want, tc.wantOK)
+		}
+	}
+}
+
+// TestNextStage_FullLadderWalk walks none→all and confirms it terminates.
+func TestNextStage_FullLadderWalk(t *testing.T) {
+	current := 0
+	wantValues := []int{1, 3, 6, 99}
+	for i, want := range wantValues {
+		variant, value, ok := NextStage(current)
+		if !ok {
+			t.Fatalf("step %d: NextStage(%d) ok=false, want advance", i, current)
+		}
+		if value != want {
+			t.Fatalf("step %d: NextStage(%d) value=%d, want %d", i, current, value, want)
+		}
+		if v, vok := StageVariantForValue(value); !vok || v != variant {
+			t.Fatalf("step %d: StageVariantForValue(%d) = (%q,%v), NextStage variant=%q", i, value, v, vok, variant)
+		}
+		current = value
+	}
+	if _, _, ok := NextStage(current); ok {
+		t.Fatalf("NextStage(%d) ok=true, want terminal", current)
+	}
+}
+
+// TestSetControllerCount_ConcurrentRace drives concurrent flips to exercise the
+// per-writer mutex under -race. Final state must be one of the valid variants.
+func TestSetControllerCount_ConcurrentRace(t *testing.T) {
+	w, path := newTestRolloutWriter(t)
+	variants := []string{"one", "three", "six", "all", "none"}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			if err := w.SetControllerCount(variants[n%len(variants)]); err != nil {
+				t.Errorf("SetControllerCount: %v", err)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	got := defaultVariantOf(t, path, flagCurrentControllerCount)
+	valid := map[string]bool{"one": true, "three": true, "six": true, "all": true, "none": true}
+	if !valid[got] {
+		t.Fatalf("final defaultVariant = %q, want one of the valid variants", got)
+	}
+}
+
+func TestDryRunRolloutWriter_NeverWrites(t *testing.T) {
+	w := NewDryRunRolloutWriter(discardLogger())
+	if err := w.SetControllerCount("all"); err != nil {
+		t.Fatalf("dry-run SetControllerCount: %v", err)
+	}
+	// Ladder helpers must match the real writer's.
+	if v, _, ok := w.NextStage(0); !ok || v != "one" {
+		t.Errorf("dry-run NextStage(0) = (%q,%v)", v, ok)
+	}
+	if v, ok := w.StageVariantForValue(6); !ok || v != "six" {
+		t.Errorf("dry-run StageVariantForValue(6) = (%q,%v)", v, ok)
+	}
+}

--- a/services/agent/actions/testdata/rollout.json
+++ b/services/agent/actions/testdata/rollout.json
@@ -1,0 +1,43 @@
+{
+  "metadata": {
+    "flagSetId": "rollout"
+  },
+  "flags": {
+    "target_backend": {
+      "state": "ENABLED",
+      "variants": {
+        "python": "python",
+        "rust": "rust"
+      },
+      "defaultVariant": "python"
+    },
+    "strategy": {
+      "state": "ENABLED",
+      "variants": {
+        "progressive": "progressive",
+        "immediate": "immediate",
+        "off": "off"
+      },
+      "defaultVariant": "off"
+    },
+    "current_controller_count": {
+      "state": "ENABLED",
+      "variants": {
+        "none": 0,
+        "one": 1,
+        "three": 3,
+        "six": 6,
+        "all": 99
+      },
+      "defaultVariant": "none"
+    },
+    "remediation_allowed": {
+      "state": "ENABLED",
+      "variants": {
+        "on": true,
+        "off": false
+      },
+      "defaultVariant": "off"
+    }
+  }
+}

--- a/services/agent/decision/infra_loop.go
+++ b/services/agent/decision/infra_loop.go
@@ -6,80 +6,291 @@ import (
 	"sync"
 	"time"
 
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+
 	"github.com/joustmania/agent/infracontext"
 )
 
 // InfraEvaluator is the seam the infrastructure observe path triggers when the
-// Bluetooth-health context updates. PR E plugs the real fitness + remediation
-// loop in behind this interface; this PR ships only the logging stub below.
+// Bluetooth-health context updates. InfraLoop is the real fitness + rollout
+// expansion implementation behind it (#734).
 //
-// OnInfraEvaluate receives the inbound gRPC context (for trace propagation in
-// PR E) and an isolated InfraContext snapshot.
+// OnInfraEvaluate receives the inbound gRPC context (for trace propagation) and
+// an isolated InfraContext snapshot.
 type InfraEvaluator interface {
 	OnInfraEvaluate(ctx context.Context, snap infracontext.InfraContext)
 }
 
-// InfraLoop is the OBSERVE-only infrastructure evaluation stub (#733, M3 PR C).
-// It logs the observed Bluetooth-health snapshot at debug level, throttled to at
-// most one line per throttle interval so the ~1Hz health-span stream does not
-// flood the log. The real fitness/decision/remediation loop lands in PR E,
-// plugging in behind the InfraEvaluator seam.
-type InfraLoop struct {
-	log      *slog.Logger
-	throttle time.Duration
-	// fitness supplies the live fitness.bluetooth.* thresholds (#735). The real
-	// fitness/remediation consumer arrives in PR E; for now the stub only logs the
-	// thresholds in effect so the seam is exercised. May be nil (defaults logged).
-	fitness BluetoothFitnessSource
-
-	mu      sync.Mutex
-	lastLog time.Time
-	now     func() time.Time
+// RolloutActuator is the write seam the InfraLoop uses to advance the rollout
+// stage. It is satisfied by actions.RolloutWriter (which flips the
+// current_controller_count defaultVariant in services/flagd/rollout.json) and by
+// a fake in tests. The actions package imports decision, so the dependency runs
+// loop → interface ← actions; the loop never imports actions.
+//
+// The ladder helpers live here too (NextStage / StageVariantForValue): the loop
+// reasons over controller-count VALUES but flagd flips by VARIANT NAME, so the
+// actuator owns the value↔variant mapping that bridges the two.
+type RolloutActuator interface {
+	// SetControllerCount flips current_controller_count's defaultVariant to the
+	// named variant; an unknown variant is an error and nothing is written.
+	SetControllerCount(variant string) error
+	// NextStage returns the next stage up the ladder from a controller-count
+	// value: the variant name, its value, and ok (false at/above the terminal
+	// stage or for an unknown current value).
+	NextStage(current int) (variant string, value int, ok bool)
+	// StageVariantForValue maps a controller-count value to its ladder variant
+	// name; ok is false for any value not on the ladder.
+	StageVariantForValue(value int) (string, bool)
 }
 
-// NewInfraLoop builds the observe-only stub. log may be nil (slog.Default() is
-// used). A non-positive throttle falls back to DefaultThrottleInterval. fitness
-// may be nil; the per-cycle Bluetooth thresholds it provides (#735) are only
-// logged in this PR — PR E plugs the fitness evaluation in behind this seam.
-func NewInfraLoop(log *slog.Logger, throttle time.Duration, fitness BluetoothFitnessSource) *InfraLoop {
+// rolloutGate decides whether the infrastructure observe path should evaluate at
+// all this cycle (≥1 controller reporting fresh health). It is the infra-domain
+// parallel to gate.ShouldEvaluate, injected so the loop stays unit-testable
+// without importing the gate package (which would be a layering inversion).
+type rolloutGate func(snap infracontext.InfraContext, now time.Time) bool
+
+// DefaultRolloutDwell is the minimum time the rollout must dwell at a stage with
+// passing fitness before the loop expands to the next stage. Each new stage adds
+// controllers to the target backend; fitness needs a few health windows to
+// observe whether the larger set is still healthy before we expand again. Tunable
+// via AGENT_ROLLOUT_DWELL_SECONDS (read at construction in main.go).
+const DefaultRolloutDwell = 15 * time.Second
+
+// Non-action remediation placeholder for the rollout decision span. In PR E the
+// loop OBSERVES — it expands when fitness passes but never rolls back. A
+// fitness-failing cycle therefore records remediation.action="none" (observe
+// only). PR F introduces the rollback semantics ("rollback" /
+// "recommended_only"); keeping this distinct from those values lets the M3 PR G
+// narrative test tell an E observe-cycle apart from an F rollback-blocked cycle.
+const (
+	RemediationNone   = "none"
+	RemediationExpand = "expand"
+)
+
+// AttrRolloutControllerCount is the new rollout stage VALUE recorded on the
+// decision span when the loop expands (e.g. 3 after advancing none→one→three).
+const AttrRolloutControllerCount = "rollout.controller_count"
+
+// InfraLoop runs the progressive-rollout expansion controller (#734). On each
+// infra observe cycle it gates on controller freshness, evaluates Bluetooth
+// fitness against the live fitness.bluetooth.* thresholds, reads the OBSERVED
+// rollout state from the health span, and — when fitness passes, the dwell has
+// elapsed, and no hold is in force — expands the rollout one stage up the ladder
+// by flipping current_controller_count. Every cycle where the rollout is ACTIVE
+// emits an agent.infrastructure.decision span.
+//
+// Rollback is PR F: this PR's fitness-failing branch only records (no write), and
+// the holdExpansion hook (always false here) is where PR F's post-rollback
+// cooldown plugs in. The loop is safe for concurrent OnInfraEvaluate calls (the
+// trace Export handler may invoke it from multiple goroutines): all loop state is
+// guarded by mu.
+type InfraLoop struct {
+	log     *slog.Logger
+	fitness BluetoothFitnessSource
+	rollout RolloutActuator
+	tracer  trace.Tracer
+
+	gate  rolloutGate
+	dwell time.Duration
+	now   func() time.Time
+
+	// holdExpansion is a hook that, when it returns true, suppresses an otherwise
+	// eligible expansion. It is always nil/false in PR E; PR F sets it to enforce a
+	// post-rollback cooldown. Guarded by mu (read inside the locked decide path).
+	holdExpansion func(now time.Time) bool
+
+	mu            sync.Mutex
+	lastExpansion time.Time
+}
+
+// NewInfraLoop builds the progressive-rollout loop (#734). log nil → slog.Default.
+// fitness nil → flagd-schema defaults each cycle. dwell ≤ 0 → DefaultRolloutDwell.
+//
+// rollout may be nil, in which case the loop NEVER expands (every active-rollout
+// cycle records remediation.action="none"); it still gates, evaluates fitness,
+// and emits the observe span. When AGENT_ROLLOUT_ENABLED is off, main.go passes a
+// dry-run actuator (real ladder, no-op write) instead, so the disabled path is
+// recorded as decided-but-not-applied rather than not-decided.
+func NewInfraLoop(log *slog.Logger, dwell time.Duration, fitness BluetoothFitnessSource, rollout RolloutActuator) *InfraLoop {
 	if log == nil {
 		log = slog.Default()
 	}
-	if throttle <= 0 {
-		throttle = DefaultThrottleInterval
+	if dwell <= 0 {
+		dwell = DefaultRolloutDwell
 	}
 	return &InfraLoop{
-		log:      log,
-		throttle: throttle,
-		fitness:  fitness,
-		now:      time.Now,
+		log:     log,
+		fitness: fitness,
+		rollout: rollout,
+		tracer:  otel.Tracer(instrumentationName),
+		gate:    defaultRolloutGate,
+		dwell:   dwell,
+		now:     time.Now,
 	}
 }
 
-// OnInfraEvaluate logs the current Bluetooth-health snapshot, throttled. It is
-// safe for concurrent use: the trace Export handler invokes it from its own
-// goroutine.
-func (l *InfraLoop) OnInfraEvaluate(_ context.Context, snap infracontext.InfraContext) {
-	l.mu.Lock()
+// defaultRolloutGate returns true when ≥1 controller has a fresh health update.
+// main.go injects the real gate.ShouldEvaluateInfra at construction; this
+// fallback keeps a default-constructed loop from gating everything out. The TTL
+// matches the infra controller retention default (5s ≈ five 1Hz windows).
+func defaultRolloutGate(snap infracontext.InfraContext, now time.Time) bool {
+	const ttl = 5 * time.Second
+	for _, c := range snap.Controllers {
+		if c != nil && now.Sub(c.LastUpdate) <= ttl {
+			return true
+		}
+	}
+	return false
+}
+
+// SetGate overrides the freshness gate (main.go injects gate.ShouldEvaluateInfra).
+func (l *InfraLoop) SetGate(g func(snap infracontext.InfraContext, now time.Time) bool) {
+	if g != nil {
+		l.gate = g
+	}
+}
+
+// OnInfraEvaluate runs one rollout-expansion decision cycle. See InfraLoop's doc
+// for the decision matrix. Safe for concurrent use.
+func (l *InfraLoop) OnInfraEvaluate(ctx context.Context, snap infracontext.InfraContext) {
 	now := l.now()
-	if !l.lastLog.IsZero() && now.Sub(l.lastLog) < l.throttle {
-		l.mu.Unlock()
+
+	// (1) Gate: no fresh controllers → nothing to observe, no span (PR G may
+	// revisit emitting an "idle" span).
+	if l.gate != nil && !l.gate(snap, now) {
 		return
 	}
-	l.lastLog = now
-	l.mu.Unlock()
 
+	// (2) Fitness against the live thresholds.
 	th := DefaultBluetoothThresholds()
 	if l.fitness != nil {
 		th = l.fitness.BluetoothThresholds()
 	}
-	l.log.Debug("infrastructure observe (#733 stub)",
-		"active_controllers", snap.Window.ActiveControllers,
-		"target_backend", snap.Window.TargetBackend,
-		"rollout_count", snap.Window.RolloutCount,
-		"controllers", len(snap.Controllers),
-		"max_event_gap_ms", th.MaxEventGapMs,
-		"max_dropped_events_pct", th.MaxDroppedEventsPct,
-		"min_movement_update_hz", th.MinMovementUpdateHz,
+	fit := EvaluateInfraFitness(snap, th)
+
+	// (3) Observed rollout state from the health span. The rollout is ACTIVE only
+	// when the controller-manager reports a target backend ("" means strategy off).
+	target := snap.Window.TargetBackend
+	stage := snap.Window.RolloutCount
+	if target == "" {
+		// Rollout inactive → no decision span, nothing to do.
+		return
+	}
+
+	// (4) Decide.
+	l.mu.Lock()
+	action := RemediationNone
+	var expandedTo int
+	wroteVariant := ""
+	var writeErr error
+
+	if fit.Evaluated && fit.Passing && l.rollout != nil {
+		if variant, value, ok := l.rollout.NextStage(stage); ok && l.shouldExpandLocked(now) {
+			action = RemediationExpand
+			expandedTo = value
+			wroteVariant = variant
+			writeErr = l.rollout.SetControllerCount(variant)
+			if writeErr == nil {
+				l.lastExpansion = now
+			}
+		}
+	}
+	// fitness failing → action stays RemediationNone (observe only; rollback is PR F).
+	l.mu.Unlock()
+
+	// (5) Span: every ACTIVE-rollout cycle is audited.
+	l.emitDecisionSpan(ctx, now, snap, fit, target, stage, action, expandedTo, wroteVariant, writeErr)
+}
+
+// shouldExpandLocked is the expansion guard: the dwell since the last expansion
+// must have elapsed AND no hold may be in force. Caller holds mu.
+//
+//   - dwell: fitness needs time to observe each new stage before we add more
+//     controllers. lastExpansion zero (never expanded) passes the dwell check so
+//     the first expansion is not delayed.
+//   - holdExpansion: always false in PR E; PR F's post-rollback cooldown sets it
+//     to block re-expansion for a window after a rollback.
+func (l *InfraLoop) shouldExpandLocked(now time.Time) bool {
+	if !l.lastExpansion.IsZero() && now.Sub(l.lastExpansion) < l.dwell {
+		return false
+	}
+	if l.holdExpansion != nil && l.holdExpansion(now) {
+		return false
+	}
+	return true
+}
+
+// emitDecisionSpan emits the agent.infrastructure.decision span for one
+// ACTIVE-rollout cycle, mirroring telemetry.go conventions (tracer.Start +
+// WithAttributes, error.type + status on write failure). expandedTo/wroteVariant
+// are only meaningful when action == RemediationExpand.
+func (l *InfraLoop) emitDecisionSpan(
+	ctx context.Context,
+	now time.Time,
+	snap infracontext.InfraContext,
+	fit InfraFitnessResult,
+	target string,
+	stage int,
+	action string,
+	expandedTo int,
+	wroteVariant string,
+	writeErr error,
+) {
+	attrs := []attribute.KeyValue{
+		attribute.String(AttrRolloutTarget, target),
+		attribute.Bool(AttrFitnessPassing, fit.Evaluated && fit.Passing),
+		attribute.String(AttrFitnessViolations, fit.ViolationsString()),
+		attribute.String(AttrRemediationAction, action),
+		attribute.String(AttrBluetoothTargetBackend, snap.Window.TargetBackend),
+		attribute.Int(AttrBluetoothRolloutCount, snap.Window.RolloutCount),
+	}
+	if v := snap.Window.EventGapMs; v != nil {
+		attrs = append(attrs, attribute.Float64(AttrBluetoothEventGapMs, *v))
+	}
+	if v := snap.Window.DroppedEventsPct; v != nil {
+		attrs = append(attrs, attribute.Float64(AttrBluetoothDroppedEventsPct, *v))
+	}
+	if v := snap.Window.MovementUpdateHz; v != nil {
+		attrs = append(attrs, attribute.Float64(AttrBluetoothMovementUpdateHz, *v))
+	}
+	if v := snap.Window.ActiveControllers; v != nil {
+		attrs = append(attrs, attribute.Int(AttrBluetoothActiveControllers, *v))
+	}
+	if action == RemediationExpand {
+		// The stage the loop expanded to (the WOULD-be stage in DRY-RUN).
+		attrs = append(attrs, attribute.Int(AttrRolloutControllerCount, expandedTo))
+	}
+
+	_, span := l.tracer.Start(ctx, SpanInfraDecision,
+		trace.WithSpanKind(trace.SpanKindInternal),
+		trace.WithAttributes(attrs...),
 	)
+	defer span.End()
+
+	if writeErr != nil {
+		span.RecordError(writeErr)
+		span.SetStatus(codes.Error, writeErr.Error())
+		l.log.Error("agent.rollout_expand_failed",
+			"target", target, "from_stage", stage, "to_variant", wroteVariant, "error", writeErr)
+		return
+	}
+
+	if action == RemediationExpand {
+		l.log.Info("agent.rollout_expand",
+			"target", target, "from_stage", stage, "to_stage", expandedTo,
+			"to_variant", wroteVariant)
+	}
+}
+
+// SetHoldExpansion installs the PR F post-rollback cooldown hook. When hold
+// returns true an otherwise-eligible expansion is suppressed (the loop still
+// emits an observe span). Nil clears the hook (no hold). Safe to call before the
+// loop is driven.
+func (l *InfraLoop) SetHoldExpansion(hold func(now time.Time) bool) {
+	l.mu.Lock()
+	l.holdExpansion = hold
+	l.mu.Unlock()
 }

--- a/services/agent/decision/infra_loop_test.go
+++ b/services/agent/decision/infra_loop_test.go
@@ -1,0 +1,303 @@
+package decision
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"github.com/joustmania/agent/infracontext"
+)
+
+// fakeRollout is an in-memory RolloutActuator: it records SetControllerCount
+// calls and uses the real ladder semantics (so the loop walks the same stages as
+// production). An err makes SetControllerCount fail.
+type fakeRollout struct {
+	mu      sync.Mutex
+	written []string
+	err     error
+}
+
+func (f *fakeRollout) SetControllerCount(variant string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.err != nil {
+		return f.err
+	}
+	f.written = append(f.written, variant)
+	return nil
+}
+
+func (f *fakeRollout) calls() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.written...)
+}
+
+// Ladder mirrors the production ladder (none→one→three→six→all).
+func (f *fakeRollout) NextStage(current int) (string, int, bool) {
+	ladder := [][2]int{{0, 1}, {1, 3}, {3, 6}, {6, 99}}
+	names := map[int]string{1: "one", 3: "three", 6: "six", 99: "all"}
+	for _, p := range ladder {
+		if p[0] == current {
+			return names[p[1]], p[1], true
+		}
+	}
+	return "", 0, false
+}
+
+func (f *fakeRollout) StageVariantForValue(value int) (string, bool) {
+	names := map[int]string{0: "none", 1: "one", 3: "three", 6: "six", 99: "all"}
+	n, ok := names[value]
+	return n, ok
+}
+
+// infraSnap builds an active-rollout InfraContext: a target backend, a rollout
+// count (stage), one fresh controller, and a passing or failing window.
+func infraSnap(target string, stage int, now time.Time, hz float64) infracontext.InfraContext {
+	h := hz
+	return infracontext.InfraContext{
+		Window: infracontext.WindowSignals{
+			EventGapMs:       fp(20),
+			DroppedEventsPct: fp(0.01),
+			MovementUpdateHz: &h,
+			TargetBackend:    target,
+			RolloutCount:     stage,
+		},
+		Controllers: map[string]*infracontext.ControllerHealth{
+			"AA:BB": {Serial: "AA:BB", LastUpdate: now},
+		},
+	}
+}
+
+// newInfraLoop builds a loop with a fake clock, fake rollout actuator, default
+// thresholds, an always-pass gate, and a recording tracer.
+func newInfraLoop(t *testing.T, rollout RolloutActuator, clock *time.Time) (*InfraLoop, *tracetest.SpanRecorder) {
+	t.Helper()
+	sr := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+
+	l := NewInfraLoop(slog.New(slog.NewTextHandler(io.Discard, nil)), DefaultRolloutDwell, NewLiveBluetoothFitness(), rollout)
+	l.tracer = tp.Tracer("test")
+	l.now = func() time.Time { return *clock }
+	l.SetGate(func(snap infracontext.InfraContext, now time.Time) bool { return true })
+	return l, sr
+}
+
+func infraSpans(sr *tracetest.SpanRecorder) []sdktrace.ReadOnlySpan {
+	return spansByName(sr.Ended(), SpanInfraDecision)
+}
+
+func spanStr(s sdktrace.ReadOnlySpan, key string) (string, bool) {
+	for _, kv := range s.Attributes() {
+		if string(kv.Key) == key {
+			return kv.Value.AsString(), true
+		}
+	}
+	return "", false
+}
+
+func spanInt(s sdktrace.ReadOnlySpan, key string) (int64, bool) {
+	for _, kv := range s.Attributes() {
+		if string(kv.Key) == key {
+			return kv.Value.AsInt64(), true
+		}
+	}
+	return 0, false
+}
+
+func TestInfraLoop_ExpandsWhenPassing(t *testing.T) {
+	clock := time.Unix(1000, 0)
+	rollout := &fakeRollout{}
+	l, sr := newInfraLoop(t, rollout, &clock)
+
+	// Stage none(0), passing fitness, dwell satisfied (never expanded): expand to one.
+	l.OnInfraEvaluate(context.Background(), infraSnap("rust", 0, clock, 30))
+
+	if got := rollout.calls(); len(got) != 1 || got[0] != "one" {
+		t.Fatalf("writes = %v, want [one]", got)
+	}
+	spans := infraSpans(sr)
+	if len(spans) != 1 {
+		t.Fatalf("got %d decision spans, want 1", len(spans))
+	}
+	if v, _ := spanStr(spans[0], AttrRemediationAction); v != RemediationExpand {
+		t.Errorf("remediation.action = %q, want %q", v, RemediationExpand)
+	}
+	if v, _ := spanStr(spans[0], AttrRolloutTarget); v != "rust" {
+		t.Errorf("rollout.target = %q, want rust", v)
+	}
+	if v, _ := spanInt(spans[0], AttrRolloutControllerCount); v != 1 {
+		t.Errorf("rollout.controller_count = %d, want 1", v)
+	}
+	if v, _ := spanStr(spans[0], AttrFitnessViolations); v != "" {
+		t.Errorf("fitness.violations = %q, want empty", v)
+	}
+}
+
+func TestInfraLoop_NoExpandWhenFitnessFailing(t *testing.T) {
+	clock := time.Unix(1000, 0)
+	rollout := &fakeRollout{}
+	l, sr := newInfraLoop(t, rollout, &clock)
+
+	// hz below the floor (10) → movement_update_hz violation → failing.
+	l.OnInfraEvaluate(context.Background(), infraSnap("rust", 0, clock, 5))
+
+	if got := rollout.calls(); len(got) != 0 {
+		t.Fatalf("writes = %v, want none (fitness failing → no rollback in PR E)", got)
+	}
+	spans := infraSpans(sr)
+	if len(spans) != 1 {
+		t.Fatalf("got %d spans, want 1 (failing cycle still spans)", len(spans))
+	}
+	if v, _ := spanStr(spans[0], AttrRemediationAction); v != RemediationNone {
+		t.Errorf("remediation.action = %q, want %q (observe only)", v, RemediationNone)
+	}
+	if v, ok := spanStr(spans[0], AttrFitnessViolations); !ok || v == "" {
+		t.Errorf("fitness.violations = %q, want non-empty", v)
+	}
+}
+
+func TestInfraLoop_NoExpandAtTerminalStage(t *testing.T) {
+	clock := time.Unix(1000, 0)
+	rollout := &fakeRollout{}
+	l, sr := newInfraLoop(t, rollout, &clock)
+
+	// Stage all(99), passing: nothing above, no expansion, but still spans (active).
+	l.OnInfraEvaluate(context.Background(), infraSnap("rust", 99, clock, 30))
+
+	if got := rollout.calls(); len(got) != 0 {
+		t.Fatalf("writes = %v, want none at terminal stage", got)
+	}
+	if spans := infraSpans(sr); len(spans) != 1 {
+		t.Fatalf("got %d spans, want 1", len(spans))
+	} else if v, _ := spanStr(spans[0], AttrRemediationAction); v != RemediationNone {
+		t.Errorf("remediation.action = %q, want %q", v, RemediationNone)
+	}
+}
+
+func TestInfraLoop_DwellBlocksImmediateReExpand(t *testing.T) {
+	clock := time.Unix(1000, 0)
+	rollout := &fakeRollout{}
+	l, sr := newInfraLoop(t, rollout, &clock)
+
+	// First expansion: none→one.
+	l.OnInfraEvaluate(context.Background(), infraSnap("rust", 0, clock, 30))
+	// Immediately re-evaluate at stage one(1): dwell not elapsed → no expansion.
+	clock = clock.Add(5 * time.Second)
+	l.OnInfraEvaluate(context.Background(), infraSnap("rust", 1, clock, 30))
+
+	if got := rollout.calls(); len(got) != 1 {
+		t.Fatalf("writes = %v, want only the first expansion (dwell blocks re-expand)", got)
+	}
+
+	// After the dwell elapses, the next evaluation expands one→three.
+	clock = clock.Add(DefaultRolloutDwell)
+	l.OnInfraEvaluate(context.Background(), infraSnap("rust", 1, clock, 30))
+	if got := rollout.calls(); len(got) != 2 || got[1] != "three" {
+		t.Fatalf("writes = %v, want second expansion to three after dwell", got)
+	}
+	if n := len(infraSpans(sr)); n != 3 {
+		t.Errorf("got %d spans, want 3 (one per active cycle)", n)
+	}
+}
+
+func TestInfraLoop_InactiveRolloutNoSpan(t *testing.T) {
+	clock := time.Unix(1000, 0)
+	rollout := &fakeRollout{}
+	l, sr := newInfraLoop(t, rollout, &clock)
+
+	// TargetBackend "" → rollout off → no decision span, no write.
+	snap := infraSnap("", 0, clock, 30)
+	l.OnInfraEvaluate(context.Background(), snap)
+
+	if got := rollout.calls(); len(got) != 0 {
+		t.Fatalf("writes = %v, want none when rollout inactive", got)
+	}
+	if n := len(infraSpans(sr)); n != 0 {
+		t.Fatalf("got %d spans, want 0 when rollout inactive", n)
+	}
+}
+
+func TestInfraLoop_GatedOutNoSpan(t *testing.T) {
+	clock := time.Unix(1000, 0)
+	rollout := &fakeRollout{}
+	l, sr := newInfraLoop(t, rollout, &clock)
+	l.SetGate(func(snap infracontext.InfraContext, now time.Time) bool { return false })
+
+	l.OnInfraEvaluate(context.Background(), infraSnap("rust", 0, clock, 30))
+
+	if len(rollout.calls()) != 0 || len(infraSpans(sr)) != 0 {
+		t.Fatalf("gated-out cycle must not write or span")
+	}
+}
+
+func TestInfraLoop_WriteErrorRecordedOnSpan(t *testing.T) {
+	clock := time.Unix(1000, 0)
+	rollout := &fakeRollout{err: errors.New("disk full")}
+	l, sr := newInfraLoop(t, rollout, &clock)
+
+	l.OnInfraEvaluate(context.Background(), infraSnap("rust", 0, clock, 30))
+
+	spans := infraSpans(sr)
+	if len(spans) != 1 {
+		t.Fatalf("got %d spans, want 1", len(spans))
+	}
+	if status := spans[0].Status(); status.Code.String() != "Error" {
+		t.Errorf("span status = %v, want Error", status.Code)
+	}
+	if n := len(spans[0].Events()); n == 0 {
+		t.Errorf("write error not recorded as a span event")
+	}
+	// lastExpansion must NOT advance on a failed write, so the next passing cycle
+	// retries the expansion.
+	rollout.mu.Lock()
+	rollout.err = nil
+	rollout.mu.Unlock()
+	clock = clock.Add(time.Second)
+	l.OnInfraEvaluate(context.Background(), infraSnap("rust", 0, clock, 30))
+	if got := rollout.calls(); len(got) != 1 || got[0] != "one" {
+		t.Fatalf("after failed write then success, writes = %v, want [one] (retry not dwell-blocked)", got)
+	}
+}
+
+func TestInfraLoop_HoldExpansionSuppresses(t *testing.T) {
+	clock := time.Unix(1000, 0)
+	rollout := &fakeRollout{}
+	l, sr := newInfraLoop(t, rollout, &clock)
+	// PR F hook: hold always on → no expansion even though everything else is clear.
+	l.SetHoldExpansion(func(now time.Time) bool { return true })
+
+	l.OnInfraEvaluate(context.Background(), infraSnap("rust", 0, clock, 30))
+
+	if got := rollout.calls(); len(got) != 0 {
+		t.Fatalf("writes = %v, want none while hold is in force", got)
+	}
+	if spans := infraSpans(sr); len(spans) != 1 {
+		t.Fatalf("got %d spans, want 1 (still observes)", len(spans))
+	} else if v, _ := spanStr(spans[0], AttrRemediationAction); v != RemediationNone {
+		t.Errorf("remediation.action = %q, want %q while held", v, RemediationNone)
+	}
+}
+
+func TestInfraLoop_NilActuatorNeverExpands(t *testing.T) {
+	clock := time.Unix(1000, 0)
+	l, sr := newInfraLoop(t, nil, &clock)
+
+	l.OnInfraEvaluate(context.Background(), infraSnap("rust", 0, clock, 30))
+
+	spans := infraSpans(sr)
+	if len(spans) != 1 {
+		t.Fatalf("got %d spans, want 1 (still observes with nil actuator)", len(spans))
+	}
+	if v, _ := spanStr(spans[0], AttrRemediationAction); v != RemediationNone {
+		t.Errorf("remediation.action = %q, want %q (nil actuator never expands)", v, RemediationNone)
+	}
+}

--- a/services/agent/gate/infra_gate.go
+++ b/services/agent/gate/infra_gate.go
@@ -1,0 +1,27 @@
+package gate
+
+import (
+	"time"
+
+	"github.com/joustmania/agent/infracontext"
+)
+
+// ShouldEvaluateInfra gates the infrastructure (rollout) decision loop (#734).
+// It returns true when at least one controller reported a fresh
+// controller.bluetooth_health update (LastUpdate within ttl of now).
+//
+// Unlike ShouldEvaluate, this gate is GAME-STATE-INDEPENDENT: controllers
+// connect and stream Bluetooth health in the lobby, before and after any game,
+// and the rollout is expanded based on transport health alone. Gating on a live
+// game here would stall the rollout whenever no game is running, which is most of
+// the time. A stale-only context (every controller older than ttl) gates out: a
+// rollout decision on signals nobody is currently producing would be acting on
+// nothing.
+func ShouldEvaluateInfra(infra infracontext.InfraContext, now time.Time, ttl time.Duration) bool {
+	for _, c := range infra.Controllers {
+		if c != nil && now.Sub(c.LastUpdate) <= ttl {
+			return true
+		}
+	}
+	return false
+}

--- a/services/agent/gate/infra_gate_test.go
+++ b/services/agent/gate/infra_gate_test.go
@@ -1,0 +1,40 @@
+package gate
+
+import (
+	"testing"
+	"time"
+
+	"github.com/joustmania/agent/infracontext"
+)
+
+func TestShouldEvaluateInfra(t *testing.T) {
+	now := time.Unix(1000, 0)
+	ttl := 5 * time.Second
+
+	fresh := &infracontext.ControllerHealth{Serial: "AA:BB", LastUpdate: now}
+	stale := &infracontext.ControllerHealth{Serial: "CC:DD", LastUpdate: now.Add(-10 * time.Second)}
+	edge := &infracontext.ControllerHealth{Serial: "EE:FF", LastUpdate: now.Add(-5 * time.Second)} // exactly ttl
+
+	cases := []struct {
+		name        string
+		controllers map[string]*infracontext.ControllerHealth
+		want        bool
+	}{
+		{"no controllers", map[string]*infracontext.ControllerHealth{}, false},
+		{"nil map", nil, false},
+		{"one fresh", map[string]*infracontext.ControllerHealth{"AA:BB": fresh}, true},
+		{"one stale", map[string]*infracontext.ControllerHealth{"CC:DD": stale}, false},
+		{"fresh + stale mix", map[string]*infracontext.ControllerHealth{"AA:BB": fresh, "CC:DD": stale}, true},
+		{"exactly at ttl boundary", map[string]*infracontext.ControllerHealth{"EE:FF": edge}, true},
+		{"nil entry only", map[string]*infracontext.ControllerHealth{"X": nil}, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			infra := infracontext.InfraContext{Controllers: tc.controllers}
+			if got := ShouldEvaluateInfra(infra, now, ttl); got != tc.want {
+				t.Fatalf("ShouldEvaluateInfra = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/services/agent/main.go
+++ b/services/agent/main.go
@@ -32,6 +32,7 @@ import (
 	"github.com/joustmania/agent/decision"
 	"github.com/joustmania/agent/flags"
 	"github.com/joustmania/agent/gamecontext"
+	"github.com/joustmania/agent/gate"
 	"github.com/joustmania/agent/infracontext"
 )
 
@@ -96,6 +97,36 @@ func actionSink(logger *slog.Logger) decision.ActionSink {
 	logger.Warn("Agent intervention writes enabled (#730)",
 		"path", getEnv("INTERVENTIONS_FLAG_PATH", actions.DefaultPath))
 	return actions.NewWriterFromEnv(logger)
+}
+
+// rolloutActuator returns the rollout write seam for the infra loop (#734). When
+// AGENT_ROLLOUT_ENABLED=true it is the real RolloutWriter (flips
+// current_controller_count in ROLLOUT_FLAG_PATH); otherwise it is a dry-run
+// actuator that decides+spans expansions but never writes the file. Mirrors the
+// actionSink env-gate shape, but always returns a non-nil actuator so the loop
+// reports disabled expansions as decided-but-not-applied.
+func rolloutActuator(logger *slog.Logger) decision.RolloutActuator {
+	if strings.EqualFold(getEnv("AGENT_ROLLOUT_ENABLED", ""), "true") {
+		logger.Warn("Agent rollout expansion enabled (#734)",
+			"path", getEnv("ROLLOUT_FLAG_PATH", actions.DefaultRolloutPath))
+		return actions.NewRolloutWriterFromEnv(logger)
+	}
+	logger.Info("Agent rollout expansion disabled (dry-run; decisions spanned, not applied)")
+	return actions.NewDryRunRolloutWriter(logger)
+}
+
+// rolloutDwell reads the per-stage dwell from AGENT_ROLLOUT_DWELL_SECONDS,
+// falling back to decision.DefaultRolloutDwell.
+func rolloutDwell() time.Duration {
+	s := strings.TrimSpace(os.Getenv("AGENT_ROLLOUT_DWELL_SECONDS"))
+	if s == "" {
+		return decision.DefaultRolloutDwell
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil || n <= 0 {
+		return decision.DefaultRolloutDwell
+	}
+	return time.Duration(n) * time.Second
 }
 
 func main() {
@@ -175,18 +206,26 @@ func main() {
 		slog.Warn("Probe decisions enabled (demo/verification mode)",
 			"interval", probeInterval)
 	}
-	// Infrastructure observe path (#733, M3 PR C): a parallel store fed by the
-	// controller.bluetooth_health span on the same OTLP trace receiver. It honors
-	// the same self-ingestion skip as the game store. The InfraLoop is an
-	// OBSERVE-only logging stub for this PR; the real fitness/remediation loop
-	// plugs in behind the decision.InfraEvaluator seam in PR E.
+	// Infrastructure observe + rollout path (#733/#734, M3): a parallel store fed
+	// by the controller.bluetooth_health span on the same OTLP trace receiver. It
+	// honors the same self-ingestion skip as the game store. The InfraLoop runs the
+	// progressive-rollout expansion controller (#734): when Bluetooth fitness passes
+	// and the per-stage dwell has elapsed it advances current_controller_count one
+	// stage up the ladder, emitting an agent.infrastructure.decision span every
+	// active-rollout cycle.
 	infraStore := infracontext.NewStore(infraControllerTTL, nil)
 	infraStore.SetOwnService(resolveServiceName())
 	// Bluetooth fitness source (#735): seeds the flagd-schema defaults; the infra
-	// loop reads the live fitness.bluetooth.* thresholds through it each cycle. The
-	// real fitness/remediation consumer arrives in PR E.
+	// loop reads the live fitness.bluetooth.* thresholds through it each cycle.
 	bluetoothFitness := decision.NewLiveBluetoothFitness()
-	infraLoop := decision.NewInfraLoop(logger, lifecycle.DecisionThrottle, bluetoothFitness)
+	// Rollout actuator (#734): real RolloutWriter when AGENT_ROLLOUT_ENABLED=true,
+	// else a dry-run actuator (decides+spans but does not write rollout.json).
+	infraLoop := decision.NewInfraLoop(logger, rolloutDwell(), bluetoothFitness, rolloutActuator(logger))
+	// Freshness gate (#734): evaluate the rollout only when ≥1 controller is
+	// reporting fresh Bluetooth health. Game-state-independent (lobby connects).
+	infraLoop.SetGate(func(snap infracontext.InfraContext, now time.Time) bool {
+		return gate.ShouldEvaluateInfra(snap, now, infraControllerTTL)
+	})
 	pipe := newPipeline(store, loop, lifecycle.PlayerTTL).withInfra(infraStore, infraLoop)
 
 	grpcServer := grpc.NewServer()


### PR DESCRIPTION
## Summary

M3 Infrastructure Agent rollout expansion (#734), stacked on #796. The agent advances a Bluetooth backend rollout one stage at a time — none(0) → 1 → 3 → 6 → all(99) — by flipping `current_controller_count`'s defaultVariant in `services/flagd/rollout.json`, only while infrastructure fitness is passing. Controller-manager consumes the flag (shipped in #783); flagd file-watch closes the loop at runtime.

- **`RolloutWriter`** (`actions/`): in-place RMW over rollout.json reusing the order-preserving document machinery; own mutex; validates variant existence before flipping. Ladder helpers (`NextStage`/`StageVariantForValue`) own the value↔variant mapping — flagd flips by *variant name*, the loop reasons over values.
- **Real `InfraLoop`**: gate (≥1 fresh controller, game-state-independent — controllers connect in the lobby) → fitness (#735) → decide. Observed rollout state comes from the health span (`bluetooth.target_backend`/`rollout_count`), not a flag re-read. Expansion requires: fitness passing, stage < all, **15s dwell** since last expansion (`AGENT_ROLLOUT_DWELL_SECONDS`) so fitness can observe each stage, and no hold (PR F's cooldown hook).
- **Spans**: every active-rollout cycle emits `agent.infrastructure.decision` with `rollout.target`, `fitness.passing`, `fitness.violations`, `remediation.action` (`"expand"` on expansion, `"none"` otherwise — fitness-failing cycles record violations but never write; rollback semantics are PR F), `rollout.controller_count` on expansion, write errors → span status Error.
- **Env gate** `AGENT_ROLLOUT_ENABLED` (default off): disabled runs a dry-run actuator — decisions recorded as decided-but-not-applied, rollout.json untouched (same shape as the interventions sink).

## Test plan

- [x] `go test -race ./...` green: writer (fixture byte-stability, ladder, unknown variant, concurrent flips), loop (fake clock/actuator/recording tracer: expand-only-when-passing+dwell, terminal stage, failing-fitness no-write + violations on span, inactive rollout silent, write-error span status), gate
- [x] `go vet`, `gofmt -l` clean; docker-compose YAML validated

Closes #734.

🤖 Generated with [Claude Code](https://claude.com/claude-code)