### PR TITLE
feat(agent): auto-remediation rollback gated on remediation_allowed (#736)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -709,6 +709,11 @@ services:
       # decides and spans expansions but does not apply them (dry-run).
       - AGENT_ROLLOUT_ENABLED=${AGENT_ROLLOUT_ENABLED:-false}
       - ROLLOUT_FLAG_PATH=/etc/flagd/rollout.json
+      # Auto-remediation / rollback (#736): on fitness failure during an active
+      # rollout the agent rolls current_controller_count back to "none", gated on
+      # the remediation_allowed flag (rollout flagd domain, read from rollout.json).
+      # After a rollback, re-expansion is suppressed for the cooldown below.
+      - AGENT_ROLLOUT_COOLDOWN_SECONDS=${AGENT_ROLLOUT_COOLDOWN_SECONDS:-30}
       - LOG_LEVEL=${LOG_LEVEL:-info}
       - OTEL_SERVICE_NAME=agent
       - OTEL_SERVICE_NAMESPACE=infrastructure

--- a/services/agent/README.md
+++ b/services/agent/README.md
@@ -177,26 +177,26 @@ flagd flips by **variant name**, not value, so the loop maps the observed count
 **Decision matrix** (per observe cycle; observed state comes from the health
 span, **not** a flag re-read):
 
-| Rollout state | Fitness | Dwell elapsed & not held | Action | `remediation.action` | Span? |
+| Rollout state | Fitness | Allowed / Dwell-or-hold | Action | `remediation.action` | Span? |
 |---------------|---------|--------------------------|--------|----------------------|-------|
 | inactive (`target_backend==""`) | — | — | nothing | — | **no span** |
-| active, stage `< all` | passing | yes | flip to next variant | `expand` | yes |
-| active, stage `< all` | passing | no (dwell / hold) | nothing | `none` | yes |
+| active, stage `< all` | passing | dwell elapsed, not held | flip to next variant | `expand` | yes |
+| active, stage `< all` | passing | dwell not elapsed / held (cooldown) | nothing | `none` | yes |
 | active, stage `== all` | passing | — | nothing (terminal) | `none` | yes |
-| active | **failing** | — | **nothing** (no write — rollback is PR F) | `none` | yes |
-| active | write error | — | attempted, failed | `expand` (+ span error/status) | yes |
+| active, stage `> none` | **failing** | **allowed** | reset to `none` (roll back) | `rollback` | yes |
+| active, stage `> none` | **failing** | **not allowed** | nothing (recommend) | `recommended_only` | yes |
+| active, stage `> none` | **failing** | rollback already in flight (settling) | nothing | `none` | yes |
+| active, stage `== none` | **failing** | — | nothing (nothing to roll back) | `none` | yes |
+| active | write error | — | attempted, failed | `expand` / `rollback` (+ span error/status) | yes |
+
+See [Auto-remediation / rollback](#auto-remediation--rollback-736) for the
+failing-fitness rows.
 
 **Dwell:** after each expansion the loop waits `AGENT_ROLLOUT_DWELL_SECONDS`
 (default **15s**) before expanding again, so fitness has time to observe the
 newly-added controllers at the current stage. The first expansion (no prior
 `lastExpansion`) is not delayed. A failed write does **not** advance the dwell
 clock, so the next passing cycle retries.
-
-**Fitness-failing branch (observe-only in this PR):** PR E records but never
-rolls back — a failing cycle emits the span with `remediation.action="none"` and
-the populated `fitness.violations`. **Rollback (PR F)** plugs into the
-`holdExpansion` hook (`InfraLoop.SetHoldExpansion`, always false here) for its
-post-rollback cooldown, and adds the rollback write (reset toward `none`).
 
 **Freshness gate** (`gate.ShouldEvaluateInfra`): the loop only evaluates when
 ≥1 controller reported fresh `controller.bluetooth_health` within the controller
@@ -214,8 +214,76 @@ failure sets the span status to error and records the error.
 | Env | Default | Effect |
 |-----|---------|--------|
 | `AGENT_ROLLOUT_ENABLED` | `false` | `true` → real `RolloutWriter` applies flips. `false` → **dry-run**: the loop still decides and spans expansions (`remediation.action="expand"`, `rollout.controller_count` set) but does **not** write `rollout.json` (decided-but-not-applied; logged `agent.rollout_dry_run`). |
-| `ROLLOUT_FLAG_PATH` | `/etc/flagd/rollout.json` | rollout flag file path |
+| `ROLLOUT_FLAG_PATH` | `/etc/flagd/rollout.json` | rollout flag file path (read for `remediation_allowed`, written on expand/rollback) |
 | `AGENT_ROLLOUT_DWELL_SECONDS` | `15` | per-stage dwell before re-expansion |
+| `AGENT_ROLLOUT_COOLDOWN_SECONDS` | `30` | post-rollback cooldown: re-expansion is suppressed this long after a rollback |
+
+### Auto-remediation / rollback (#736)
+
+When infrastructure fitness **fails** during an active rollout, the loop closes
+the remediation loop: it can **roll the backend rollout back** by resetting
+`current_controller_count` to `none` (value 0), pulling **all** controllers back
+to the stable default backend. `target_backend` is **left untouched** — that
+preserves the operator's intent for the next attempt; only the controller count
+is wound back.
+
+**The loop:**
+
+```
+if not fitness.passing and stage > none:
+    if remediation_allowed:
+        rollback_backend()                 # writes current_controller_count = "none"
+        span: remediation.action = "rollback"
+        start cooldown                     # suppress re-expansion for AGENT_ROLLOUT_COOLDOWN_SECONDS
+    else:
+        span: remediation.action = "recommended_only"   # no write
+```
+
+**`remediation_allowed` gating.** Auto-rollback is gated on the
+`remediation_allowed` flag. That flag lives in the **`rollout` flagd domain**
+(`services/flagd/rollout.json`, `flagSetId: "rollout"`), **not** the agent
+domain. The agent already owns that file (it is the sole writer of
+`rollout.json`), so it resolves the gate by reading the flag's `defaultVariant`
+**directly from that document** each cycle (`actions.RemediationReader`), rather
+than standing up a second flagd RPC domain client. Any read/parse error →
+**`false`** (recommend-only) — the fail-closed safe default. Flip the flag's
+`defaultVariant` to `on`/`off` to enable/disable auto-rollback live (no restart).
+
+**Cooldown.** After a successful rollback the loop starts a cooldown
+(`AGENT_ROLLOUT_COOLDOWN_SECONDS`, default **30s**), wired through the
+`holdExpansion` hook. While in cooldown the loop will **not** re-expand even if
+fitness recovers — otherwise it would roll back, immediately see passing fitness
+at stage `none`, and climb straight back into the same failure. The cooldown is
+held **in-memory** (`cooldownUntil`), so restarting the agent process clears it
+(a demo reset path).
+
+**Span value set & the settling window.** `remediation.action` is a **closed
+set** of exactly four values — `none | expand | rollback | recommended_only`.
+The rollback is written **once per failure episode**: after the write, the
+controller-manager takes several windows to converge `current_controller_count`
+back to 0. During that **settling window** (rollback written, observed
+`bluetooth.rollout_count` still `> 0`), further failing cycles record
+**`none`** (with the populated `fitness.violations`) and do **not** re-write —
+re-emitting `rollback` without a write would lie. The episode ends when the
+observed count returns to 0; a later failure can then trigger a fresh rollback.
+
+| Failing-fitness state | observed `rollout_count` | allowed | write | `remediation.action` |
+|------------------------|--------------------------|---------|-------|----------------------|
+| active stage           | `> 0`, no rollback in flight | yes | `current_controller_count="none"` | `rollback` |
+| active stage           | `> 0`, no rollback in flight | no  | none | `recommended_only` |
+| rollback in flight (settling) | `> 0` | — | none | `none` |
+| at stable default      | `0` | — | none (nothing to roll back) | `none` |
+
+**Dry-run** (`AGENT_ROLLOUT_ENABLED=false`): the rollback is **decided and
+spanned** (`remediation.action="rollback"`) but the `DryRunRolloutWriter`'s
+`SetControllerCount("none")` is a no-op — decided-but-not-applied, consistent
+with dry-run expansion. A rollback **write error** sets the span status to error,
+records the error, and does **not** mark the episode in flight, so the next
+failing cycle retries (mirrors the expansion error path).
+
+**Demo reset.** Flip `remediation_allowed` to `off` to stop auto-rollback (the
+loop drops back to `recommended_only`); restart the agent to clear an in-progress
+cooldown.
 
 ## Gating & decisions
 

--- a/services/agent/actions/remediation_reader.go
+++ b/services/agent/actions/remediation_reader.go
@@ -1,0 +1,110 @@
+package actions
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"sync"
+)
+
+// flagRemediationAllowed is the rollout-domain flag whose resolved value gates
+// auto-rollback. It lives in the SAME file the agent already owns and writes
+// (services/flagd/rollout.json), so the agent reads it directly from that
+// document rather than standing up a second flagd RPC domain client.
+const flagRemediationAllowed = "remediation_allowed"
+
+// RemediationReader resolves the `remediation_allowed` gate from the rollout
+// flag file. PR F's auto-rollback is allowed ONLY when this is true; on any
+// error (file missing, unparseable, flag absent) it returns false so the loop
+// falls back to recommend-only — the fail-closed safe default.
+//
+// remediation_allowed lives in the `rollout` flagd domain (rollout.json,
+// flagSetId "rollout"), NOT the agent domain (agent.json). The agent already
+// owns rollout.json's path (it is the sole writer via RolloutWriter), so the
+// simplest authoritative source is to resolve the flag's defaultVariant from
+// that document directly — reusing the same order-preserving parser as the
+// writer — rather than registering a second OpenFeature named provider. It
+// reads the file fresh on each call so flipping the flag takes effect live.
+type RemediationReader struct {
+	path string
+	log  *slog.Logger
+
+	mu sync.Mutex
+}
+
+// NewRemediationReader builds a reader over the rollout flag file at path.
+// path "" uses DefaultRolloutPath. log nil uses slog.Default().
+func NewRemediationReader(path string, log *slog.Logger) *RemediationReader {
+	if path == "" {
+		path = DefaultRolloutPath
+	}
+	if log == nil {
+		log = slog.Default()
+	}
+	return &RemediationReader{path: path, log: log}
+}
+
+// NewRemediationReaderFromEnv builds a reader using ROLLOUT_FLAG_PATH (default
+// DefaultRolloutPath), mirroring NewRolloutWriterFromEnv — both target the same
+// file, so the reader and writer always agree on the path.
+func NewRemediationReaderFromEnv(log *slog.Logger) *RemediationReader {
+	return NewRemediationReader(os.Getenv("ROLLOUT_FLAG_PATH"), log)
+}
+
+// RemediationAllowed resolves the `remediation_allowed` flag's currently-served
+// boolean value from the rollout file: it reads defaultVariant, looks that
+// variant up in the variants map, and returns its bool. ANY error path (read,
+// parse, missing flag/variant, non-bool value) returns false — auto-rollback
+// stays gated off unless the document unambiguously says it is allowed.
+func (r *RemediationReader) RemediationAllowed() bool {
+	allowed, err := r.resolve()
+	if err != nil {
+		r.log.Debug("agent.remediation_allowed fell back to false", "path", r.path, "error", err)
+		return false
+	}
+	return allowed
+}
+
+// resolve performs the file read + defaultVariant resolution. Separated from
+// RemediationAllowed so tests can assert on the error path explicitly.
+func (r *RemediationReader) resolve() (bool, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	raw, err := os.ReadFile(r.path)
+	if err != nil {
+		return false, fmt.Errorf("read rollout file %q: %w", r.path, err)
+	}
+	doc, err := parseDoc(raw)
+	if err != nil {
+		return false, err
+	}
+	f, err := doc.flag(flagRemediationAllowed)
+	if err != nil {
+		return false, err
+	}
+
+	var defaultVariant string
+	if ok, err := f.get("defaultVariant", &defaultVariant); err != nil {
+		return false, err
+	} else if !ok {
+		return false, fmt.Errorf("flag %q has no defaultVariant", flagRemediationAllowed)
+	}
+
+	variants := map[string]any{}
+	if ok, err := f.get("variants", &variants); err != nil {
+		return false, err
+	} else if !ok {
+		return false, fmt.Errorf("flag %q has no variants object", flagRemediationAllowed)
+	}
+
+	val, ok := variants[defaultVariant]
+	if !ok {
+		return false, fmt.Errorf("flag %q defaultVariant %q not in variants", flagRemediationAllowed, defaultVariant)
+	}
+	b, ok := val.(bool)
+	if !ok {
+		return false, fmt.Errorf("flag %q variant %q is not a boolean", flagRemediationAllowed, defaultVariant)
+	}
+	return b, nil
+}

--- a/services/agent/actions/remediation_reader_test.go
+++ b/services/agent/actions/remediation_reader_test.go
@@ -1,0 +1,139 @@
+package actions
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeRolloutFile writes content to a temp rollout file and returns its path.
+func writeRolloutFile(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "rollout.json")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write temp rollout file: %v", err)
+	}
+	return path
+}
+
+const rolloutDocAllowed = `{
+  "metadata": { "flagSetId": "rollout" },
+  "flags": {
+    "remediation_allowed": {
+      "state": "ENABLED",
+      "variants": { "on": true, "off": false },
+      "defaultVariant": "on"
+    }
+  }
+}`
+
+const rolloutDocBlocked = `{
+  "metadata": { "flagSetId": "rollout" },
+  "flags": {
+    "remediation_allowed": {
+      "state": "ENABLED",
+      "variants": { "on": true, "off": false },
+      "defaultVariant": "off"
+    }
+  }
+}`
+
+func TestRemediationReader_AllowedTrue(t *testing.T) {
+	path := writeRolloutFile(t, rolloutDocAllowed)
+	r := NewRemediationReader(path, nil)
+	if !r.RemediationAllowed() {
+		t.Fatalf("RemediationAllowed() = false, want true (defaultVariant on)")
+	}
+}
+
+func TestRemediationReader_BlockedFalse(t *testing.T) {
+	path := writeRolloutFile(t, rolloutDocBlocked)
+	r := NewRemediationReader(path, nil)
+	if r.RemediationAllowed() {
+		t.Fatalf("RemediationAllowed() = true, want false (defaultVariant off)")
+	}
+}
+
+func TestRemediationReader_LiveFlip(t *testing.T) {
+	// Reads the file fresh each call: rewriting the file flips the result with no
+	// reader rebuild (mirrors flagd live evaluation).
+	path := writeRolloutFile(t, rolloutDocBlocked)
+	r := NewRemediationReader(path, nil)
+	if r.RemediationAllowed() {
+		t.Fatalf("initial RemediationAllowed() = true, want false")
+	}
+	if err := os.WriteFile(path, []byte(rolloutDocAllowed), 0o644); err != nil {
+		t.Fatalf("rewrite: %v", err)
+	}
+	if !r.RemediationAllowed() {
+		t.Fatalf("after flip RemediationAllowed() = false, want true")
+	}
+}
+
+func TestRemediationReader_MissingFileFalse(t *testing.T) {
+	r := NewRemediationReader(filepath.Join(t.TempDir(), "nope.json"), nil)
+	if r.RemediationAllowed() {
+		t.Fatalf("missing file → RemediationAllowed() = true, want false (fail-closed)")
+	}
+}
+
+func TestRemediationReader_MalformedFalse(t *testing.T) {
+	path := writeRolloutFile(t, `{ not json`)
+	r := NewRemediationReader(path, nil)
+	if r.RemediationAllowed() {
+		t.Fatalf("malformed doc → RemediationAllowed() = true, want false (fail-closed)")
+	}
+}
+
+func TestRemediationReader_FlagAbsentFalse(t *testing.T) {
+	path := writeRolloutFile(t, `{
+  "metadata": { "flagSetId": "rollout" },
+  "flags": { "target_backend": { "variants": { "python": "python" }, "defaultVariant": "python" } }
+}`)
+	r := NewRemediationReader(path, nil)
+	if r.RemediationAllowed() {
+		t.Fatalf("flag absent → RemediationAllowed() = true, want false (fail-closed)")
+	}
+}
+
+func TestRemediationReader_NonBoolVariantFalse(t *testing.T) {
+	// defaultVariant points at a non-boolean variant value → fail-closed.
+	path := writeRolloutFile(t, `{
+  "flags": {
+    "remediation_allowed": {
+      "variants": { "on": "yes" },
+      "defaultVariant": "on"
+    }
+  }
+}`)
+	r := NewRemediationReader(path, nil)
+	if r.RemediationAllowed() {
+		t.Fatalf("non-bool variant → RemediationAllowed() = true, want false (fail-closed)")
+	}
+}
+
+func TestRemediationReader_DanglingDefaultVariantFalse(t *testing.T) {
+	// defaultVariant names a variant that does not exist → fail-closed.
+	path := writeRolloutFile(t, `{
+  "flags": {
+    "remediation_allowed": {
+      "variants": { "on": true, "off": false },
+      "defaultVariant": "maybe"
+    }
+  }
+}`)
+	r := NewRemediationReader(path, nil)
+	if r.RemediationAllowed() {
+		t.Fatalf("dangling defaultVariant → RemediationAllowed() = true, want false (fail-closed)")
+	}
+}
+
+func TestNewRemediationReaderFromEnv_UsesRolloutPath(t *testing.T) {
+	path := writeRolloutFile(t, rolloutDocAllowed)
+	t.Setenv("ROLLOUT_FLAG_PATH", path)
+	r := NewRemediationReaderFromEnv(nil)
+	if !r.RemediationAllowed() {
+		t.Fatalf("FromEnv reader did not resolve allowed from ROLLOUT_FLAG_PATH")
+	}
+}

