### PR TITLE
test: concurrent headless games + shadow-vs-menu isolation (#779)

### DIFF
--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -55,6 +55,11 @@ services:
     environment: !override
       OTEL_SERVICE_NAME: game-coordinator-service
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317
+      # Raise the concurrent-games cap for the integration suite only (#779).
+      # The coordinator defaults to 1 (production default, unchanged); the
+      # concurrent/shadow-isolation tests need multiple live sessions on one
+      # stack. This override stays in CI compose; production keeps cap=1.
+      GAME_MAX_CONCURRENT_GAMES: "4"
 
   # Pairing Daemon - Requires hardware, excluded from CI
   pairing-daemon:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -116,6 +116,7 @@ async def ensure_game_stopped(docker_compose):
     Use this fixture explicitly in tests that start games to prevent
     'Game already in progress' errors between tests.
     """
+
     async def force_end_game():
         """Force end any running game."""
         try:
@@ -141,3 +142,62 @@ async def ensure_game_stopped(docker_compose):
 
     # After test: cleanup any game that was started
     await force_end_game()
+
+
+@pytest.fixture
+async def headless_cleanup(docker_compose):
+    """Per-test cleanup for headless (shadow) games.
+
+    Menu-flow tests use ``ensure_game_stopped`` (force-ends the single primary
+    game). Headless tests instead own specific game_ids and reserved-controller
+    tags, so cleanup must be targeted: this fixture returns a registry the test
+    populates, then force-ends each registered game_id and removes each reserved
+    controller tag on teardown — even if the test body raised.
+
+    Usage:
+        async def test_x(docker_compose, headless_cleanup):
+            game_id, collector = await start_game_headless(...)
+            headless_cleanup.add_game(game_id)
+            headless_cleanup.add_tag("shadow-x")
+            ...
+    """
+    from tests.integration.helpers import (
+        force_end_game_by_id,
+        remove_reserved_controllers,
+    )
+
+    class _Registry:
+        def __init__(self):
+            self.game_ids: list[str] = []
+            self.tags: list[str] = []
+
+        def add_game(self, game_id: str) -> str:
+            if game_id and game_id not in self.game_ids:
+                self.game_ids.append(game_id)
+            return game_id
+
+        def add_tag(self, tag: str) -> str:
+            if tag and tag not in self.tags:
+                self.tags.append(tag)
+            return tag
+
+    registry = _Registry()
+
+    yield registry
+
+    # Teardown: best-effort force-end every registered game and sweep tags.
+    host = docker_compose.get_service_host("game-coordinator", 50053)
+    port = docker_compose.get_service_port("game-coordinator", 50053)
+    channel = grpc.aio.insecure_channel(f"{host}:{port}")
+    game_client = game_coordinator_pb2_grpc.GameCoordinatorServiceStub(channel)
+    try:
+        for game_id in registry.game_ids:
+            await force_end_game_by_id(game_client, game_id, reason="headless_cleanup")
+        for tag in registry.tags:
+            try:
+                await remove_reserved_controllers(docker_compose, tag)
+            except Exception:
+                pass
+        await asyncio.sleep(0.3)
+    finally:
+        await channel.close()

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -19,6 +19,8 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
 from proto import (
     controller_manager_mock_pb2,
     controller_manager_mock_pb2_grpc,
+    controller_manager_pb2,
+    controller_manager_pb2_grpc,
     game_coordinator_pb2,
     game_coordinator_pb2_grpc,
     menu_pb2,
@@ -55,6 +57,14 @@ async def get_game_client(docker_compose):
     return game_coordinator_pb2_grpc.GameCoordinatorServiceStub(channel), channel
 
 
+async def get_controller_client(docker_compose):
+    """Get ControllerManager gRPC client (port 50052)."""
+    host = docker_compose.get_service_host("controller-manager", 50052)
+    port = docker_compose.get_service_port("controller-manager", 50052)
+    channel = grpc.aio.insecure_channel(f"{host}:{port}")
+    return controller_manager_pb2_grpc.ControllerManagerServiceStub(channel), channel
+
+
 # =============================================================================
 # Controller helpers
 # =============================================================================
@@ -67,13 +77,17 @@ async def get_mock_controller_serials(docker_compose) -> list[str]:
     channel = grpc.aio.insecure_channel(f"{host}:{port}")
     client = controller_manager_mock_pb2_grpc.MockControllerServiceStub(channel)
 
-    response = await client.ListMockControllers(controller_manager_mock_pb2.ListRequest())
+    response = await client.ListMockControllers(
+        controller_manager_mock_pb2.ListRequest()
+    )
     await channel.close()
 
     return list(response.serials)
 
 
-async def setup_mock_controllers(docker_compose, count: int = 4) -> list[str]:
+async def setup_mock_controllers(
+    docker_compose, count: int = 4, reserved: bool = False, tag: str = ""
+) -> list[str]:
     """Add mock controllers via RPC and return their serials.
 
     Uses AddControllers RPC to dynamically create controllers.
@@ -83,31 +97,96 @@ async def setup_mock_controllers(docker_compose, count: int = 4) -> list[str]:
     Args:
         docker_compose: Docker compose fixture
         count: Number of controllers to add
+        reserved: When True, the added controllers are reserved (hidden from
+            the menu / button-stream consumers). Used by headless shadow games.
+        tag: Owning game/agent identifier, applied to all added controllers.
+            Enables ``remove_reserved_controllers(tag)`` cleanup.
 
     Returns:
         List of serial strings for the added controllers
+
+    Note:
+        Reuse of existing controllers (the fast path) only applies to the
+        default unreserved/untagged case. Reserved or tagged requests always
+        add fresh controllers so the reservation/tag is honored.
     """
     mock_client, channel = await get_mock_client(docker_compose)
 
-    # First check if controllers already exist (e.g., from a previous test)
-    existing = await mock_client.ListMockControllers(
-        controller_manager_mock_pb2.ListRequest()
-    )
-    if existing.count >= count:
-        await channel.close()
-        return list(existing.serials[:count])
+    # Reserved/tagged requests must create fresh controllers so the reservation
+    # actually applies; only the plain unreserved case reuses existing ones.
+    if not reserved and not tag:
+        existing = await mock_client.ListMockControllers(
+            controller_manager_mock_pb2.ListRequest()
+        )
+        if existing.count >= count:
+            await channel.close()
+            return list(existing.serials[:count])
 
-    # Add the needed controllers
-    needed = count - existing.count
+        # Add the needed controllers
+        needed = count - existing.count
+        response = await mock_client.AddControllers(
+            controller_manager_mock_pb2.AddControllersRequest(count=needed)
+        )
+        assert response.success, f"Failed to add controllers: {response.error}"
+        await channel.close()
+
+        # Return all serials (existing + newly added)
+        all_serials = list(existing.serials) + list(response.serials)
+        return all_serials[:count]
+
     response = await mock_client.AddControllers(
-        controller_manager_mock_pb2.AddControllersRequest(count=needed)
+        controller_manager_mock_pb2.AddControllersRequest(
+            count=count, reserved=reserved, tag=tag
+        )
     )
     assert response.success, f"Failed to add controllers: {response.error}"
     await channel.close()
+    return list(response.serials)
 
-    # Return all serials (existing + newly added)
-    all_serials = list(existing.serials) + list(response.serials)
-    return all_serials[:count]
+
+async def remove_reserved_controllers(docker_compose, tag: str) -> list[str]:
+    """Remove all mock controllers whose tag matches ``tag``.
+
+    Lists controllers via ListMockControllers, filters by the reservation tag,
+    and removes each. Used as per-test cleanup for headless shadow games so a
+    crashed/failed test does not leak reserved controllers into the next one.
+
+    Args:
+        docker_compose: Docker compose fixture
+        tag: Reservation tag to sweep (empty tag is a no-op to avoid removing
+            untagged lobby controllers).
+
+    Returns:
+        List of serials that were removed.
+    """
+    if not tag:
+        return []
+
+    mock_client, channel = await get_mock_client(docker_compose)
+    try:
+        listing = await mock_client.ListMockControllers(
+            controller_manager_mock_pb2.ListRequest()
+        )
+        to_remove = [c.serial for c in listing.controllers if c.tag == tag]
+        for serial in to_remove:
+            await mock_client.RemoveController(
+                controller_manager_mock_pb2.RemoveControllerRequest(serial=serial)
+            )
+        return to_remove
+    finally:
+        await channel.close()
+
+
+async def list_mock_controllers_detailed(docker_compose) -> list:
+    """Return the detailed MockControllerInfo list (serial, reserved, tag)."""
+    mock_client, channel = await get_mock_client(docker_compose)
+    try:
+        listing = await mock_client.ListMockControllers(
+            controller_manager_mock_pb2.ListRequest()
+        )
+        return list(listing.controllers)
+    finally:
+        await channel.close()
 
 
 async def get_controller_serials(docker_compose) -> list[str]:
@@ -153,11 +232,39 @@ class GameEventCollector:
         await collector.stop()
     """
 
-    def __init__(self, game_client):
+    def __init__(self, game_client, game_id: str | None = None, start_config=None):
+        """Create a collector.
+
+        Args:
+            game_client: GameCoordinator gRPC client.
+            game_id: When set, the collector subscribes to that specific
+                session's stream (``StreamEventsRequest(game_id=...)``) AND
+                filters collected events to that game_id. When None, it
+                subscribes to the primary stream and collects every event
+                (legacy behavior).
+            start_config: When set, the underlying StreamGameEvents call carries
+                this ``start_config`` so it both STARTS a game and subscribes to
+                that new session's bus. The assigned game_id is captured from the
+                event stream into ``self.game_id`` (see ``wait_for_game_id``).
+        """
         self.game_client = game_client
+        # Filter applied to collected events. Captured/assigned game_id when a
+        # headless start is used (start_config set).
+        self.game_id = game_id
+        self._start_config = start_config
+        # game_id filtering is enabled ONLY when this collector is bound to a
+        # specific session: an explicit game_id, or a headless start_config (the
+        # assigned id is learned from the stream). A plain zero-arg collector on
+        # the primary stream must NOT filter — it would otherwise lock onto a
+        # stale/late event's game_id and drop the new game's events (the exact
+        # zero-arg menu-collector semantics the intervention tests rely on).
+        self._filter_enabled = bool(game_id) or start_config is not None
         self.events: list = []
         self._task: asyncio.Task | None = None
         self._event_conditions: dict[str, asyncio.Event] = {}
+        self._game_id_known = asyncio.Event()
+        if game_id:
+            self._game_id_known.set()
 
     async def __aenter__(self):
         """Start collecting on context entry."""
@@ -173,12 +280,44 @@ class GameEventCollector:
         """Start collecting game events in background."""
         self._task = asyncio.create_task(self._collect())
 
+    def _build_request(self):
+        """Build the StreamEventsRequest for this collector's mode."""
+        if self._start_config is not None:
+            return game_coordinator_pb2.StreamEventsRequest(
+                start_config=self._start_config
+            )
+        if self.game_id:
+            return game_coordinator_pb2.StreamEventsRequest(game_id=self.game_id)
+        return game_coordinator_pb2.StreamEventsRequest()
+
+    def _accepts(self, event) -> bool:
+        """Whether an event passes this collector's game_id filter."""
+        # Unfiltered (plain zero-arg primary collector): accept every event.
+        if not self._filter_enabled:
+            return True
+        # Filter target not yet captured (headless start, first event pending):
+        # accept until the assigned game_id is learned below.
+        if not self.game_id:
+            return True
+        # Lifecycle/idle events with no game_id bound are still relevant.
+        if not event.game_id:
+            return True
+        return event.game_id == self.game_id
+
     async def _collect(self):
         """Background task to collect events from stream."""
         try:
-            async for event in self.game_client.StreamGameEvents(
-                game_coordinator_pb2.StreamEventsRequest()
-            ):
+            async for event in self.game_client.StreamGameEvents(self._build_request()):
+                # Headless start only: learn the assigned game_id from the first
+                # event that carries one and adopt it as the filter. Never do
+                # this for an unfiltered primary collector.
+                if self._filter_enabled and self.game_id is None and event.game_id:
+                    self.game_id = event.game_id
+                    self._game_id_known.set()
+
+                if not self._accepts(event):
+                    continue
+
                 self.events.append(event)
                 # Signal any waiters for this event type
                 event_type = event.event_type
@@ -186,6 +325,15 @@ class GameEventCollector:
                     self._event_conditions[event_type].set()
         except asyncio.CancelledError:
             pass
+
+    async def wait_for_game_id(self, timeout: float = 15.0) -> str:
+        """Wait until the assigned/observed game_id is known and return it.
+
+        Used by headless starts (start_config) where the game_id is assigned by
+        the coordinator and learned from the event stream.
+        """
+        await asyncio.wait_for(self._game_id_known.wait(), timeout=timeout)
+        return self.game_id
 
     async def stop(self):
         """Stop collecting events and cancel the background task."""
@@ -219,15 +367,16 @@ class GameEventCollector:
         # Wait for the event
         try:
             await asyncio.wait_for(
-                self._event_conditions[event_type].wait(),
-                timeout=timeout
+                self._event_conditions[event_type].wait(), timeout=timeout
             )
             # Find and return the event
             for event in reversed(self.events):
                 if event.event_type == event_type:
                     return event
         except asyncio.TimeoutError:
-            raise TimeoutError(f"Game did not emit '{event_type}' within {timeout} seconds")
+            raise TimeoutError(
+                f"Game did not emit '{event_type}' within {timeout} seconds"
+            )
 
     async def wait_for_any_event(self, event_types: list[str], timeout: float = 10.0):
         """Wait for any of the specified event types.
@@ -249,7 +398,9 @@ class GameEventCollector:
                     return event
             await asyncio.sleep(0.1)
 
-        raise TimeoutError(f"Game did not emit any of {event_types} within {timeout} seconds")
+        raise TimeoutError(
+            f"Game did not emit any of {event_types} within {timeout} seconds"
+        )
 
     def get_events(self, event_type: str | None = None) -> list:
         """Get collected events, optionally filtered by type."""
@@ -287,9 +438,142 @@ async def force_end_game(
 
     # Wait for end event via collector
     await event_collector.wait_for_any_event(
-        ["game_ended", "game_force_ended", "game_error"],
-        timeout=timeout
+        ["game_ended", "game_force_ended", "game_error"], timeout=timeout
     )
+
+
+async def force_end_game_by_id(
+    game_client, game_id: str, reason: str = "test_cleanup"
+) -> bool:
+    """Force-end a specific game session by game_id.
+
+    Best-effort cleanup helper for headless tests: targets one session via
+    ``ForceEndGameRequest(game_id=...)`` and never raises (an already-ended or
+    unknown game_id is fine during teardown).
+
+    Returns:
+        True if the coordinator reported success, False otherwise.
+    """
+    if not game_id:
+        return False
+    try:
+        response = await game_client.ForceEndGame(
+            game_coordinator_pb2.ForceEndGameRequest(reason=reason, game_id=game_id)
+        )
+        return response.success
+    except Exception:
+        return False
+
+
+async def list_games(game_client) -> list:
+    """Return the list of live GameInfo sessions via the ListGames RPC."""
+    response = await game_client.ListGames(game_coordinator_pb2.ListGamesRequest())
+    assert response.success, f"ListGames failed: {response.error}"
+    return list(response.games)
+
+
+async def start_game_headless(
+    game_client,
+    start_config,
+    timeout: float = 20.0,
+) -> tuple[str, "GameEventCollector"]:
+    """Start a game directly via StreamGameEvents (no menu) and return its id.
+
+    Bypasses the lobby entirely: opens a ``StreamGameEvents`` stream carrying
+    ``start_config``, which both starts a new session and subscribes to that
+    session's event bus. The collector captures the coordinator-assigned
+    game_id from the event stream and filters to only that game's events.
+
+    Args:
+        game_client: GameCoordinator gRPC client.
+        start_config: A ``StartGameConfig`` (see ``build_start_config``).
+        timeout: Max time to wait for the game to start (game_started event).
+
+    Returns:
+        Tuple of (game_id, collector). The collector is already running and
+        keeps consuming events; callers wait on it for lifecycle events and
+        must ``stop()`` it (or use it as a context manager) when done.
+
+    Raises:
+        TimeoutError: If the game does not start within ``timeout``.
+        RuntimeError: If the coordinator rejects the start.
+    """
+    collector = GameEventCollector(game_client, start_config=start_config)
+    await collector.start()
+
+    # A rejected start yields a single game_start_error event then closes the
+    # stream — surface it instead of hanging until timeout.
+    try:
+        await collector.wait_for_any_event(
+            ["game_starting", "game_started", "game_start_error"],
+            timeout=timeout,
+        )
+    except TimeoutError:
+        await collector.stop()
+        raise
+
+    errors = collector.get_events("game_start_error")
+    if errors:
+        await collector.stop()
+        raise RuntimeError(f"Headless game start rejected: {dict(errors[0].data)}")
+
+    game_id = await collector.wait_for_game_id(timeout=timeout)
+    return game_id, collector
+
+
+def build_start_config(
+    game_name: str,
+    serials: list[str],
+    sensitivity: int = 2,
+):
+    """Build a minimal StartGameConfig for a headless game start.
+
+    Assigns players alternating teams (so team modes have both teams populated)
+    and attaches the matching mode-specific config sub-message where one is
+    required. Mirrors the menu's ``_build_game_config`` for the modes used by
+    the concurrent/isolation tests; uses CI-friendly defaults.
+
+    Args:
+        game_name: Game mode name (e.g. "JoustFFA", "JoustTeams", "Swapper").
+        serials: Controller serials to use as players.
+        sensitivity: Common sensitivity 0-4 (default 2 = MEDIUM).
+    """
+    players = [
+        game_coordinator_pb2.Player(serial=serial, team=i % 2, alive=True, score=0)
+        for i, serial in enumerate(serials)
+    ]
+    config = game_coordinator_pb2.StartGameConfig(
+        game_name=game_name,
+        players=players,
+        sensitivity=sensitivity,
+    )
+
+    # Attach the mode-specific oneof where the factory expects one. Modes whose
+    # config is empty/optional (FFA, Werewolf, Zombies) work without it.
+    if game_name == "JoustFFA":
+        config.ffa_config.CopyFrom(game_coordinator_pb2.FFAConfig())
+    elif game_name == "JoustTeams":
+        config.teams_config.CopyFrom(
+            game_coordinator_pb2.TeamsConfig(num_teams=2, random_assignment=False)
+        )
+    elif game_name == "JoustRandomTeams":
+        config.random_teams_config.CopyFrom(
+            game_coordinator_pb2.RandomTeamsConfig(num_teams=2)
+        )
+    elif game_name == "Swapper":
+        config.swapper_config.CopyFrom(game_coordinator_pb2.SwapperConfig())
+    elif game_name == "Werewolf":
+        config.werewolf_config.CopyFrom(
+            game_coordinator_pb2.WerewolfConfig(reveal_time_seconds=35.0)
+        )
+    elif game_name == "Zombies":
+        config.zombie_config.CopyFrom(game_coordinator_pb2.ZombieConfig())
+    elif game_name == "NonStop":
+        config.nonstop_config.CopyFrom(
+            game_coordinator_pb2.NonstopConfig(time_limit_seconds=0)
+        )
+
+    return config
 
 
 # =============================================================================
@@ -429,7 +713,9 @@ async def start_game_via_menu(
         TimeoutError: If game does not start within timeout
     """
     if event_collector is None:
-        raise ValueError("event_collector is required - start a GameEventCollector before calling")
+        raise ValueError(
+            "event_collector is required - start a GameEventCollector before calling"
+        )
 
     # Get clients
     menu_client, menu_channel = await get_menu_client(docker_compose)
@@ -439,7 +725,9 @@ async def start_game_via_menu(
     game_client, _ = await get_game_client(docker_compose)
 
     # Force-end any previous game to ensure clean state
-    await game_client.ForceEndGame(game_coordinator_pb2.ForceEndGameRequest(reason="test_cleanup"))
+    await game_client.ForceEndGame(
+        game_coordinator_pb2.ForceEndGameRequest(reason="test_cleanup")
+    )
     await asyncio.sleep(0.2)  # Allow game cleanup to complete
 
     # Stop Menu first to clear any stale controller state, then restart fresh
@@ -472,7 +760,9 @@ async def start_game_via_menu(
         await event_collector.wait_for_event("game_started", timeout=timeout)
     except TimeoutError:
         # Debug: print collected events before re-raising
-        print(f"DEBUG: Game start timeout. Collected {len(event_collector.events)} events:")
+        print(
+            f"DEBUG: Game start timeout. Collected {len(event_collector.events)} events:"
+        )
         for event in event_collector.events:
             print(f"  - {event.event_type}: {dict(event.data)}")
         raise
@@ -533,7 +823,9 @@ async def verify_controllers_have_color(mock_client, serials: list[str]):
         assert total > 0, f"{serial} LED is off (color: {color})"
 
 
-def _color_matches(actual: tuple[int, int, int], expected: tuple[int, int, int], tolerance: int) -> bool:
+def _color_matches(
+    actual: tuple[int, int, int], expected: tuple[int, int, int], tolerance: int
+) -> bool:
     """Check if actual color matches expected within tolerance."""
     for a, e in zip(actual, expected):
         if abs(a - e) > tolerance:
@@ -596,7 +888,9 @@ async def wait_for_lobby_colors(
         color = last_colors.get(serial, (0, 0, 0))
         if sum(color) == 0:
             mismatches.append(f"{serial}: LED is off (color: {color})")
-        elif expected_color is not None and not _color_matches(color, expected_color, tolerance):
+        elif expected_color is not None and not _color_matches(
+            color, expected_color, tolerance
+        ):
             mismatches.append(f"{serial}: got {color}, expected {expected_color}")
 
     raise AssertionError(
@@ -605,7 +899,10 @@ async def wait_for_lobby_colors(
 
 
 async def verify_lobby_colors(
-    mock_client, serials: list[str], expected_color: tuple[int, int, int] | None = None, tolerance: int = 30
+    mock_client,
+    serials: list[str],
+    expected_color: tuple[int, int, int] | None = None,
+    tolerance: int = 30,
 ):
     """Verify all controllers show the expected lobby color.
 
@@ -702,6 +999,84 @@ class ObservabilityObserver:
         return last_colors
 
 
+class ButtonStreamObserver:
+    """Subscribes to ControllerManager.StreamButtonEvents and records the roster.
+
+    This is exactly the view the menu has of the controller fleet. Reserved
+    controllers must never appear here: no CONNECT event, never in any
+    ``connected_serials`` roster. Used by the shadow-vs-menu isolation test to
+    prove reserved controllers stay invisible to lobby logic.
+
+    Usage:
+        observer = ButtonStreamObserver(controller_client)
+        await observer.start()
+        # ... add reserved controllers, run shadow game ...
+        assert "MOCK0005" not in observer.all_seen_serials()
+        await observer.stop()
+    """
+
+    def __init__(self, controller_client):
+        self.controller_client = controller_client
+        self.events: list = []
+        self._task: asyncio.Task | None = None
+
+    async def start(self):
+        """Open the button-event stream and collect in background."""
+        self._task = asyncio.create_task(self._collect())
+        # Let the initial connection snapshot arrive before callers assert.
+        await asyncio.sleep(0.5)
+
+    async def _collect(self):
+        """Send an initial (empty) config then collect button events."""
+
+        async def request_iter():
+            # Empty config opens the stream and triggers the initial roster
+            # snapshot (the menu's subscribe path).
+            yield controller_manager_pb2.ButtonEventStreamControl(
+                config=controller_manager_pb2.ButtonEventStreamConfig()
+            )
+            # Keep the request stream open for the stream's lifetime.
+            while True:
+                await asyncio.sleep(3600)
+
+        try:
+            async for event in self.controller_client.StreamButtonEvents(
+                request_iter()
+            ):
+                self.events.append(event)
+        except asyncio.CancelledError:
+            pass
+        except Exception:
+            # Stream closed/cancelled during teardown — fine.
+            pass
+
+    async def stop(self):
+        if self._task:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+            self._task = None
+
+    def all_seen_serials(self) -> set[str]:
+        """Every serial this observer has seen, across event serials + rosters."""
+        seen: set[str] = set()
+        for event in self.events:
+            if event.serial:
+                seen.add(event.serial)
+            for serial in event.connected_serials:
+                seen.add(serial)
+        return seen
+
+    def latest_roster(self) -> list[str]:
+        """The most recent non-empty ``connected_serials`` roster seen."""
+        for event in reversed(self.events):
+            if event.connected_serials:
+                return list(event.connected_serials)
+        return []
+
+
 def verify_death_effects(events: list, killed_serials: list[str]):
     """Verify death effects occurred for killed players.
 
@@ -775,13 +1150,20 @@ KILL_VERIFY_TIMEOUT = 12.0
 _VERIFY_POLL_INTERVAL = 0.2
 
 
-async def get_player_states(game_client) -> dict | None:
-    """Query current game state and return {serial: PlayerInfo}.
+async def get_player_states(game_client, game_id: str = "") -> dict | None:
+    """Query a game's state and return {serial: PlayerInfo}.
 
     Returns None if the game is no longer running (ended or not started),
     so callers can distinguish "game over" from "kill not registered yet".
+
+    Args:
+        game_client: GameCoordinator gRPC client.
+        game_id: Target a specific session; empty = primary (legacy).
     """
-    response = await game_client.GetGameState(game_coordinator_pb2.GetGameStateRequest())
+    request = game_coordinator_pb2.GetGameStateRequest()
+    if game_id:
+        request.game_id = game_id
+    response = await game_client.GetGameState(request)
     if not response.success:
         return None
     if response.game_info.state != game_coordinator_pb2.RUNNING:
@@ -795,6 +1177,7 @@ async def kill_player_verified(
     serial: str,
     registered,
     timeout: float = KILL_VERIFY_TIMEOUT,
+    game_id: str = "",
 ) -> bool:
     """SimulateDeath and verify it registered in the game, retrying if dropped.
 
@@ -830,7 +1213,7 @@ async def kill_player_verified(
             assert response.success, f"SimulateDeath RPC failed for {serial}"
             next_kill_at = now + KILL_RETRY_INTERVAL
 
-        players = await get_player_states(game_client)
+        players = await get_player_states(game_client, game_id=game_id)
         if players is None:
             # Game ended (possibly because this kill landed) — nothing left to verify
             return False
@@ -847,7 +1230,11 @@ async def kill_player_verified(
 
 
 async def kill_players_until_one_remains(
-    mock_client, serials: list[str], delay: float = 0.5, game_client=None
+    mock_client,
+    serials: list[str],
+    delay: float = 0.5,
+    game_client=None,
+    game_id: str = "",
 ) -> list[str]:
     """Kill players one by one until only one remains.
 
@@ -868,7 +1255,7 @@ async def kill_players_until_one_remains(
     for serial in serials[:-1]:
         await asyncio.sleep(delay)
         if not await kill_player_verified(
-            mock_client, game_client, serial, lambda p: not p.alive
+            mock_client, game_client, serial, lambda p: not p.alive, game_id=game_id
         ):
             break  # Game already ended
         killed.append(serial)
@@ -911,7 +1298,11 @@ async def kill_players_for_team_win(
 
 
 async def end_swapper_game(
-    mock_client, serials: list[str], game_client, delay: float = 0.3, timeout: float = 30.0
+    mock_client,
+    serials: list[str],
+    game_client,
+    delay: float = 0.3,
+    timeout: float = 30.0,
 ) -> list[str]:
     """End a Swapper game by swapping all players to one team.
 
@@ -997,7 +1388,11 @@ async def end_werewolf_game(
 
 
 async def end_zombies_game(
-    mock_client, serials: list[str], delay: float = 0.3, game_client=None, timeout: float = 30.0
+    mock_client,
+    serials: list[str],
+    delay: float = 0.3,
+    game_client=None,
+    timeout: float = 30.0,
 ) -> list[str]:
     """End a Zombies game by converting all humans to zombies.
 

--- a/tests/integration/test_concurrent_games.py
+++ b/tests/integration/test_concurrent_games.py
@@ -1,0 +1,354 @@
+"""
+Integration tests for concurrent headless games and shadow-vs-menu isolation.
+
+These tests are the payoff of the shadow-games feature (#774, phase 5 / #779).
+They exercise capabilities that did not exist before the multi-session game
+coordinator (#775/#776) and reserved mock controllers (#777):
+
+- Two headless games running concurrently on one compose stack, each with its
+  own reserved controller set and its own game_id, fully isolated.
+- A headless (shadow) game running ALONGSIDE a menu-driven game without the
+  reserved controllers ever leaking into the menu's lobby view. This is the
+  direct regression test for the whole #774 feature.
+- Natural-end then immediate restart — the #793 CI bug, where an ENDED session
+  pinned the primary slot and the next start was rejected.
+
+The menu remains single-lobby, so the menu-flow portions stay sequential; the
+headless games are what run in parallel.
+"""
+
+import asyncio
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+
+from proto import game_coordinator_pb2
+from tests.integration.helpers import (
+    ButtonStreamObserver,
+    GameEventCollector,
+    build_start_config,
+    force_end_game_by_id,
+    get_controller_client,
+    get_game_client,
+    get_mock_client,
+    kill_players_until_one_remains,
+    list_games,
+    setup_mock_controllers,
+    start_game_headless,
+    start_game_via_menu,
+    wait_for_lobby_colors,
+)
+
+
+def _running_ids(games) -> set[str]:
+    """Set of game_ids whose GameInfo.state is RUNNING."""
+    return {g.game_id for g in games if g.state == game_coordinator_pb2.RUNNING}
+
+
+@pytest.mark.asyncio
+async def test_two_concurrent_headless_games(docker_compose, headless_cleanup):
+    """Two headless games run concurrently and stay fully isolated.
+
+    Asserts:
+    - Distinct game_ids.
+    - Each collector only sees its own game's events.
+    - ListGames shows both RUNNING; GetGameState(game_id) returns each.
+    - Ending one (kills) leaves the other running and its event stream intact.
+    """
+    tag_a = "concurrent-a"
+    tag_b = "concurrent-b"
+    headless_cleanup.add_tag(tag_a)
+    headless_cleanup.add_tag(tag_b)
+
+    serials_a = await setup_mock_controllers(
+        docker_compose, count=2, reserved=True, tag=tag_a
+    )
+    serials_b = await setup_mock_controllers(
+        docker_compose, count=4, reserved=True, tag=tag_b
+    )
+    assert set(serials_a).isdisjoint(serials_b), "reserved sets must be distinct"
+
+    mock_client, mock_channel = await get_mock_client(docker_compose)
+    game_client, game_channel = await get_game_client(docker_compose)
+
+    collector_a = None
+    collector_b = None
+    try:
+        # Start two headless games with different modes.
+        game_id_a, collector_a = await start_game_headless(
+            game_client, build_start_config("JoustFFA", serials_a), timeout=25.0
+        )
+        headless_cleanup.add_game(game_id_a)
+
+        game_id_b, collector_b = await start_game_headless(
+            game_client, build_start_config("JoustTeams", serials_b), timeout=25.0
+        )
+        headless_cleanup.add_game(game_id_b)
+
+        assert game_id_a != game_id_b, "concurrent games must get distinct game_ids"
+
+        # Both should be RUNNING and enumerable.
+        await asyncio.sleep(1.0)
+        games = await list_games(game_client)
+        running = _running_ids(games)
+        assert game_id_a in running, f"{game_id_a} not RUNNING in {running}"
+        assert game_id_b in running, f"{game_id_b} not RUNNING in {running}"
+
+        # GetGameState(game_id) returns each game's own roster.
+        state_a = await game_client.GetGameState(
+            game_coordinator_pb2.GetGameStateRequest(game_id=game_id_a)
+        )
+        state_b = await game_client.GetGameState(
+            game_coordinator_pb2.GetGameStateRequest(game_id=game_id_b)
+        )
+        assert state_a.success and state_b.success
+        roster_a = {p.serial for p in state_a.game_info.players}
+        roster_b = {p.serial for p in state_b.game_info.players}
+        assert roster_a == set(serials_a), (
+            f"game A roster {roster_a} != {set(serials_a)}"
+        )
+        assert roster_b == set(serials_b), (
+            f"game B roster {roster_b} != {set(serials_b)}"
+        )
+
+        # Each collector only saw its own game's events.
+        for e in collector_a.get_events():
+            if e.game_id:
+                assert e.game_id == game_id_a, (
+                    f"game A collector saw foreign event {e.game_id}"
+                )
+        for e in collector_b.get_events():
+            if e.game_id:
+                assert e.game_id == game_id_b, (
+                    f"game B collector saw foreign event {e.game_id}"
+                )
+
+        # End game A by killing players (FFA: kill until one remains).
+        await kill_players_until_one_remains(
+            mock_client,
+            serials_a,
+            delay=0.2,
+            game_client=game_client,
+            game_id=game_id_a,
+        )
+        await collector_a.wait_for_any_event(
+            ["game_ended", "game_force_ended", "game_error"], timeout=20.0
+        )
+
+        # Game B must be unaffected: still RUNNING, no end event, no foreign events.
+        await asyncio.sleep(0.5)
+        games = await list_games(game_client)
+        assert game_id_b in _running_ids(games), (
+            "game B should still be RUNNING after A ends"
+        )
+
+        b_end_events = [
+            e
+            for e in collector_b.get_events()
+            if e.event_type in ("game_ended", "game_force_ended", "game_error")
+        ]
+        assert not b_end_events, f"game B saw end events while A ended: {b_end_events}"
+        for e in collector_b.get_events():
+            if e.game_id:
+                assert e.game_id == game_id_b, "game B stream contaminated by game A"
+
+        # End game B too.
+        ended = await force_end_game_by_id(game_client, game_id_b)
+        assert ended, "force-end of game B should succeed"
+        await collector_b.wait_for_any_event(
+            ["game_ended", "game_force_ended", "game_error"], timeout=20.0
+        )
+    finally:
+        if collector_a:
+            await collector_a.stop()
+        if collector_b:
+            await collector_b.stop()
+        await mock_channel.close()
+        await game_channel.close()
+
+
+@pytest.mark.asyncio
+async def test_shadow_game_isolated_from_menu(
+    docker_compose, ensure_game_stopped, headless_cleanup
+):
+    """A headless shadow game runs alongside a menu game without leaking.
+
+    This is the direct regression test for #774. With a menu-flow (primary)
+    game on 4 unreserved mocks AND a headless shadow game on reserved mocks:
+
+    - The reserved controllers never appear to the menu's controller view
+      (StreamButtonEvents roster — the exact source the menu reads from).
+    - The shadow game's events carry its own game_id and the PRIMARY stream
+      never receives them.
+    - The menu game runs and ends normally, and the menu restores lobby colors
+      on its (unreserved) controllers.
+    """
+    shadow_tag = "shadow-menu"
+    headless_cleanup.add_tag(shadow_tag)
+
+    mock_client, mock_channel = await get_mock_client(docker_compose)
+    game_client, game_channel = await get_game_client(docker_compose)
+    controller_client, controller_channel = await get_controller_client(docker_compose)
+
+    # Create the 4 unreserved menu controllers first; add reserved shadow
+    # controllers only AFTER the menu game has started so the menu's ready-up
+    # flow operates on exactly the 4 it can see.
+    menu_serials = await setup_mock_controllers(docker_compose, count=4)
+
+    primary_collector = GameEventCollector(game_client)  # zero-arg: primary stream
+    button_observer = ButtonStreamObserver(controller_client)
+    shadow_collector = None
+    try:
+        await primary_collector.start()
+        await button_observer.start()
+
+        # 1. Menu-flow game on the 4 unreserved mocks (primary session).
+        await start_game_via_menu(
+            docker_compose,
+            game_mode="JoustFFA",
+            timeout=25.0,
+            event_collector=primary_collector,
+        )
+        primary_started = primary_collector.get_events("game_started")
+        assert primary_started, "menu game should emit game_started"
+        primary_game_id = primary_started[0].game_id
+
+        # 2. Reserved shadow controllers + headless shadow game, concurrently.
+        shadow_serials = await setup_mock_controllers(
+            docker_compose, count=3, reserved=True, tag=shadow_tag
+        )
+        assert set(menu_serials).isdisjoint(shadow_serials)
+        shadow_game_id, shadow_collector = await start_game_headless(
+            game_client, build_start_config("JoustFFA", shadow_serials), timeout=25.0
+        )
+        headless_cleanup.add_game(shadow_game_id)
+        assert shadow_game_id != primary_game_id
+
+        await asyncio.sleep(1.0)
+
+        # 3. Reserved controllers are invisible to the menu's controller view.
+        seen_by_menu = button_observer.all_seen_serials()
+        for serial in shadow_serials:
+            assert serial not in seen_by_menu, (
+                f"reserved controller {serial} leaked into button-stream roster "
+                f"{sorted(seen_by_menu)}"
+            )
+        # The unreserved menu controllers DO appear (sanity: the observer works).
+        roster = set(button_observer.latest_roster())
+        assert set(menu_serials).issubset(roster), (
+            f"menu controllers missing from roster {sorted(roster)}"
+        )
+
+        # 4. Shadow events carry the shadow game_id; the primary stream never
+        # received them.
+        for e in shadow_collector.get_events():
+            if e.game_id:
+                assert e.game_id == shadow_game_id
+        for e in primary_collector.get_events():
+            if e.game_id:
+                assert e.game_id != shadow_game_id, (
+                    f"primary stream received shadow event {e.game_id}"
+                )
+
+        # 5. Both games are RUNNING.
+        games = await list_games(game_client)
+        running = _running_ids(games)
+        assert primary_game_id in running
+        assert shadow_game_id in running
+
+        # 6. End the shadow game; the menu game must be unaffected.
+        await force_end_game_by_id(game_client, shadow_game_id)
+        await shadow_collector.wait_for_any_event(
+            ["game_ended", "game_force_ended", "game_error"], timeout=20.0
+        )
+        await asyncio.sleep(0.5)
+        games = await list_games(game_client)
+        assert primary_game_id in _running_ids(games), (
+            "menu game ended when shadow ended"
+        )
+
+        # 7. End the menu game normally and verify lobby colors restore on the
+        # menu controllers (the menu's own lifecycle still works). The menu
+        # dims lobby colors to ~30% brightness, so assert non-zero (not stuck
+        # at the death black) rather than the full-brightness base color —
+        # mirroring test_full_game_lifecycle.
+        await kill_players_until_one_remains(
+            mock_client, menu_serials, delay=0.2, game_client=game_client
+        )
+        await primary_collector.wait_for_any_event(
+            ["game_ended", "game_force_ended", "game_error"], timeout=20.0
+        )
+        await wait_for_lobby_colors(mock_client, menu_serials, timeout=12.0)
+    finally:
+        await button_observer.stop()
+        await primary_collector.stop()
+        if shadow_collector:
+            await shadow_collector.stop()
+        await mock_channel.close()
+        await game_channel.close()
+        await controller_channel.close()
+
+
+@pytest.mark.asyncio
+async def test_headless_natural_end_then_restart(docker_compose, headless_cleanup):
+    """A headless game ends naturally, then a new headless game starts cleanly.
+
+    Regression for the #793 CI bug: a session that reached its natural win
+    condition stayed registered as ENDED and pinned the primary slot, so the
+    NEXT start was rejected with "Game already in progress". The coordinator now
+    lazily retires ENDED sessions on the next start; this proves it end to end.
+    """
+    tag = "natural-end"
+    headless_cleanup.add_tag(tag)
+
+    serials = await setup_mock_controllers(
+        docker_compose, count=2, reserved=True, tag=tag
+    )
+
+    mock_client, mock_channel = await get_mock_client(docker_compose)
+    game_client, game_channel = await get_game_client(docker_compose)
+
+    first_collector = None
+    second_collector = None
+    try:
+        # First game: run to natural end (FFA, kill until one remains).
+        game_id_1, first_collector = await start_game_headless(
+            game_client, build_start_config("JoustFFA", serials), timeout=25.0
+        )
+        headless_cleanup.add_game(game_id_1)
+
+        await kill_players_until_one_remains(
+            mock_client, serials, delay=0.2, game_client=game_client, game_id=game_id_1
+        )
+        await first_collector.wait_for_any_event(
+            ["game_ended", "game_force_ended", "game_error"], timeout=20.0
+        )
+        await first_collector.stop()
+        first_collector = None
+
+        # Immediately start a second headless game — must succeed (the #793 bug
+        # rejected this). Reuse the same controllers (they are free now).
+        game_id_2, second_collector = await start_game_headless(
+            game_client, build_start_config("JoustFFA", serials), timeout=25.0
+        )
+        headless_cleanup.add_game(game_id_2)
+
+        assert game_id_2 != game_id_1, "restart must get a fresh game_id"
+
+        games = await list_games(game_client)
+        assert game_id_2 in _running_ids(games), "restarted game should be RUNNING"
+
+        await force_end_game_by_id(game_client, game_id_2)
+        await second_collector.wait_for_any_event(
+            ["game_ended", "game_force_ended", "game_error"], timeout=20.0
+        )
+    finally:
+        if first_collector:
+            await first_collector.stop()
+        if second_collector:
+            await second_collector.stop()
+        await mock_channel.close()
+        await game_channel.close()


### PR DESCRIPTION
## What

Phase 5 of #774 (shadow games): integration coverage for concurrent headless games and shadow-vs-menu isolation, built on the multi-session game coordinator (#775/#776, PR #793) and reserved mock controllers (#777, PR #784). Diff is limited to `tests/integration/` + `docker-compose.ci.yml`.

## Helper API (`tests/integration/helpers.py`)

- `setup_mock_controllers(..., reserved=False, tag="")` — passes through to the `AddControllers` reservation fields. Reserved/tagged requests always add fresh controllers (so the reservation applies); the default unreserved path keeps the existing reuse fast-path.
- `start_game_headless(game_client, start_config) -> (game_id, collector)` — starts a game directly via `StreamGameEvents(start_config)` (no menu) and returns the coordinator-assigned `game_id` plus a running collector. `build_start_config(mode, serials)` builds a minimal per-mode `StartGameConfig`.
- `GameEventCollector` is now game_id-aware: an explicit `game_id` subscribes to that session's stream and filters to it; a `start_config` collector learns and filters by the assigned id. **A plain zero-arg primary collector stays unfiltered** (see note below).
- `force_end_game_by_id(game_id)`, `list_games()`, `remove_reserved_controllers(tag)`, `list_mock_controllers_detailed()`.
- `ButtonStreamObserver` — subscribes to `StreamButtonEvents` (the exact source the menu reads) to assert reserved controllers never appear in any connect event or `connected_serials` roster.
- `get_player_states` / `kill_player_verified` / `kill_players_until_one_remains` accept an optional `game_id` for per-session kills.

## Fixtures (`tests/integration/conftest.py`)

- `ensure_game_stopped` unchanged (menu-flow tests, force-ends the primary).
- New `headless_cleanup` factory: each headless test registers its owned `game_id`s and reserved tags; teardown force-ends each game and sweeps each tag, even on failure.

## CI cap (`docker-compose.ci.yml`)

- `GAME_MAX_CONCURRENT_GAMES=4` on the game-coordinator service. **CI only** — the coordinator's production default stays 1. The override lives in CI compose, not baked into images.

## New tests (`tests/integration/test_concurrent_games.py`)

- **`test_two_concurrent_headless_games`** — two headless games (FFA + Teams) on distinct reserved controller sets: distinct game_ids, per-collector event isolation, `ListGames` shows both RUNNING, `GetGameState(game_id)` returns each roster, ending one leaves the other running with an uncontaminated stream.
- **`test_shadow_game_isolated_from_menu`** — the direct regression net for #774: a menu-flow game on 4 unreserved mocks AND a headless shadow game on reserved mocks at the same time. Asserts reserved controllers never leak into the menu's button-stream view, shadow events carry the shadow game_id and never reach the primary stream, ending the shadow leaves the menu game running, and the menu restores lobby colors on its own controllers.
- **`test_headless_natural_end_then_restart`** — runs a headless game to its natural win condition, then immediately starts another. This is the regression for the #793 CI incident, where an ENDED session pinned the primary slot and the next start was rejected with "Game already in progress" (the coordinator now lazily retires ENDED sessions on the next start).

## Note: zero-arg collector must stay unfiltered

While bringing up the suite, the game_id-aware collector initially auto-locked its filter onto the first event carrying a game_id. For a zero-arg primary collector that subscribes before the game starts, that first event can be a stale/late event from a previously-ended game — the collector then dropped the new game's `game_started`, breaking the existing menu-flow and intervention tests. Fixed by only enabling game_id filtering for collectors explicitly bound to a session (explicit `game_id` or `start_config`); plain zero-arg primary collectors collect everything, exactly as before.

## Verification

Full integration suite (`make test` equivalent, prebuilt images): **21 passed**. Includes all 13 menu-flow lifecycle modes, all intervention-flow tests, and the 3 new tests.

## Follow-up

pytest-xdist adoption was deliberately deferred. The headless data plane multiplexes (so parallel non-menu tests are viable), but the menu is single-lobby, so menu-flow tests must stay sequential. Running sequentially within one stack is fine for now; xdist with worker-pinned menu tests is a clean follow-up if CI time becomes a concern (related: #770).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
