### PR TITLE
fix(agent): live bluetooth fitness thresholds + dry-run span honesty (M3 audit)

### DIFF
--- a/services/agent/README.md
+++ b/services/agent/README.md
@@ -131,12 +131,20 @@ structured `InfraFitnessResult` (`Evaluated` / `Passing` / `Violations` /
 | movement rate | `fitness.bluetooth.min_movement_update_hz` (10) | an update rate `< threshold`, evaluated at both window-min and **per-controller** granularity |
 
 **Live-tunable:** the thresholds are read from the `fitness.bluetooth.*` flags on
-**every** evaluation through a `decision.BluetoothFitnessSource`
-(`decision.LiveBluetoothFitness`, seeded with the flagd-schema defaults), so a
-threshold change on stage takes effect on the next evaluation with no restart.
-This source is **separate** from the game-objective `FitnessSource` — distinct
-flags, distinct concerns. The rollout-expansion loop (#734) reads these
-thresholds through it every cycle.
+**every** infra observe cycle through a `decision.BluetoothFitnessSource`. In
+production that source is `decision.FlagBluetoothFitness`, which is backed
+**directly by the flags client** (`flags.Flags.BluetoothFitness`, a narrow
+accessor that evaluates only the three `fitness.bluetooth.*` flags, not the full
+four-layer agent `Snapshot`). The infra loop re-reads it once per ~1Hz cycle, so
+a threshold flipped on stage takes effect on the **next** evaluation with no
+restart — and it does so **in the lobby too**, independent of whether a game is
+active (the game decision loop only publishes thresholds while a session runs, so
+it cannot keep the infra loop live on its own). On any evaluation error the
+accessor falls back to the flagd-schema defaults, so a down flagd reverts to safe
+thresholds rather than failing the cycle. This source is **separate** from the
+game-objective `FitnessSource` — distinct flags, distinct concerns. (A
+`decision.LiveBluetoothFitness` push-source also exists, seeded with the defaults,
+used as a static seed in tests.)
 
 **Missing signals are skipped, not failed** (mirroring game fitness): a `nil`
 window signal contributes no violation, and a context with *no* window signals at

--- a/services/agent/README.md
+++ b/services/agent/README.md
@@ -213,7 +213,8 @@ the lobby, and the rollout is driven by transport health alone.
 
 **Span** — `agent.infrastructure.decision`, emitted on **every active-rollout
 cycle**, carries `rollout.target`, `fitness.passing`, `fitness.violations`
-(empty when passing), `remediation.action`, the observed `bluetooth.*` signals,
+(empty when passing), `remediation.action`, `rollout.dry_run` (whether the
+decision was only rehearsed, not applied), the observed `bluetooth.*` signals,
 and `rollout.controller_count` (the new stage value) when expanding. A write
 failure sets the span status to error and records the error.
 
@@ -221,7 +222,7 @@ failure sets the span status to error and records the error.
 
 | Env | Default | Effect |
 |-----|---------|--------|
-| `AGENT_ROLLOUT_ENABLED` | `false` | `true` → real `RolloutWriter` applies flips. `false` → **dry-run**: the loop still decides and spans expansions (`remediation.action="expand"`, `rollout.controller_count` set) but does **not** write `rollout.json` (decided-but-not-applied; logged `agent.rollout_dry_run`). |
+| `AGENT_ROLLOUT_ENABLED` | `false` | `true` → real `RolloutWriter` applies flips (`rollout.dry_run=false`). `false` → **dry-run**: the loop still decides and spans expansions (`remediation.action="expand"`, `rollout.controller_count` set, **`rollout.dry_run=true`**) but does **not** write `rollout.json` (decided-but-not-applied; logged `agent.rollout_dry_run`). |
 | `ROLLOUT_FLAG_PATH` | `/etc/flagd/rollout.json` | rollout flag file path (read for `remediation_allowed`, written on expand/rollback) |
 | `AGENT_ROLLOUT_DWELL_SECONDS` | `15` | per-stage dwell before re-expansion |
 | `AGENT_ROLLOUT_COOLDOWN_SECONDS` | `30` | post-rollback cooldown: re-expansion is suppressed this long after a rollback |
@@ -283,9 +284,11 @@ observed count returns to 0; a later failure can then trigger a fresh rollback.
 | at stable default      | `0` | — | none (nothing to roll back) | `none` |
 
 **Dry-run** (`AGENT_ROLLOUT_ENABLED=false`): the rollback is **decided and
-spanned** (`remediation.action="rollback"`) but the `DryRunRolloutWriter`'s
-`SetControllerCount("none")` is a no-op — decided-but-not-applied, consistent
-with dry-run expansion. A rollback **write error** sets the span status to error,
+spanned** (`remediation.action="rollback"`, **`rollout.dry_run=true`**) but the
+`DryRunRolloutWriter`'s `SetControllerCount("none")` is a no-op —
+decided-but-not-applied, consistent with dry-run expansion. The `rollout.dry_run`
+attribute is what lets a Jaeger consumer tell this rehearsal apart from a real
+rollback (the spans are otherwise identical). A rollback **write error** sets the span status to error,
 records the error, and does **not** mark the episode in flight, so the next
 failing cycle retries (mirrors the expansion error path).
 
@@ -300,7 +303,7 @@ Every active-rollout cycle emits one `agent.infrastructure.decision` span, and t
 expanded → transport degraded → fitness violated → rollback executed → fitness
 recovered → re-expanded — with no extra logging. The spans are built by a **single
 attribute builder** (`infraDecisionAttributes`), so **every** decision span — on
-**every** outcome — carries the same four core attributes:
+**every** outcome — carries the same five core attributes:
 
 | Attribute | Type | On every span | Meaning |
 |-----------|------|---------------|---------|
@@ -308,6 +311,7 @@ attribute builder** (`infraDecisionAttributes`), so **every** decision span — 
 | `fitness.passing` | bool | yes | did the Bluetooth fitness check pass this cycle |
 | `fitness.violations` | string | yes (**empty when passing**, never absent) | the failing checks, e.g. `movement_update_hz[AA:BB] 8.3<10` |
 | `remediation.action` | string | yes | `none \| expand \| rollback \| recommended_only` |
+| `rollout.dry_run` | bool | yes | did the actuator only **rehearse** this decision (no write to `rollout.json`) rather than apply it — `true` for the dry-run actuator (`AGENT_ROLLOUT_ENABLED=false`, the compose default) and when there is no actuator; `false` for the real `RolloutWriter`. Lets a trace tell a rehearsed `expand`/`rollback` apart from a real one. |
 
 plus the observed `bluetooth.*` window signals (`target_backend` + `rollout_count`
 always; `event_gap_ms` / `dropped_events_pct` / `movement_update_hz` /
@@ -346,7 +350,7 @@ with Jaeger under the `/jaeger` base path:
 The Go narrative test (`decision/infra_narrative_test.go`,
 `TestInfraNarrative_FullIncident`) drives this exact sequence with a fake
 clock/actuator/remediation and asserts the timeline; the schema-completeness test
-(`TestInfraSchemaCompleteness_AllOutcomes`) asserts the four core attributes are
+(`TestInfraSchemaCompleteness_AllOutcomes`) asserts the five core attributes are
 present on **every** outcome, catching any future emission path that forgets the
 builder.
 

--- a/services/agent/actions/rollout_writer.go
+++ b/services/agent/actions/rollout_writer.go
@@ -207,6 +207,10 @@ func (w *RolloutWriter) StageVariantForValue(value int) (string, bool) {
 	return StageVariantForValue(value)
 }
 
+// DryRun reports false: the real writer applies flips to rollout.json. The loop
+// records this on the rollout.dry_run span attribute.
+func (w *RolloutWriter) DryRun() bool { return false }
+
 // DryRunRolloutWriter satisfies the same actuator seam as RolloutWriter but
 // NEVER writes the rollout file: SetControllerCount logs the would-be flip and
 // returns nil. It is the disabled-mode (AGENT_ROLLOUT_ENABLED=false) actuator —
@@ -239,3 +243,8 @@ func (w *DryRunRolloutWriter) NextStage(current int) (variant string, value int,
 func (w *DryRunRolloutWriter) StageVariantForValue(value int) (string, bool) {
 	return StageVariantForValue(value)
 }
+
+// DryRun reports true: SetControllerCount never writes the rollout file. The
+// loop records this on the rollout.dry_run span attribute so a rehearsed
+// expand/rollback is distinguishable from a real one in Jaeger.
+func (w *DryRunRolloutWriter) DryRun() bool { return true }

--- a/services/agent/decision/infra_fitness_test.go
+++ b/services/agent/decision/infra_fitness_test.go
@@ -1,9 +1,11 @@
 package decision
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
+	"github.com/joustmania/agent/flags"
 	"github.com/joustmania/agent/infracontext"
 )
 
@@ -268,4 +270,60 @@ func TestLiveBluetoothFitness_SeedsDefaultsAndSet(t *testing.T) {
 	}
 	// Interface conformance.
 	var _ BluetoothFitnessSource = src
+}
+
+// fakeBluetoothFlags is a mutable bluetoothFitnessEvaluator: each
+// BluetoothFitness call returns whatever value is currently stored, so a test
+// can flip the thresholds between two reads and assert the source re-reads them.
+type fakeBluetoothFlags struct {
+	value flags.BluetoothFitness
+	calls int
+}
+
+func (f *fakeBluetoothFlags) BluetoothFitness(_ context.Context) flags.BluetoothFitness {
+	f.calls++
+	return f.value
+}
+
+// TestFlagBluetoothFitness_ReReadsEachEvaluation is the #735 liveness contract:
+// the flag-backed source re-evaluates the fitness.bluetooth.* flags on EVERY
+// BluetoothThresholds call, so a threshold flipped between two evaluations takes
+// effect on the second — no restart, no cached startup value.
+func TestFlagBluetoothFitness_ReReadsEachEvaluation(t *testing.T) {
+	fake := &fakeBluetoothFlags{value: flags.BluetoothFitness{
+		MaxEventGapMs: 50, MaxDroppedEventsPct: 0.02, MinMovementUpdateHz: 10,
+	}}
+	src := NewFlagBluetoothFitness(fake)
+
+	// First evaluation sees the initial thresholds.
+	first := src.BluetoothThresholds()
+	want1 := BluetoothThresholds{MaxEventGapMs: 50, MaxDroppedEventsPct: 0.02, MinMovementUpdateHz: 10}
+	if first != want1 {
+		t.Fatalf("first eval = %+v, want %+v", first, want1)
+	}
+
+	// Operator flips the thresholds on stage (flagd change).
+	fake.value = flags.BluetoothFitness{MaxEventGapMs: 25, MaxDroppedEventsPct: 0.05, MinMovementUpdateHz: 20}
+
+	// Second evaluation MUST observe the new values (live, not frozen at startup).
+	second := src.BluetoothThresholds()
+	want2 := BluetoothThresholds{MaxEventGapMs: 25, MaxDroppedEventsPct: 0.05, MinMovementUpdateHz: 20}
+	if second != want2 {
+		t.Errorf("second eval = %+v, want %+v (thresholds not live)", second, want2)
+	}
+	if fake.calls != 2 {
+		t.Errorf("flags evaluated %d times, want 2 (once per BluetoothThresholds call)", fake.calls)
+	}
+
+	var _ BluetoothFitnessSource = src
+}
+
+// TestFlagBluetoothFitness_NilClientServesDefaults pins the fail-safe: a nil
+// flags client serves the flagd-schema defaults rather than a zero-value
+// (thresholdless) struct, so the infra loop is never thresholdless.
+func TestFlagBluetoothFitness_NilClientServesDefaults(t *testing.T) {
+	src := NewFlagBluetoothFitness(nil)
+	if got := src.BluetoothThresholds(); got != DefaultBluetoothThresholds() {
+		t.Errorf("nil-client thresholds = %+v, want defaults %+v", got, DefaultBluetoothThresholds())
+	}
 }

--- a/services/agent/decision/infra_fitnesssource.go
+++ b/services/agent/decision/infra_fitnesssource.go
@@ -1,6 +1,11 @@
 package decision
 
-import "sync"
+import (
+	"context"
+	"sync"
+
+	"github.com/joustmania/agent/flags"
+)
 
 // BluetoothFitnessSource provides the infrastructure (Bluetooth) fitness
 // thresholds (the fitness.bluetooth.* flags, #735). It is the infra-domain
@@ -42,4 +47,55 @@ func (f *LiveBluetoothFitness) BluetoothThresholds() BluetoothThresholds {
 	f.mu.RLock()
 	defer f.mu.RUnlock()
 	return f.threshold
+}
+
+// bluetoothFitnessEvaluator is the narrow flags seam FlagBluetoothFitness reads
+// each infra cycle: ONLY the three fitness.bluetooth.* thresholds (not the full
+// four-layer agent Snapshot the game loop evaluates). *flags.Flags satisfies it
+// via its BluetoothFitness accessor; tests supply a fake. Keeping the seam this
+// narrow means the ~1Hz infra path never pays for the unrelated game/agent flag
+// layers, and the source can be unit-tested without a live flagd.
+type bluetoothFitnessEvaluator interface {
+	BluetoothFitness(ctx context.Context) flags.BluetoothFitness
+}
+
+// FlagBluetoothFitness is a BluetoothFitnessSource backed DIRECTLY by the flags
+// client (#735): it re-evaluates the fitness.bluetooth.* flags on EVERY infra
+// observe cycle, so a threshold flipped on stage takes effect on the very next
+// evaluation with no restart — and it does so in the lobby too, independent of
+// whether a GAME is active (the game decision loop only publishes thresholds
+// while a session runs, so it cannot keep the infra loop live on its own).
+//
+// This is the infra-domain parallel to how the game loop threads live
+// fitness.* thresholds (flags.Evaluate per cycle → Loop.SetFitness → LiveFitness),
+// collapsed into one read-through source because the infra loop already reads
+// its BluetoothFitnessSource every cycle.
+//
+// On any evaluation error the underlying flags accessor falls back to the
+// flagd-schema defaults (last-known-good is the safe default), so a down flagd
+// never makes the infra loop thresholdless.
+type FlagBluetoothFitness struct {
+	flags bluetoothFitnessEvaluator
+}
+
+// NewFlagBluetoothFitness builds a flag-backed Bluetooth fitness source over the
+// given flags client. A nil client falls back to serving the flagd-schema
+// defaults each cycle, so the infra loop is never thresholdless.
+func NewFlagBluetoothFitness(f bluetoothFitnessEvaluator) *FlagBluetoothFitness {
+	return &FlagBluetoothFitness{flags: f}
+}
+
+// BluetoothThresholds implements BluetoothFitnessSource by evaluating the
+// fitness.bluetooth.* flags now. The infra loop calls this once per observe
+// cycle, so the thresholds are always live.
+func (s *FlagBluetoothFitness) BluetoothThresholds() BluetoothThresholds {
+	if s.flags == nil {
+		return DefaultBluetoothThresholds()
+	}
+	bf := s.flags.BluetoothFitness(context.Background())
+	return BluetoothThresholds{
+		MaxEventGapMs:       bf.MaxEventGapMs,
+		MaxDroppedEventsPct: bf.MaxDroppedEventsPct,
+		MinMovementUpdateHz: bf.MinMovementUpdateHz,
+	}
 }

--- a/services/agent/decision/infra_loop.go
+++ b/services/agent/decision/infra_loop.go
@@ -43,6 +43,12 @@ type RolloutActuator interface {
 	// StageVariantForValue maps a controller-count value to its ladder variant
 	// name; ok is false for any value not on the ladder.
 	StageVariantForValue(value int) (string, bool)
+	// DryRun reports whether SetControllerCount is a no-op (the rehearsal
+	// actuator) rather than an applied write. The loop lifts it onto every
+	// decision span as rollout.dry_run so a Jaeger consumer can tell a rehearsed
+	// "expand"/"rollback" apart from one that actually flipped rollout.json.
+	// RolloutWriter → false (real); DryRunRolloutWriter → true.
+	DryRun() bool
 }
 
 // RemediationSource resolves the `remediation_allowed` gate that decides
@@ -382,12 +388,17 @@ func (l *InfraLoop) emitDecisionSpan(
 	writeErr error,
 ) {
 	// Single builder: EVERY emission path lands the full attribute schema (#737).
+	// dry-run is true when the actuator never applies writes (the rehearsal
+	// actuator) or is absent entirely — either way no flip reached rollout.json,
+	// so the span must say so (M3 audit: rehearsed decisions were indistinguishable
+	// from real ones).
 	attrs := infraDecisionAttributes(infraDecisionAttrs{
 		snap:       snap,
 		fit:        fit,
 		target:     target,
 		action:     action,
 		expandedTo: expandedTo,
+		dryRun:     l.rollout == nil || l.rollout.DryRun(),
 	})
 
 	_, span := l.tracer.Start(ctx, SpanInfraDecision,

--- a/services/agent/decision/infra_loop_test.go
+++ b/services/agent/decision/infra_loop_test.go
@@ -58,6 +58,18 @@ func (f *fakeRollout) StageVariantForValue(value int) (string, bool) {
 	return n, ok
 }
 
+// DryRun reports false: the fake applies its (in-memory) writes, mirroring the
+// real RolloutWriter. dryRollout below overrides this to true.
+func (f *fakeRollout) DryRun() bool { return false }
+
+// dryRollout is a fakeRollout that reports DryRun()==true: it still records
+// would-be writes (so dwell/ladder behavior matches), but the loop tags every
+// span rollout.dry_run=true. Mirrors actions.DryRunRolloutWriter for the loop's
+// purposes while keeping the in-memory call log.
+type dryRollout struct{ fakeRollout }
+
+func (d *dryRollout) DryRun() bool { return true }
+
 // infraSnap builds an active-rollout InfraContext: a target backend, a rollout
 // count (stage), one fresh controller, and a passing or failing window.
 func infraSnap(target string, stage int, now time.Time, hz float64) infracontext.InfraContext {
@@ -111,6 +123,15 @@ func spanInt(s sdktrace.ReadOnlySpan, key string) (int64, bool) {
 		}
 	}
 	return 0, false
+}
+
+func spanBool(s sdktrace.ReadOnlySpan, key string) (bool, bool) {
+	for _, kv := range s.Attributes() {
+		if string(kv.Key) == key {
+			return kv.Value.AsBool(), true
+		}
+	}
+	return false, false
 }
 
 func TestInfraLoop_ExpandsWhenPassing(t *testing.T) {
@@ -299,5 +320,44 @@ func TestInfraLoop_NilActuatorNeverExpands(t *testing.T) {
 	}
 	if v, _ := spanStr(spans[0], AttrRemediationAction); v != RemediationNone {
 		t.Errorf("remediation.action = %q, want %q (nil actuator never expands)", v, RemediationNone)
+	}
+}
+
+// TestInfraLoop_DryRunAttributeReflectsActuator is the M3 trace-honesty test: the
+// rollout.dry_run span attribute must distinguish a rehearsed decision from a
+// real one. A real actuator → false; a dry-run actuator → true (the same
+// remediation.action="expand" span otherwise); a nil actuator (never writes) →
+// true.
+func TestInfraLoop_DryRunAttributeReflectsActuator(t *testing.T) {
+	cases := []struct {
+		name    string
+		rollout RolloutActuator
+		want    bool
+	}{
+		{"real actuator", &fakeRollout{}, false},
+		{"dry-run actuator", &dryRollout{}, true},
+		{"nil actuator", nil, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			clock := time.Unix(1000, 0)
+			l, sr := newInfraLoop(t, tc.rollout, &clock)
+
+			// Passing fitness at stage 0 → an expand decision (real/dry), or "none"
+			// (nil), but the span is emitted on every active-rollout cycle either way.
+			l.OnInfraEvaluate(context.Background(), infraSnap("rust", 0, clock, 30))
+
+			spans := infraSpans(sr)
+			if len(spans) != 1 {
+				t.Fatalf("got %d spans, want 1", len(spans))
+			}
+			got, ok := spanBool(spans[0], AttrRolloutDryRun)
+			if !ok {
+				t.Fatalf("rollout.dry_run absent; want present on every decision span")
+			}
+			if got != tc.want {
+				t.Errorf("rollout.dry_run = %v, want %v", got, tc.want)
+			}
+		})
 	}
 }

--- a/services/agent/decision/infra_narrative_test.go
+++ b/services/agent/decision/infra_narrative_test.go
@@ -14,14 +14,14 @@ import (
 // is auditable end-to-end in the trace timeline. Two kinds of assertions:
 //
 //  1. Schema completeness — every emitted agent.infrastructure.decision span,
-//     across ALL decision outcomes, carries the four core attributes (present, not
+//     across ALL decision outcomes, carries the five core attributes (present, not
 //     absent), so a future change that drops one on some path is caught here.
 //  2. The narrative — the ordered remediation.action sequence of a full incident
 //     (expand → expand → rollback → settle → cooldown → re-expand) reconstructs the
 //     story exactly, and the violations string is non-empty exactly on the failing
 //     cycles.
 
-// requireCoreAttrs asserts the four core attributes are PRESENT on a span and
+// requireCoreAttrs asserts the five core attributes are PRESENT on a span and
 // returns the action + violations so callers can assert the narrative. A missing
 // core attribute is a fatal schema regression.
 func requireCoreAttrs(t *testing.T, s sdktrace.ReadOnlySpan, idx int) (action, violations string) {
@@ -42,6 +42,11 @@ func requireCoreAttrs(t *testing.T, s sdktrace.ReadOnlySpan, idx int) (action, v
 	if !ok {
 		t.Fatalf("span[%d] missing core attribute %q", idx, AttrRemediationAction)
 	}
+	// rollout.dry_run is core (#737 + M3 audit): present on every span so a
+	// rehearsed expand/rollback is distinguishable from a real one.
+	if _, ok := spanBool(s, AttrRolloutDryRun); !ok {
+		t.Fatalf("span[%d] missing core attribute %q", idx, AttrRolloutDryRun)
+	}
 	// bluetooth.target_backend + bluetooth.rollout_count always accompany the
 	// decision (the observed signals that drove it).
 	if _, ok := spanStr(s, AttrBluetoothTargetBackend); !ok {
@@ -55,7 +60,7 @@ func requireCoreAttrs(t *testing.T, s sdktrace.ReadOnlySpan, idx int) (action, v
 
 // TestInfraSchemaCompleteness_AllOutcomes drives the loop through EVERY decision
 // outcome (expand, none-while-passing/terminal, rollback, recommended_only,
-// none-while-settling, none-during-cooldown) and asserts the four core attributes
+// none-while-settling, none-during-cooldown) and asserts the five core attributes
 // are present on every resulting span. This is the regression net: a future
 // emission path that forgets to route through infraDecisionAttributes fails here.
 func TestInfraSchemaCompleteness_AllOutcomes(t *testing.T) {
@@ -141,7 +146,7 @@ func TestInfraSchemaCompleteness_PassingSpanHasEmptyViolations(t *testing.T) {
 // TestInfraNarrative_FullIncident is the milestone acceptance test: it drives a
 // complete rollout → instability → rollback → recovery → re-expand incident and
 // asserts the recorded remediation.action timeline tells exactly that story, with
-// the four attributes present on every span and the violations string non-empty
+// the five attributes present on every span and the violations string non-empty
 // on exactly the failing cycles.
 func TestInfraNarrative_FullIncident(t *testing.T) {
 	clock := time.Unix(1000, 0)
@@ -252,6 +257,42 @@ func TestInfraNarrative_RecommendedOnlyStalls(t *testing.T) {
 	// rollback was applied because remediation was not allowed.
 	if got := rollout.calls(); len(got) != 2 || got[0] != "one" || got[1] != "three" {
 		t.Fatalf("writes = %v, want [one three] only (recommendation never writes)", got)
+	}
+}
+
+// TestInfraNarrative_DryRunTagsEverySpan is the M3 trace-honesty narrative: with
+// the dry-run actuator the loop still DECIDES and SPANS the same
+// expand→...→rollback story, but rollout.dry_run=true on EVERY span so a Jaeger
+// consumer can tell the rehearsal apart from a real rollout. The real-actuator
+// narrative (TestInfraNarrative_FullIncident) is the dry_run=false counterpart.
+func TestInfraNarrative_DryRunTagsEverySpan(t *testing.T) {
+	clock := time.Unix(1000, 0)
+	rollout := &dryRollout{}
+	l, sr := newInfraLoop(t, rollout, &clock)
+	l.SetRemediationSource(StaticRemediation(true))
+	l.SetCooldown(30 * time.Second)
+
+	// Same incident shape as the real-actuator narrative: expand, expand, rollback.
+	l.OnInfraEvaluate(context.Background(), infraSnap("rust", 0, clock, passingHz))
+	clock = clock.Add(DefaultRolloutDwell)
+	l.OnInfraEvaluate(context.Background(), infraSnap("rust", 1, clock, passingHz))
+	clock = clock.Add(time.Second)
+	l.OnInfraEvaluate(context.Background(), infraSnap("rust", 3, clock, failingHz))
+
+	wantActions := []string{RemediationExpand, RemediationExpand, RemediationRollback}
+	spans := infraSpans(sr)
+	if len(spans) != len(wantActions) {
+		t.Fatalf("got %d spans, want %d", len(spans), len(wantActions))
+	}
+	for i, want := range wantActions {
+		action, _ := requireCoreAttrs(t, spans[i], i)
+		if action != want {
+			t.Errorf("dry-run span[%d] action = %q, want %q", i, action, want)
+		}
+		dry, ok := spanBool(spans[i], AttrRolloutDryRun)
+		if !ok || !dry {
+			t.Errorf("dry-run span[%d] rollout.dry_run = %v (ok=%v), want true", i, dry, ok)
+		}
 	}
 }
 

--- a/services/agent/decision/infra_telemetry.go
+++ b/services/agent/decision/infra_telemetry.go
@@ -36,6 +36,13 @@ const (
 	// AttrRemediationAction is the remediation the decision selected (e.g. roll
 	// back the rollout); the infra-domain parallel to AttrDecisionAction.
 	AttrRemediationAction = "remediation.action"
+	// AttrRolloutDryRun is whether the actuator only REHEARSED the decision (true)
+	// rather than applying it to rollout.json (false). True for the dry-run
+	// actuator (AGENT_ROLLOUT_ENABLED=false, the compose default) and for a nil
+	// actuator (the loop never writes); false for the real RolloutWriter. Present
+	// on EVERY decision span so a Jaeger consumer can tell a rehearsed
+	// expand/rollback apart from an applied one — they were otherwise identical.
+	AttrRolloutDryRun = "rollout.dry_run"
 
 	// Bluetooth signal attribute keys (controller.bluetooth_health contract).
 	// Re-declared here, decoupled from the infracontext extractor constants, so
@@ -67,6 +74,9 @@ type infraDecisionAttrs struct {
 	// expandedTo is the rollout stage VALUE the loop expanded to; only meaningful
 	// (and only recorded) when action == RemediationExpand.
 	expandedTo int
+	// dryRun is whether the actuator only rehearsed this decision (no write to
+	// rollout.json) rather than applying it. Recorded on every span.
+	dryRun bool
 }
 
 // infraDecisionAttributes is the SOLE builder of the agent.infrastructure.decision
@@ -74,7 +84,7 @@ type infraDecisionAttrs struct {
 // through it, so the schema is guaranteed complete and consistent.
 //
 // The contract — enforced by the schema-completeness test — is that EVERY emitted
-// decision span carries ALL FOUR core attributes, present (not absent) on every
+// decision span carries ALL FIVE core attributes, present (not absent) on every
 // outcome:
 //
 //   - rollout.target        — the rollout target adapter (always)
@@ -83,6 +93,9 @@ type infraDecisionAttrs struct {
 //     (present-but-empty, never absent, so a query can distinguish "passing" from
 //     "attribute missing")
 //   - remediation.action    — the selected action (always)
+//   - rollout.dry_run       — bool, always: whether the actuator only rehearsed
+//     this decision (no write) rather than applying it, so a Jaeger consumer can
+//     tell a rehearsed expand/rollback apart from a real one
 //
 // Plus the observed bluetooth.* window signals (target_backend + rollout_count
 // always; the four optional float/int signals only when present in the window so
@@ -90,11 +103,12 @@ type infraDecisionAttrs struct {
 // expand (the stage the loop advanced to).
 func infraDecisionAttributes(in infraDecisionAttrs) []attribute.KeyValue {
 	attrs := []attribute.KeyValue{
-		// The four core attributes — unconditional on every path.
+		// The five core attributes — unconditional on every path.
 		attribute.String(AttrRolloutTarget, in.target),
 		attribute.Bool(AttrFitnessPassing, in.fit.Evaluated && in.fit.Passing),
 		attribute.String(AttrFitnessViolations, in.fit.ViolationsString()),
 		attribute.String(AttrRemediationAction, in.action),
+		attribute.Bool(AttrRolloutDryRun, in.dryRun),
 		// Window context that always exists on an active-rollout cycle.
 		attribute.String(AttrBluetoothTargetBackend, in.snap.Window.TargetBackend),
 		attribute.Int(AttrBluetoothRolloutCount, in.snap.Window.RolloutCount),

--- a/services/agent/flags/flags.go
+++ b/services/agent/flags/flags.go
@@ -327,11 +327,22 @@ func (f *Flags) Evaluate(ctx context.Context) Snapshot {
 			BalancedSpikeSurvivalThreshold: f.floatFlag(ctx, keyBalancedSpikeSurvival, DefaultBalancedSpikeSurvivalThreshold),
 			AccelerateTargetSessionSeconds: f.intFlag(ctx, keyAccelerateTargetSessionSecs, DefaultAccelerateTargetSessionSeconds),
 		},
-		BluetoothFitness: BluetoothFitness{
-			MaxEventGapMs:       f.floatFlag(ctx, keyBluetoothMaxEventGapMs, DefaultBluetoothMaxEventGapMs),
-			MaxDroppedEventsPct: f.floatFlag(ctx, keyBluetoothMaxDroppedEventsPct, DefaultBluetoothMaxDroppedEventsPct),
-			MinMovementUpdateHz: f.floatFlag(ctx, keyBluetoothMinMovementUpdateHz, DefaultBluetoothMinMovementUpdateHz),
-		},
+		BluetoothFitness: f.BluetoothFitness(ctx),
+	}
+}
+
+// BluetoothFitness evaluates ONLY the three fitness.bluetooth.* thresholds
+// (#735). It is the narrow accessor the infrastructure loop reads on every
+// observe cycle (~1Hz) so the Bluetooth fitness thresholds are tunable live on
+// stage with no restart — without paying for a full four-layer Evaluate the
+// infra path never consumes. Each flag falls back to its safe default on any
+// evaluation error (e.g. flagd unreachable), so a down control plane reverts to
+// the flagd-schema defaults rather than failing the cycle.
+func (f *Flags) BluetoothFitness(ctx context.Context) BluetoothFitness {
+	return BluetoothFitness{
+		MaxEventGapMs:       f.floatFlag(ctx, keyBluetoothMaxEventGapMs, DefaultBluetoothMaxEventGapMs),
+		MaxDroppedEventsPct: f.floatFlag(ctx, keyBluetoothMaxDroppedEventsPct, DefaultBluetoothMaxDroppedEventsPct),
+		MinMovementUpdateHz: f.floatFlag(ctx, keyBluetoothMinMovementUpdateHz, DefaultBluetoothMinMovementUpdateHz),
 	}
 }
 

--- a/services/agent/flags/flags_test.go
+++ b/services/agent/flags/flags_test.go
@@ -198,6 +198,37 @@ func defaultBluetoothFitness() BluetoothFitness {
 	}
 }
 
+// TestBluetoothFitness_Accessor pins the narrow #735 accessor the infra loop
+// reads each cycle: it returns the three fitness.bluetooth.* thresholds and
+// nothing else, falling back to defaults on an evaluation error.
+func TestBluetoothFitness_Accessor(t *testing.T) {
+	stub := stubEvaluator{
+		floats: map[string]float64{
+			keyBluetoothMaxEventGapMs:       25,
+			keyBluetoothMaxDroppedEventsPct: 0.05,
+			keyBluetoothMinMovementUpdateHz: 20,
+		},
+	}
+	f := New(stub, nil)
+	got := f.BluetoothFitness(context.Background())
+	want := BluetoothFitness{MaxEventGapMs: 25, MaxDroppedEventsPct: 0.05, MinMovementUpdateHz: 20}
+	if got != want {
+		t.Errorf("BluetoothFitness = %+v, want %+v", got, want)
+	}
+
+	// On error every threshold falls back to its flagd-schema default, so a down
+	// flagd reverts the infra loop to safe defaults rather than failing.
+	boom := errors.New("flagd down")
+	errStub := stubEvaluator{errs: map[string]error{
+		keyBluetoothMaxEventGapMs:       boom,
+		keyBluetoothMaxDroppedEventsPct: boom,
+		keyBluetoothMinMovementUpdateHz: boom,
+	}}
+	if got := New(errStub, nil).BluetoothFitness(context.Background()); got != defaultBluetoothFitness() {
+		t.Errorf("BluetoothFitness on error = %+v, want defaults %+v", got, defaultBluetoothFitness())
+	}
+}
+
 func TestEvaluate_DefaultsOnError(t *testing.T) {
 	// Every evaluation errors (e.g. flagd unreachable). Defaults must apply and
 	// the agent must come up disabled with no permitted interventions.

--- a/services/agent/main.go
+++ b/services/agent/main.go
@@ -265,9 +265,13 @@ func main() {
 	// active-rollout cycle.
 	infraStore := infracontext.NewStore(infraControllerTTL, nil)
 	infraStore.SetOwnService(resolveServiceName())
-	// Bluetooth fitness source (#735): seeds the flagd-schema defaults; the infra
-	// loop reads the live fitness.bluetooth.* thresholds through it each cycle.
-	bluetoothFitness := decision.NewLiveBluetoothFitness()
+	// Bluetooth fitness source (#735): backed DIRECTLY by the flags client, so the
+	// infra loop re-reads the live fitness.bluetooth.* thresholds on every observe
+	// cycle (~1Hz) — tunable live on stage with no restart, and in the lobby too
+	// (the game loop only publishes thresholds while a session is active, so it
+	// cannot keep the infra loop live on its own). On any evaluation error the
+	// accessor falls back to the flagd-schema defaults.
+	bluetoothFitness := decision.NewFlagBluetoothFitness(agentFlags)
 	// Rollout actuator (#734): real RolloutWriter when AGENT_ROLLOUT_ENABLED=true,
 	// else a dry-run actuator (decides+spans but does not write rollout.json).
 	infraLoop := decision.NewInfraLoop(logger, rolloutDwell(), bluetoothFitness, rolloutActuator(logger))


### PR DESCRIPTION
## Summary

Fixes the two bugs found by the M3 post-milestone audit. Stacked on #825.

**1. `fitness.bluetooth.*` thresholds were frozen at startup (#735 AC breach — "tunable live on stage").** `LiveBluetoothFitness` was seeded with compile-time defaults and `Set()` had zero callers; the infra path never called `flags.Evaluate`. Now: a narrow `flags.BluetoothFitness(ctx)` accessor evaluates only the three threshold flags, and `FlagBluetoothFitness` (a read-through `BluetoothFitnessSource`) re-reads it on every ~1Hz infra cycle — live in the lobby too, where the game loop's evaluate-then-push pattern never runs. Falls back to schema defaults on flagd errors. `Evaluate()` reuses the accessor.

**2. Dry-run spans were indistinguishable from real actions.** With `AGENT_ROLLOUT_ENABLED=false` (the compose default) the loop recorded `remediation.action="expand"/"rollback"` while writing nothing — only a log line differed. Now: `RolloutActuator` gains `DryRun() bool` and the single span builder stamps `rollout.dry_run` on EVERY infra decision span (nil actuator → also dry-run). The schema-completeness test enforces it as the fifth core attribute; a dry-run narrative test asserts it across a full expand→rollback story.

## Test plan

- [x] `go test -race ./...` green (threshold change between cycles takes effect; dry-run attr real/dry/nil cases; updated schema + narrative tests)
- [x] `go vet`, `gofmt -l` clean

Addresses the #735 acceptance criterion and the trace-honesty gap from the audit (memory: M3 plan §audit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)