--- a/services/agent/decision/infra_loop.go
+++ b/services/agent/decision/infra_loop.go
@@ -46,6 +46,30 @@ type RolloutActuator interface {
 	StageVariantForValue(value int) (string, bool)
 }
 
+// RemediationSource resolves the `remediation_allowed` gate that decides
+// whether the loop may auto-roll-back (write the rollout file) or may only
+// RECOMMEND a rollback (span only). It is the infra-domain parallel to the
+// agent-domain permission gate, but `remediation_allowed` lives in the rollout
+// flagd domain (rollout.json), not the agent domain — so it is sourced
+// separately from the per-cycle agent Snapshot.
+//
+// It is satisfied by actions.RemediationReader (which resolves the flag's
+// defaultVariant from rollout.json each call) in production, and by a static
+// fake in tests. RemediationAllowed MUST be fail-closed: any error returns
+// false (recommend-only), so a missing/garbled control plane never auto-writes.
+type RemediationSource interface {
+	RemediationAllowed() bool
+}
+
+// staticRemediation is a constant RemediationSource (test/default helper).
+type staticRemediation bool
+
+func (s staticRemediation) RemediationAllowed() bool { return bool(s) }
+
+// StaticRemediation returns a RemediationSource that always reports allowed. It
+// is exported for tests and for any caller that wants a constant gate.
+func StaticRemediation(allowed bool) RemediationSource { return staticRemediation(allowed) }
+
 // rolloutGate decides whether the infrastructure observe path should evaluate at
 // all this cycle (≥1 controller reporting fresh health). It is the infra-domain
 // parallel to gate.ShouldEvaluate, injected so the loop stays unit-testable
