### PR TITLE
chore: coordinated flagd + openfeature provider upgrade (#843)

### DIFF
--- a/docker-compose.lite.yml
+++ b/docker-compose.lite.yml
@@ -29,7 +29,7 @@ services:
 
   # flagd for feature flag evaluation
   flagd:
-    image: ghcr.io/open-feature/flagd:v0.13.2
+    image: ghcr.io/open-feature/flagd:v0.16.0
     container_name: joustmania-flagd
     command:
       - "start"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,7 +61,7 @@ services:
 
   # flagd for feature flag evaluation
   flagd:
-    image: ghcr.io/open-feature/flagd:v0.13.2
+    image: ghcr.io/open-feature/flagd:v0.16.0
     container_name: joustmania-flagd
     command:
       - "start"

--- a/lib/pyproject.toml
+++ b/lib/pyproject.toml
@@ -26,8 +26,8 @@ dependencies = [
     "pyroscope-io>=0.8.16",
 
     # Feature Flags
-    "openfeature-sdk>=0.6.0",
-    "openfeature-provider-flagd>=0.2.7",
+    "openfeature-sdk>=0.8.4",
+    "openfeature-provider-flagd>=0.5.0",
     "openfeature-hooks-opentelemetry>=0.1.0",
 ]
 

--- a/proto/pyproject.toml
+++ b/proto/pyproject.toml
@@ -6,7 +6,9 @@ requires-python = ">=3.11"
 dependencies = [
     "grpcio>=1.70.0",
     "grpcio-tools>=1.70.0",
-    "protobuf>=5.29.0",
+    # >=6.33.5: openfeature-provider-flagd 0.5.0 ships proto gencode built with
+    # protobuf 6.33.5; an older runtime fails the gencode/runtime guarantee (#843).
+    "protobuf>=6.33.5",
 ]
 
 [build-system]

--- a/services/controller_manager/pyproject.toml
+++ b/services/controller_manager/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "psutil>=5.9.0",
 
     # Feature Flags (OpenFeature SDK for flag evaluation; provider comes via joustmania-lib)
-    "openfeature-sdk>=0.6.0",
+    "openfeature-sdk>=0.8.4",
 
     # Performance: uvloop for faster event loop (Linux only)
     "uvloop>=0.19.0; sys_platform == 'linux'",

--- a/tests/integration/pyproject.toml
+++ b/tests/integration/pyproject.toml
@@ -20,8 +20,8 @@ dependencies = [
 
     # OpenFeature flagd client — evaluate intervention targeting rules directly
     # against live flagd RPC (test_intervention_flow.py, #730).
-    "openfeature-sdk>=0.6.0",
-    "openfeature-provider-flagd>=0.2.7",
+    "openfeature-sdk>=0.8.4",
+    "openfeature-provider-flagd>=0.5.0",
 ]
 
 [tool.uv.sources]

--- a/uv.lock
+++ b/uv.lock
@@ -253,33 +253,33 @@ wheels = [
 
 [[package]]
 name = "grpcio"
-version = "1.76.0"
+version = "1.81.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b6/e0/318c1ce3ae5a17894d5791e87aea147587c9e702f24122cc7a5c8bbaeeb1/grpcio-1.76.0.tar.gz", hash = "sha256:7be78388d6da1a25c0d5ec506523db58b18be22d9c37d8d3a32c08be4987bd73", size = 12785182, upload-time = "2025-10-21T16:23:12.106Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/15/f3/23f47b24f8d8c2028eba501db3acfbb2f592cbb5995eaa6e363a627b74d7/grpcio-1.81.0.tar.gz", hash = "sha256:a5acd7efd3b1fe9b4eb0bcaaa1507eed68a0ad0678b654c3f7b464df9ba9dca5", size = 13032272, upload-time = "2026-06-01T05:56:22.827Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/00/8163a1beeb6971f66b4bbe6ac9457b97948beba8dd2fc8e1281dce7f79ec/grpcio-1.76.0-cp311-cp311-linux_armv7l.whl", hash = "sha256:2e1743fbd7f5fa713a1b0a8ac8ebabf0ec980b5d8809ec358d488e273b9cf02a", size = 5843567, upload-time = "2025-10-21T16:20:52.829Z" },
-    { url = "https://files.pythonhosted.org/packages/10/c1/934202f5cf335e6d852530ce14ddb0fef21be612ba9ecbbcbd4d748ca32d/grpcio-1.76.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:a8c2cf1209497cf659a667d7dea88985e834c24b7c3b605e6254cbb5076d985c", size = 11848017, upload-time = "2025-10-21T16:20:56.705Z" },
-    { url = "https://files.pythonhosted.org/packages/11/0b/8dec16b1863d74af6eb3543928600ec2195af49ca58b16334972f6775663/grpcio-1.76.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:08caea849a9d3c71a542827d6df9d5a69067b0a1efbea8a855633ff5d9571465", size = 6412027, upload-time = "2025-10-21T16:20:59.3Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/64/7b9e6e7ab910bea9d46f2c090380bab274a0b91fb0a2fe9b0cd399fffa12/grpcio-1.76.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:f0e34c2079d47ae9f6188211db9e777c619a21d4faba6977774e8fa43b085e48", size = 7075913, upload-time = "2025-10-21T16:21:01.645Z" },
-    { url = "https://files.pythonhosted.org/packages/68/86/093c46e9546073cefa789bd76d44c5cb2abc824ca62af0c18be590ff13ba/grpcio-1.76.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8843114c0cfce61b40ad48df65abcfc00d4dba82eae8718fab5352390848c5da", size = 6615417, upload-time = "2025-10-21T16:21:03.844Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/b6/5709a3a68500a9c03da6fb71740dcdd5ef245e39266461a03f31a57036d8/grpcio-1.76.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8eddfb4d203a237da6f3cc8a540dad0517d274b5a1e9e636fd8d2c79b5c1d397", size = 7199683, upload-time = "2025-10-21T16:21:06.195Z" },
-    { url = "https://files.pythonhosted.org/packages/91/d3/4b1f2bf16ed52ce0b508161df3a2d186e4935379a159a834cb4a7d687429/grpcio-1.76.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:32483fe2aab2c3794101c2a159070584e5db11d0aa091b2c0ea9c4fc43d0d749", size = 8163109, upload-time = "2025-10-21T16:21:08.498Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/61/d9043f95f5f4cf085ac5dd6137b469d41befb04bd80280952ffa2a4c3f12/grpcio-1.76.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:dcfe41187da8992c5f40aa8c5ec086fa3672834d2be57a32384c08d5a05b4c00", size = 7626676, upload-time = "2025-10-21T16:21:10.693Z" },
-    { url = "https://files.pythonhosted.org/packages/36/95/fd9a5152ca02d8881e4dd419cdd790e11805979f499a2e5b96488b85cf27/grpcio-1.76.0-cp311-cp311-win32.whl", hash = "sha256:2107b0c024d1b35f4083f11245c0e23846ae64d02f40b2b226684840260ed054", size = 3997688, upload-time = "2025-10-21T16:21:12.746Z" },
-    { url = "https://files.pythonhosted.org/packages/60/9c/5c359c8d4c9176cfa3c61ecd4efe5affe1f38d9bae81e81ac7186b4c9cc8/grpcio-1.76.0-cp311-cp311-win_amd64.whl", hash = "sha256:522175aba7af9113c48ec10cc471b9b9bd4f6ceb36aeb4544a8e2c80ed9d252d", size = 4709315, upload-time = "2025-10-21T16:21:15.26Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/05/8e29121994b8d959ffa0afd28996d452f291b48cfc0875619de0bde2c50c/grpcio-1.76.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:81fd9652b37b36f16138611c7e884eb82e0cec137c40d3ef7c3f9b3ed00f6ed8", size = 5799718, upload-time = "2025-10-21T16:21:17.939Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/75/11d0e66b3cdf998c996489581bdad8900db79ebd83513e45c19548f1cba4/grpcio-1.76.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:04bbe1bfe3a68bbfd4e52402ab7d4eb59d72d02647ae2042204326cf4bbad280", size = 11825627, upload-time = "2025-10-21T16:21:20.466Z" },
-    { url = "https://files.pythonhosted.org/packages/28/50/2f0aa0498bc188048f5d9504dcc5c2c24f2eb1a9337cd0fa09a61a2e75f0/grpcio-1.76.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d388087771c837cdb6515539f43b9d4bf0b0f23593a24054ac16f7a960be16f4", size = 6359167, upload-time = "2025-10-21T16:21:23.122Z" },
-    { url = "https://files.pythonhosted.org/packages/66/e5/bbf0bb97d29ede1d59d6588af40018cfc345b17ce979b7b45424628dc8bb/grpcio-1.76.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:9f8f757bebaaea112c00dba718fc0d3260052ce714e25804a03f93f5d1c6cc11", size = 7044267, upload-time = "2025-10-21T16:21:25.995Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/86/f6ec2164f743d9609691115ae8ece098c76b894ebe4f7c94a655c6b03e98/grpcio-1.76.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:980a846182ce88c4f2f7e2c22c56aefd515daeb36149d1c897f83cf57999e0b6", size = 6573963, upload-time = "2025-10-21T16:21:28.631Z" },
-    { url = "https://files.pythonhosted.org/packages/60/bc/8d9d0d8505feccfdf38a766d262c71e73639c165b311c9457208b56d92ae/grpcio-1.76.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f92f88e6c033db65a5ae3d97905c8fea9c725b63e28d5a75cb73b49bda5024d8", size = 7164484, upload-time = "2025-10-21T16:21:30.837Z" },
-    { url = "https://files.pythonhosted.org/packages/67/e6/5d6c2fc10b95edf6df9b8f19cf10a34263b7fd48493936fffd5085521292/grpcio-1.76.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:4baf3cbe2f0be3289eb68ac8ae771156971848bb8aaff60bad42005539431980", size = 8127777, upload-time = "2025-10-21T16:21:33.577Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/c8/dce8ff21c86abe025efe304d9e31fdb0deaaa3b502b6a78141080f206da0/grpcio-1.76.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:615ba64c208aaceb5ec83bfdce7728b80bfeb8be97562944836a7a0a9647d882", size = 7594014, upload-time = "2025-10-21T16:21:41.882Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/42/ad28191ebf983a5d0ecef90bab66baa5a6b18f2bfdef9d0a63b1973d9f75/grpcio-1.76.0-cp312-cp312-win32.whl", hash = "sha256:45d59a649a82df5718fd9527ce775fd66d1af35e6d31abdcdc906a49c6822958", size = 3984750, upload-time = "2025-10-21T16:21:44.006Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/00/7bd478cbb851c04a48baccaa49b75abaa8e4122f7d86da797500cccdd771/grpcio-1.76.0-cp312-cp312-win_amd64.whl", hash = "sha256:c088e7a90b6017307f423efbb9d1ba97a22aa2170876223f9709e9d1de0b5347", size = 4704003, upload-time = "2025-10-21T16:21:46.244Z" },
+    { url = "https://files.pythonhosted.org/packages/45/a8/9916ab10a0201f4c7afb6918125aa2f38a7626ee18ffbc066dd9cb04a74d/grpcio-1.81.0-cp311-cp311-linux_armv7l.whl", hash = "sha256:794e6aa648e8df47d8f908dc8c3b42347d04ec58438f1dcd4e445f09b4f6b0ce", size = 6093557, upload-time = "2026-06-01T05:54:32.64Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/43/99e969a048904a65df3129ee53c5f523b7c4e43127786460cac4bee82470/grpcio-1.81.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:cd78145b7f7784661c524624f3526c9c6f891b30a4b54cb93a40806d0d0d61e9", size = 12075345, upload-time = "2026-06-01T05:54:35.77Z" },
+    { url = "https://files.pythonhosted.org/packages/83/70/4c3a204e190333768d4f63f4ff56bd0bf405f05b9188f3a59a8bcf161f8b/grpcio-1.81.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:638ccc1b86f7540170a169cb900799b9296a1381e47879ce60b0de9d3db73d33", size = 6640664, upload-time = "2026-06-01T05:54:38.854Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/a9/0fa17ac8b4e29cf59b26915be6cab8c0d4583ce24a6208a287b6e5f6d072/grpcio-1.81.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:21ec30b9ea320c8207ea7cd05873ad64aa69fdd0e81b6758b3347983ba20b50a", size = 7332542, upload-time = "2026-06-01T05:54:41.39Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/18/7c8e3d0dda2fb7a17076fcd6c9085209eabad3354696c64230f87b3a14eb/grpcio-1.81.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:dbdb99986548a7e87f8343805ef315fd4eb50ffaabf4fb1206e42f2542bb805d", size = 6842564, upload-time = "2026-06-01T05:54:43.57Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/19/2f1726c2e03ad3f3fe241e6b41534532ad580d595de14a4054ad84999c80/grpcio-1.81.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c36f5d5e97944cbda2d4096b4ae262e6e68506246b61582acf1b8591607f3ccc", size = 7446236, upload-time = "2026-06-01T05:54:46.042Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/dc/0321f892212e2c0bfe248cea24c00d7d7111639688ec5ffd8e36b5c02fe6/grpcio-1.81.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:9f355384e5543ab77a755a7085225ecc19f32b76032e851cbd8145715d79dec8", size = 8445633, upload-time = "2026-06-01T05:54:48.809Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/20/0e7ea7494955cf1beea3077b2fd2c04c84d4480c2ae85a1e1cfa150c62d7/grpcio-1.81.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:77eb4e9fe61486bd1198cc7236ebb0f70e66234e63c0348f40bc2553ed16a88b", size = 7873958, upload-time = "2026-06-01T05:54:52.135Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/9e/6438e226046c2a0778060e2b1d791a4827277bbd9d223013c2c63ee7435e/grpcio-1.81.0-cp311-cp311-win32.whl", hash = "sha256:7915a2e63acdc05264a206e1bddfd8e1fb8a29e406c18d72d30f8c124e021374", size = 4202110, upload-time = "2026-06-01T05:54:54.134Z" },
+    { url = "https://files.pythonhosted.org/packages/42/6b/d0895e93d65b186f5f1737fcc186d7faa487e2d9d934eda111a37a309869/grpcio-1.81.0-cp311-cp311-win_amd64.whl", hash = "sha256:5e925a70fe99fe5794f7beca0ea034c75f068afcc356d79047e73f99cdcca34c", size = 4940942, upload-time = "2026-06-01T05:54:56.749Z" },
+    { url = "https://files.pythonhosted.org/packages/82/d5/896a3aaf07068d707d88b282a04914b872db4d32d3c7e6d88e43a3b911fa/grpcio-1.81.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:57b3b0e73a518fa286959b40c3eddd02703504ca186e8b7b2945954519bd8b2c", size = 6053538, upload-time = "2026-06-01T05:54:58.965Z" },
+    { url = "https://files.pythonhosted.org/packages/68/6a/7e3eafa4727cd405ff917605ed2949e2af162f233f5cbdd773723a5fea7d/grpcio-1.81.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:8bb1789c94322a13336a2b6c58d9c14d68f8628b6e24205a799c69f5bf8516ce", size = 12053447, upload-time = "2026-06-01T05:55:01.862Z" },
+    { url = "https://files.pythonhosted.org/packages/16/79/a4302aa82428de48a922421f522b027a1a727ab4d0926368454aa953d36d/grpcio-1.81.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e4d053900a0d24b75d7521139a3872150301b3d6bde3bed5e12318fb25791e4d", size = 6595872, upload-time = "2026-06-01T05:55:04.946Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/1f/7ff2850eaefbecf99af3f624dbb28dd1ad6c5fd4c1d8c26909ed6482673b/grpcio-1.81.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:db217c2e52931719f9937bd12082cd4d7b495b35803d5760686975c285924bf8", size = 7303857, upload-time = "2026-06-01T05:55:07.205Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/98/1f3896a9baae1f2aedf4e99c55291d6fa1f30ad9603d63bc18bda967b53e/grpcio-1.81.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:19f201da7b4e5c0559198abe5a97157e726f3abe6e8f5e832d4a50740f6dcc22", size = 6809676, upload-time = "2026-06-01T05:55:09.513Z" },
+    { url = "https://files.pythonhosted.org/packages/34/8b/3441983718095208c5d797fd3239882e97ea89a629f41c8df94b4eef4df9/grpcio-1.81.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:275144b0115353339dbb8a6f28a9cf8997b5bf40e37f8f66ac0b0ea57e95b43f", size = 7412654, upload-time = "2026-06-01T05:55:12.777Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/98/1eddf07df6e4fe85cf67502a793f7b05468b2dca3d1ef35b972cf5d54468/grpcio-1.81.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5192857589f223e5a98ff0e31f6e551b19040e647d17bfe10116c8a2ce3b8696", size = 8408026, upload-time = "2026-06-01T05:55:15.514Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/73/3860341e6a1f5347be6ab35c6c0e1e3a8eb59d010388207fd561dcf01a88/grpcio-1.81.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c6ff087cb1f563f47b504b4e29e684129fc5ae4863faf3ebca08a327764ee6cb", size = 7849498, upload-time = "2026-06-01T05:55:18.078Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3f/0ea06bd85c701966aa3f8f37314f2ed83520d2b7590f42d643d445d8bc8b/grpcio-1.81.0-cp312-cp312-win32.whl", hash = "sha256:98c6240f563178fc5877bd50e6ff274463e53e1472128f4110742450739659fa", size = 4184161, upload-time = "2026-06-01T05:55:20.127Z" },
+    { url = "https://files.pythonhosted.org/packages/39/e3/a7c387406827a86f99ad7838b995bf9b4a182ffe2d2c439ed2873efec952/grpcio-1.81.0-cp312-cp312-win_amd64.whl", hash = "sha256:87e33b7afcfb3585121b5f007d2c52b8c534104d18f556e840d35193ca2a9141", size = 4929958, upload-time = "2026-06-01T05:55:22.736Z" },
 ]
 
 [[package]]
