### PR TITLE
docs: mark five interventions as LLM-path-only (#800)

### DIFF
--- a/services/agent/README.md
+++ b/services/agent/README.md
@@ -385,6 +385,16 @@ per second. The weighted per-minute budget is enforced downstream by the loop
 | R8 | chaos | movement variance ≈ 0 ("statue") — dormant until producers ship the variance metric | `send_controller_effect` |
 | R9 | chaos | periodic random nudge (injectable rng) | `send_controller_effect` |
 
+**LLM-only interventions (#800).** Five intervention types are fully plumbed
+(flag schema, action-sink mapping, game-side handlers, weight table) but are
+**deliberately not emitted by any rule**: `adjust_volume`, `revive_player`,
+`adjust_global_sensitivity`, `adjust_global_difficulty`, and
+`set_pacing_profile`. They require judgment the deterministic ruleset cannot
+encode (who deserves a revive; when reshaping the whole session's difficulty
+or pacing is socially right) and are reserved for the M4 LLM path. They remain
+reachable today via the permission layer for manual/operator dispatch — they
+are intentionally unreached by `rules_decide`, not dead code.
+
 **Policy constraints** (`policy.*` flags):
 
 - `battery_threshold` (20): players below it lose controller effects and

--- a/services/agent/decision/ruleset.go
+++ b/services/agent/decision/ruleset.go
@@ -7,6 +7,14 @@ import (
 	"github.com/joustmania/agent/gamecontext"
 )
 
+// LLM-only interventions (#800): adjust_volume, revive_player,
+// adjust_global_sensitivity, adjust_global_difficulty, and set_pacing_profile
+// are deliberately NOT emitted by any rule in this set. They need judgment a
+// deterministic ruleset cannot encode (who deserves a revive; when reshaping
+// session-wide difficulty/pacing is socially right) and are reserved for the
+// M4 LLM path. Adding a rule for one of them is a product decision, not an
+// oversight fix — see services/agent/README.md "LLM-only interventions".
+//
 // candidate is a potential decision produced by a rule, before objective
 // weighting, policy filtering, and budget admission.
 type candidate struct {


### PR DESCRIPTION
Closes #800.

Per the decision on #800: the five fully-plumbed-but-unreached intervention types (`adjust_volume`, `revive_player`, `adjust_global_sensitivity`, `adjust_global_difficulty`, `set_pacing_profile`) are **LLM-path-only by design** — they require judgment the deterministic ruleset cannot encode and are reserved for M4.

- `services/agent/README.md`: "LLM-only interventions" note in the rules-engine section (incl. the F6 levers, which the audit confirmed are also unreached by rules)
- `services/agent/decision/ruleset.go`: comment at the candidate definition so adding a rule for one of these reads as a product decision, not an oversight fix

Docs/comments only — no behavior change. `gofmt`/`go vet`/`go build` and `make lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)