@@ -59,16 +83,47 @@ type rolloutGate func(snap infracontext.InfraContext, now time.Time) bool
 // via AGENT_ROLLOUT_DWELL_SECONDS (read at construction in main.go).
 const DefaultRolloutDwell = 15 * time.Second
 
-// Non-action remediation placeholder for the rollout decision span. In PR E the
-// loop OBSERVES — it expands when fitness passes but never rolls back. A
-// fitness-failing cycle therefore records remediation.action="none" (observe
-// only). PR F introduces the rollback semantics ("rollback" /
-// "recommended_only"); keeping this distinct from those values lets the M3 PR G
-// narrative test tell an E observe-cycle apart from an F rollback-blocked cycle.
+// Remediation action values recorded on remediation.action of the rollout
+// decision span. The set is CLOSED — exactly these four values — because PR G's
+// narrative test discriminates cycles by this attribute:
+//
+//   - none: no remediation taken this cycle. Either fitness passes and the loop
+//     is observing/holding/terminal (PR E), or fitness fails but there is
+//     nothing to roll back (stage already none), or a rollback is already in
+//     flight (the settling window — the write happened, the count has not yet
+//     returned to 0).
+//   - expand: the loop advanced the rollout one stage (PR E).
+//   - rollback: fitness failed at an active stage (>0), rollback was ALLOWED,
+//     and the loop reset current_controller_count toward "none" (PR F). In
+//     dry-run this is "decided but not applied".
+//   - recommended_only: fitness failed at an active stage (>0) but rollback was
+//     NOT allowed (remediation_allowed=false); the loop records the recommended
+//     rollback WITHOUT writing the file (PR F).
 const (
-	RemediationNone   = "none"
-	RemediationExpand = "expand"
+	RemediationNone            = "none"
+	RemediationExpand          = "expand"
+	RemediationRollback        = "rollback"
+	RemediationRecommendedOnly = "recommended_only"
 )