@@ -498,7 +498,7 @@ requires-dist = [
     { name = "hidapi", specifier = ">=0.14.0" },
     { name = "joustmania-lib", editable = "lib" },
     { name = "joustmania-proto", editable = "proto" },
-    { name = "openfeature-sdk", specifier = ">=0.6.0" },
+    { name = "openfeature-sdk", specifier = ">=0.8.4" },
     { name = "opentelemetry-distro", specifier = ">=0.49b0" },
     { name = "opentelemetry-exporter-otlp", specifier = ">=1.28.0" },
     { name = "opentelemetry-instrumentation-grpc", specifier = ">=0.49b0" },
@@ -576,8 +576,8 @@ dependencies = [
 requires-dist = [
     { name = "grpcio", specifier = ">=1.50.0" },
     { name = "joustmania-proto", editable = "proto" },
-    { name = "openfeature-provider-flagd", specifier = ">=0.2.7" },
-    { name = "openfeature-sdk", specifier = ">=0.6.0" },
+    { name = "openfeature-provider-flagd", specifier = ">=0.5.0" },
+    { name = "openfeature-sdk", specifier = ">=0.8.4" },
     { name = "pytest", specifier = ">=7.0.0" },
     { name = "pytest-asyncio", specifier = ">=0.23.0" },
     { name = "pytest-cov", specifier = ">=4.0.0" },
@@ -615,8 +615,8 @@ requires-dist = [
     { name = "dbus-fast", marker = "sys_platform == 'linux'", specifier = ">=2.0.0" },
     { name = "grpcio", specifier = ">=1.70.0" },
     { name = "openfeature-hooks-opentelemetry", specifier = ">=0.1.0" },
-    { name = "openfeature-provider-flagd", specifier = ">=0.2.7" },
-    { name = "openfeature-sdk", specifier = ">=0.6.0" },
+    { name = "openfeature-provider-flagd", specifier = ">=0.5.0" },
+    { name = "openfeature-sdk", specifier = ">=0.8.4" },
     { name = "opentelemetry-api", specifier = ">=1.28.0" },
     { name = "opentelemetry-exporter-otlp", specifier = ">=1.28.0" },
     { name = "opentelemetry-instrumentation-grpc", specifier = ">=0.49b0" },
@@ -722,7 +722,7 @@ dependencies = [
 requires-dist = [
     { name = "grpcio", specifier = ">=1.70.0" },
     { name = "grpcio-tools", specifier = ">=1.70.0" },
-    { name = "protobuf", specifier = ">=5.29.0" },
+    { name = "protobuf", specifier = ">=6.33.5" },
 ]
 
 [[package]]
@@ -910,6 +910,34 @@ wheels = [
 ]
 
 [[package]]
+name = "openfeature-flagd-api"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "openfeature-sdk" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/0c/72445d10f22cd963d5f9d94fe9ead847938e5c8487970b3729d168643941/openfeature_flagd_api-1.0.0.tar.gz", hash = "sha256:58d481c0e4bf806ca94a67e12457a8d1823cf772c1801ce20f50d011d8764b5e", size = 6648, upload-time = "2026-04-30T21:19:07.561Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d3/f3/d146491c0bb3ce1d66b1afc865ebcc418e219058f0075f767f1834df939e/openfeature_flagd_api-1.0.0-py3-none-any.whl", hash = "sha256:81c6624c17ae4e78f842ceef67a87743ad8a360105d47a1fef8722b9eeca0f69", size = 7671, upload-time = "2026-04-30T21:19:06.406Z" },
+]
+
+[[package]]
+name = "openfeature-flagd-core"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mmh3" },
+    { name = "openfeature-flagd-api" },
+    { name = "openfeature-sdk" },
+    { name = "panzi-json-logic" },
+    { name = "semver" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/f2/c32dcef17e160963ae1b0b6ee26535c5f12c306f645aa4ba7f9b9efec7b0/openfeature_flagd_core-1.0.0.tar.gz", hash = "sha256:e843d395de54dbc83d4d46fcee6cbc276204f3dfe5e8cc24ae3ea7247479c232", size = 11337, upload-time = "2026-04-30T21:11:25.097Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/00/74300b66ba2629076b4f0772ab9b59b5c1342d11ff9b1f730306c615d90c/openfeature_flagd_core-1.0.0-py3-none-any.whl", hash = "sha256:c140259806c20e5fcda40452425131be6b58e4d790d7faa830d9cd89333e13ef", size = 14403, upload-time = "2026-04-30T21:11:23.875Z" },
+]
+
+[[package]]
 name = "openfeature-hooks-opentelemetry"
 version = "0.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -925,21 +953,19 @@ wheels = [
 
 [[package]]
 name = "openfeature-provider-flagd"
-version = "0.2.7"
+version = "0.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cachebox" },
     { name = "grpcio" },
-    { name = "mmh3" },
+    { name = "openfeature-flagd-core" },
     { name = "openfeature-sdk" },
-    { name = "panzi-json-logic" },
     { name = "protobuf" },
     { name = "pyyaml" },
-    { name = "semver" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/51/f5/02c0c03ffcdf740737dabca096256e78afb3711168e3e44f486288cdb860/openfeature_provider_flagd-0.2.7.tar.gz", hash = "sha256:ee6dee7551e9fd479ec00aa78de84d1f53d4bb8a5d1ce93e5ca9c67bf879fea7", size = 64308, upload-time = "2026-02-04T06:44:20.786Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/0a/13077d0725d5fae30930724a228da20f3dbf2390ba1b477cc2f2647e885e/openfeature_provider_flagd-0.5.0.tar.gz", hash = "sha256:d5cac8fb9194ccd454f67fa48da195b0e9d629c77493160b93fa2cf5400ec288", size = 70307, upload-time = "2026-06-03T00:13:55.976Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/35/4d/a296df991f7fbbb3652f3f0125ad6de31fa7fe366e640a2b50ba80f78637/openfeature_provider_flagd-0.2.7-py3-none-any.whl", hash = "sha256:645aabbafae932df1c98257763b8afbbd874ff2aa70088249f45314cf5009dda", size = 58854, upload-time = "2026-02-04T06:44:19.156Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/02/cdaa0930aa88ca20a19be824fd01d40dc8730a3ce95e75db786bb3cd1ea5/openfeature_provider_flagd-0.5.0-py3-none-any.whl", hash = "sha256:667f536b92601ab4f2a473142989a55f6044a153b90627f6860fb367a4062724", size = 63969, upload-time = "2026-06-03T00:13:54.524Z" },
 ]
 
 [[package]]
@@ -1146,17 +1172,17 @@ wheels = [
 
 [[package]]
 name = "protobuf"
-version = "6.33.3"
+version = "6.33.6"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/cc/5c/f912bdebdd4af4160da6a2c2b1b3aaa1b8c578d0243ba8f694f93c7095f0/protobuf-6.33.3.tar.gz", hash = "sha256:c8794debeb402963fddff41a595e1f649bcd76616ba56c835645cab4539e810e", size = 444318, upload-time = "2026-01-09T23:05:02.79Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/70/e908e9c5e52ef7c3a6c7902c9dfbb34c7e29c25d2f81ade3856445fd5c94/protobuf-6.33.6.tar.gz", hash = "sha256:a6768d25248312c297558af96a9f9c929e8c4cee0659cb07e780731095f38135", size = 444531, upload-time = "2026-03-18T19:05:00.988Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/56/2a41b9dcc3b92fa672bb89610608f4fd4f71bec075d314956710503b29f5/protobuf-6.33.3-cp310-abi3-win32.whl", hash = "sha256:b4046f9f2ede57ad5b1d9917baafcbcad42f8151a73c755a1e2ec9557b0a764f", size = 425597, upload-time = "2026-01-09T23:04:50.11Z" },
-    { url = "https://files.pythonhosted.org/packages/23/07/1f1300fe7d204fd7aaabd9a0aafd54e6358de833b783f5bd161614e8e1e4/protobuf-6.33.3-cp310-abi3-win_amd64.whl", hash = "sha256:1fd18f030ae9df97712fbbb0849b6e54c63e3edd9b88d8c3bb4771f84d8db7a4", size = 436945, upload-time = "2026-01-09T23:04:51.921Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/5d/0ef28dded98973a26443a6a7bc49bff6206be8c57dc1d1e28e6c1147b879/protobuf-6.33.3-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:648b7b0144222eb06cf529a3d7b01333c5f30b4196773b682d388f04db373759", size = 427594, upload-time = "2026-01-09T23:04:53.358Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/46/551c69b6ff1957bd703654342bfb776bb97db400bc80afc56fbb64e7c11d/protobuf-6.33.3-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:08a6ca12f60ba99097dd3625ef4275280f99c9037990e47ce9368826b159b890", size = 324469, upload-time = "2026-01-09T23:04:54.332Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/6d/ade1cca06c64a421ee9745e082671465ead28164c809efaf2c15bc93f9a0/protobuf-6.33.3-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:642fce7187526c98683c79a3ad68e5d646a5ef5eb004582fe123fc9a33a9456b", size = 339242, upload-time = "2026-01-09T23:04:55.347Z" },
-    { url = "https://files.pythonhosted.org/packages/38/8c/6522b8e543ece46f645911c3cebe361d8460134c0fee02ddcf70ebf32999/protobuf-6.33.3-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:6fa9b5f4baa12257542273e5e6f3c3d3867b30bc2770c14ad9ac8315264bf986", size = 323298, upload-time = "2026-01-09T23:04:56.866Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/b9/067b8a843569d5605ba6f7c039b9319720a974f82216cd623e13186d3078/protobuf-6.33.3-py3-none-any.whl", hash = "sha256:c2bf221076b0d463551efa2e1319f08d4cffcc5f0d864614ccd3d0e77a637794", size = 170518, upload-time = "2026-01-09T23:05:01.227Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/9f/2f509339e89cfa6f6a4c4ff50438db9ca488dec341f7e454adad60150b00/protobuf-6.33.6-cp310-abi3-win32.whl", hash = "sha256:7d29d9b65f8afef196f8334e80d6bc1d5d4adedb449971fefd3723824e6e77d3", size = 425739, upload-time = "2026-03-18T19:04:48.373Z" },
+    { url = "https://files.pythonhosted.org/packages/76/5d/683efcd4798e0030c1bab27374fd13a89f7c2515fb1f3123efdfaa5eab57/protobuf-6.33.6-cp310-abi3-win_amd64.whl", hash = "sha256:0cd27b587afca21b7cfa59a74dcbd48a50f0a6400cfb59391340ad729d91d326", size = 437089, upload-time = "2026-03-18T19:04:50.381Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/01/a3c3ed5cd186f39e7880f8303cc51385a198a81469d53d0fdecf1f64d929/protobuf-6.33.6-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:9720e6961b251bde64edfdab7d500725a2af5280f3f4c87e57c0208376aa8c3a", size = 427737, upload-time = "2026-03-18T19:04:51.866Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/90/b3c01fdec7d2f627b3a6884243ba328c1217ed2d978def5c12dc50d328a3/protobuf-6.33.6-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:e2afbae9b8e1825e3529f88d514754e094278bb95eadc0e199751cdd9a2e82a2", size = 324610, upload-time = "2026-03-18T19:04:53.096Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ca/25afc144934014700c52e05103c2421997482d561f3101ff352e1292fb81/protobuf-6.33.6-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:c96c37eec15086b79762ed265d59ab204dabc53056e3443e702d2681f4b39ce3", size = 339381, upload-time = "2026-03-18T19:04:54.616Z" },
+    { url = "https://files.pythonhosted.org/packages/16/92/d1e32e3e0d894fe00b15ce28ad4944ab692713f2e7f0a99787405e43533a/protobuf-6.33.6-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:e9db7e292e0ab79dd108d7f1a94fe31601ce1ee3f7b79e0692043423020b0593", size = 323436, upload-time = "2026-03-18T19:04:55.768Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/72/02445137af02769918a93807b2b7890047c32bfb9f90371cbc12688819eb/protobuf-6.33.6-py3-none-any.whl", hash = "sha256:77179e006c476e69bf8e8ce866640091ec42e1beb80b213c3900006ecfba6901", size = 170656, upload-time = "2026-03-18T19:04:59.826Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #843.

> Originally planned to stack on #839; that PR merged to `main` while this was in progress, so this is rebased onto and targets `main`.

## Why this is a coordinated, single-PR upgrade
The flag architecture is flagSetId-per-domain: each `services/flagd/*.json` declares `metadata.flagSetId` and clients connect with `selector="flagSetId=<domain>"` (`lib/feature_flags.py`). With flagd v0.13.2, provider versions >=0.3.0 break this **silently** (fall back to defaults, no error). Provider 0.5.0 sends the new `flagd-selector` **header**, which only newer flagd honors. So flagd and the provider must move together, gated by the integration suite.

## Version matrix
| Component | From | To | Notes |
|---|---|---|---|
| flagd image (docker-compose.yml, docker-compose.lite.yml) | v0.13.2 | **v0.16.0** | newest; honors `flagd-selector` header |
| openfeature-provider-flagd (lib, tests/integration) | 0.2.7 | **0.5.0** | newest; `flagd-selector` header in RPC + in-process resolvers |
| openfeature-sdk (lib, controller_manager, tests/integration) | >=0.6.0 | **>=0.8.4** | provider 0.5.0 needs >=0.8.2; hooks-otel 0.3.x needs >=0.8.4 |
| protobuf (proto floor) | >=5.29.0 | **>=6.33.5** | provider 0.5.0 gencode built with 6.33.5 (runtime guarantee) |
| grpcio (resolved) | 1.76.0 | **1.81.0** | pulled by provider 0.5.0 |
| openfeature-flagd-core / -api | — | **1.0.0** | new in-process eval engine deps of provider 0.5.0 |
| openfeature-hooks-opentelemetry (resolved) | 0.1.x | 0.3.0 | TracingHook, unchanged API |
| go-sdk-contrib flagd provider (services/agent) | v0.6.0 | v0.6.0 | **already newest — no change** |
| open-feature/go-sdk (services/agent) | v1.17.2 | v1.17.2 | **already newest — no change** |

## Breaking-changes audit
1. **DISABLED semantics** (flagd v0.16 + provider 0.5.0: disabled flags resolve successfully with `reason=DISABLED` instead of erroring). **No impact** — all 168 flags across `services/flagd/*.json` are `state: ENABLED`; no code branches on a DISABLED-induced resolution error. Python `read_*` helpers and Go `flags.go` fail-closed paths trigger on unreachable flagd / undefined flag / unparseable shape — none affected by this change. Fail-closed stays fail-closed.
2. **Selector mechanics** — provider 0.5.0 passes the raw `config.selector` string as the `flagd-selector` header (RPC `resolvers/grpc.py` and in-process `grpc_watcher.py`, which also keeps the legacy request-body selector for back-compat). flagd's documented header value format is `flagSetId=<id>` — exactly what every call site already passes (`lib/feature_flags.py`, `test_rollout_plumbing.py:152`, `test_intervention_flow.py:398`). **No selector call-site changes required.**
3. **Event-listener `'data'` KeyError fix** (>=0.3.0): the `renovate.json` `<0.3.0` cap and the `#843` `filterwarnings` marker only exist if PR #840 had merged — **neither is present on `main`**, so nothing to lift/remove.
4. **flagd v0.14/v0.15 CLI/sync changes**: `--uri` unchanged; no flagd compose healthcheck to adjust; no `services/flagd/*.json` schema change required.

## Verification
- **Local unit suites green**: lib (350), controller_manager (643), game_coordinator (919), menu (358), audio (228); Go agent `go build` / `go vet` / `go test ./...` all pass; `make lint` clean.
- Provider 0.5.0 constructor (`resolver_type=IN_PROCESS`, `selector="flagSetId=…"`, `keep_alive_time`) verified compatible.
- The **Integration Tests CI job** is the only trustworthy detector for the silent-defaults failure mode (rollout plumbing, F6 presets, intervention targeting must pass on REAL resolved values).

🤖 Generated with [Claude Code](https://claude.com/claude-code)