### PR TITLE
test: parallelize game-mode lifecycle coverage via headless shadow-game batches (#826)

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -212,6 +212,35 @@ async def ensure_game_stopped(docker_compose):
     await force_end_game()
 
 
+@pytest.fixture(autouse=True)
+async def coordinator_idle(docker_compose):
+    """Enforce the no-leftover-games invariant before EVERY integration test.
+
+    Tests must leave the coordinator idle. A live session leaking out of a
+    test occupies one of the GAME_MAX_CONCURRENT_GAMES slots, so the next test
+    that starts a game gets "Game already in progress" (this rejected one mode
+    per batch on the first CI run of the parallel lifecycle tests). This
+    fixture force-ends any leak and reports it loudly — when it fires, the
+    LEAKING test is the one that ran immediately before the reporting test.
+
+    NOTE (cross-test parallelism): this global quiesce assumes the sequential
+    single-process suite. If pytest-xdist with a shared stack is introduced,
+    scope this to tests needing exclusive coordinator access instead.
+    """
+    from tests.integration.helpers import quiesce_coordinator
+
+    host = docker_compose.get_service_host("game-coordinator", 50053)
+    port = docker_compose.get_service_port("game-coordinator", 50053)
+    channel = grpc.aio.insecure_channel(f"{host}:{port}")
+    game_client = game_coordinator_pb2_grpc.GameCoordinatorServiceStub(channel)
+    try:
+        await quiesce_coordinator(game_client, context="pre-test idle check")
+    finally:
+        await channel.close()
+
+    yield
+
+
 @pytest.fixture
 async def headless_cleanup(docker_compose):
     """Per-test cleanup for headless (shadow) games.

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -525,6 +525,8 @@ def build_start_config(
     game_name: str,
     serials: list[str],
     sensitivity: int = 2,
+    invincibility_seconds: float = 2.0,
+    min_rounds: int = 5,
 ):
     """Build a minimal StartGameConfig for a headless game start.
 
@@ -533,10 +535,20 @@ def build_start_config(
     required. Mirrors the menu's ``_build_game_config`` for the modes used by
     the concurrent/isolation tests; uses CI-friendly defaults.
 
+    Note on timing-sensitive modes: the headless path resolves mode config from
+    this proto via ``GameFactory._extract_mode_config`` and does NOT consult
+    flagd, so an unset (0) invincibility/min_rounds falls back to the
+    coordinator's slow production defaults (4.0s / 10 rounds), NOT the CI flagd
+    values the menu-flow uses. We therefore set them explicitly to the CI
+    defaults (2.0s / 5) so the ``end_tournament``/``end_fight_club`` round-wait
+    timings line up.
+
     Args:
         game_name: Game mode name (e.g. "JoustFFA", "JoustTeams", "Swapper").
         serials: Controller serials to use as players.
         sensitivity: Common sensitivity 0-4 (default 2 = MEDIUM).
+        invincibility_seconds: Tournament/FightClub invincibility (CI default 2.0).
+        min_rounds: FightClub minimum rounds before a winner (CI default 5).
     """
     players = [
         game_coordinator_pb2.Player(serial=serial, team=i % 2, alive=True, score=0)
@@ -571,6 +583,24 @@ def build_start_config(
     elif game_name == "NonStop":
         config.nonstop_config.CopyFrom(
             game_coordinator_pb2.NonstopConfig(time_limit_seconds=0)
+        )
+    elif game_name == "Tournament":
+        config.tournament_config.CopyFrom(
+            game_coordinator_pb2.TournamentConfig(
+                invincibility_seconds=invincibility_seconds
+            )
+        )
+    elif game_name == "FightClub":
+        config.fight_club_config.CopyFrom(
+            game_coordinator_pb2.FightClubConfig(
+                invincibility_seconds=invincibility_seconds,
+                min_rounds=min_rounds,
+            )
+        )
+    elif game_name == "Traitor":
+        # num_teams=0 lets the coordinator auto-calculate from player count.
+        config.traitor_config.CopyFrom(
+            game_coordinator_pb2.TraitorConfig(num_teams=0)
         )
 
     return config
@@ -1281,7 +1311,7 @@ async def kill_players_until_one_remains(
 
 
 async def kill_players_for_team_win(
-    mock_client, serials: list[str], delay: float = 0.5, game_client=None
+    mock_client, serials: list[str], delay: float = 0.5, game_client=None, game_id: str = ""
 ) -> list[str]:
     """Kill enough players to trigger a team game win.
 
@@ -1293,6 +1323,7 @@ async def kill_players_for_team_win(
         serials: List of all controller serials
         delay: Delay between kills in seconds
         game_client: GameCoordinator gRPC client for kill verification
+        game_id: Target a specific session (empty = primary/legacy).
 
     Returns:
         List of serials that were killed
@@ -1303,7 +1334,7 @@ async def kill_players_for_team_win(
     for serial in players_to_kill:
         await asyncio.sleep(delay)
         if not await kill_player_verified(
-            mock_client, game_client, serial, lambda p: not p.alive
+            mock_client, game_client, serial, lambda p: not p.alive, game_id=game_id
         ):
             break  # Game already ended
         killed.append(serial)
@@ -1321,6 +1352,7 @@ async def end_swapper_game(
     game_client,
     delay: float = 0.3,
     timeout: float = 30.0,
+    game_id: str = "",
 ) -> list[str]:
     """End a Swapper game by swapping all players to one team.
 
@@ -1339,6 +1371,7 @@ async def end_swapper_game(
         game_client: GameCoordinator client for GetGameState
         delay: Delay between kills in seconds
         timeout: Max total time for the convergence loop
+        game_id: Target a specific session (empty = primary/legacy).
 
     Returns:
         List of serials that were swapped (killed)
@@ -1347,7 +1380,7 @@ async def end_swapper_game(
     deadline = asyncio.get_event_loop().time() + timeout
 
     while True:
-        players = await get_player_states(game_client)
+        players = await get_player_states(game_client, game_id=game_id)
         if players is None:
             return killed  # Game ended — converged
 
@@ -1364,14 +1397,14 @@ async def end_swapper_game(
         print(f"Swapper: killing {serial} (team 1 has {len(team_1)} players)")
         await asyncio.sleep(delay)
         if not await kill_player_verified(
-            mock_client, game_client, serial, lambda p: p.team == 0
+            mock_client, game_client, serial, lambda p: p.team == 0, game_id=game_id
         ):
             return killed  # Game ended during the kill
         killed.append(serial)
 
 
 async def end_werewolf_game(
-    mock_client, serials: list[str], delay: float = 0.3, game_client=None
+    mock_client, serials: list[str], delay: float = 0.3, game_client=None, game_id: str = ""
 ) -> list[str]:
     """End a Werewolf game by killing all but one player.
 
@@ -1387,6 +1420,7 @@ async def end_werewolf_game(
         serials: List of all controller serials
         delay: Delay between kills in seconds
         game_client: GameCoordinator gRPC client for kill verification
+        game_id: Target a specific session (empty = primary/legacy).
 
     Returns:
         List of serials that were killed
@@ -1397,7 +1431,7 @@ async def end_werewolf_game(
     for serial in serials[:-1]:
         await asyncio.sleep(delay)
         if not await kill_player_verified(
-            mock_client, game_client, serial, lambda p: not p.alive
+            mock_client, game_client, serial, lambda p: not p.alive, game_id=game_id
         ):
             break  # Game already ended (one team eliminated early)
         killed.append(serial)
@@ -1411,6 +1445,7 @@ async def end_zombies_game(
     delay: float = 0.3,
     game_client=None,
     timeout: float = 30.0,
+    game_id: str = "",
 ) -> list[str]:
     """End a Zombies game by converting all humans to zombies.
 
@@ -1429,6 +1464,7 @@ async def end_zombies_game(
         delay: Delay between kills in seconds
         game_client: GameCoordinator gRPC client for state queries
         timeout: Max total time for the conversion loop
+        game_id: Target a specific session (empty = primary/legacy).
 
     Returns:
         List of serials that were killed (converted)
@@ -1437,7 +1473,7 @@ async def end_zombies_game(
     deadline = asyncio.get_event_loop().time() + timeout
 
     while True:
-        players = await get_player_states(game_client)
+        players = await get_player_states(game_client, game_id=game_id)
         if players is None:
             return killed  # Game ended — all humans converted
 
@@ -1454,7 +1490,7 @@ async def end_zombies_game(
         print(f"Zombies: converting {serial} ({len(humans)} humans remain)")
         await asyncio.sleep(delay)
         if not await kill_player_verified(
-            mock_client, game_client, serial, lambda p: p.team == 1
+            mock_client, game_client, serial, lambda p: p.team == 1, game_id=game_id
         ):
             return killed  # Game ended during the kill
         killed.append(serial)

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -472,6 +472,54 @@ async def list_games(game_client) -> list:
     return list(response.games)
 
 
+_LIVE_GAME_STATES = (
+    game_coordinator_pb2.GameState.STARTING,
+    game_coordinator_pb2.GameState.RUNNING,
+)
+
+
+async def quiesce_coordinator(game_client, timeout: float = 15.0, context: str = "") -> list:
+    """Ensure the coordinator has no live sessions; force-end and report leaks.
+
+    Tests must leave the coordinator idle — a live leftover session occupies a
+    concurrency slot and gets the NEXT test rejected with "Game already in
+    progress". This helper makes that invariant explicit: any live session it
+    finds is a cleanup leak in a previous test, reported loudly (the leaker is
+    the test that ran right before the reporting one in the log).
+
+    NOTE: this assumes tests run sequentially in one process. If cross-test
+    parallelism (pytest-xdist with a shared stack) is ever introduced, this
+    global force-end would kill other workers' games — it must then be scoped
+    to tests that need exclusive coordinator access (menu-flow, full batches).
+
+    Returns:
+        The list of leaked GameInfo sessions found (empty = clean).
+    """
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    leaked = [g for g in await list_games(game_client) if g.state in _LIVE_GAME_STATES]
+    if not leaked:
+        return []
+
+    print(
+        f"COORDINATOR LEAK{f' ({context})' if context else ''}: "
+        f"{len(leaked)} live session(s) left behind by a previous test: "
+        + ", ".join(f"{g.game_id}/{g.game_mode}(state={g.state})" for g in leaked)
+    )
+    live = leaked
+    while live:
+        for game in live:
+            await force_end_game_by_id(game_client, game.game_id, reason="quiesce_leak_cleanup")
+        if loop.time() > deadline:
+            raise AssertionError(
+                f"Coordinator did not quiesce within {timeout}s: "
+                f"{[(g.game_id, g.state) for g in live]}"
+            )
+        await asyncio.sleep(0.5)
+        live = [g for g in await list_games(game_client) if g.state in _LIVE_GAME_STATES]
+    return leaked
+
+
 async def start_game_headless(
     game_client,
     start_config,

--- a/tests/integration/test_full_game_lifecycle.py
+++ b/tests/integration/test_full_game_lifecycle.py
@@ -20,11 +20,6 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
 from tests.integration.helpers import (
     GameEventCollector,
     ObservabilityObserver,
-    end_fight_club_game,
-    end_swapper_game,
-    end_tournament_game,
-    end_werewolf_game,
-    end_zombies_game,
     force_end_game,
     get_game_client,
     get_mock_client,
@@ -43,9 +38,6 @@ from tests.integration.helpers import (
 # =============================================================================
 # Game settings are now stored in Menu service's state_manager and passed via
 # typed proto config when starting games. Integration tests use default values.
-
-FIGHT_CLUB_ROUNDS = 6  # CI default min_rounds=5, run 1 extra to ensure clear winner
-
 
 # =============================================================================
 # End strategy type and helpers
@@ -82,51 +74,6 @@ async def end_team_game(mock_client, serials: list[str], game_client, _event_col
     await kill_players_for_team_win(mock_client, serials, delay=0.1, game_client=game_client)
 
 
-async def end_swapper(mock_client, serials: list[str], game_client, _event_collector) -> None:
-    """End Swapper by swapping all to one team (state-driven convergence)."""
-    await end_swapper_game(mock_client, serials, game_client, delay=0.3)
-
-
-async def end_zombies(mock_client, serials: list[str], game_client, _event_collector) -> None:
-    """End Zombies by converting all humans (state-driven, verified kills)."""
-    await end_zombies_game(mock_client, serials, delay=0.3, game_client=game_client)
-
-
-async def end_werewolf(mock_client, serials: list[str], game_client, _event_collector) -> None:
-    """End Werewolf by killing all but one player (verified kills).
-
-    Werewolf roles are randomly assigned, so we can't target specific roles.
-    Killing all but one guarantees one team is fully eliminated.
-    """
-    await end_werewolf_game(mock_client, serials, delay=0.3, game_client=game_client)
-
-
-async def end_tournament(mock_client, serials: list[str], _game_client, _event_collector) -> None:
-    """End Tournament by running through bracket.
-
-    CI default: invincibility=2.0s.
-    """
-    await end_tournament_game(
-        mock_client, serials, delay=0.2, invincibility_wait=2.5  # 2.0s CI default + buffer
-    )
-
-
-async def end_fight_club(mock_client, serials: list[str], game_client, _event_collector) -> None:
-    """End FightClub by running minimum rounds until winner.
-
-    CI defaults: invincibility=2.0s, fight_club_min_rounds=5.
-    Round timing: 1.0s inter-round pause + 2.0s invincibility + 0.5s buffer = 3.5s.
-    """
-    await end_fight_club_game(
-        mock_client,
-        serials,
-        game_client,
-        delay=0.2,
-        round_wait=3.5,  # 1.0s pause + 2.0s invincibility + 0.5s buffer
-        rounds=FIGHT_CLUB_ROUNDS,
-    )
-
-
 async def end_with_force(_mock_client, _serials: list[str], game_client, event_collector) -> None:
     """End game via ForceEndGame RPC."""
     await asyncio.sleep(2.0)  # Let game run briefly
@@ -137,23 +84,23 @@ async def end_with_force(_mock_client, _serials: list[str], game_client, event_c
 # Game mode configurations - single list with callable end strategies
 # =============================================================================
 
-# All game modes with their end strategies and timeouts
+# Thin sequential menu-flow set (#826): only 2 representative modes run through
+# the full menu flow here, because menu ready-up, mode selection, and
+# lobby-color *restore* are single-lobby menu behavior that cannot parallelize.
+# JoustFFA (per-elimination FFA) and JoustTeams (team win) are kept as the
+# representatives. Per-mode game-logic coverage for ALL OTHER modes
+# (JoustRandomTeams, Swapper, Zombies, Werewolf, Tournament, FightClub, NonStop,
+# Traitor) moved to headless parallel batches in test_parallel_lifecycle.py.
+#
+# Note: FightClub's menu-start flake (#757) is deliberately dodged by moving it
+# to the headless set — it no longer runs through the flaky menu start here.
+#
 # Format: (game_mode, min_players, end_strategy_fn, timeout_seconds)
 ALL_GAME_MODES = [
     # FFA games - kill until one remains
     pytest.param("JoustFFA", 2, end_ffa_game, 15, id="JoustFFA"),
     # Team games - eliminate one team
     pytest.param("JoustTeams", 3, end_team_game, 15, id="JoustTeams"),
-    pytest.param("JoustRandomTeams", 3, end_team_game, 15, id="JoustRandomTeams"),
-    # Complex game modes
-    pytest.param("Swapper", 4, end_swapper, 15, id="Swapper"),
-    pytest.param("Zombies", 4, end_zombies, 15, id="Zombies"),
-    pytest.param("Werewolf", 4, end_werewolf, 20, id="Werewolf"),
-    pytest.param("Tournament", 4, end_tournament, 30, id="Tournament"),
-    pytest.param("FightClub", 4, end_fight_club, 30, id="FightClub"),
-    pytest.param("NonStop", 2, end_with_force, 15, id="NonStop"),
-    pytest.param("Traitor", 4, end_with_force, 15, id="Traitor"),
-    # Note: Ninja, Commander not implemented in GameFactory
 ]
 
 
@@ -167,17 +114,17 @@ ALL_GAME_MODES = [
 async def test_full_game_lifecycle(
     docker_compose, game_mode: str, _min_players: int, end_strategy: EndStrategy, game_timeout: int
 ):
-    """Test full game lifecycle for all game modes.
+    """Test the full menu-driven lifecycle for the representative modes.
 
-    Each game mode has its own end strategy:
+    This is the thin SEQUENTIAL menu-flow set (#826): only JoustFFA and
+    JoustTeams run here, exercising the single-lobby menu behavior that cannot
+    parallelize (ready-up, mode selection, lobby-color restore). Per-mode game
+    logic for every other mode runs headless and in parallel in
+    test_parallel_lifecycle.py.
+
+    Each mode has its own end strategy:
     - FFA games: Kill until one player remains
     - Team games: Eliminate one team
-    - Swapper: Swap all players to one team
-    - Zombies: Convert all humans to zombies
-    - Werewolf: Kill all but one (roles are random, guarantees one team eliminated)
-    - Tournament: Run bracket matches (invincibility=2.0s CI default)
-    - FightClub: Run 6 rounds (min_rounds=5, invincibility=2.0s CI defaults)
-    - NonStop/Traitor: Force-end (no natural end in tests)
 
     Verifies:
     1. Game starts via Menu flow

--- a/tests/integration/test_parallel_lifecycle.py
+++ b/tests/integration/test_parallel_lifecycle.py
@@ -41,7 +41,6 @@ import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
 
-from proto import game_coordinator_pb2
 from tests.integration.helpers import (
     build_start_config,
     end_fight_club_game,
@@ -54,7 +53,6 @@ from tests.integration.helpers import (
     get_mock_client,
     kill_players_for_team_win,
     kill_players_until_one_remains,
-    list_games,
     setup_mock_controllers,
     start_game_headless,
     verify_controllers_have_color,
@@ -178,35 +176,6 @@ _BATCHES = [
 
 _TERMINAL_EVENTS = ["game_ended", "game_force_ended", "game_error"]
 
-_LIVE_STATES = (
-    game_coordinator_pb2.GameState.STARTING,
-    game_coordinator_pb2.GameState.RUNNING,
-)
-
-
-async def _quiesce_coordinator(game_client, timeout: float = 15.0) -> None:
-    """Wait until the coordinator has no live sessions, force-ending leftovers.
-
-    A previous test's game can linger in STARTING/RUNNING (the lazy natural-end
-    sweep only retires ENDED sessions), eating one of the cap's 4 slots so a
-    batch start gets rejected with "Game already in progress" (seen in CI on
-    the first run of this file).
-    """
-    loop = asyncio.get_running_loop()
-    deadline = loop.time() + timeout
-    while True:
-        live = [g for g in await list_games(game_client) if g.state in _LIVE_STATES]
-        if not live:
-            return
-        for game in live:
-            await force_end_game_by_id(game_client, game.game_id, reason="parallel_quiesce")
-        if loop.time() > deadline:
-            raise AssertionError(
-                f"Coordinator did not quiesce within {timeout}s: "
-                f"{[(g.game_id, g.state) for g in live]}"
-            )
-        await asyncio.sleep(0.5)
-
 
 async def _start_headless_with_retry(
     game_client, start_config, attempts: int = 4, backoff: float = 2.0
@@ -316,13 +285,8 @@ async def test_parallel_mode_lifecycle(docker_compose, headless_cleanup, modes):
     """
     specs = [_SPECS[m] for m in modes]
 
-    # A leftover live session from a previous test would eat one of the cap's
-    # slots and reject a batch start; quiesce the coordinator first.
-    game_client, game_channel = await get_game_client(docker_compose)
-    try:
-        await _quiesce_coordinator(game_client)
-    finally:
-        await game_channel.close()
+    # Coordinator idleness (no leftover live sessions eating cap slots) is
+    # enforced by the autouse ``coordinator_idle`` fixture in conftest.
 
     # Register tags up front so the fixture sweeps reserved controllers even if a
     # coroutine dies before its own finally-block cleanup runs.

--- a/tests/integration/test_parallel_lifecycle.py
+++ b/tests/integration/test_parallel_lifecycle.py
@@ -143,13 +143,17 @@ class ModeSpec:
     players: int
     end: EndStrategy
     timeout: int  # seconds to await the terminal event after the end strategy
+    pre_end_delay: float = 0.0  # wait before the end strategy (e.g. formation phase)
 
 
 # Per-mode specs. JoustFFA + JoustTeams stay in the sequential menu-flow set
 # (test_full_game_lifecycle) to keep menu ready-up / lobby-restore coverage, so
 # they are intentionally absent here.
 _SPECS = {
-    "JoustRandomTeams": ModeSpec("JoustRandomTeams", 4, end_team, 15),
+    # RandomTeams runs a 5s team-formation phase (TEAM_FORMATION_DURATION in
+    # random_teams.py) before the game proper — kills during it are swallowed,
+    # so wait it out before driving the win condition (caught in CI).
+    "JoustRandomTeams": ModeSpec("JoustRandomTeams", 4, end_team, 20, pre_end_delay=6.5),
     "Swapper": ModeSpec("Swapper", 4, end_swapper, 15),
     "Zombies": ModeSpec("Zombies", 4, end_zombies, 15),
     "NonStop": ModeSpec("NonStop", 2, end_force, 15),
@@ -249,7 +253,10 @@ async def _run_mode_headless(docker_compose, spec: ModeSpec, tag: str) -> None:
         # GetColor); polled, since parallel load can delay the feedback stream.
         await _wait_for_game_colors(mock_client, serials)
 
-        # Drive the mode's win condition on THIS game only.
+        # Drive the mode's win condition on THIS game only (after any
+        # mode-specific warm-up phase, e.g. RandomTeams team formation).
+        if spec.pre_end_delay:
+            await asyncio.sleep(spec.pre_end_delay)
         await spec.end(mock_client, serials, game_client, game_id)
 
         # The mode's terminal event must arrive for this game_id. (Force-end

--- a/tests/integration/test_parallel_lifecycle.py
+++ b/tests/integration/test_parallel_lifecycle.py
@@ -41,6 +41,7 @@ import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
 
+from proto import game_coordinator_pb2
 from tests.integration.helpers import (
     build_start_config,
     end_fight_club_game,
@@ -53,6 +54,7 @@ from tests.integration.helpers import (
     get_mock_client,
     kill_players_for_team_win,
     kill_players_until_one_remains,
+    list_games,
     setup_mock_controllers,
     start_game_headless,
     verify_controllers_have_color,
@@ -176,6 +178,76 @@ _BATCHES = [
 
 _TERMINAL_EVENTS = ["game_ended", "game_force_ended", "game_error"]
 
+_LIVE_STATES = (
+    game_coordinator_pb2.GameState.STARTING,
+    game_coordinator_pb2.GameState.RUNNING,
+)
+
+
+async def _quiesce_coordinator(game_client, timeout: float = 15.0) -> None:
+    """Wait until the coordinator has no live sessions, force-ending leftovers.
+
+    A previous test's game can linger in STARTING/RUNNING (the lazy natural-end
+    sweep only retires ENDED sessions), eating one of the cap's 4 slots so a
+    batch start gets rejected with "Game already in progress" (seen in CI on
+    the first run of this file).
+    """
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while True:
+        live = [g for g in await list_games(game_client) if g.state in _LIVE_STATES]
+        if not live:
+            return
+        for game in live:
+            await force_end_game_by_id(game_client, game.game_id, reason="parallel_quiesce")
+        if loop.time() > deadline:
+            raise AssertionError(
+                f"Coordinator did not quiesce within {timeout}s: "
+                f"{[(g.game_id, g.state) for g in live]}"
+            )
+        await asyncio.sleep(0.5)
+
+
+async def _start_headless_with_retry(
+    game_client, start_config, attempts: int = 4, backoff: float = 2.0
+):
+    """Start headless, retrying brief "Game already in progress" windows.
+
+    Within a batch, a sibling's force-ended game may still be in its ENDING
+    window when this start hits the cap check; the lazy sweep frees the slot
+    moments later, so a short retry is correct (and a persistent rejection
+    still fails after ``attempts``).
+    """
+    last_exc: Exception | None = None
+    for _ in range(attempts):
+        try:
+            return await start_game_headless(game_client, start_config, timeout=25.0)
+        except Exception as exc:
+            if "Game already in progress" not in str(exc):
+                raise
+            last_exc = exc
+            await asyncio.sleep(backoff)
+    raise last_exc
+
+
+async def _wait_for_game_colors(mock_client, serials: list[str], timeout: float = 10.0) -> None:
+    """Poll until every controller shows a non-zero LED.
+
+    Under 4-way parallel load the feedback stream can lag (and modes with a
+    team-formation phase set colors late); the previous one-shot check after a
+    fixed 0.5s sleep was flaky in CI.
+    """
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while True:
+        try:
+            await verify_controllers_have_color(mock_client, serials)
+            return
+        except AssertionError:
+            if loop.time() > deadline:
+                raise
+            await asyncio.sleep(0.5)
+
 
 async def _run_mode_headless(docker_compose, spec: ModeSpec, tag: str) -> None:
     """Run one mode end-to-end as a headless shadow game.
@@ -198,14 +270,15 @@ async def _run_mode_headless(docker_compose, spec: ModeSpec, tag: str) -> None:
         )
 
         # Start headless: bypasses the lobby; returns the coordinator-assigned
-        # game_id plus a collector already filtered to that session.
-        game_id, collector = await start_game_headless(
-            game_client, build_start_config(spec.mode, serials), timeout=25.0
+        # game_id plus a collector already filtered to that session. Retries
+        # transient cap rejections (sibling games in their ENDING window).
+        game_id, collector = await _start_headless_with_retry(
+            game_client, build_start_config(spec.mode, serials)
         )
 
-        # Controllers must get game colors (non-zero LED, per serial via GetColor).
-        await asyncio.sleep(0.5)
-        await verify_controllers_have_color(mock_client, serials)
+        # Controllers must get game colors (non-zero LED, per serial via
+        # GetColor); polled, since parallel load can delay the feedback stream.
+        await _wait_for_game_colors(mock_client, serials)
 
         # Drive the mode's win condition on THIS game only.
         await spec.end(mock_client, serials, game_client, game_id)
@@ -242,6 +315,14 @@ async def test_parallel_mode_lifecycle(docker_compose, headless_cleanup, modes):
     together, each tagged with its mode name.
     """
     specs = [_SPECS[m] for m in modes]
+
+    # A leftover live session from a previous test would eat one of the cap's
+    # slots and reject a batch start; quiesce the coordinator first.
+    game_client, game_channel = await get_game_client(docker_compose)
+    try:
+        await _quiesce_coordinator(game_client)
+    finally:
+        await game_channel.close()
 
     # Register tags up front so the fixture sweeps reserved controllers even if a
     # coroutine dies before its own finally-block cleanup runs.

--- a/tests/integration/test_parallel_lifecycle.py
+++ b/tests/integration/test_parallel_lifecycle.py
@@ -1,0 +1,265 @@
+"""
+Parallel per-mode lifecycle coverage via headless shadow games (#826).
+
+Follow-up to #779 / part of #774 (M6). The 14 per-mode lifecycle tests used to
+run strictly sequentially through the menu (``test_full_game_lifecycle``). Now
+that the coordinator supports concurrent games (#775/#776) and reserved mock
+controllers are invisible to the menu (#777), the per-mode *game logic* coverage
+moves here: each mode runs as a headless shadow game, and modes run in batches
+of up to 4 concurrently via ``asyncio.gather`` on the one shared compose stack.
+
+What this file covers (per mode, headless):
+- Controllers receive game colors (non-zero LED via GetColor per serial).
+- The mode-specific end strategy drives the win condition (reusing the
+  game_id-aware ``end_*`` helpers from helpers.py).
+- The mode's terminal event (``game_ended``/``game_force_ended``) arrives on the
+  collector bound to THAT game_id.
+
+What this file deliberately does NOT cover (still in test_full_game_lifecycle):
+- Menu ready-up, mode selection, and lobby-color *restore* — those are menu
+  behavior on the single shared lobby and cannot parallelize. A thin sequential
+  menu-flow set (JoustFFA + JoustTeams) keeps verifying them.
+
+Why ``asyncio.gather`` and NOT pytest-xdist: the ``docker_compose`` fixture is
+session-scoped, but each xdist worker gets its own session -> one compose stack
+per worker. In-process async batches share the single stack and multiplex over
+the already-concurrent data plane (§2.3 of the shadow-games research).
+
+Why reserved controllers are mandatory: the menu service writes lobby LEDs to
+every controller it can see; unreserved parallel games would race the LED
+assertions. Each mode gets its own reserved/tagged controller set.
+"""
+
+import asyncio
+import os
+import sys
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+
+from tests.integration.helpers import (
+    build_start_config,
+    end_fight_club_game,
+    end_swapper_game,
+    end_tournament_game,
+    end_werewolf_game,
+    end_zombies_game,
+    force_end_game_by_id,
+    get_game_client,
+    get_mock_client,
+    kill_players_for_team_win,
+    kill_players_until_one_remains,
+    setup_mock_controllers,
+    start_game_headless,
+    verify_controllers_have_color,
+)
+
+# =============================================================================
+# End strategies (game_id-aware)
+# =============================================================================
+# Each strategy ends a single headless game identified by game_id, using only
+# that game's reserved controller serials. Signature:
+#   async def(mock_client, serials, game_client, game_id) -> None
+
+EndStrategy = Callable[[Any, list[str], Any, str], Any]
+
+
+async def end_ffa(mock_client, serials, game_client, game_id) -> None:
+    """FFA / Random-teams via per-elimination: kill until one remains."""
+    await kill_players_until_one_remains(
+        mock_client, serials, delay=0.1, game_client=game_client, game_id=game_id
+    )
+
+
+async def end_team(mock_client, serials, game_client, game_id) -> None:
+    """Team game: eliminate one whole team."""
+    await kill_players_for_team_win(
+        mock_client, serials, delay=0.1, game_client=game_client, game_id=game_id
+    )
+
+
+async def end_swapper(mock_client, serials, game_client, game_id) -> None:
+    """Swapper: converge all players onto one team."""
+    await end_swapper_game(
+        mock_client, serials, game_client, delay=0.3, game_id=game_id
+    )
+
+
+async def end_zombies(mock_client, serials, game_client, game_id) -> None:
+    """Zombies: convert all humans."""
+    await end_zombies_game(
+        mock_client, serials, delay=0.3, game_client=game_client, game_id=game_id
+    )
+
+
+async def end_werewolf(mock_client, serials, game_client, game_id) -> None:
+    """Werewolf: kill all but one (roles random; guarantees a team wipe)."""
+    await end_werewolf_game(
+        mock_client, serials, delay=0.3, game_client=game_client, game_id=game_id
+    )
+
+
+async def end_tournament(mock_client, serials, game_client, game_id) -> None:
+    """Tournament: run the bracket. CI invincibility=2.0s (set in start config)."""
+    # Pure SimulateDeath-driven (no per-game state query needed): game_id-agnostic.
+    await end_tournament_game(
+        mock_client, serials, delay=0.2, invincibility_wait=2.5
+    )
+
+
+async def end_fight_club(mock_client, serials, game_client, game_id) -> None:
+    """FightClub: run minimum rounds to a winner. CI: invincibility=2.0s, min_rounds=5."""
+    # Pure SimulateDeath-driven (queued players ignored): game_id-agnostic.
+    await end_fight_club_game(
+        mock_client,
+        serials,
+        game_client,
+        delay=0.2,
+        round_wait=3.5,  # 1.0s inter-round pause + 2.0s invincibility + 0.5 buffer
+        rounds=6,  # CI min_rounds=5 + 1 to ensure a clear winner
+    )
+
+
+async def end_force(mock_client, serials, game_client, game_id) -> None:
+    """Modes with no natural end in tests (NonStop, Traitor): force-end by id."""
+    await asyncio.sleep(2.0)  # let the game run briefly
+    await force_end_game_by_id(game_client, game_id, reason="parallel_lifecycle_end")
+
+
+# =============================================================================
+# Per-mode spec + duration-grouped batches
+# =============================================================================
+
+
+@dataclass(frozen=True)
+class ModeSpec:
+    """One game mode's headless lifecycle parameters."""
+
+    mode: str
+    players: int
+    end: EndStrategy
+    timeout: int  # seconds to await the terminal event after the end strategy
+
+
+# Per-mode specs. JoustFFA + JoustTeams stay in the sequential menu-flow set
+# (test_full_game_lifecycle) to keep menu ready-up / lobby-restore coverage, so
+# they are intentionally absent here.
+_SPECS = {
+    "JoustRandomTeams": ModeSpec("JoustRandomTeams", 4, end_team, 15),
+    "Swapper": ModeSpec("Swapper", 4, end_swapper, 15),
+    "Zombies": ModeSpec("Zombies", 4, end_zombies, 15),
+    "NonStop": ModeSpec("NonStop", 2, end_force, 15),
+    "Traitor": ModeSpec("Traitor", 4, end_force, 15),
+    "Werewolf": ModeSpec("Werewolf", 4, end_werewolf, 20),
+    "Tournament": ModeSpec("Tournament", 4, end_tournament, 30),
+    "FightClub": ModeSpec("FightClub", 4, end_fight_club, 30),
+}
+
+# Duration-grouped batches (size <= GAME_MAX_CONCURRENT_GAMES=4). Wall time of a
+# batch == the slowest mode in it, so the slow modes (Tournament, FightClub,
+# Werewolf) are pooled into ONE batch rather than each anchoring a separate one.
+# A fast mode (Zombies) fills the 4th slot of the slow batch for free.
+_BATCHES = [
+    pytest.param(
+        ["Tournament", "FightClub", "Werewolf", "Zombies"],
+        id="slow-batch",
+    ),
+    pytest.param(
+        ["JoustRandomTeams", "Swapper", "NonStop", "Traitor"],
+        id="fast-batch",
+    ),
+]
+
+_TERMINAL_EVENTS = ["game_ended", "game_force_ended", "game_error"]
+
+
+async def _run_mode_headless(docker_compose, spec: ModeSpec, tag: str) -> None:
+    """Run one mode end-to-end as a headless shadow game.
+
+    Reserves its own controller set (distinct tag), starts headless, verifies
+    game colors, runs the mode's end strategy, and awaits the terminal event on
+    the collector bound to this game's game_id. Cleans up its game + reserved
+    controllers even on failure. Raises with the mode name on any failure so a
+    gathered batch surfaces exactly which mode broke.
+    """
+    from tests.integration.helpers import remove_reserved_controllers
+
+    mock_client, mock_channel = await get_mock_client(docker_compose)
+    game_client, game_channel = await get_game_client(docker_compose)
+    collector = None
+    game_id = ""
+    try:
+        serials = await setup_mock_controllers(
+            docker_compose, count=spec.players, reserved=True, tag=tag
+        )
+
+        # Start headless: bypasses the lobby; returns the coordinator-assigned
+        # game_id plus a collector already filtered to that session.
+        game_id, collector = await start_game_headless(
+            game_client, build_start_config(spec.mode, serials), timeout=25.0
+        )
+
+        # Controllers must get game colors (non-zero LED, per serial via GetColor).
+        await asyncio.sleep(0.5)
+        await verify_controllers_have_color(mock_client, serials)
+
+        # Drive the mode's win condition on THIS game only.
+        await spec.end(mock_client, serials, game_client, game_id)
+
+        # The mode's terminal event must arrive for this game_id. (Force-end
+        # strategies already triggered it; awaiting it is still correct.)
+        await collector.wait_for_any_event(_TERMINAL_EVENTS, timeout=spec.timeout)
+    except Exception as exc:  # noqa: BLE001 - re-raise tagged with the mode name
+        raise AssertionError(f"[{spec.mode}] headless lifecycle failed: {exc}") from exc
+    finally:
+        if collector is not None:
+            await collector.stop()
+        if game_id:
+            await force_end_game_by_id(game_client, game_id, reason="parallel_cleanup")
+        await remove_reserved_controllers(docker_compose, tag)
+        await mock_channel.close()
+        await game_channel.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("modes", _BATCHES)
+async def test_parallel_mode_lifecycle(docker_compose, headless_cleanup, modes):
+    """Run a duration-grouped batch of game modes concurrently, headless.
+
+    Each mode in the batch:
+    1. reserves its own tagged controller set (distinct serials per mode),
+    2. starts a headless game (its own game_id),
+    3. verifies controllers got game colors,
+    4. runs the mode-specific end strategy (game_id-aware),
+    5. awaits its terminal event on the collector bound to that game_id.
+
+    The batch runs all modes via ``asyncio.gather(..., return_exceptions=True)``
+    so a single mode's failure doesn't mask the others; failures are re-raised
+    together, each tagged with its mode name.
+    """
+    specs = [_SPECS[m] for m in modes]
+
+    # Register tags up front so the fixture sweeps reserved controllers even if a
+    # coroutine dies before its own finally-block cleanup runs.
+    tags = []
+    for spec in specs:
+        tag = f"parallel-{spec.mode.lower()}"
+        headless_cleanup.add_tag(tag)
+        tags.append(tag)
+
+    results = await asyncio.gather(
+        *(
+            _run_mode_headless(docker_compose, spec, tag)
+            for spec, tag in zip(specs, tags)
+        ),
+        return_exceptions=True,
+    )
+
+    failures = [r for r in results if isinstance(r, BaseException)]
+    if failures:
+        messages = "; ".join(str(f) for f in failures)
+        raise AssertionError(f"{len(failures)}/{len(specs)} modes failed: {messages}")


### PR DESCRIPTION
## Summary

Implements #826 (M6 follow-up, serves #770): per-mode game-logic coverage moves off the sequential menu flow into **headless shadow games running 4 at a time** via `asyncio.gather` on the single shared compose stack.

### Design (per the issue)
- **Duration-grouped batches**: slow modes (Tournament, FightClub, Werewolf) pooled into one batch with Zombies filling the 4th slot; fast modes in the other. Wall time per batch = its slowest mode, so 12 sequential mode-runs become 2 batch-runs.
- **Reserved controllers per mode** (distinct tags) — mandatory, since the menu writes lobby LEDs to any controller it can see.
- **`asyncio.gather`, NOT pytest-xdist**: the `docker_compose` fixture is session-scoped; xdist workers would each boot their own stack.
- **Thin menu-flow set retained**: `test_full_game_lifecycle` keeps JoustFFA + JoustTeams for menu ready-up / lobby-color-restore coverage (single-lobby, inherently sequential). FightClub leaves the menu-start path entirely — which should also sidestep the #757 menu-start flake.
- Failures surface per mode: `gather(return_exceptions=True)` + mode-tagged re-raise, double cleanup (per-coroutine `finally` + `headless_cleanup` tag sweep).

### Timing
Local before/after timing was not completed (the implementing agent stalled on the baseline run; see below). The honest comparison is CI's Integration Tests job: **baseline 9m50s** on #827's run — compare against this PR's job time.

### Note on provenance
The implementation was committed by a background agent that then stalled for ~4h waiting on a background baseline-suite run that never started. The code was reviewed, rebased onto current main (clean, including #824), and linted; the integration suite run on this PR's CI is the primary verification. If CI shows mode failures under 4-way parallelism, that itself is valuable signal (product race vs test design) — do not merge until Integration Tests is green.

Stacked-on-#827 originally; rebased onto main after #827 merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)