+
+// Stable-default rollout stage. A rollback resets current_controller_count to
+// this variant (value 0), pulling all controllers back to the stable backend.
+// Mirrors actions.StageNoneVariant / actions.StageNoneValue, redeclared here so
+// the decision package needs no dependency on actions (actions imports decision,
+// not the other way around). The actuator's StageVariantForValue(0) would also
+// yield this, but the rollback target is a fixed, named constant.
+const (
+	rolloutStageNoneVariant = "none"
+	rolloutStageNoneValue   = 0
+)
+
+// DefaultRolloutCooldown is how long re-expansion is suppressed after a
+// rollback, so fitness has time to recover and stabilize at the reset stage
+// before the loop starts climbing the ladder again. Without it the loop would
+// roll back, immediately see passing fitness at stage none, and re-expand into
+// the same failure. Tunable via AGENT_ROLLOUT_COOLDOWN_SECONDS (read at
+// construction in main.go); held in-memory, so an agent restart clears it.
+const DefaultRolloutCooldown = 30 * time.Second
 
 // AttrRolloutControllerCount is the new rollout stage VALUE recorded on the
 // decision span when the loop expands (e.g. 3 after advancing none→one→three).
@@ -82,28 +137,43 @@ const AttrRolloutControllerCount = "rollout.controller_count"
 // by flipping current_controller_count. Every cycle where the rollout is ACTIVE
 // emits an agent.infrastructure.decision span.
 //
-// Rollback is PR F: this PR's fitness-failing branch only records (no write), and
-// the holdExpansion hook (always false here) is where PR F's post-rollback
-// cooldown plugs in. The loop is safe for concurrent OnInfraEvaluate calls (the
+// Rollback is PR F: when fitness FAILS at an active stage (>0) and
+// remediation_allowed is true, the loop resets current_controller_count to
+// "none" (rolls the whole rollout back) and starts a cooldown that suppresses
+// re-expansion (via the holdExpansion hook) until fitness has had time to
+// recover. When remediation_allowed is false it records "recommended_only"
+// without writing. The loop is safe for concurrent OnInfraEvaluate calls (the
 // trace Export handler may invoke it from multiple goroutines): all loop state is
 // guarded by mu.
 type InfraLoop struct {
-	log     *slog.Logger
-	fitness BluetoothFitnessSource
-	rollout RolloutActuator
-	tracer  trace.Tracer
+	log         *slog.Logger
+	fitness     BluetoothFitnessSource
+	rollout     RolloutActuator
+	remediation RemediationSource
+	tracer      trace.Tracer
 
-	gate  rolloutGate
-	dwell time.Duration
-	now   func() time.Time
+	gate     rolloutGate
+	dwell    time.Duration
+	cooldown time.Duration
+	now      func() time.Time
 
 	// holdExpansion is a hook that, when it returns true, suppresses an otherwise
-	// eligible expansion. It is always nil/false in PR E; PR F sets it to enforce a
-	// post-rollback cooldown. Guarded by mu (read inside the locked decide path).
+	// eligible expansion. PR F installs the post-rollback cooldown hook here in
+	// NewInfraLoop (it reads cooldownUntil under mu). Guarded by mu (read inside
+	// the locked decide path). Kept as a settable seam for tests.
 	holdExpansion func(now time.Time) bool
 
 	mu            sync.Mutex
 	lastExpansion time.Time
+	// cooldownUntil is the wall-clock time until which re-expansion is suppressed
+	// after a rollback. Zero = no cooldown. In-memory only (process restart clears
+	// it, which is the demo reset path).
+	cooldownUntil time.Time
+	// rollbackInFlight is true between writing a rollback and observing the
+	// rollout count return to 0. While set, further failing cycles record "none"
+	// (the reset is already in flight) and do NOT re-write. Cleared when the
+	// observed RolloutCount reaches 0 — the failure episode is over.
+	rollbackInFlight bool
 }
 
 // NewInfraLoop builds the progressive-rollout loop (#734). log nil → slog.Default.
