### PR TITLE
feat: intervention machinery self-observability (#803)

### DIFF
--- a/services/agent/actions/metrics_test.go
+++ b/services/agent/actions/metrics_test.go
@@ -1,0 +1,126 @@
+package actions
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/joustmania/agent/decision"
+)
+
+// newMeteredWriter builds a Writer whose agent_intervention_writes_total counter
+// is wired to a manual-reader meter provider, returning the Writer, its file
+// path, and the reader for collecting metrics.
+func newMeteredWriter(t *testing.T) (*Writer, string, *metric.ManualReader) {
+	t.Helper()
+	src, err := os.ReadFile(filepath.Join("testdata", "interventions.json"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "interventions.json")
+	if err := os.WriteFile(path, src, 0o644); err != nil {
+		t.Fatalf("write temp fixture: %v", err)
+	}
+
+	reader := metric.NewManualReader()
+	mp := metric.NewMeterProvider(metric.WithReader(reader))
+
+	w := &Writer{
+		path:   path,
+		log:    slog.New(slog.NewTextHandler(os.Stderr, nil)),
+		nonce:  newNonceGen(),
+		writes: newWritesCounter(mp),
+	}
+	return w, path, reader
+}
+
+// writesByResult collects the manual reader and returns a result->value map for
+// the agent_intervention_writes_total counter (empty when not yet recorded).
+func writesByResult(t *testing.T, reader *metric.ManualReader) map[string]int64 {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("collect metrics: %v", err)
+	}
+	out := map[string]int64{}
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != "agent_intervention_writes_total" {
+				continue
+			}
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			if !ok {
+				t.Fatalf("expected Sum[int64], got %T", m.Data)
+			}
+			for _, dp := range sum.DataPoints {
+				result, _ := dp.Attributes.Value("result")
+				out[result.AsString()] = dp.Value
+			}
+		}
+	}
+	return out
+}
+
+func TestApply_RecordsOKResult(t *testing.T) {
+	w, _, reader := newMeteredWriter(t)
+
+	err := w.Apply(context.Background(), decision.Decision{
+		Intervention: decision.InterventionEndGame,
+	})
+	if err != nil {
+		t.Fatalf("Apply returned error: %v", err)
+	}
+
+	got := writesByResult(t, reader)
+	if got["ok"] != 1 {
+		t.Errorf("result=ok count = %d, want 1", got["ok"])
+	}
+	if got["error"] != 0 {
+		t.Errorf("result=error count = %d, want 0", got["error"])
+	}
+}
+
+func TestApply_RecordsErrorResult_OnMissingFile(t *testing.T) {
+	w, path, reader := newMeteredWriter(t)
+	// Remove the backing file so the read-modify-write cycle fails.
+	if err := os.Remove(path); err != nil {
+		t.Fatalf("remove fixture: %v", err)
+	}
+
+	err := w.Apply(context.Background(), decision.Decision{
+		Intervention: decision.InterventionEndGame,
+	})
+	if err == nil {
+		t.Fatal("Apply succeeded, want error from missing file")
+	}
+
+	got := writesByResult(t, reader)
+	if got["error"] != 1 {
+		t.Errorf("result=error count = %d, want 1", got["error"])
+	}
+	if got["ok"] != 0 {
+		t.Errorf("result=ok count = %d, want 0", got["ok"])
+	}
+}
+
+func TestApply_RecordsErrorResult_OnUnknownIntervention(t *testing.T) {
+	w, _, reader := newMeteredWriter(t)
+
+	err := w.Apply(context.Background(), decision.Decision{
+		Intervention: "definitely_not_a_real_intervention",
+	})
+	if err == nil {
+		t.Fatal("Apply succeeded, want error from unknown intervention")
+	}
+
+	got := writesByResult(t, reader)
+	if got["error"] != 1 {
+		t.Errorf("result=error count = %d, want 1", got["error"])
+	}
+}

