### PR TITLE
feat: game_id routing for game coordinator RPCs + ListGames (#776)

### DIFF
--- a/proto/game_coordinator.proto
+++ b/proto/game_coordinator.proto
@@ -16,6 +16,10 @@ service GameCoordinatorService {
 
   // Get current game state (for testing/observability)
   rpc GetGameState(GetGameStateRequest) returns (GetGameStateResponse);
+
+  // List all live game sessions (primary + shadow). Lets agents and tests
+  // enumerate concurrent games and learn their game_ids.
+  rpc ListGames(ListGamesRequest) returns (ListGamesResponse);
 }
 
 // Game status
@@ -105,6 +109,7 @@ message TraitorConfig {
 
 message ForceEndGameRequest {
   string reason = 1;  // Reason for force ending
+  optional string game_id = 2;  // Target a specific game; empty = primary (legacy)
 }
 
 message ForceEndGameResponse {
@@ -116,21 +121,36 @@ message StreamEventsRequest {
   // If provided, starts a new game before streaming events.
   // If empty, subscribes to current/upcoming game events.
   optional StartGameConfig start_config = 1;
+  // Subscribe to a specific game's event bus. Empty = primary (legacy).
+  // Ignored when start_config is set (the new session's bus is used).
+  optional string game_id = 2;
 }
 
 message GameEvent {
   string event_type = 1;  // "player_death", "game_start", "game_end", "score_update"
   map<string, string> data = 2;  // Event-specific data
   int64 timestamp = 3;  // Unix timestamp in milliseconds
+  string game_id = 4;  // Game this event belongs to (empty if no game bound)
 }
 
 // GetGameState - Query current game state (for testing/observability)
-message GetGameStateRequest {}
+message GetGameStateRequest {
+  optional string game_id = 1;  // Target a specific game; empty = primary (legacy)
+}
 
 message GetGameStateResponse {
   bool success = 1;
   string error = 2;
   GameInfo game_info = 3;
+}
+
+// ListGames - enumerate all live game sessions (primary + shadow)
+message ListGamesRequest {}
+
+message ListGamesResponse {
+  bool success = 1;
+  string error = 2;
+  repeated GameInfo games = 3;
 }
 
 message GameInfo {

--- a/proto/game_coordinator_pb2.py
+++ b/proto/game_coordinator_pb2.py
@@ -24,7 +24,7 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x16game_coordinator.proto\x12\x1bjoustmania.game_coordinator\"D\n\x06Player\x12\x0e\n\x06serial\x18\x01 \x01(\t\x12\x0c\n\x04team\x18\x02 \x01(\x05\x12\r\n\x05\x61live\x18\x03 \x01(\x08\x12\r\n\x05score\x18\x04 \x01(\x05\"\xc2\x06\n\x0fStartGameConfig\x12\x11\n\tgame_name\x18\x01 \x01(\t\x12\x34\n\x07players\x18\x02 \x03(\x0b\x32#.joustmania.game_coordinator.Player\x12\x13\n\x0bsensitivity\x18\x03 \x01(\x05\x12<\n\nffa_config\x18\n \x01(\x0b\x32&.joustmania.game_coordinator.FFAConfigH\x00\x12@\n\x0cteams_config\x18\x0b \x01(\x0b\x32(.joustmania.game_coordinator.TeamsConfigH\x00\x12\x44\n\x0enonstop_config\x18\x0c \x01(\x0b\x32*.joustmania.game_coordinator.NonstopConfigH\x00\x12J\n\x11tournament_config\x18\r \x01(\x0b\x32-.joustmania.game_coordinator.TournamentConfigH\x00\x12I\n\x11\x66ight_club_config\x18\x0e \x01(\x0b\x32,.joustmania.game_coordinator.FightClubConfigH\x00\x12\x46\n\x0fwerewolf_config\x18\x0f \x01(\x0b\x32+.joustmania.game_coordinator.WerewolfConfigH\x00\x12\x42\n\rzombie_config\x18\x10 \x01(\x0b\x32).joustmania.game_coordinator.ZombieConfigH\x00\x12\x44\n\x0eswapper_config\x18\x11 \x01(\x0b\x32*.joustmania.game_coordinator.SwapperConfigH\x00\x12\x44\n\x0etraitor_config\x18\x12 \x01(\x0b\x32*.joustmania.game_coordinator.TraitorConfigH\x00\x12M\n\x13random_teams_config\x18\x13 \x01(\x0b\x32..joustmania.game_coordinator.RandomTeamsConfigH\x00\x42\r\n\x0bgame_config\"\x0b\n\tFFAConfig\";\n\x0bTeamsConfig\x12\x11\n\tnum_teams\x18\x01 \x01(\x05\x12\x19\n\x11random_assignment\x18\x02 \x01(\x08\"&\n\x11RandomTeamsConfig\x12\x11\n\tnum_teams\x18\x01 \x01(\x05\"+\n\rNonstopConfig\x12\x1a\n\x12time_limit_seconds\x18\x01 \x01(\x05\"1\n\x10TournamentConfig\x12\x1d\n\x15invincibility_seconds\x18\x01 \x01(\x02\"D\n\x0f\x46ightClubConfig\x12\x1d\n\x15invincibility_seconds\x18\x01 \x01(\x02\x12\x12\n\nmin_rounds\x18\x02 \x01(\x05\"-\n\x0eWerewolfConfig\x12\x1b\n\x13reveal_time_seconds\x18\x01 \x01(\x02\"\x0e\n\x0cZombieConfig\"\x0f\n\rSwapperConfig\"\"\n\rTraitorConfig\x12\x11\n\tnum_teams\x18\x01 \x01(\x05\"%\n\x13\x46orceEndGameRequest\x12\x0e\n\x06reason\x18\x01 \x01(\t\"6\n\x14\x46orceEndGameResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\r\n\x05\x65rror\x18\x02 \x01(\t\"o\n\x13StreamEventsRequest\x12G\n\x0cstart_config\x18\x01 \x01(\x0b\x32,.joustmania.game_coordinator.StartGameConfigH\x00\x88\x01\x01\x42\x0f\n\r_start_config\"\x9f\x01\n\tGameEvent\x12\x12\n\nevent_type\x18\x01 \x01(\t\x12>\n\x04\x64\x61ta\x18\x02 \x03(\x0b\x32\x30.joustmania.game_coordinator.GameEvent.DataEntry\x12\x11\n\ttimestamp\x18\x03 \x01(\x03\x1a+\n\tDataEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"\x15\n\x13GetGameStateRequest\"p\n\x14GetGameStateResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\r\n\x05\x65rror\x18\x02 \x01(\t\x12\x38\n\tgame_info\x18\x03 \x01(\x0b\x32%.joustmania.game_coordinator.GameInfo\"\xb6\x01\n\x08GameInfo\x12\x11\n\tgame_mode\x18\x01 \x01(\t\x12\x35\n\x05state\x18\x02 \x01(\x0e\x32&.joustmania.game_coordinator.GameState\x12\x38\n\x07players\x18\x03 \x03(\x0b\x32\'.joustmania.game_coordinator.PlayerInfo\x12\x0f\n\x07game_id\x18\x04 \x01(\t\x12\x15\n\rstart_time_ms\x18\x05 \x01(\x03\"\xa8\x01\n\nPlayerInfo\x12\x0e\n\x06serial\x18\x01 \x01(\t\x12\x0c\n\x04team\x18\x02 \x01(\x05\x12\x11\n\tteam_name\x18\x03 \x01(\t\x12/\n\x05\x63olor\x18\x04 \x01(\x0b\x32 .joustmania.game_coordinator.RGB\x12\r\n\x05\x61live\x18\x05 \x01(\x08\x12\x1a\n\x12sensitivity_factor\x18\x06 \x01(\x02\x12\r\n\x05score\x18\x07 \x01(\x05\"&\n\x03RGB\x12\t\n\x01r\x18\x01 \x01(\x05\x12\t\n\x01g\x18\x02 \x01(\x05\x12\t\n\x01\x62\x18\x03 \x01(\x05*G\n\tGameState\x12\x08\n\x04IDLE\x10\x00\x12\x0c\n\x08STARTING\x10\x01\x12\x0b\n\x07RUNNING\x10\x02\x12\n\n\x06\x45NDING\x10\x03\x12\t\n\x05\x45NDED\x10\x04\x32\xf2\x02\n\x16GameCoordinatorService\x12s\n\x0c\x46orceEndGame\x12\x30.joustmania.game_coordinator.ForceEndGameRequest\x1a\x31.joustmania.game_coordinator.ForceEndGameResponse\x12n\n\x10StreamGameEvents\x12\x30.joustmania.game_coordinator.StreamEventsRequest\x1a&.joustmania.game_coordinator.GameEvent0\x01\x12s\n\x0cGetGameState\x12\x30.joustmania.game_coordinator.GetGameStateRequest\x1a\x31.joustmania.game_coordinator.GetGameStateResponseB:Z8github.com/joustmania/connect-proxy/gen/game_coordinatorb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x16game_coordinator.proto\x12\x1bjoustmania.game_coordinator\"D\n\x06Player\x12\x0e\n\x06serial\x18\x01 \x01(\t\x12\x0c\n\x04team\x18\x02 \x01(\x05\x12\r\n\x05\x61live\x18\x03 \x01(\x08\x12\r\n\x05score\x18\x04 \x01(\x05\"\xc2\x06\n\x0fStartGameConfig\x12\x11\n\tgame_name\x18\x01 \x01(\t\x12\x34\n\x07players\x18\x02 \x03(\x0b\x32#.joustmania.game_coordinator.Player\x12\x13\n\x0bsensitivity\x18\x03 \x01(\x05\x12<\n\nffa_config\x18\n \x01(\x0b\x32&.joustmania.game_coordinator.FFAConfigH\x00\x12@\n\x0cteams_config\x18\x0b \x01(\x0b\x32(.joustmania.game_coordinator.TeamsConfigH\x00\x12\x44\n\x0enonstop_config\x18\x0c \x01(\x0b\x32*.joustmania.game_coordinator.NonstopConfigH\x00\x12J\n\x11tournament_config\x18\r \x01(\x0b\x32-.joustmania.game_coordinator.TournamentConfigH\x00\x12I\n\x11\x66ight_club_config\x18\x0e \x01(\x0b\x32,.joustmania.game_coordinator.FightClubConfigH\x00\x12\x46\n\x0fwerewolf_config\x18\x0f \x01(\x0b\x32+.joustmania.game_coordinator.WerewolfConfigH\x00\x12\x42\n\rzombie_config\x18\x10 \x01(\x0b\x32).joustmania.game_coordinator.ZombieConfigH\x00\x12\x44\n\x0eswapper_config\x18\x11 \x01(\x0b\x32*.joustmania.game_coordinator.SwapperConfigH\x00\x12\x44\n\x0etraitor_config\x18\x12 \x01(\x0b\x32*.joustmania.game_coordinator.TraitorConfigH\x00\x12M\n\x13random_teams_config\x18\x13 \x01(\x0b\x32..joustmania.game_coordinator.RandomTeamsConfigH\x00\x42\r\n\x0bgame_config\"\x0b\n\tFFAConfig\";\n\x0bTeamsConfig\x12\x11\n\tnum_teams\x18\x01 \x01(\x05\x12\x19\n\x11random_assignment\x18\x02 \x01(\x08\"&\n\x11RandomTeamsConfig\x12\x11\n\tnum_teams\x18\x01 \x01(\x05\"+\n\rNonstopConfig\x12\x1a\n\x12time_limit_seconds\x18\x01 \x01(\x05\"1\n\x10TournamentConfig\x12\x1d\n\x15invincibility_seconds\x18\x01 \x01(\x02\"D\n\x0f\x46ightClubConfig\x12\x1d\n\x15invincibility_seconds\x18\x01 \x01(\x02\x12\x12\n\nmin_rounds\x18\x02 \x01(\x05\"-\n\x0eWerewolfConfig\x12\x1b\n\x13reveal_time_seconds\x18\x01 \x01(\x02\"\x0e\n\x0cZombieConfig\"\x0f\n\rSwapperConfig\"\"\n\rTraitorConfig\x12\x11\n\tnum_teams\x18\x01 \x01(\x05\"G\n\x13\x46orceEndGameRequest\x12\x0e\n\x06reason\x18\x01 \x01(\t\x12\x14\n\x07game_id\x18\x02 \x01(\tH\x00\x88\x01\x01\x42\n\n\x08_game_id\"6\n\x14\x46orceEndGameResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\r\n\x05\x65rror\x18\x02 \x01(\t\"\x91\x01\n\x13StreamEventsRequest\x12G\n\x0cstart_config\x18\x01 \x01(\x0b\x32,.joustmania.game_coordinator.StartGameConfigH\x00\x88\x01\x01\x12\x14\n\x07game_id\x18\x02 \x01(\tH\x01\x88\x01\x01\x42\x0f\n\r_start_configB\n\n\x08_game_id\"\xb0\x01\n\tGameEvent\x12\x12\n\nevent_type\x18\x01 \x01(\t\x12>\n\x04\x64\x61ta\x18\x02 \x03(\x0b\x32\x30.joustmania.game_coordinator.GameEvent.DataEntry\x12\x11\n\ttimestamp\x18\x03 \x01(\x03\x12\x0f\n\x07game_id\x18\x04 \x01(\t\x1a+\n\tDataEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"7\n\x13GetGameStateRequest\x12\x14\n\x07game_id\x18\x01 \x01(\tH\x00\x88\x01\x01\x42\n\n\x08_game_id\"p\n\x14GetGameStateResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\r\n\x05\x65rror\x18\x02 \x01(\t\x12\x38\n\tgame_info\x18\x03 \x01(\x0b\x32%.joustmania.game_coordinator.GameInfo\"\x12\n\x10ListGamesRequest\"i\n\x11ListGamesResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\x12\r\n\x05\x65rror\x18\x02 \x01(\t\x12\x34\n\x05games\x18\x03 \x03(\x0b\x32%.joustmania.game_coordinator.GameInfo\"\xb6\x01\n\x08GameInfo\x12\x11\n\tgame_mode\x18\x01 \x01(\t\x12\x35\n\x05state\x18\x02 \x01(\x0e\x32&.joustmania.game_coordinator.GameState\x12\x38\n\x07players\x18\x03 \x03(\x0b\x32\'.joustmania.game_coordinator.PlayerInfo\x12\x0f\n\x07game_id\x18\x04 \x01(\t\x12\x15\n\rstart_time_ms\x18\x05 \x01(\x03\"\xa8\x01\n\nPlayerInfo\x12\x0e\n\x06serial\x18\x01 \x01(\t\x12\x0c\n\x04team\x18\x02 \x01(\x05\x12\x11\n\tteam_name\x18\x03 \x01(\t\x12/\n\x05\x63olor\x18\x04 \x01(\x0b\x32 .joustmania.game_coordinator.RGB\x12\r\n\x05\x61live\x18\x05 \x01(\x08\x12\x1a\n\x12sensitivity_factor\x18\x06 \x01(\x02\x12\r\n\x05score\x18\x07 \x01(\x05\"&\n\x03RGB\x12\t\n\x01r\x18\x01 \x01(\x05\x12\t\n\x01g\x18\x02 \x01(\x05\x12\t\n\x01\x62\x18\x03 \x01(\x05*G\n\tGameState\x12\x08\n\x04IDLE\x10\x00\x12\x0c\n\x08STARTING\x10\x01\x12\x0b\n\x07RUNNING\x10\x02\x12\n\n\x06\x45NDING\x10\x03\x12\t\n\x05\x45NDED\x10\x04\x32\xde\x03\n\x16GameCoordinatorService\x12s\n\x0c\x46orceEndGame\x12\x30.joustmania.game_coordinator.ForceEndGameRequest\x1a\x31.joustmania.game_coordinator.ForceEndGameResponse\x12n\n\x10StreamGameEvents\x12\x30.joustmania.game_coordinator.StreamEventsRequest\x1a&.joustmania.game_coordinator.GameEvent0\x01\x12s\n\x0cGetGameState\x12\x30.joustmania.game_coordinator.GetGameStateRequest\x1a\x31.joustmania.game_coordinator.GetGameStateResponse\x12j\n\tListGames\x12-.joustmania.game_coordinator.ListGamesRequest\x1a..joustmania.game_coordinator.ListGamesResponseB:Z8github.com/joustmania/connect-proxy/gen/game_coordinatorb\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -34,8 +34,8 @@ if not _descriptor._USE_C_DESCRIPTORS:
   _globals['DESCRIPTOR']._serialized_options = b'Z8github.com/joustmania/connect-proxy/gen/game_coordinator'
   _globals['_GAMEEVENT_DATAENTRY']._loaded_options = None
   _globals['_GAMEEVENT_DATAENTRY']._serialized_options = b'8\001'
-  _globals['_GAMESTATE']._serialized_start=2261
-  _globals['_GAMESTATE']._serialized_end=2332
+  _globals['_GAMESTATE']._serialized_start=2508
+  _globals['_GAMESTATE']._serialized_end=2579
   _globals['_PLAYER']._serialized_start=55
   _globals['_PLAYER']._serialized_end=123
   _globals['_STARTGAMECONFIG']._serialized_start=126
@@ -61,25 +61,29 @@ if not _descriptor._USE_C_DESCRIPTORS:
   _globals['_TRAITORCONFIG']._serialized_start=1322
   _globals['_TRAITORCONFIG']._serialized_end=1356
   _globals['_FORCEENDGAMEREQUEST']._serialized_start=1358
-  _globals['_FORCEENDGAMEREQUEST']._serialized_end=1395
-  _globals['_FORCEENDGAMERESPONSE']._serialized_start=1397
-  _globals['_FORCEENDGAMERESPONSE']._serialized_end=1451
-  _globals['_STREAMEVENTSREQUEST']._serialized_start=1453
-  _globals['_STREAMEVENTSREQUEST']._serialized_end=1564
-  _globals['_GAMEEVENT']._serialized_start=1567
-  _globals['_GAMEEVENT']._serialized_end=1726
-  _globals['_GAMEEVENT_DATAENTRY']._serialized_start=1683
-  _globals['_GAMEEVENT_DATAENTRY']._serialized_end=1726
-  _globals['_GETGAMESTATEREQUEST']._serialized_start=1728
-  _globals['_GETGAMESTATEREQUEST']._serialized_end=1749
-  _globals['_GETGAMESTATERESPONSE']._serialized_start=1751
-  _globals['_GETGAMESTATERESPONSE']._serialized_end=1863
-  _globals['_GAMEINFO']._serialized_start=1866
-  _globals['_GAMEINFO']._serialized_end=2048
-  _globals['_PLAYERINFO']._serialized_start=2051
-  _globals['_PLAYERINFO']._serialized_end=2219
-  _globals['_RGB']._serialized_start=2221
-  _globals['_RGB']._serialized_end=2259
-  _globals['_GAMECOORDINATORSERVICE']._serialized_start=2335
-  _globals['_GAMECOORDINATORSERVICE']._serialized_end=2705
+  _globals['_FORCEENDGAMEREQUEST']._serialized_end=1429
+  _globals['_FORCEENDGAMERESPONSE']._serialized_start=1431
+  _globals['_FORCEENDGAMERESPONSE']._serialized_end=1485
+  _globals['_STREAMEVENTSREQUEST']._serialized_start=1488
+  _globals['_STREAMEVENTSREQUEST']._serialized_end=1633
+  _globals['_GAMEEVENT']._serialized_start=1636
+  _globals['_GAMEEVENT']._serialized_end=1812
+  _globals['_GAMEEVENT_DATAENTRY']._serialized_start=1769
+  _globals['_GAMEEVENT_DATAENTRY']._serialized_end=1812
+  _globals['_GETGAMESTATEREQUEST']._serialized_start=1814
+  _globals['_GETGAMESTATEREQUEST']._serialized_end=1869
+  _globals['_GETGAMESTATERESPONSE']._serialized_start=1871
+  _globals['_GETGAMESTATERESPONSE']._serialized_end=1983
+  _globals['_LISTGAMESREQUEST']._serialized_start=1985
+  _globals['_LISTGAMESREQUEST']._serialized_end=2003
+  _globals['_LISTGAMESRESPONSE']._serialized_start=2005
+  _globals['_LISTGAMESRESPONSE']._serialized_end=2110
+  _globals['_GAMEINFO']._serialized_start=2113
+  _globals['_GAMEINFO']._serialized_end=2295
+  _globals['_PLAYERINFO']._serialized_start=2298
+  _globals['_PLAYERINFO']._serialized_end=2466
+  _globals['_RGB']._serialized_start=2468
+  _globals['_RGB']._serialized_end=2506
+  _globals['_GAMECOORDINATORSERVICE']._serialized_start=2582
+  _globals['_GAMECOORDINATORSERVICE']._serialized_end=3060
 # @@protoc_insertion_point(module_scope)

--- a/proto/game_coordinator_pb2_grpc.py
+++ b/proto/game_coordinator_pb2_grpc.py
@@ -50,6 +50,11 @@ class GameCoordinatorServiceStub(object):
                 request_serializer=game__coordinator__pb2.GetGameStateRequest.SerializeToString,
                 response_deserializer=game__coordinator__pb2.GetGameStateResponse.FromString,
                 _registered_method=True)
+        self.ListGames = channel.unary_unary(
+                '/joustmania.game_coordinator.GameCoordinatorService/ListGames',
+                request_serializer=game__coordinator__pb2.ListGamesRequest.SerializeToString,
+                response_deserializer=game__coordinator__pb2.ListGamesResponse.FromString,
+                _registered_method=True)
 
 
 class GameCoordinatorServiceServicer(object):
@@ -79,6 +84,14 @@ class GameCoordinatorServiceServicer(object):
         context.set_details('Method not implemented!')
         raise NotImplementedError('Method not implemented!')
 
+    def ListGames(self, request, context):
+        """List all live game sessions (primary + shadow). Lets agents and tests
+        enumerate concurrent games and learn their game_ids.
+        """
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
+
 
 def add_GameCoordinatorServiceServicer_to_server(servicer, server):
     rpc_method_handlers = {
@@ -96,6 +109,11 @@ def add_GameCoordinatorServiceServicer_to_server(servicer, server):
                     servicer.GetGameState,
                     request_deserializer=game__coordinator__pb2.GetGameStateRequest.FromString,
                     response_serializer=game__coordinator__pb2.GetGameStateResponse.SerializeToString,
+            ),
+            'ListGames': grpc.unary_unary_rpc_method_handler(
+                    servicer.ListGames,
+                    request_deserializer=game__coordinator__pb2.ListGamesRequest.FromString,
+                    response_serializer=game__coordinator__pb2.ListGamesResponse.SerializeToString,
             ),
     }
     generic_handler = grpc.method_handlers_generic_handler(
@@ -180,6 +198,33 @@ class GameCoordinatorService(object):
             '/joustmania.game_coordinator.GameCoordinatorService/GetGameState',
             game__coordinator__pb2.GetGameStateRequest.SerializeToString,
             game__coordinator__pb2.GetGameStateResponse.FromString,
+            options,
+            channel_credentials,
+            insecure,
+            call_credentials,
+            compression,
+            wait_for_ready,
+            timeout,
+            metadata,
+            _registered_method=True)
+
+    @staticmethod
+    def ListGames(request,
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
+        return grpc.experimental.unary_unary(
+            request,
+            target,
+            '/joustmania.game_coordinator.GameCoordinatorService/ListGames',
+            game__coordinator__pb2.ListGamesRequest.SerializeToString,
+            game__coordinator__pb2.ListGamesResponse.FromString,
             options,
             channel_credentials,
             insecure,

--- a/services/connect-proxy/main.go
+++ b/services/connect-proxy/main.go
@@ -338,6 +338,17 @@ func (p *GameCoordinatorProxy) GetGameState(
 	return connect.NewResponse(resp), nil
 }
 
+func (p *GameCoordinatorProxy) ListGames(
+	ctx context.Context,
+	req *connect.Request[gamepb.ListGamesRequest],
+) (*connect.Response[gamepb.ListGamesResponse], error) {
+	resp, err := p.client.ListGames(ctx, req.Msg)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+	return connect.NewResponse(resp), nil
+}
+
 // MenuProxy implements the Connect handler by proxying to gRPC
 type MenuProxy struct {
 	client menupb.MenuServiceClient

--- a/services/dashboard/src/gen/game_coordinator_pb.ts
+++ b/services/dashboard/src/gen/game_coordinator_pb.ts
@@ -37,6 +37,7 @@ export interface StartGameResponse {
 // Force end game request
 export interface ForceEndGameRequest {
   reason: string;
+  gameId?: string;  // empty = primary (legacy)
 }
 
 // Force end game response
@@ -46,13 +47,16 @@ export interface ForceEndGameResponse {
 }
 
 // Stream events request
-export interface StreamEventsRequest {}
+export interface StreamEventsRequest {
+  gameId?: string;  // subscribe to a specific game; empty = primary (legacy)
+}
 
 // Game event
 export interface GameEvent {
   eventType: string;
   data: { [key: string]: string };
   timestamp: bigint;
+  gameId: string;  // game this event belongs to (empty if no game bound)
 }
 
 // Service definition for Connect-Web

--- a/services/game_coordinator/event_bus.py
+++ b/services/game_coordinator/event_bus.py
@@ -59,6 +59,12 @@ class EventBus:
         # Single asyncio.Lock for all _subscribers access (subscribe, unsubscribe, publish)
         self._event_lock = asyncio.Lock()
         self._state_sync_callback = state_sync_callback
+        # game_id stamped onto every published GameEvent (#776). MUTABLE because
+        # the persistent primary bus outlives sessions: the primary session sets
+        # this when it binds and the servicer clears it on retire, so a game_id
+        # fixed at construction would be wrong for the long-lived primary bus.
+        # Empty string => no game bound (events published while idle).
+        self.current_game_id: str = ""
 
     @property
     def subscriber_count(self) -> int:
@@ -140,11 +146,13 @@ class EventBus:
         if "tracestate" in carrier:
             string_data["_tracestate"] = carrier["tracestate"]
 
-        # Create protobuf event
+        # Create protobuf event, stamped with the game_id this bus is bound to
+        # (#776). Empty when no game is bound (e.g. primary bus while idle).
         event = game_coordinator_pb2.GameEvent(
             event_type=event_type,
             data=string_data,
             timestamp=int(time.time() * 1000),
+            game_id=self.current_game_id,
         )
 
         # Publish to all subscribers (put_nowait is thread-safe for asyncio.Queue)

--- a/services/game_coordinator/servicer.py
+++ b/services/game_coordinator/servicer.py
@@ -124,6 +124,17 @@ class GameCoordinatorServicer(game_coordinator_pb2_grpc.GameCoordinatorServiceSe
                 return None
             return self.sessions.get(self._primary_game_id)
 
+    def _resolve_session(self, game_id: str) -> GameSession | None:
+        """Resolve a request game_id to a session (#776).
+
+        Empty game_id => the active primary session (exact legacy semantics).
+        A non-empty game_id => that specific session, or None if unknown.
+        """
+        if not game_id:
+            return self._get_primary_session()
+        with self._sessions_lock:
+            return self.sessions.get(game_id)
+
     @property
     def current_game(self):
         """Primary session's running game instance (back-compat for tests)."""
@@ -212,6 +223,11 @@ class GameCoordinatorServicer(game_coordinator_pb2_grpc.GameCoordinatorServiceSe
                 if game_kind == GAME_KIND_SHADOW:
                     event_bus._state_sync_callback = session.on_event_state_sync
 
+                # Stamp every event published on this bus with this game's id
+                # (#776). The primary bus is persistent, so this mutable field is
+                # set on bind and cleared on retire (see _retire_session).
+                event_bus.current_game_id = game_id
+
                 self.sessions[game_id] = session
                 if game_kind == GAME_KIND_PRIMARY:
                     self._primary_game_id = game_id
@@ -270,11 +286,33 @@ class GameCoordinatorServicer(game_coordinator_pb2_grpc.GameCoordinatorServiceSe
             self.sessions.pop(game_id, None)
             if self._primary_game_id == game_id:
                 self._primary_game_id = None
+                # The primary bus is persistent and outlives the session; clear
+                # its game_id stamp so post-retire idle events carry empty
+                # game_id (#776). Shadow buses are discarded, no cleanup needed.
+                self.primary_event_bus.current_game_id = ""
 
     async def ForceEndGame(self, request, _context):
-        """Force end the current (primary) game."""
+        """Force end a game (#776).
+
+        ``request.game_id`` selects the target session; empty resolves to the
+        primary session (exact legacy semantics). An unknown game_id returns
+        success=False with a clear error.
+        """
         try:
-            success, error = await self._force_end_current_game(request.reason)
+            game_id = request.game_id or ""
+
+            if not game_id:
+                # Legacy path: end the primary game.
+                success, error = await self._force_end_current_game(request.reason)
+                return game_coordinator_pb2.ForceEndGameResponse(success=success, error=error)
+
+            session = self._resolve_session(game_id)
+            if session is None:
+                return game_coordinator_pb2.ForceEndGameResponse(success=False, error=f"Unknown game_id: {game_id}")
+
+            success, error = await session.force_end(request.reason)
+            if success:
+                self._retire_session(session.game_id)
             return game_coordinator_pb2.ForceEndGameResponse(success=success, error=error)
         except Exception as e:
             logger.error(f"ForceEndGame error: {e}", exc_info=True)
@@ -288,10 +326,14 @@ class GameCoordinatorServicer(game_coordinator_pb2_grpc.GameCoordinatorServiceSe
         """
         Stream game events in real-time.
 
-        If start_config is provided, starts a new game and subscribes to THAT
-        session's bus (so a headless starter receives its own game's events).
-        Otherwise, subscribes to the persistent primary bus (legacy zero-arg
-        behavior — the menu's subscribe-before-start path).
+        Subscription target (#776):
+        - start_config provided: start a new game and subscribe to THAT session's
+          bus (so a headless starter receives its own game's events). Any
+          request.game_id is ignored in this case.
+        - start_config empty, request.game_id set: subscribe to that game's bus;
+          an unknown game_id yields a ``game_error`` event and closes the stream.
+        - start_config empty, game_id empty: subscribe to the persistent primary
+          bus (legacy zero-arg behavior — the menu's subscribe-before-start path).
         """
         subscriber_id = f"events_{time.time()}"
 
@@ -327,11 +369,26 @@ class GameCoordinatorServicer(game_coordinator_pb2_grpc.GameCoordinatorServiceSe
             logger.info(f"Game {result} started via stream")
 
             # Subscribe to the bus of the session we just created so a headless
-            # starter receives its own game's events (works without proto
-            # changes; #776 adds explicit game_id routing).
+            # starter receives its own game's events.
             started = self.sessions.get(result)
             if started is not None:
                 event_bus = started.event_bus
+
+        elif request.game_id:
+            # Subscribe-by-game_id (#776): route to that session's bus.
+            span.set_attribute("game.id", request.game_id)
+            session = self._resolve_session(request.game_id)
+            if session is None:
+                logger.warning(f"StreamGameEvents: unknown game_id {request.game_id}")
+                span.set_attribute("error", "unknown_game_id")
+                yield game_coordinator_pb2.GameEvent(
+                    event_type="game_error",
+                    data={"error": f"Unknown game_id: {request.game_id}"},
+                    timestamp=int(time.time() * 1000),
+                    game_id=request.game_id,
+                )
+                return
+            event_bus = session.event_bus
 
         # Subscribe to event bus
         event_queue = await event_bus.subscribe(subscriber_id)
@@ -358,16 +415,67 @@ class GameCoordinatorServicer(game_coordinator_pb2_grpc.GameCoordinatorServiceSe
     # State query
     # ------------------------------------------------------------------
 
-    async def GetGameState(self, _request, _context):
-        """
-        Get current (primary) game state for testing and observability.
+    @staticmethod
+    def _build_game_info(session: "GameSession") -> game_coordinator_pb2.GameInfo:
+        """Snapshot a session into a GameInfo proto (#776).
 
-        Returns detailed player information including team assignments,
-        colors, and alive status. Operates on the primary session until game_id
-        routing lands (#776).
+        Shared by GetGameState and ListGames. Acquires the session's state lock
+        so the game_state/players snapshot is consistent.
+        """
+        with session._state_lock:
+            game_info = game_coordinator_pb2.GameInfo(
+                game_mode=session.game_name or "",
+                state=session.game_state,
+                game_id=session.game_id or "",
+                start_time_ms=int((session.game_start_time or 0) * 1000),
+            )
+
+            current_game = session.current_game
+            if current_game and hasattr(current_game, "players"):
+                teams = getattr(current_game, "teams", {})
+
+                for serial, player in current_game.players.items():
+                    team_name = ""
+                    if player.team >= 0 and player.team in teams:
+                        team_name = teams[player.team].name
+
+                    color = player.color if player.color else (0, 0, 0)
+                    r, g, b = color[0], color[1], color[2]
+
+                    player_info = game_coordinator_pb2.PlayerInfo(
+                        serial=serial,
+                        team=player.team,
+                        team_name=team_name,
+                        color=game_coordinator_pb2.RGB(r=r, g=g, b=b),
+                        alive=player.alive,
+                        sensitivity_factor=player.sensitivity_factor,
+                        score=0,  # Score tracking not yet implemented in base Player
+                    )
+                    game_info.players.append(player_info)
+
+        return game_info
+
+    async def GetGameState(self, request, _context):
+        """
+        Get a game's state for testing and observability.
+
+        ``request.game_id`` selects the target session; empty resolves to the
+        primary session (exact legacy semantics). An unknown game_id returns
+        success=False. Returns detailed player information including team
+        assignments, colors, and alive status.
         """
         try:
-            session = self._get_primary_session()
+            game_id = request.game_id or ""
+
+            # Unknown explicit game_id is an error (legacy empty-id idle stays a
+            # success with an IDLE GameInfo).
+            if game_id and self._resolve_session(game_id) is None:
+                return game_coordinator_pb2.GetGameStateResponse(
+                    success=False,
+                    error=f"Unknown game_id: {game_id}",
+                )
+
+            session = self._resolve_session(game_id)
 
             if session is None:
                 game_info = game_coordinator_pb2.GameInfo(
@@ -378,36 +486,7 @@ class GameCoordinatorServicer(game_coordinator_pb2_grpc.GameCoordinatorServiceSe
                 )
                 return game_coordinator_pb2.GetGameStateResponse(success=True, error="", game_info=game_info)
 
-            with session._state_lock:
-                game_info = game_coordinator_pb2.GameInfo(
-                    game_mode=session.game_name or "",
-                    state=session.game_state,
-                    game_id=session.game_id or "",
-                    start_time_ms=int((session.game_start_time or 0) * 1000),
-                )
-
-                current_game = session.current_game
-                if current_game and hasattr(current_game, "players"):
-                    teams = getattr(current_game, "teams", {})
-
-                    for serial, player in current_game.players.items():
-                        team_name = ""
-                        if player.team >= 0 and player.team in teams:
-                            team_name = teams[player.team].name
-
-                        color = player.color if player.color else (0, 0, 0)
-                        r, g, b = color[0], color[1], color[2]
-
-                        player_info = game_coordinator_pb2.PlayerInfo(
-                            serial=serial,
-                            team=player.team,
-                            team_name=team_name,
-                            color=game_coordinator_pb2.RGB(r=r, g=g, b=b),
-                            alive=player.alive,
-                            sensitivity_factor=player.sensitivity_factor,
-                            score=0,  # Score tracking not yet implemented in base Player
-                        )
-                        game_info.players.append(player_info)
+            game_info = self._build_game_info(session)
 
             logger.debug(
                 f"GetGameState: mode={game_info.game_mode}, state={game_info.state}, players={len(game_info.players)}"
@@ -424,6 +503,25 @@ class GameCoordinatorServicer(game_coordinator_pb2_grpc.GameCoordinatorServiceSe
                 success=False,
                 error=str(e),
             )
+
+    async def ListGames(self, _request, _context):
+        """List all live game sessions (primary + shadow) (#776).
+
+        Returns a GameInfo per registered session so agents and tests can
+        enumerate concurrent games and learn their game_ids.
+        """
+        try:
+            with self._sessions_lock:
+                sessions = list(self.sessions.values())
+
+            response = game_coordinator_pb2.ListGamesResponse(success=True, error="")
+            for session in sessions:
+                response.games.append(self._build_game_info(session))
+            logger.debug(f"ListGames: {len(response.games)} live game(s)")
+            return response
+        except Exception as e:
+            logger.error(f"ListGames error: {e}", exc_info=True)
+            return game_coordinator_pb2.ListGamesResponse(success=False, error=str(e))
 
     # ------------------------------------------------------------------
     # Shutdown

--- a/services/game_coordinator/tests/test_servicer_sessions.py
+++ b/services/game_coordinator/tests/test_servicer_sessions.py
@@ -361,6 +361,203 @@ class TestMultiSession:
             mock_death.set.assert_called_once_with(0)
 
 
+class TestGameIdRouting:
+    """game_id routing in the proto + coordinator wiring (#776)."""
+
+    @pytest.fixture
+    def servicer(self):
+        return GameCoordinatorServicer()
+
+    @pytest.fixture
+    def cap_two(self):
+        with patch.dict(os.environ, {"GAME_MAX_CONCURRENT_GAMES": "2"}):
+            yield
+
+    @pytest.mark.asyncio
+    async def test_events_stamped_with_session_game_id(self, servicer, cap_two):
+        """Each session's published events carry that session's game_id (#776).
+
+        The headless starter learns its game_id from the stamped event, and a
+        second concurrent session's events carry the OTHER id.
+        """
+        with _NO_THREAD:
+            _, gid1 = await servicer._start_game_from_config(_config(serials=("a1", "a2")), _MockSpan())
+            _, gid2 = await servicer._start_game_from_config(_config(serials=("b1", "b2")), _MockSpan())
+
+        bus1 = servicer.sessions[gid1].event_bus
+        bus2 = servicer.sessions[gid2].event_bus
+
+        q1 = await bus1.subscribe("sub1")
+        q2 = await bus2.subscribe("sub2")
+        await bus1.publish("player_death", {"serial": "a1"})
+        await bus2.publish("player_death", {"serial": "b1"})
+
+        e1 = q1.get_nowait()
+        e2 = q2.get_nowait()
+        # The GameEvent.game_id FIELD (not data map) is stamped per session.
+        assert e1.game_id == gid1
+        assert e2.game_id == gid2
+        assert gid1 != gid2
+
+    @pytest.mark.asyncio
+    async def test_primary_bus_game_id_cleared_on_retire(self, servicer):
+        """The persistent primary bus stamps the live game_id, then clears it.
+
+        Because the primary bus outlives sessions, a game_id fixed at
+        construction would be wrong — it must be set on bind and cleared on
+        retire so post-retire idle events carry empty game_id.
+        """
+        _, _session = await _start_running(servicer, _config())
+        gid = servicer.game_id
+        assert servicer.primary_event_bus.current_game_id == gid
+
+        q = await servicer.primary_event_bus.subscribe("sub")
+        await servicer.primary_event_bus.publish("player_death", {"serial": "p1"})
+        assert q.get_nowait().game_id == gid
+
+        await servicer.ForceEndGame(game_coordinator_pb2.ForceEndGameRequest(reason="done"), MockGrpcContext())
+        # Primary slot freed and bus stamp cleared.
+        assert servicer.primary_event_bus.current_game_id == ""
+        # Drain any events queued during force-end (e.g. game_force_ended, still
+        # stamped with gid because the stamp is cleared only after they publish).
+        while not q.empty():
+            q.get_nowait()
+        # A NEW event published after retire carries empty game_id.
+        await servicer.primary_event_bus.publish("ambient", {})
+        assert q.get_nowait().game_id == ""
+
+    @pytest.mark.asyncio
+    async def test_subscribe_by_game_id_receives_only_that_game(self, servicer, cap_two):
+        """StreamGameEvents(game_id=...) subscribes to exactly that game's bus."""
+        with _NO_THREAD:
+            _, gid1 = await servicer._start_game_from_config(_config(serials=("a1", "a2")), _MockSpan())
+            _, gid2 = await servicer._start_game_from_config(_config(serials=("b1", "b2")), _MockSpan())
+
+        request = game_coordinator_pb2.StreamEventsRequest(game_id=gid2)
+        context = MockGrpcContext()
+
+        async def _publish():
+            # Publish on both buses; only gid2's event should reach the stream.
+            await servicer.sessions[gid1].event_bus.publish("player_death", {"serial": "a1"})
+            await servicer.sessions[gid2].event_bus.publish("player_death", {"serial": "b1"})
+
+        collected = await _stream_until_event(servicer, request, context, after=_publish)
+        assert collected
+        assert all(e.game_id == gid2 for e in collected)
+        assert any(e.data.get("serial") == "b1" for e in collected)
+
+    @pytest.mark.asyncio
+    async def test_subscribe_unknown_game_id_yields_error_and_closes(self, servicer):
+        """StreamGameEvents with an unknown game_id yields a game_error and closes."""
+        request = game_coordinator_pb2.StreamEventsRequest(game_id="game_doesnotexist")
+        context = MockGrpcContext()
+
+        collected = [event async for event in servicer.StreamGameEvents(request, context)]
+
+        assert len(collected) == 1
+        assert collected[0].event_type == "game_error"
+        assert "game_doesnotexist" in collected[0].data["error"]
+        assert collected[0].game_id == "game_doesnotexist"
+
+    @pytest.mark.asyncio
+    async def test_force_end_by_game_id_targets_only_that_session(self, servicer, cap_two):
+        """ForceEndGame(game_id=shadow) ends only the shadow, leaving the primary."""
+        with _NO_THREAD:
+            _, gid1 = await servicer._start_game_from_config(_config(serials=("a1", "a2")), _MockSpan())
+            _, gid2 = await servicer._start_game_from_config(_config(serials=("b1", "b2")), _MockSpan())
+
+            resp = await servicer.ForceEndGame(
+                game_coordinator_pb2.ForceEndGameRequest(reason="test", game_id=gid2), MockGrpcContext()
+            )
+
+        assert resp.success is True
+        # Shadow retired; primary untouched and still owns the primary slot.
+        assert gid2 not in servicer.sessions
+        assert gid1 in servicer.sessions
+        assert servicer._primary_game_id == gid1
+
+    @pytest.mark.asyncio
+    async def test_force_end_unknown_game_id_returns_failure(self, servicer):
+        """ForceEndGame with an unknown game_id returns success=False."""
+        resp = await servicer.ForceEndGame(
+            game_coordinator_pb2.ForceEndGameRequest(reason="x", game_id="game_nope"), MockGrpcContext()
+        )
+        assert resp.success is False
+        assert "game_nope" in resp.error
+
+    @pytest.mark.asyncio
+    async def test_get_game_state_by_game_id(self, servicer, cap_two):
+        """GetGameState(game_id=...) returns that specific session's state."""
+        gid1, _ = await _start_running(servicer, _config(game_name="FFA", serials=("a1", "a2")))
+        gid2, _ = await _start_running(servicer, _config(game_name="Teams", serials=("b1", "b2")))
+
+        resp1 = await servicer.GetGameState(game_coordinator_pb2.GetGameStateRequest(game_id=gid1), MockGrpcContext())
+        resp2 = await servicer.GetGameState(game_coordinator_pb2.GetGameStateRequest(game_id=gid2), MockGrpcContext())
+        assert resp1.game_info.game_id == gid1
+        assert resp1.game_info.game_mode == "FFA"
+        assert resp2.game_info.game_id == gid2
+        assert resp2.game_info.game_mode == "Teams"
+
+    @pytest.mark.asyncio
+    async def test_get_game_state_unknown_game_id_returns_failure(self, servicer):
+        """GetGameState with an unknown game_id returns success=False."""
+        resp = await servicer.GetGameState(
+            game_coordinator_pb2.GetGameStateRequest(game_id="game_nope"), MockGrpcContext()
+        )
+        assert resp.success is False
+        assert "game_nope" in resp.error
+
+    @pytest.mark.asyncio
+    async def test_list_games_shows_running_then_empties(self, servicer, cap_two):
+        """ListGames enumerates all live sessions, then empties as they end."""
+        gid1, _ = await _start_running(servicer, _config(game_name="FFA", serials=("a1", "a2")))
+        gid2, _ = await _start_running(servicer, _config(game_name="Teams", serials=("b1", "b2")))
+
+        resp = await servicer.ListGames(game_coordinator_pb2.ListGamesRequest(), MockGrpcContext())
+        assert resp.success is True
+        ids = {g.game_id for g in resp.games}
+        assert ids == {gid1, gid2}
+
+        # End both; ListGames empties out.
+        await servicer.ForceEndGame(
+            game_coordinator_pb2.ForceEndGameRequest(reason="x", game_id=gid2), MockGrpcContext()
+        )
+        await servicer.ForceEndGame(game_coordinator_pb2.ForceEndGameRequest(reason="x"), MockGrpcContext())
+
+        resp_empty = await servicer.ListGames(game_coordinator_pb2.ListGamesRequest(), MockGrpcContext())
+        assert resp_empty.success is True
+        assert list(resp_empty.games) == []
+
+    @pytest.mark.asyncio
+    async def test_legacy_empty_game_id_requests_unchanged(self, servicer):
+        """Zero-field requests behave exactly as before (#776 backward compat).
+
+        Empty game_id on ForceEndGame/GetGameState resolves to the primary, and
+        a zero-arg StreamGameEvents still subscribes to the primary bus.
+        """
+        gid, _ = await _start_running(servicer, _config(game_name="FFA"))
+
+        # Empty-game_id GetGameState -> primary.
+        state = await servicer.GetGameState(game_coordinator_pb2.GetGameStateRequest(), MockGrpcContext())
+        assert state.game_info.game_id == gid
+
+        # Zero-arg stream still receives the primary game's events.
+        context = MockGrpcContext()
+
+        async def _publish():
+            await servicer.event_bus.publish("player_death", {"serial": "p1"})
+
+        collected = await _stream_until_event(
+            servicer, game_coordinator_pb2.StreamEventsRequest(), context, after=_publish
+        )
+        assert any(e.event_type == "player_death" for e in collected)
+
+        # Empty-game_id ForceEndGame -> ends the primary.
+        resp = await servicer.ForceEndGame(game_coordinator_pb2.ForceEndGameRequest(reason="done"), MockGrpcContext())
+        assert resp.success is True
+        assert servicer.game_state == game_coordinator_pb2.GameState.IDLE
+
+
 class _MockSpan:
     """Minimal span supporting set_attribute + context-manager protocol."""
 


### PR DESCRIPTION
## Summary

Phase 2 of the shadow-games work (#774). Makes `game_id` a first-class routing key in `proto/game_coordinator.proto` and wires it through the game coordinator. Fully backward compatible: an empty `game_id` resolves to the primary (menu-driven) session, so **the menu and dashboard need zero changes**.

### Proto (additive, backward-compatible)
- `StreamEventsRequest.game_id` (optional) — subscribe to a specific game; empty = primary. Ignored when `start_config` is set.
- `GameEvent.game_id` — every event stamped with its game (**load-bearing**: a headless starter learns its assigned `game_id` from the event stream).
- `ForceEndGameRequest.game_id` / `GetGameStateRequest.game_id` (optional) — empty = primary.
- New `ListGames(ListGamesRequest) returns (ListGamesResponse)` RPC, reusing the existing `GameInfo` message.

### Coordinator wiring
- `EventBus` carries a mutable `current_game_id` (set on bind, cleared on retire). The persistent primary bus outlives sessions, so a game_id fixed at construction would be wrong — it is set when a session binds and cleared in `_retire_session`. `publish()` stamps `GameEvent.game_id`.
- `_resolve_session(game_id)`: empty → primary (exact legacy semantics), else the specific session (or `None` if unknown).
- `ForceEndGame` / `GetGameState`: resolve `request.game_id`; unknown id → `success=False` with a clear error.
- `StreamGameEvents`: with `game_id` (and no `start_config`) subscribes to `sessions[game_id].event_bus`; unknown id yields a `game_error` event and closes. `start_config` keeps #775's behavior (subscribe to the new session's bus) and ignores `game_id`.
- `ListGames`: snapshots all sessions → `repeated GameInfo` via a shared `_build_game_info` helper extracted from `GetGameState`.

### Other consumers (mechanical regen)
- **connect-proxy** (Go): added a `ListGames` passthrough so `GameCoordinatorProxy` still satisfies the build-time-regenerated handler interface. Go stubs are generated during the docker build; the additive `game_id` fields appear automatically. *(buf/Go toolchain not available in this env — `go build` not run locally; the passthrough mirrors the existing `GetGameState` handler exactly and is gofmt-clean.)*
- **dashboard** (TS): kept the hand-maintained gen interfaces in sync with the new optional fields. Request construction is object-literal, so additive optional fields are non-breaking.

### Backward compatibility
- Zero-field requests behave exactly as before (characterization tests from #775 stay green, untouched).
- CI proto-validation gate passes: committed Python stubs are byte-identical to `proto/generate_proto.sh` output (verified idempotent).

## Tests
`cd services/game_coordinator && uv run --extra test pytest` — **864 passed**. New `TestGameIdRouting` group (10 tests) covers per-session event stamping, primary-bus stamp set/clear, subscribe-by-game_id (+ unknown → error), force-end/get-state by id (+ unknown → failure), `ListGames` populate-then-empty, and legacy empty-id behavior. `make lint` clean.

## Stacked PR
Stacked on #793 (`feat/775-multi-session-coordinator`). **Base is set to `feat/775-multi-session-coordinator`, not main**, so the diff shows only #776's changes. After #793 squash-merges to main, rebase onto main (`git rebase --onto main <stale-base-commit>` + force-push) and retarget this PR's base to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