@@ -121,15 +191,48 @@ func NewInfraLoop(log *slog.Logger, dwell time.Duration, fitness BluetoothFitnes
 	if dwell <= 0 {
 		dwell = DefaultRolloutDwell
 	}
-	return &InfraLoop{
+	l := &InfraLoop{
 		log:     log,
 		fitness: fitness,
 		rollout: rollout,
-		tracer:  otel.Tracer(instrumentationName),
-		gate:    defaultRolloutGate,
-		dwell:   dwell,
-		now:     time.Now,
+		// Fail-closed default: until main.go injects the real RemediationReader,
+		// rollback is recommend-only (never auto-writes).
+		remediation: staticRemediation(false),
+		tracer:      otel.Tracer(instrumentationName),
+		gate:        defaultRolloutGate,
+		dwell:       dwell,
+		cooldown:    DefaultRolloutCooldown,
+		now:         time.Now,
 	}
+	// Wire the post-rollback cooldown into the expansion hold seam. The hook reads
+	// cooldownUntil, which the failing branch sets after a rollback. shouldExpandLocked
+	// already holds mu when it calls this, so read cooldownUntil directly.
+	l.holdExpansion = func(now time.Time) bool {
+		return !l.cooldownUntil.IsZero() && now.Before(l.cooldownUntil)
+	}
+	return l
+}
+
+// SetRemediationSource injects the `remediation_allowed` gate (main.go passes
+// actions.RemediationReader). nil leaves the fail-closed default (recommend-only).
+func (l *InfraLoop) SetRemediationSource(src RemediationSource) {
+	if src == nil {
+		return
+	}
+	l.mu.Lock()
+	l.remediation = src
+	l.mu.Unlock()
+}
+
+// SetCooldown overrides the post-rollback cooldown (main.go reads
+// AGENT_ROLLOUT_COOLDOWN_SECONDS). d ≤ 0 is ignored (keeps the default).
+func (l *InfraLoop) SetCooldown(d time.Duration) {
+	if d <= 0 {
+		return
+	}
+	l.mu.Lock()
+	l.cooldown = d
+	l.mu.Unlock()
 }
 
 // defaultRolloutGate returns true when ≥1 controller has a fresh health update.
@@ -187,18 +290,57 @@ func (l *InfraLoop) OnInfraEvaluate(ctx context.Context, snap infracontext.Infra
 	wroteVariant := ""
 	var writeErr error
 
-	if fit.Evaluated && fit.Passing && l.rollout != nil {
-		if variant, value, ok := l.rollout.NextStage(stage); ok && l.shouldExpandLocked(now) {
-			action = RemediationExpand
-			expandedTo = value
-			wroteVariant = variant
-			writeErr = l.rollout.SetControllerCount(variant)
-			if writeErr == nil {
-				l.lastExpansion = now
+	// Episode bookkeeping: once a rollback's reset has been observed to land
+	// (RolloutCount back to 0), the failure episode is over — clear the in-flight
+	// flag so a later failure can trigger a fresh rollback.
+	if l.rollbackInFlight && stage == rolloutStageNoneValue {
+		l.rollbackInFlight = false
+	}
+
+	switch {
+	case fit.Evaluated && fit.Passing:
+		// Fitness passes → climb the ladder if eligible (PR E expansion).
+		if l.rollout != nil {
+			if variant, value, ok := l.rollout.NextStage(stage); ok && l.shouldExpandLocked(now) {
+				action = RemediationExpand
+				expandedTo = value
+				wroteVariant = variant
+				writeErr = l.rollout.SetControllerCount(variant)
+				if writeErr == nil {
+					l.lastExpansion = now
+				}
 			}
 		}
+
+	case fit.Evaluated && !fit.Passing:
+		// Fitness FAILS → remediation (PR F). Three sub-cases:
+		switch {
+		case stage <= rolloutStageNoneValue:
+			// Nothing to roll back: already at (or below) the stable default. Record
+			// "none" with the violations; no write.
+			action = RemediationNone
+		case l.rollbackInFlight:
+			// A rollback is already in flight (written, count not yet back to 0).
+			// Re-emitting "rollback" would lie (no write this cycle), so record "none"
+			// with the violations while the controller-manager catches up.
+			action = RemediationNone
+		case l.remediation != nil && l.remediation.RemediationAllowed() && l.rollout != nil:
+			// Allowed + active stage → roll the whole rollout back to "none".
+			// target_backend is deliberately left untouched (operator intent for the
+			// next attempt). Start the post-rollback cooldown so the loop does not
+			// immediately re-expand into the same failure once fitness recovers.
+			action = RemediationRollback
+			wroteVariant = rolloutStageNoneVariant
+			writeErr = l.rollout.SetControllerCount(rolloutStageNoneVariant)
+			if writeErr == nil {
+				l.rollbackInFlight = true
+				l.cooldownUntil = now.Add(l.cooldown)
+			}
+		default:
+			// Active stage but rollback NOT allowed → recommend only (span, no write).
+			action = RemediationRecommendedOnly
+		}
 	}
-	// fitness failing → action stays RemediationNone (observe only; rollback is PR F).
 	l.mu.Unlock()
 
 	// (5) Span: every ACTIVE-rollout cycle is audited.
@@ -211,8 +353,8 @@ func (l *InfraLoop) OnInfraEvaluate(ctx context.Context, snap infracontext.Infra
 //   - dwell: fitness needs time to observe each new stage before we add more
 //     controllers. lastExpansion zero (never expanded) passes the dwell check so
 //     the first expansion is not delayed.
-//   - holdExpansion: always false in PR E; PR F's post-rollback cooldown sets it
-//     to block re-expansion for a window after a rollback.
+//   - holdExpansion: PR F's post-rollback cooldown — true while now is before
+//     cooldownUntil, blocking re-expansion for a window after a rollback.
 func (l *InfraLoop) shouldExpandLocked(now time.Time) bool {
 	if !l.lastExpansion.IsZero() && now.Sub(l.lastExpansion) < l.dwell {
 		return false
@@ -225,8 +367,9 @@ func (l *InfraLoop) shouldExpandLocked(now time.Time) bool {
 
 // emitDecisionSpan emits the agent.infrastructure.decision span for one
 // ACTIVE-rollout cycle, mirroring telemetry.go conventions (tracer.Start +
-// WithAttributes, error.type + status on write failure). expandedTo/wroteVariant
-// are only meaningful when action == RemediationExpand.
+// WithAttributes, error.type + status on write failure). expandedTo is only
+// meaningful when action == RemediationExpand; wroteVariant is set for both
+// expand (next variant) and rollback ("none").
 func (l *InfraLoop) emitDecisionSpan(
 	ctx context.Context,
 	now time.Time,
@@ -273,22 +416,36 @@ func (l *InfraLoop) emitDecisionSpan(
 	if writeErr != nil {
 		span.RecordError(writeErr)
 		span.SetStatus(codes.Error, writeErr.Error())
-		l.log.Error("agent.rollout_expand_failed",
+		event := "agent.rollout_expand_failed"
+		if action == RemediationRollback {
+			event = "agent.rollout_rollback_failed"
+		}
+		l.log.Error(event,
 			"target", target, "from_stage", stage, "to_variant", wroteVariant, "error", writeErr)
 		return
 	}
 
-	if action == RemediationExpand {
+	switch action {
+	case RemediationExpand:
 		l.log.Info("agent.rollout_expand",
 			"target", target, "from_stage", stage, "to_stage", expandedTo,
 			"to_variant", wroteVariant)
+	case RemediationRollback:
+		l.log.Warn("agent.rollout_rollback",
+			"target", target, "from_stage", stage, "to_variant", wroteVariant,
+			"violations", fit.ViolationsString())
+	case RemediationRecommendedOnly:
+		l.log.Warn("agent.rollout_rollback_recommended",
+			"target", target, "stage", stage, "violations", fit.ViolationsString(),
+			"reason", "remediation_allowed=false")
 	}
 }
 
-// SetHoldExpansion installs the PR F post-rollback cooldown hook. When hold
-// returns true an otherwise-eligible expansion is suppressed (the loop still
-// emits an observe span). Nil clears the hook (no hold). Safe to call before the
-// loop is driven.
+// SetHoldExpansion OVERRIDES the expansion-hold hook. NewInfraLoop already
+// installs the post-rollback cooldown hook (reads cooldownUntil); this seam lets
+// tests substitute a deterministic hold (or nil to disable holding entirely).
+// When hold returns true an otherwise-eligible expansion is suppressed (the loop
+// still emits an observe span). Safe to call before the loop is driven.
 func (l *InfraLoop) SetHoldExpansion(hold func(now time.Time) bool) {
 	l.mu.Lock()
 	l.holdExpansion = hold

--- a/services/agent/decision/infra_loop_rollback_test.go
+++ b/services/agent/decision/infra_loop_rollback_test.go
@@ -1,0 +1,288 @@
+package decision
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// failingHz is below the default movement-update floor (10), so infraSnap with
+// this rate produces a movement_update_hz violation → failing fitness.
+const failingHz = 5
+
+// passingHz is comfortably above the floor → passing fitness.
+const passingHz = 30
+
+// TestInfraRollback_AllowedAtActiveStage: failing fitness + remediation allowed
+// + stage>0 → one SetControllerCount("none"), span "rollback".
+func TestInfraRollback_AllowedAtActiveStage(t *testing.T) {
+	clock := time.Unix(1000, 0)
+	rollout := &fakeRollout{}
+	l, sr := newInfraLoop(t, rollout, &clock)
+	l.SetRemediationSource(StaticRemediation(true))
+
+	l.OnInfraEvaluate(context.Background(), infraSnap("rust", 3, clock, failingHz))
+
+	if got := rollout.calls(); len(got) != 1 || got[0] != "none" {
+		t.Fatalf("writes = %v, want [none] (rollback resets to stable default)", got)
+	}
+	spans := infraSpans(sr)
+	if len(spans) != 1 {
+		t.Fatalf("got %d spans, want 1", len(spans))
+	}
+	if v, _ := spanStr(spans[0], AttrRemediationAction); v != RemediationRollback {
+		t.Errorf("remediation.action = %q, want %q", v, RemediationRollback)
+	}
+	if v, ok := spanStr(spans[0], AttrFitnessViolations); !ok || v == "" {
+		t.Errorf("fitness.violations = %q, want non-empty on rollback", v)
+	}
+}
+
+// TestInfraRollback_NotAllowedRecommendsOnly: failing fitness + NOT allowed →
+// no write, span "recommended_only" with violations.
+func TestInfraRollback_NotAllowedRecommendsOnly(t *testing.T) {
+	clock := time.Unix(1000, 0)
+	rollout := &fakeRollout{}
+	l, sr := newInfraLoop(t, rollout, &clock)
+	l.SetRemediationSource(StaticRemediation(false))
+
+	l.OnInfraEvaluate(context.Background(), infraSnap("rust", 3, clock, failingHz))
+
+	if got := rollout.calls(); len(got) != 0 {
+		t.Fatalf("writes = %v, want none (remediation not allowed)", got)
+	}
+	spans := infraSpans(sr)
+	if len(spans) != 1 {
+		t.Fatalf("got %d spans, want 1", len(spans))
+	}
+	if v, _ := spanStr(spans[0], AttrRemediationAction); v != RemediationRecommendedOnly {
+		t.Errorf("remediation.action = %q, want %q", v, RemediationRecommendedOnly)
+	}
+	if v, ok := spanStr(spans[0], AttrFitnessViolations); !ok || v == "" {
+		t.Errorf("fitness.violations = %q, want non-empty", v)
+	}
+}
+
+// TestInfraRollback_NothingToRollBackAtStageNone: failing + allowed + stage==0
+// → nothing to roll back, "none", no write.
+func TestInfraRollback_NothingToRollBackAtStageNone(t *testing.T) {
+	clock := time.Unix(1000, 0)
+	rollout := &fakeRollout{}
+	l, sr := newInfraLoop(t, rollout, &clock)
+	l.SetRemediationSource(StaticRemediation(true))
+
+	l.OnInfraEvaluate(context.Background(), infraSnap("rust", 0, clock, failingHz))
+
+	if got := rollout.calls(); len(got) != 0 {
+		t.Fatalf("writes = %v, want none (already at stage none)", got)
+	}
+	spans := infraSpans(sr)
+	if len(spans) != 1 {
+		t.Fatalf("got %d spans, want 1", len(spans))
+	}
+	if v, _ := spanStr(spans[0], AttrRemediationAction); v != RemediationNone {
+		t.Errorf("remediation.action = %q, want %q (nothing to roll back)", v, RemediationNone)
+	}
+}
+
+// TestInfraRollback_SettlingWindowNoSecondWrite: after a rollback write, while
+// the observed count is still >0 (controller-manager catching up), subsequent
+// failing cycles record "none" and do NOT write again.
+func TestInfraRollback_SettlingWindowNoSecondWrite(t *testing.T) {
+	clock := time.Unix(1000, 0)
+	rollout := &fakeRollout{}
+	l, sr := newInfraLoop(t, rollout, &clock)
+	l.SetRemediationSource(StaticRemediation(true))
+
+	// First failing cycle at stage 3 → rollback written.
+	l.OnInfraEvaluate(context.Background(), infraSnap("rust", 3, clock, failingHz))
+	// Settling: count not yet back to 0, still failing → no second write.
+	clock = clock.Add(time.Second)
+	l.OnInfraEvaluate(context.Background(), infraSnap("rust", 3, clock, failingHz))
+	clock = clock.Add(time.Second)
+	l.OnInfraEvaluate(context.Background(), infraSnap("rust", 1, clock, failingHz))
+
+	if got := rollout.calls(); len(got) != 1 {
+		t.Fatalf("writes = %v, want exactly one rollback during settling window", got)
+	}
+	spans := infraSpans(sr)
+	if len(spans) != 3 {
+		t.Fatalf("got %d spans, want 3", len(spans))
+	}
+	if v, _ := spanStr(spans[0], AttrRemediationAction); v != RemediationRollback {
+		t.Errorf("span[0] action = %q, want %q", v, RemediationRollback)
+	}
+	for i := 1; i < 3; i++ {
+		if v, _ := spanStr(spans[i], AttrRemediationAction); v != RemediationNone {
+			t.Errorf("settling span[%d] action = %q, want %q (rollback in flight)", i, v, RemediationNone)
+		}
+	}
+}
+
+// TestInfraRollback_CooldownThenExpand: after a rollback, observed count returns
+// to 0 and fitness recovers → expansion is HELD for the cooldown ("none"), then
+// expands once the cooldown elapses ("expand").
+func TestInfraRollback_CooldownThenExpand(t *testing.T) {
+	clock := time.Unix(1000, 0)
+	rollout := &fakeRollout{}
+	l, sr := newInfraLoop(t, rollout, &clock)
+	l.SetRemediationSource(StaticRemediation(true))
+	l.SetCooldown(30 * time.Second)
+
+	// Rollback at stage 3.
+	l.OnInfraEvaluate(context.Background(), infraSnap("rust", 3, clock, failingHz))
+	// Count back to 0, fitness recovered, but within cooldown → no expand.
+	clock = clock.Add(5 * time.Second)
+	l.OnInfraEvaluate(context.Background(), infraSnap("rust", 0, clock, passingHz))
+	if got := rollout.calls(); len(got) != 1 {
+		t.Fatalf("writes = %v, want only the rollback (expansion held by cooldown)", got)
+	}
+	if spans := infraSpans(sr); len(spans) != 2 {
+		t.Fatalf("got %d spans, want 2", len(spans))
+	} else if v, _ := spanStr(spans[1], AttrRemediationAction); v != RemediationNone {
+		t.Errorf("in-cooldown action = %q, want %q", v, RemediationNone)
+	}
+
+	// Advance past the cooldown → expansion resumes (none→one).
+	clock = clock.Add(30 * time.Second)
+	l.OnInfraEvaluate(context.Background(), infraSnap("rust", 0, clock, passingHz))
+	if got := rollout.calls(); len(got) != 2 || got[1] != "one" {
+		t.Fatalf("writes = %v, want rollback then expand-to-one after cooldown", got)
+	}
+	spans := infraSpans(sr)
+	if v, _ := spanStr(spans[len(spans)-1], AttrRemediationAction); v != RemediationExpand {
+		t.Errorf("post-cooldown action = %q, want %q", v, RemediationExpand)
+	}
+}
+
+// TestInfraRollback_EndToEndNarrative: the mini PR-G narrative —
+// failing(rollback) → settling(none) → recovered+cooldown(none) → expand.
+func TestInfraRollback_EndToEndNarrative(t *testing.T) {
+	clock := time.Unix(1000, 0)
+	rollout := &fakeRollout{}
+	l, sr := newInfraLoop(t, rollout, &clock)
+	l.SetRemediationSource(StaticRemediation(true))
+	l.SetCooldown(30 * time.Second)
+
+	// 1. Failing at stage 6 → rollback.
+	l.OnInfraEvaluate(context.Background(), infraSnap("rust", 6, clock, failingHz))
+	// 2. Settling: still observed >0, still failing → none.
+	clock = clock.Add(time.Second)
+	l.OnInfraEvaluate(context.Background(), infraSnap("rust", 6, clock, failingHz))
+	// 3. Count back to 0, fitness recovered, within cooldown → none.
+	clock = clock.Add(time.Second)
+	l.OnInfraEvaluate(context.Background(), infraSnap("rust", 0, clock, passingHz))
+	// 4. Cooldown elapsed, still passing → expand.
+	clock = clock.Add(30 * time.Second)
+	l.OnInfraEvaluate(context.Background(), infraSnap("rust", 0, clock, passingHz))
+
+	want := []string{
+		RemediationRollback,
+		RemediationNone,
+		RemediationNone,
+		RemediationExpand,
+	}
+	spans := infraSpans(sr)
+	if len(spans) != len(want) {
+		t.Fatalf("got %d spans, want %d", len(spans), len(want))
+	}
+	for i, w := range want {
+		if v, _ := spanStr(spans[i], AttrRemediationAction); v != w {
+			t.Errorf("narrative span[%d] action = %q, want %q", i, v, w)
+		}
+	}
+	if got := rollout.calls(); len(got) != 2 || got[0] != "none" || got[1] != "one" {
+		t.Fatalf("writes = %v, want [none one] (rollback then expand)", got)
+	}
+}
+
+// TestInfraRollback_SourceErrorTreatedAsFalse: a RemediationSource that reports
+// not-allowed (the fail-closed projection of any error) → recommend-only.
+func TestInfraRollback_SourceErrorTreatedAsFalse(t *testing.T) {
+	clock := time.Unix(1000, 0)
+	rollout := &fakeRollout{}
+	l, sr := newInfraLoop(t, rollout, &clock)
+	// erroringRemediation models an error path: the live reader returns false on
+	// any error, so the loop sees not-allowed.
+	l.SetRemediationSource(errorRemediation{})
+
+	l.OnInfraEvaluate(context.Background(), infraSnap("rust", 3, clock, failingHz))
+
+	if got := rollout.calls(); len(got) != 0 {
+		t.Fatalf("writes = %v, want none (source error → not allowed)", got)
+	}
+	if v, _ := spanStr(infraSpans(sr)[0], AttrRemediationAction); v != RemediationRecommendedOnly {
+		t.Errorf("remediation.action = %q, want %q", v, RemediationRecommendedOnly)
+	}
+}
+
+// errorRemediation is a RemediationSource whose underlying resolution failed; it
+// fails closed to not-allowed, exactly like actions.RemediationReader does.
+type errorRemediation struct{}
+
+func (errorRemediation) RemediationAllowed() bool { return false }
+
+// dryRunRollout is a RolloutActuator that records nothing (a write seam that
+// would be a no-op in the disabled rollout). It models actions.DryRunRolloutWriter
+// for the rollback path.
+type dryRunRollout struct{ fakeRollout }
+
+func (d *dryRunRollout) SetControllerCount(variant string) error {
+	// no-op: dry-run never writes, mirrors DryRunRolloutWriter.
+	return nil
+}
+
+// TestInfraRollback_DryRunDecidedNotApplied: with a dry-run actuator, a failing
+// allowed cycle still records "rollback" (decided) but performs no real write.
+func TestInfraRollback_DryRunDecidedNotApplied(t *testing.T) {
+	clock := time.Unix(1000, 0)
+	dry := &dryRunRollout{}
+	l, sr := newInfraLoop(t, dry, &clock)
+	l.SetRemediationSource(StaticRemediation(true))
+
+	l.OnInfraEvaluate(context.Background(), infraSnap("rust", 3, clock, failingHz))
+
+	// dry-run records nothing in the embedded fakeRollout's slice.
+	if got := dry.calls(); len(got) != 0 {
+		t.Fatalf("dry-run recorded writes = %v, want none", got)
+	}
+	if v, _ := spanStr(infraSpans(sr)[0], AttrRemediationAction); v != RemediationRollback {
+		t.Errorf("dry-run action = %q, want %q (decided but not applied)", v, RemediationRollback)
+	}
+}
+
+var _ RolloutActuator = (*dryRunRollout)(nil)
+
+// TestInfraRollback_WriteErrorRecordedOnSpan: a failing rollback write sets the
+// span status to Error and does NOT mark the episode in flight (so a retry can
+// happen), mirroring the expansion error path.
+func TestInfraRollback_WriteErrorRecordedOnSpan(t *testing.T) {
+	clock := time.Unix(1000, 0)
+	rollout := &fakeRollout{err: errors.New("disk full")}
+	l, sr := newInfraLoop(t, rollout, &clock)
+	l.SetRemediationSource(StaticRemediation(true))
+
+	l.OnInfraEvaluate(context.Background(), infraSnap("rust", 3, clock, failingHz))
+
+	spans := infraSpans(sr)
+	if len(spans) != 1 {
+		t.Fatalf("got %d spans, want 1", len(spans))
+	}
+	if status := spans[0].Status(); status.Code.String() != "Error" {
+		t.Errorf("span status = %v, want Error", status.Code)
+	}
+	if v, _ := spanStr(spans[0], AttrRemediationAction); v != RemediationRollback {
+		t.Errorf("action = %q, want %q even on write error", v, RemediationRollback)
+	}
+
+	// Episode NOT in flight after failed write: a subsequent failing cycle retries.
+	rollout.mu.Lock()
+	rollout.err = nil
+	rollout.mu.Unlock()
+	clock = clock.Add(time.Second)
+	l.OnInfraEvaluate(context.Background(), infraSnap("rust", 3, clock, failingHz))
+	if got := rollout.calls(); len(got) != 1 || got[0] != "none" {
+		t.Fatalf("after failed write then success, writes = %v, want one retried rollback", got)
+	}
+}

--- a/services/agent/main.go
+++ b/services/agent/main.go
@@ -118,13 +118,25 @@ func rolloutActuator(logger *slog.Logger) decision.RolloutActuator {
 // rolloutDwell reads the per-stage dwell from AGENT_ROLLOUT_DWELL_SECONDS,
 // falling back to decision.DefaultRolloutDwell.
 func rolloutDwell() time.Duration {
-	s := strings.TrimSpace(os.Getenv("AGENT_ROLLOUT_DWELL_SECONDS"))
+	return secondsEnv("AGENT_ROLLOUT_DWELL_SECONDS", decision.DefaultRolloutDwell)
+}
+
+// rolloutCooldown reads the post-rollback cooldown from
+// AGENT_ROLLOUT_COOLDOWN_SECONDS, falling back to decision.DefaultRolloutCooldown.
+func rolloutCooldown() time.Duration {
+	return secondsEnv("AGENT_ROLLOUT_COOLDOWN_SECONDS", decision.DefaultRolloutCooldown)
+}
+
+// secondsEnv parses a positive integer "seconds" env var into a Duration,
+// returning fallback on an empty/invalid/non-positive value.
+func secondsEnv(key string, fallback time.Duration) time.Duration {
+	s := strings.TrimSpace(os.Getenv(key))
 	if s == "" {
-		return decision.DefaultRolloutDwell
+		return fallback
 	}
 	n, err := strconv.Atoi(s)
 	if err != nil || n <= 0 {
-		return decision.DefaultRolloutDwell
+		return fallback
 	}
 	return time.Duration(n) * time.Second
 }
@@ -221,6 +233,16 @@ func main() {
 	// Rollout actuator (#734): real RolloutWriter when AGENT_ROLLOUT_ENABLED=true,
 	// else a dry-run actuator (decides+spans but does not write rollout.json).
 	infraLoop := decision.NewInfraLoop(logger, rolloutDwell(), bluetoothFitness, rolloutActuator(logger))
+	// Auto-remediation gate (#736): remediation_allowed lives in the ROLLOUT flagd
+	// domain (rollout.json), so the loop reads it directly from that file (the agent
+	// already owns the path). When false, fitness failures are RECOMMENDED only (span,
+	// no write). Default on any read error is false (fail-closed). The dry-run
+	// actuator above also applies to rollback, so a disabled rollout records the
+	// rollback decision without writing.
+	infraLoop.SetRemediationSource(actions.NewRemediationReaderFromEnv(logger))
+	// Post-rollback cooldown (#736): suppress re-expansion for this long after a
+	// rollback so fitness can recover before the loop climbs again.
+	infraLoop.SetCooldown(rolloutCooldown())
 	// Freshness gate (#734): evaluate the rollout only when ≥1 controller is
 	// reporting fresh Bluetooth health. Game-state-independent (lobby connects).
 	infraLoop.SetGate(func(snap infracontext.InfraContext, now time.Time) bool {


### PR DESCRIPTION
## Summary

M3 Infrastructure Agent remediation (#736), stacked on #809. Closes the loop: when infrastructure fitness fails during an active rollout, the agent rolls the backend back by writing rollout.json — same control layer that configured it — gated on `rollout.remediation_allowed`.

- **Rollback** = `current_controller_count → "none"` (all controllers return to the stable default backend); `target_backend` untouched, preserving operator intent for the next attempt.
- **Permission gate**: `remediation_allowed=false` → no write, span records `remediation.action="recommended_only"` with the violations; flips live (read fresh each decision). Fail-closed: any read error → recommend-only.
- **Sourcing**: read directly from rollout.json's defaultVariant via `actions.RemediationReader` — the agent already owns that file (sole writer, same path); a second flagd RPC domain client would be disproportionate plumbing for one bool.
- **One rollback per failure episode**: settling cycles (rollback written, observed count still >0) record `"none"` — re-emitting `"rollback"` without a write would lie. Episode ends when the observed count reaches 0.
- **Post-rollback cooldown** (30s, `AGENT_ROLLOUT_COOLDOWN_SECONDS`): suppresses re-expansion after recovery so the loop can't flap expand→degrade→rollback. In-memory; agent restart clears it (demo reset).
- Span value set stays exactly `none | expand | rollback | recommended_only` — the #737 narrative test depends on it. Dry-run mode (`AGENT_ROLLOUT_ENABLED=false`) records rollback decided-but-not-applied, consistent with expansion.

## Test plan

- [x] `go test -race ./...` green — 9 reader tests (parse, fail-closed paths) + 9 loop tests incl. the mini narrative: failing→rollback → settling→none → recovered+cooldown→none → cooldown elapsed→expand
- [x] `go vet`, `gofmt -l` clean; compose YAML validated

Closes #736.

🤖 Generated with [Claude Code](https://claude.com/claude-code)