### PR TITLE
fix: wire battery provider into InterventionManager (#798)

### DIFF
--- a/lib/controller_constants.py
+++ b/lib/controller_constants.py
@@ -135,6 +135,25 @@ def normalize_serial(serial: str) -> str:
     return serial
 
 
+def battery_to_pct(battery: float) -> float:
+    """Normalize a controller battery reading to a 0-100 percentage (#730, #798).
+
+    Two sources feed battery values:
+    - The psmoveapi path reports a coarse 0-5 charge level -> multiply by 20.
+    - The Rust HID path (proto/psmove_hid.proto) already reports 0-100 -> pass
+      through unchanged.
+
+    Heuristic: values in the 0-5 range are treated as the coarse scale; anything
+    above 5 is assumed to already be a percentage. Result is clamped to [0, 100].
+
+    Shared so both the controller manager (``controller_battery_pct`` metric)
+    and the game coordinator (intervention battery guard) derive the percentage
+    identically.
+    """
+    pct = battery * 20.0 if battery <= 5 else float(battery)
+    return max(0.0, min(100.0, pct))
+
+
 # Default values
 DEFAULT_BATTERY = 5
 DEFAULT_ACCEL = {"x": 0.0, "y": 0.0, "z": 1.0}  # At rest (1g gravity)

--- a/services/game_coordinator/games/base.py
+++ b/services/game_coordinator/games/base.py
@@ -28,6 +28,7 @@ from typing import TYPE_CHECKING, Any
 from opentelemetry import context as otel_context
 from opentelemetry import trace
 
+from lib.controller_constants import battery_to_pct
 from lib.feature_flags import read_float_flag, read_object_flag, set_game_transaction_context
 from lib.telemetry import inject_trace_context
 from lib.types import GameEvent, Sensitivity, Sound
@@ -348,6 +349,11 @@ class Player:
     alive: bool = True
     color: tuple = (255, 255, 255)
     last_accel_mag: float = 0.0
+    # Latest battery percentage (0-100) seen on this player's gameplay frames,
+    # or None until the first frame carrying a battery reading arrives. Sourced
+    # from GameplayData.battery and normalized via lib.controller_constants
+    # (#798). Read by the InterventionManager battery guard.
+    battery_pct: float | None = None
     # Exponential moving average of acceleration (from original JoustMania)
     # EMA smooths sensor noise and prevents false positives from single-frame spikes
     smoothed_accel: float = 0.0
@@ -1372,6 +1378,11 @@ class BaseGameMode(ABC):
 
         # Process controller health counters (#571)
         self._process_health(player, serial, controller_state)
+
+        # Capture the latest battery reading (#798) so the intervention battery
+        # guard has a live in-process source. GameplayData.battery is the same
+        # signal that feeds controller_battery_pct; normalize identically.
+        player.battery_pct = battery_to_pct(controller_state.battery)
 
         accel = controller_state.accel
         accel_mag = self._compute_accel_magnitude(accel)

--- a/services/game_coordinator/servicer.py
+++ b/services/game_coordinator/servicer.py
@@ -92,6 +92,7 @@ class GameCoordinatorServicer(game_coordinator_pb2_grpc.GameCoordinatorServiceSe
         self.intervention_manager = InterventionManager(
             event_publisher=self.primary_event_bus.publish,
             get_game=self.get_live_game,
+            battery_provider=self._battery_pct_for_serial,
             end_game_fn=self._force_end_current_game,
         )
         # PR E: register the ambient/session handlers (audio cue, volume,
@@ -159,6 +160,34 @@ class GameCoordinatorServicer(game_coordinator_pb2_grpc.GameCoordinatorServiceSe
         live (menu-driven) game.
         """
         return self.current_game
+
+    def _battery_pct_for_serial(self, serial: str) -> float | None:
+        """Return the live battery percentage (0-100) for a controller serial.
+
+        Backs the InterventionManager battery guard (#798). The authoritative
+        in-process source is the running game's per-player ``battery_pct``, which
+        the game updates from each ``GameplayData.battery`` frame (the same signal
+        that feeds the controller manager's ``controller_battery_pct`` metric).
+
+        Multi-session note (#775/#793): interventions target the PRIMARY session
+        only (``get_live_game`` returns the primary game), so this reads the
+        primary game's players. If/when interventions become game-id scoped or
+        shadow sessions can hold targeted players, this should search the owning
+        session instead. For the current single-active-game reality the primary
+        lookup is correct.
+
+        Returns None when no game is running, the serial is unknown, or no battery
+        frame has been seen yet — None means "unknown", so the guard does not
+        block (missing data must never block, per #798).
+        """
+        game = self.get_live_game()
+        players = getattr(game, "players", None) if game is not None else None
+        if not isinstance(players, dict):
+            return None
+        player = players.get(serial)
+        if player is None:
+            return None
+        return getattr(player, "battery_pct", None)
 
     def _on_primary_event_state_sync(self, event_type: str):
         """State-sync callback for the persistent primary bus.

--- a/services/game_coordinator/tests/test_battery_provider.py
+++ b/services/game_coordinator/tests/test_battery_provider.py
@@ -1,0 +1,235 @@
+"""
+Unit tests for the wired battery_provider path (#798).
+
+The InterventionManager battery guard was inert in production because the
+servicer constructed it with ``battery_provider=None``. These tests exercise the
+*real* provider — the servicer's ``_battery_pct_for_serial`` reading live
+``Player.battery_pct`` (populated from ``GameplayData.battery``) — rather than an
+injected fake, and verify:
+
+- below-threshold battery blocks a player-targeted intervention,
+- above-threshold passes,
+- unknown/missing battery (no game, unknown serial, no frame yet) does not block,
+- ``resolve_player_targets`` drops low-battery serials when gated by the real
+  provider shape,
+- the 0-5 -> 0-100 normalization matches the controller-manager semantics.
+
+Telemetry is disabled via conftest; the intervention metric is patched per the
+repo metric-testing convention.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from lib.controller_constants import battery_to_pct
+from lib.types import GameEvent
+from services.game_coordinator.interventions import (
+    BLOCK_LOW_BATTERY,
+    INTERVENTION_SPECS,
+    InterventionManager,
+)
+from services.game_coordinator.servicer import GameCoordinatorServicer
+
+ALL_TYPES = {spec.type_id for spec in INTERVENTION_SPECS}
+
+
+class FakeFlagClient:
+    """In-memory flag client matching the OpenFeature get_*_value surface."""
+
+    def __init__(self, values=None):
+        self.values = values or {}
+
+    def get_string_value(self, key, default, _ctx=None):
+        return str(self.values.get(key, default))
+
+    def get_integer_value(self, key, default, _ctx=None):
+        return int(self.values.get(key, default))
+
+    def get_float_value(self, key, default, _ctx=None):
+        return float(self.values.get(key, default))
+
+    def get_object_value(self, key, default, _ctx=None):
+        return self.values.get(key, default)
+
+
+class RealishPlayer:
+    """Minimal stand-in for games.base.Player carrying the fields the provider
+    and targeting resolution read (serial, alive, battery_pct)."""
+
+    def __init__(self, serial, battery_pct=None, alive=True):
+        self.serial = serial
+        self.battery_pct = battery_pct
+        self.alive = alive
+
+
+class RealishGame:
+    def __init__(self, name, players):
+        self._name = name
+        self.players = players
+
+    def get_game_name(self):
+        return self._name
+
+
+def _make_servicer_with_game(players):
+    """Construct a real servicer and attach a live game with the given players.
+
+    Returns the servicer whose ``_battery_pct_for_serial`` is the production
+    battery provider under test. ``intervention_manager.start()`` is a no-op when
+    OpenFeature is unavailable in tests; we don't rely on it here.
+
+    Multi-session (#775/#793): ``current_game`` is now a read-only property over
+    the primary session. We register a minimal primary session carrying the live
+    game so the provider resolves it exactly as production does.
+    """
+    servicer = GameCoordinatorServicer()
+    game_id = "game_test"
+    session = SimpleNamespace(current_game=RealishGame("FFA", players))
+    servicer.sessions[game_id] = session
+    servicer._primary_game_id = game_id
+    return servicer
+
+
+def _wire_manager(provider, *, threshold=20, budget=10, game=None):
+    """Build a manager wired with the REAL provider callable and fake flag
+    clients (so flag reads are deterministic without flagd)."""
+    events = []
+
+    async def publisher(event_type, data):
+        events.append((event_type, data))
+
+    mgr = InterventionManager(
+        event_publisher=publisher,
+        get_game=lambda: game,
+        battery_provider=provider,
+    )
+    mgr._interventions_client = FakeFlagClient()
+    mgr._agent_client = FakeFlagClient(
+        {
+            "interventions_allowed": list(ALL_TYPES),
+            "policy.max_interventions_per_minute": budget,
+            "policy.battery_threshold": threshold,
+        }
+    )
+    mgr._rate_limiter.set_budget(float(budget))
+    return mgr, events
+
+
+# --------------------------------------------------------------------------- #
+# Provider unit behavior (servicer._battery_pct_for_serial)
+# --------------------------------------------------------------------------- #
+def test_provider_reads_live_player_battery():
+    servicer = _make_servicer_with_game({"ctrl_a": RealishPlayer("ctrl_a", battery_pct=85.0)})
+    assert servicer._battery_pct_for_serial("ctrl_a") == 85.0
+
+
+def test_provider_unknown_serial_returns_none():
+    servicer = _make_servicer_with_game({"ctrl_a": RealishPlayer("ctrl_a", battery_pct=85.0)})
+    assert servicer._battery_pct_for_serial("ctrl_missing") is None
+
+
+def test_provider_no_game_returns_none():
+    servicer = GameCoordinatorServicer()  # no game running
+    assert servicer._battery_pct_for_serial("ctrl_a") is None
+
+
+def test_provider_no_frame_yet_returns_none():
+    # Player exists but no GameplayData frame has set battery_pct yet.
+    servicer = _make_servicer_with_game({"ctrl_a": RealishPlayer("ctrl_a", battery_pct=None)})
+    assert servicer._battery_pct_for_serial("ctrl_a") is None
+
+
+# --------------------------------------------------------------------------- #
+# Normalization parity with controller_manager (0-5 -> 0-100)
+# --------------------------------------------------------------------------- #
+def test_battery_to_pct_coarse_scale():
+    assert battery_to_pct(1) == 20.0
+    assert battery_to_pct(5) == 100.0
+
+
+def test_battery_to_pct_passthrough_and_clamp():
+    assert battery_to_pct(80) == 80.0
+    assert battery_to_pct(238) == 100.0  # psmoveapi charging sentinel
+    assert battery_to_pct(-1) == 0.0
+
+
+# --------------------------------------------------------------------------- #
+# End-to-end: enforcement chain through the REAL provider
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_wired_provider_blocks_low_battery():
+    players = {"ctrl_a": RealishPlayer("ctrl_a", battery_pct=10.0)}  # below threshold 20
+    servicer = _make_servicer_with_game(players)
+    game = servicer.current_game
+    mgr, events = _wire_manager(servicer._battery_pct_for_serial, threshold=20, game=game)
+    mgr._interventions_client = FakeFlagClient({"eliminate_player": "1:ctrl_a"})
+
+    with patch("services.game_coordinator.metrics.interventions_total"):
+        await mgr.evaluate_all()
+
+    elim = [d for et, d in events if et == GameEvent.AGENT_INTERVENTION and d["type"] == "eliminate_player"]
+    assert elim[0]["blocked"] == "true"
+    assert elim[0]["block_reason"] == BLOCK_LOW_BATTERY
+
+
+@pytest.mark.asyncio
+async def test_wired_provider_passes_above_threshold():
+    players = {"ctrl_a": RealishPlayer("ctrl_a", battery_pct=90.0)}
+    servicer = _make_servicer_with_game(players)
+    game = servicer.current_game
+    mgr, events = _wire_manager(servicer._battery_pct_for_serial, threshold=20, game=game)
+    mgr._interventions_client = FakeFlagClient({"eliminate_player": "1:ctrl_a"})
+
+    with patch("services.game_coordinator.metrics.interventions_total"):
+        await mgr.evaluate_all()
+
+    elim = [d for et, d in events if et == GameEvent.AGENT_INTERVENTION and d["type"] == "eliminate_player"]
+    assert elim[0]["blocked"] == "false"
+
+
+@pytest.mark.asyncio
+async def test_wired_provider_missing_data_does_not_block():
+    # Player present but no battery frame yet -> provider returns None -> no block.
+    players = {"ctrl_a": RealishPlayer("ctrl_a", battery_pct=None)}
+    servicer = _make_servicer_with_game(players)
+    game = servicer.current_game
+    mgr, events = _wire_manager(servicer._battery_pct_for_serial, threshold=20, game=game)
+    mgr._interventions_client = FakeFlagClient({"eliminate_player": "1:ctrl_a"})
+
+    with patch("services.game_coordinator.metrics.interventions_total"):
+        await mgr.evaluate_all()
+
+    elim = [d for et, d in events if et == GameEvent.AGENT_INTERVENTION and d["type"] == "eliminate_player"]
+    assert elim[0]["blocked"] == "false"
+
+
+# --------------------------------------------------------------------------- #
+# resolve_player_targets battery gate with the real provider shape
+# --------------------------------------------------------------------------- #
+def test_resolve_player_targets_drops_low_battery_serial():
+    players = {
+        "ctrl_low": RealishPlayer("ctrl_low", battery_pct=5.0),  # below threshold
+        "ctrl_ok": RealishPlayer("ctrl_ok", battery_pct=80.0),  # above threshold
+        "ctrl_unknown": RealishPlayer("ctrl_unknown", battery_pct=None),  # unknown -> kept
+    }
+    servicer = _make_servicer_with_game(players)
+    game = servicer.current_game
+    mgr, _events = _wire_manager(servicer._battery_pct_for_serial, threshold=20, game=game)
+    # FakeFlagClient returns the default for every serial (no targeting rules).
+    resolved = mgr.resolve_player_targets("player_sensitivity_factor", 1.0, game, battery_gate=True)
+
+    assert "ctrl_low" not in resolved  # battery-gated out
+    assert resolved["ctrl_ok"] == 1.0
+    # Unknown battery must NOT be gated (missing data does not block).
+    assert resolved["ctrl_unknown"] == 1.0
+
+
+def test_resolve_player_targets_no_gate_keeps_all():
+    players = {"ctrl_low": RealishPlayer("ctrl_low", battery_pct=5.0)}
+    servicer = _make_servicer_with_game(players)
+    game = servicer.current_game
+    mgr, _events = _wire_manager(servicer._battery_pct_for_serial, threshold=20, game=game)
+    resolved = mgr.resolve_player_targets("player_sensitivity_factor", 1.0, game, battery_gate=False)
+    assert "ctrl_low" in resolved


### PR DESCRIPTION
## Summary

The game-coordinator servicer constructed `InterventionManager` without a `battery_provider` (`servicer.py` ~78-81). With `battery_provider=None`, `_battery_pct()` always returned `None`, so the documented game-side defense-in-depth battery guard was inert in production:
- the enforcement-chain battery guard (step c) never blocked, and
- the per-serial gate in `resolve_player_targets(..., battery_gate=True)` never dropped a serial.

This wires a real provider sourced from the same signal that feeds `controller_battery_pct`.

## Battery source chosen (and why)

`GameplayData.battery` (proto field 3) already flows into the game coordinator on the `StreamGameplayData` stream that every game consumes — it is the same reading the controller manager exports as `controller_battery_pct`. The game now captures it onto a new `Player.battery_pct` field in `_process_controller_state`, normalized 0–5 → 0–100 via a shared `lib.controller_constants.battery_to_pct` (mirrors the controller-manager semantics: ×20 for the coarse psmoveapi scale, passthrough+clamp for the 0–100 Rust HID path).

The servicer exposes `_battery_pct_for_serial(serial) -> pct | None` reading the live game's player, and passes it as `battery_provider`. This is the cleanest in-process source: **no new gRPC plumbing, no Prometheus scraping** — the data is already in hand per frame. Unknown battery (no game running / unknown serial / no frame seen yet) returns `None`, so missing data never blocks (per the acceptance criteria).

## Changes
- `lib/controller_constants.py`: add shared `battery_to_pct` (0–5 → 0–100 normalization).
- `services/game_coordinator/games/base.py`: add `Player.battery_pct`; capture `GameplayData.battery` each frame.
- `services/game_coordinator/servicer.py`: add `_battery_pct_for_serial`; wire it as `battery_provider`.
- `services/game_coordinator/tests/test_battery_provider.py`: new tests for the wired path.

## Test plan
- `cd services/game_coordinator && uv run --extra test pytest` → **873 passed** (11 new in `test_battery_provider.py`).
- `cd lib && uv run --extra test pytest` → **341 passed**.
- `make lint` → clean.

New tests exercise the **real** provider (not an injected fake): below-threshold blocks a player-targeted elimination, above passes, missing/no-frame data does not block, `resolve_player_targets` drops low-battery serials while keeping unknown-battery ones, and the 0–5 → 0–100 normalization matches controller-manager parity.

Closes #798. Refs #730 #722.

🤖 Generated with [Claude Code](https://claude.com/claude-code)