--- a/services/agent/actions/writer.go
+++ b/services/agent/actions/writer.go
@@ -31,6 +31,11 @@ import (
 	"strconv"
 	"sync"
 
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	otelmetric "go.opentelemetry.io/otel/metric"
+	metricnoop "go.opentelemetry.io/otel/metric/noop"
+
 	"github.com/joustmania/agent/decision"
 )
 
@@ -65,6 +70,17 @@ const (
 // INTERVENTIONS_FLAG_PATH.
 const DefaultPath = "/etc/flagd/interventions.json"
 
+// meterName scopes the Writer's OTel instruments.
+const meterName = "github.com/joustmania/agent/actions"
+
+// Result label values for agent_intervention_writes_total. Cardinality is
+// bounded to these two values (no error strings) to keep label cardinality low
+// per .claude/rules/development.md.
+const (
+	resultOK    = "ok"
+	resultError = "error"
+)
+
 // Per-intervention defaults used when a Decision carries no explicit Value. The
 // rules engine (#726) leaves Value empty today, so these are the contract.
 const (
@@ -86,6 +102,11 @@ type Writer struct {
 	log   *slog.Logger
 	nonce *nonceGen
 
+	// writes counts flag-write outcomes (agent_intervention_writes_total),
+	// labeled result=ok|error. Sourced from the global meter provider so it is a
+	// no-op recorder until initMetrics wires the OTLP exporter.
+	writes otelmetric.Int64Counter
+
 	mu sync.Mutex
 }
 
@@ -98,7 +119,28 @@ func NewWriter(path string, log *slog.Logger) *Writer {
 	if log == nil {
 		log = slog.Default()
 	}
-	return &Writer{path: path, log: log, nonce: newNonceGen()}
+	return &Writer{
+		path:   path,
+		log:    log,
+		nonce:  newNonceGen(),
+		writes: newWritesCounter(otel.GetMeterProvider()),
+	}
+}
+
+// newWritesCounter builds the agent_intervention_writes_total counter from the
+// given meter provider. An instrument-creation error yields a no-op counter so
+// the Writer always has a usable instrument.
+func newWritesCounter(mp otelmetric.MeterProvider) otelmetric.Int64Counter {
+	c, err := mp.Meter(meterName).Int64Counter(
+		"agent_intervention_writes_total",
+		otelmetric.WithDescription("Total intervention flag-file writes by the agent ActionSink, labeled by outcome"),
+	)
+	if err != nil {
+		// Int64Counter only errors on bad config; fall back to a no-op so callers
+		// never have to nil-check.
+		c, _ = metricnoop.NewMeterProvider().Meter(meterName).Int64Counter("agent_intervention_writes_total")
+	}
+	return c
 }
 
 // NewWriterFromEnv builds a Writer using INTERVENTIONS_FLAG_PATH (default
@@ -109,15 +151,27 @@ func NewWriterFromEnv(log *slog.Logger) *Writer {
 
 // Apply implements decision.ActionSink: it maps the decision's intervention type
 // to a flag mutation and rewrites the interventions file in place.
-func (w *Writer) Apply(_ context.Context, d decision.Decision) error {
+func (w *Writer) Apply(ctx context.Context, d decision.Decision) error {
 	if err := w.edit(func(doc *orderedDoc) error { return w.mutate(doc, d) }); err != nil {
+		w.recordWrite(ctx, resultError)
+		w.log.Error("agent.action_write_failed",
+			"intervention", d.Intervention,
+			"target_serial", d.TargetSerial,
+			"path", w.path,
+			"error", err)
 		return err
 	}
+	w.recordWrite(ctx, resultOK)
 	w.log.Debug("agent.action_written",
 		"intervention", d.Intervention,
 		"target_serial", d.TargetSerial,
 		"path", w.path)
 	return nil
+}
+
+// recordWrite increments agent_intervention_writes_total for one Apply outcome.
+func (w *Writer) recordWrite(ctx context.Context, result string) {
+	w.writes.Add(ctx, 1, otelmetric.WithAttributes(attribute.String("result", result)))
 }
 
 // edit runs one read-modify-write cycle under the process mutex: read the file,

--- a/services/agent/otel.go
+++ b/services/agent/otel.go
@@ -137,6 +137,11 @@ func initMetrics(ctx context.Context) func(context.Context) error {
 		metric.WithResource(res),
 	)
 
+	// Publish as the global meter provider so instrumented packages (e.g.
+	// actions.Writer) can obtain meters via otel.Meter(...) without threading
+	// the provider through their constructors.
+	otel.SetMeterProvider(provider)
+
 	meter := provider.Meter("process")
 
 	// process_cpu_seconds_total — reads from /proc/self/stat

--- a/services/game_coordinator/interventions.py
+++ b/services/game_coordinator/interventions.py
@@ -871,6 +871,7 @@ class InterventionManager:
                 type=spec.type_id,
                 objective=objective,
                 blocked=str(blocked).lower(),
+                block_reason=block_reason,
             ).inc()
         except Exception as e:
             logger.debug(f"InterventionManager: metric record failed: {e}")

--- a/services/game_coordinator/metrics.py
+++ b/services/game_coordinator/metrics.py
@@ -325,13 +325,17 @@ def clear_all_player_analytics() -> None:
 # intervention attempt — applied or blocked. Also feeds the weighted rate limiter
 # (#722 §5) and the #731 fitness functions. Defined here now so the metric name
 # exists in the registry; zero usages in this PR is intentional.
-#   type:      intervention identifier (e.g. 'adjust_player_sensitivity', 'grant_shield')
-#   objective: active session objective ('endurance'/'balanced'/'accelerate'/'chaos')
-#   blocked:   'true' if rejected by policy/permission enforcement, else 'false'
+#   type:         intervention identifier (e.g. 'adjust_player_sensitivity', 'grant_shield')
+#   objective:    active session objective ('endurance'/'balanced'/'accelerate'/'chaos')
+#   blocked:      'true' if rejected by policy/permission enforcement, else 'false'
+#   block_reason: why a blocked attempt was rejected ('not_allowed', 'rate_limited',
+#                 'low_battery', 'mode_unsupported', 'no_game', 'handler_error'); empty
+#                 string for applied (blocked='false') attempts. Cardinality is bounded
+#                 to this fixed reason set, so it is safe as a label.
 interventions_total = Counter(
     "game_interventions_total",
     "Total agent intervention attempts (applied or blocked by policy)",
-    ["type", "objective", "blocked"],
+    ["type", "objective", "blocked", "block_reason"],
 )
 
 # EventBus stream health metrics (Issue #337)

--- a/services/game_coordinator/tests/test_interventions.py
+++ b/services/game_coordinator/tests/test_interventions.py
@@ -498,7 +498,7 @@ async def test_metric_recorded_with_labels():
     )
     with patch("services.game_coordinator.metrics.interventions_total") as metric:
         await mgr.evaluate_all()
-    metric.labels.assert_any_call(type="play_audio_cue", objective="endurance", blocked="false")
+    metric.labels.assert_any_call(type="play_audio_cue", objective="endurance", blocked="false", block_reason="")
     metric.labels.return_value.inc.assert_called()
 
 

--- a/services/grafana/dashboards/interventions.json
+++ b/services/grafana/dashboards/interventions.json
@@ -1,0 +1,624 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Agent intervention machinery self-observability (#803): attempt rates, blocked reasons, handler errors, and agent-side flag-write failures. Metric series are queried without a job filter so the same panels resolve against Prometheus (job=\"game-coordinator-service\"/\"agent-service\") and VictoriaMetrics (job=\"infrastructure/...\").",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": true,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Applied + blocked intervention attempts per minute, broken down by intervention type.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "per min",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": ["sum"],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.2.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (type) (rate(game_interventions_total[1m])) * 60",
+          "legendFormat": "{{type}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Interventions per Minute (by type)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Blocked intervention attempts by enforcement-chain reason. handler_error is a runtime failure inside a dispatched handler; the others (not_allowed, rate_limited, low_battery, mode_unsupported, no_game) are policy rejections.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "values": ["value", "percent"]
+        },
+        "pieType": "donut",
+        "reduceOptions": {
+          "values": false,
+          "calcs": ["lastNotNull"],
+          "fields": ""
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.2.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (block_reason) (rate(game_interventions_total{blocked=\"true\"}[5m]))",
+          "legendFormat": "{{block_reason}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Blocked Attempts by Reason",
+      "type": "piechart"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Fraction of intervention attempts blocked by the enforcement chain. A sustained high ratio means the agent is mostly being rejected (mis-tuned policy or disallowed types).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.3
+              },
+              {
+                "color": "red",
+                "value": 0.6
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 0,
+        "y": 8
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "values": false,
+          "calcs": ["lastNotNull"],
+          "fields": ""
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.2.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(game_interventions_total{blocked=\"true\"}[5m])) / clamp_min(sum(rate(game_interventions_total[5m])), 1e-9)",
+          "legendFormat": "Blocked ratio",
+          "refId": "A"
+        }
+      ],
+      "title": "Blocked Ratio",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Rate of interventions that passed enforcement but raised inside the handler (block_reason=handler_error). Non-zero means a dispatched handler is failing.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "errors/s",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 9,
+        "x": 6,
+        "y": 8
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": ["sum"],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.2.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (type) (rate(game_interventions_total{block_reason=\"handler_error\"}[5m]))",
+          "legendFormat": "{{type}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Handler Error Rate (by type)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Agent ActionSink flag-file write outcomes (agent_intervention_writes_total). result=error means the agent could not write the interventions flag file (e.g. flagd file unreachable).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "writes/s",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "error"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ok"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 9,
+        "x": 15,
+        "y": 8
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": ["sum"],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.2.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (result) (rate(agent_intervention_writes_total[5m]))",
+          "legendFormat": "{{result}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Agent Flag-Write Outcomes",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Total agent flag-write failures over the last hour. Non-zero means the agent's ACT path is degraded.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 0,
+        "y": 14
+      },
+      "id": 6,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "values": false,
+          "calcs": ["lastNotNull"],
+          "fields": ""
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.2.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(increase(agent_intervention_writes_total{result=\"error\"}[1h]))",
+          "legendFormat": "Write errors (1h)",
+          "refId": "A"
+        }
+      ],
+      "title": "Agent Write Errors (1h)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Applied (non-blocked) interventions per minute, split by the active session objective the agent was serving.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "per min",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 60,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 18,
+        "x": 6,
+        "y": 14
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": ["sum"],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.2.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (objective) (rate(game_interventions_total{blocked=\"false\"}[1m])) * 60",
+          "legendFormat": "{{objective}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Applied Interventions per Minute (by objective)",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 39,
+  "tags": ["joustmania", "agent", "interventions", "agentic"],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Interventions",
+  "uid": "interventions",
+  "version": 1,
+  "weekStart": ""
+}

--- a/services/prometheus/alerts.yml
+++ b/services/prometheus/alerts.yml
@@ -113,3 +113,22 @@ groups:
         annotations:
           summary: "High gRPC client error rate on {{ $labels.service }}/{{ $labels.method }}"
           description: "Service {{ $labels.service }} method {{ $labels.method }} has error rate {{ $value }}/s for 2+ minutes"
+
+      # Intervention machinery alerts (#803)
+      - alert: InterventionHandlerErrors
+        expr: sum(rate(game_interventions_total{block_reason="handler_error"}[5m])) > 0
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Intervention handlers are failing"
+          description: "Dispatched intervention handlers raised at {{ $value }}/s for 2+ minutes (block_reason=handler_error)."
+
+      - alert: AgentInterventionWriteFailures
+        expr: sum(rate(agent_intervention_writes_total{result="error"}[5m])) > 0
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Agent cannot write intervention flags"
+          description: "The agent ActionSink failed flag-file writes at {{ $value }}/s for 2+ minutes (flagd file unreachable?). The ACT path is degraded."


### PR DESCRIPTION
Closes #803

The ACT path had no health signals of its own. This PR adds an agent-side write metric, a queryable block-reason label, an Interventions dashboard, and two alerts.

## Changes

### Agent (Go)
- New counter `agent_intervention_writes_total{result="ok"|"error"}` recorded around `Writer.Apply`, exported via the existing OTLP metrics path.
- `otel.go` now publishes the SDK meter provider globally (`otel.SetMeterProvider`) — previously the provider was created but never set, so instrumented packages had no live meter. The Writer obtains its counter from the global provider and falls back to a no-op counter (so it is safe before `OTEL_EXPORTER_OTLP_ENDPOINT` is set).
- `Apply` now logs write failures at `error` level (it was slog-silent except on the debug success path).
- Unit tests use a `metric.ManualReader` to assert the ok/error data points.

### Game coordinator
- `game_interventions_total` gains a **bounded** `block_reason` label (`not_allowed`, `rate_limited`, `low_battery`, `mode_unsupported`, `no_game`, `handler_error`; empty for applied attempts). Previously `block_reason` lived only on the EventBus payload, so the acceptance criterion "handler_error rate" was not queryable from metrics. Cardinality stays bounded to the fixed reason set.

### Grafana
- New dashboard `services/grafana/dashboards/interventions.json` (auto-provisioned). Placement decision: a **dedicated dashboard** rather than panels bolted onto `game-analytics.json`, because the section mixes game-coordinator series (`game_interventions_total`) with an agent series (`agent_intervention_writes_total`) and warrants its own audit surface. Panels: interventions/min by type, blocked-by-reason donut, blocked ratio, handler-error rate, agent flag-write outcomes, write-error stat, applied/min by objective.

### Prometheus
- `InterventionHandlerErrors` (warning, `for: 2m`) and `AgentInterventionWriteFailures` (critical, `for: 2m`).

## Exact PromQL used
- Interventions/min by type: `sum by (type) (rate(game_interventions_total[1m])) * 60`
- Blocked by reason: `sum by (block_reason) (rate(game_interventions_total{blocked="true"}[5m]))`
- Blocked ratio: `sum(rate(game_interventions_total{blocked="true"}[5m])) / clamp_min(sum(rate(game_interventions_total[5m])), 1e-9)`
- Handler-error rate: `sum by (type) (rate(game_interventions_total{block_reason="handler_error"}[5m]))`
- Agent write outcomes: `sum by (result) (rate(agent_intervention_writes_total[5m]))`
- Agent write errors (1h): `sum(increase(agent_intervention_writes_total{result="error"}[1h]))`
- Alert (handler errors): `sum(rate(game_interventions_total{block_reason="handler_error"}[5m])) > 0`
- Alert (write failures): `sum(rate(agent_intervention_writes_total{result="error"}[5m])) > 0`

## Job-label caveat handling
The `prometheusremotewrite` exporter maps `service.name` -> `job` with the `service.namespace` prefix; Prometheus strips it (`job="game-coordinator-service"` / `job="agent-service"`) while VictoriaMetrics keeps it (`job="infrastructure/..."`). All dashboard and alert queries select on the **metric name only with no `job` filter** and aggregate away the differing label, so the same PromQL resolves identically against both backends.

## Test plan
- `go test -race -count=1 ./actions/` — pass (ok + error outcomes via ManualReader).
- `go vet ./...`, `gofmt -l .` — clean.
- `uv run --extra test python -m pytest tests/ -k "intervention or metric"` (game_coordinator) — 125 passed.
- `make lint` (ruff) — All checks passed.
- YAML validated (no duplicate keys) and dashboard JSON validated via parser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)