### PR TITLE
feat(agent): post-game retrospective prompt capture (#844)

### DIFF
--- a/docs/research/844-post-game-retro.md
+++ b/docs/research/844-post-game-retro.md
@@ -1,0 +1,164 @@
+# Post-game retrospective capture (#844)
+
+When a game ends, the agent has the richest data it will ever have — the full
+elimination sequence, the final duration, the per-player skill spread — and the
+suggestions it could make (calibration tweaks) take effect at the *next* game's
+init. This issue adds a **post-game analyst** path: on the `GameActive`
+true→false transition the agent builds a retrospective prompt from the full
+session and would ask an LLM to suggest **calibration tweaks for the next game**.
+
+This is the LLM use case that tolerates cloud latency: in-game decisions need
+fast local inference, but between games even a slow backend (or `claude -p` under
+a Max subscription) is fine.
+
+## Capture-first (same pattern as #739)
+
+No backend is called yet. Exactly like the #739 in-game spike, this path
+**captures** the prompt it would send onto a dedicated `agent.llm.retro` span and
+falls through; a follow-up wires a real backend once the fallback chain (#741)
+exists. The prompt is replayable offline via `services/agent/scripts/replay-prompt.sh`.
+
+## Trigger design
+
+The trigger is the `gamecontext.Store` `OnGameEnd` hook (`gamecontext/store.go`),
+fired exactly once on the `GameActive` true→false transition inside
+`SetGameActive`. The hook receives a **pre-reset** snapshot — the `SessionID` and
+the `EliminationSequence` are still intact (the snapshot is taken before any
+session-grace reset). The callback is invoked **after** the store mutex is
+released, never under `s.mu`, so it may read the store / build telemetry without a
+re-entrancy deadlock. `OnGameEnd == nil` disables the hook (behavior-neutral).
+
+`decision.RetroCoordinator.OnGameEnd` is the consumer. It is defensive:
+
+- skips if the snapshot still reports `GameActive` (only end-of-game captures);
+- skips if `SessionID` is empty;
+- skips if `SessionID` equals the last captured session (exactly-once dedupe).
+
+### No interaction with the intervention budget
+
+The coordinator **never** touches `gate.ShouldEvaluate`, the decision `Loop`, or
+the rate limiter — there is simply no code path from a retrospective to the
+limiter. A retrospective therefore cannot consume the in-game intervention
+budget. This is a structural guarantee (no shared state), not just a convention.
+Flags are evaluated with a `context.Background()` (there is no inbound RPC context
+at game end), so the retro span is a standalone root — intentional, it is not a
+child of any OTLP Export.
+
+## Span / attribute schema
+
+Span name: **`agent.llm.retro`** (constant `decision.SpanLLMRetro`). Built by the
+single attribute builder `decision.retroPromptAttributes` (one producer,
+schema-complete on every emission, mirroring `llmPromptAttributes`). Every
+attribute is present on every emission:
+
+| Attribute | Value | Source |
+|-----------|-------|--------|
+| `gen_ai.operation.name` | `"chat"` | semconv `GenAIOperationNameChat` |
+| `gen_ai.request.model` | the `model` capability flag | semconv `GenAIRequestModel` |
+| `gen_ai.output.type` | `"json"` | semconv `GenAIOutputTypeKey` (no JSON constant in semconv v1.34.0) |
+| `agent.mode` | `"retro"` | distinct from the in-game `"llm"` |
+| `agent.objectives` | sorted `k=v` weights | `summarizeObjectives` (shared) |
+| `interventions.allowed` | allow-list summary | `allowedSummary` (shared) |
+| `session.id` | the finished session's id | |
+| `llm.retro.system` | full System prompt text (uncapped) | `RetroPrompt.System` |
+| `llm.retro.user` | full User prompt text (uncapped) | `RetroPrompt.User` |
+| `llm.retro.bytes` | `len(system)+len(user)` (int) | |
+| `inference.configured` | the `model` capability flag | |
+| `inference.used` | **`"none"`** | see divergence below |
+| `inference.fallback_reason` | `"no_backend_available"` | `decision.FallbackNoBackend` |
+
+The companion log line `agent.llm.retro_captured` carries only metadata
+(`session_id`, `model`, `bytes`, `fallback_reason`) — never the prompt text,
+which lives on the span alone.
+
+### Attribution divergence: `inference.used = "none"`, not `"rules"`
+
+The in-game capture (#739) records `inference.used = "rules"` because the in-game
+path falls back to the deterministic rules engine — "rules" is the honest answer
+to "what decided this cycle". A retrospective has **no rules fallback**: nothing
+runs in place of the offline analyst at game end. Claiming `"rules"` would be a
+lie. `inference.used = "none"` (`decision.DefaultInference`) is the honest value —
+no inference of any kind ran. #741's backend will supply `used="llm"` once it
+answers.
+
+## JSON response contract → calibration surface (#766)
+
+The System prompt (rendered in `services/agent/llm/retro.go`) asks the model for
+**exactly one JSON object**, no prose:
+
+```json
+{
+  "session_assessment": "<one short sentence: how did this game go?>",
+  "suggestions": [
+    {
+      "flag": "<one of: global_difficulty_factor, pacing_profile, threshold_table, objective_variant>",
+      "value": "<the suggested value as a string>",
+      "reason": "<one short sentence tying the change to session evidence>"
+    }
+  ]
+}
+```
+
+The `flag` field is constrained to the **calibration surface** — the #766 flags
+read at game **init** (docs/research/722-intervention-surface.md §11), NOT the
+in-game intervention allow-list:
+
+| Suggestion `flag` | Calibration flag (read at init) |
+|-------------------|---------------------------------|
+| `global_difficulty_factor` | continuous global movement-demand scale (~0.5..1.5) |
+| `pacing_profile` | music-schedule preset (`relaxed`/`standard`/`intense`) |
+| `threshold_table` | named death/warning threshold table (`easy`/`standard`/`hard`) |
+| `objective_variant` | next-game session goal weighting (endurance/balanced/accelerate/chaos) |
+
+The policy is "suggest the smallest change that addresses an observed problem; if
+the session looked healthy, return an empty `suggestions` list." Suggestions are
+**recorded only**, never auto-applied in this issue.
+
+## Determinism
+
+`llm.BuildRetro` is pure and deterministic, the same contract as `llm.Build`: the
+injected `Now`, players sorted by serial, no wall clock, fixed float precision
+(2 decimals). The same `RetroInput` always yields a byte-identical `RetroPrompt`.
+Golden tests (`llm/testdata/retro_*.golden`, regenerated with `-update`) and a
+`TestRetroDeterminism` byte-identity test lock this down. `TestPlayerOutcome` and
+`TestWinnerSerial` unit-test the outcome derivation:
+
+- per-player outcome comes from the elimination-sequence position
+  (`eliminated #1` = first out); a serial absent from the sequence is a `survivor`;
+- `winner` is the sole survivor's serial when exactly one player survived, else
+  `unknown` (zero or multiple survivors are both ambiguous).
+
+## Exactly-once design
+
+Two layers guarantee one retro per session:
+
+1. The store fires `OnGameEnd` only on the true→false edge (not on start, not on
+   a repeated `false`).
+2. The coordinator dedupes on `SessionID` (a mutex-guarded `lastSession`): the
+   same id twice emits one span; a new id emits a second.
+
+## The minimal store-hook constraint (#845)
+
+`gamecontext/store.go` will be rewritten by #845 (lifecycle handling). The hook
+added here is deliberately **minimal and additive**: one `OnGameEnd` field, a
+`snapshotLocked()` helper factored out of `Snapshot()`, and a few lines in the
+existing true→false branch. The signature of `SetGameActive` is unchanged. A code
+comment on `OnGameEnd` records this constraint so #845 keeps the surface small.
+
+## Manual replay
+
+`scripts/replay-prompt.sh` replays an `agent.llm.retro` span **identically** to an
+`agent.llm.prompt` span — copy the `llm.retro.system` / `llm.retro.user`
+attribute values out of Jaeger into two files and run the script. (The script
+only invokes the `claude` CLI headless; it does not validate the JSON — the spike
+is a manual eyeball.)
+
+## Forward pointers
+
+- **#741 `resolve_backend()`** — wires a real inference backend; supplies the
+  honest `inference.used = "llm"` and unmarshals the reply.
+- **`FlagConfigWriter` auto-apply (follow-up)** — applying a suggested tweak to
+  the calibration flags behind a flag, with human review, is separate work.
+- **#847 intervention budget** — once backends exist, a retro counts as **one LLM
+  call** for budgeting purposes; it still does not draw from the in-game
+  per-minute intervention budget.

--- a/services/agent/README.md
+++ b/services/agent/README.md
@@ -661,6 +661,48 @@ a real model, copy `llm.prompt.system` / `llm.prompt.user` into two files and ru
 [docs/research/739-prompt-capture.md](../../docs/research/739-prompt-capture.md)
 for the response contract and the forward path (#741 backend, #742 auth).
 
+#### Post-game retrospective capture (M4, #844)
+
+When a game **ends** (the `GameActive` true→false transition fires the store's
+`OnGameEnd` hook with a pre-reset snapshot), the `decision.RetroCoordinator`
+builds the prompt the agent would send to an **offline analyst** asking for
+calibration tweaks for the next game, and records it on a dedicated
+**`agent.llm.retro`** span — **capture-first**, exactly like #739, no backend
+called yet. It emits **exactly once per session** (dedup on `SessionID`) and is
+structurally isolated from the decision loop: it never touches the gate, the loop,
+or the rate limiter, so a retrospective **cannot consume the in-game intervention
+budget**.
+
+The span carries the full retro prompt plus attribution (single builder
+`retroPromptAttributes`, schema-complete every emission):
+
+| Attribute | Value |
+|-----------|-------|
+| `gen_ai.operation.name` | `"chat"` |
+| `gen_ai.request.model` | the `model` capability flag |
+| `gen_ai.output.type` | `"json"` |
+| `agent.mode` | `"retro"` |
+| `agent.objectives` | sorted `k=v` weights |
+| `interventions.allowed` | the allow-list summary |
+| `session.id` | the finished session's id |
+| `llm.retro.system` / `llm.retro.user` | the **full** retro prompt text (uncapped) |
+| `llm.retro.bytes` | `len(system)+len(user)` |
+| `inference.configured` | the `model` flag |
+| `inference.used` | **`"none"`** (divergence — see below) |
+| `inference.fallback_reason` | `"no_backend_available"` |
+
+**Divergence from the in-game capture:** `inference.used` is `"none"`, **not**
+`"rules"`. The in-game path falls back to the rules engine, so `"rules"` is the
+honest "what decided this cycle". A retrospective has **no** rules fallback —
+nothing runs in place of the analyst at game end — so `"none"` is the honest
+value. The companion log line `agent.llm.retro_captured` carries only metadata
+(`session_id`, `model`, `bytes`, `fallback_reason`). The suggestion contract maps
+to the **calibration surface** (#766: `global_difficulty_factor`,
+`pacing_profile`, `threshold_table`, `objective_variant`), and `replay-prompt.sh`
+replays an `agent.llm.retro` span identically (copy `llm.retro.system` /
+`llm.retro.user`). See
+[docs/research/844-post-game-retro.md](../../docs/research/844-post-game-retro.md).
+
 #### `fitness.evaluated` (#731)
 
 `LayerState.FitnessEvaluated` (`map[string]float64`) holds the cycle-level

--- a/services/agent/decision/retro_capture.go
+++ b/services/agent/decision/retro_capture.go
@@ -1,0 +1,216 @@
+package decision
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	semconv "go.opentelemetry.io/otel/semconv/v1.34.0"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/joustmania/agent/gamecontext"
+	"github.com/joustmania/agent/llm"
+)
+
+// retro_capture.go is the POST-GAME counterpart of llm_capture.go (#844). When a
+// game ends (the gamecontext.Store fires its OnGameEnd hook on the GameActive
+// true->false transition), the RetroCoordinator builds the retrospective prompt
+// the agent WOULD send to an offline analyst and records it on a dedicated
+// `agent.llm.retro` span, exactly once per session. Like the #739 in-game
+// capture, no backend is called yet — this is capture-first.
+//
+// STRUCTURAL GUARANTEE: the coordinator never touches gate.ShouldEvaluate, the
+// decision Loop, or the rate limiter. A retrospective therefore cannot consume
+// the in-game intervention budget — there is simply no code path from here to the
+// limiter. This is a deliberate isolation, not just a convention.
+
+// SpanLLMRetro is the post-game retrospective capture span (#844): emitted once
+// per session at game end, carrying the prompt the agent would send to an offline
+// LLM analyst. Named distinctly from agent.llm.prompt so retro captures are
+// trivially greppable in Jaeger by name.
+const SpanLLMRetro = "agent.llm.retro"
+
+// Custom attribute keys of the agent.llm.retro span (#844). They mirror the
+// agent.llm.prompt keys (telemetry.go) but in the retro namespace so the two
+// capture kinds never collide in a single trace view.
+const (
+	// AttrLLMRetroSystem / AttrLLMRetroUser carry the full, uncapped System and
+	// User retrospective prompt text. As with the in-game capture, the Go SDK
+	// applies no attribute length limit and the collector does not truncate, so the
+	// entire prompt is preserved for offline replay (scripts/replay-prompt.sh).
+	AttrLLMRetroSystem = "llm.retro.system"
+	AttrLLMRetroUser   = "llm.retro.user"
+	// AttrLLMRetroBytes is len(system)+len(user), the prompt size in bytes (int).
+	AttrLLMRetroBytes = "llm.retro.bytes"
+)
+
+// retroModeValue is the agent.mode value recorded on the retro-capture span. The
+// span only ever exists at game end on the offline-analyst path, so it is
+// constant — distinct from the in-game llmModeValue.
+const retroModeValue = "retro"
+
+// RetroCoordinator builds and captures the post-game retrospective prompt. It is
+// wired to gamecontext.Store.OnGameEnd in main(). It is safe for concurrent use:
+// game-end transitions are serialized by the store, but the dedupe state is
+// mutex-guarded defensively.
+type RetroCoordinator struct {
+	// Tracer produces the agent.llm.retro span; tests inject a recording tracer.
+	Tracer trace.Tracer
+	// Log records the metadata-only agent.llm.retro_captured line (never prompt text).
+	Log *slog.Logger
+	// Flags is the same flag-source interface the Loop uses; evaluated with a
+	// background context at game end (there is no inbound RPC context then).
+	Flags FlagSource
+	// now is injectable for tests; nil uses time.Now.
+	now func() time.Time
+
+	// mu guards lastSession.
+	mu sync.Mutex
+	// lastSession is the SessionID of the most recently captured retro, for the
+	// exactly-once-per-session guarantee.
+	lastSession string
+}
+
+// NewRetroCoordinator builds a RetroCoordinator over the given flag source. log
+// may be nil (slog.Default() is used); flagSource may be nil, in which case the
+// disabled fallback source is used (so a missing control plane never captures).
+func NewRetroCoordinator(flagSource FlagSource, log *slog.Logger) *RetroCoordinator {
+	if log == nil {
+		log = slog.Default()
+	}
+	if flagSource == nil {
+		flagSource = disabledFlags{}
+	}
+	return &RetroCoordinator{
+		Tracer: otel.Tracer(instrumentationName),
+		Log:    log,
+		Flags:  flagSource,
+		now:    time.Now,
+	}
+}
+
+// OnGameEnd is the gamecontext.Store.OnGameEnd callback. It captures the
+// retrospective prompt for a finished session exactly once. It is defensive:
+//   - skips if the snapshot still reports GameActive (only end-of-game captures);
+//   - skips if SessionID is empty (nothing to attribute the retro to);
+//   - skips if SessionID == the last captured session (exactly-once per session).
+func (rc *RetroCoordinator) OnGameEnd(c gamecontext.GameContext) {
+	if c.Session.GameActive != nil && *c.Session.GameActive {
+		return // not actually a game end
+	}
+	if c.SessionID == "" {
+		return
+	}
+	if !rc.claimSession(c.SessionID) {
+		return // already captured this session
+	}
+
+	now := rc.now
+	if now == nil {
+		now = time.Now
+	}
+
+	// Evaluate flags with a background context: there is no inbound RPC context at
+	// game end, so the retro span is a standalone root (intentional — it is not a
+	// child of any Export). The flag source falls back to safe defaults if flagd is
+	// unreachable, identical to the in-game path.
+	snapshot := rc.Flags.Evaluate(context.Background())
+
+	prompt := llm.BuildRetro(llm.RetroInput{
+		Snapshot: snapshot,
+		Context:  c,
+		Now:      now(),
+	})
+
+	_, span := rc.Tracer.Start(context.Background(), SpanLLMRetro,
+		trace.WithAttributes(retroPromptAttributes(retroPromptAttrs{
+			prompt:     prompt,
+			sessionID:  c.SessionID,
+			objectives: snapshot.Objectives,
+			allowed:    snapshot.InterventionsAllowed,
+		})...))
+	span.End()
+
+	rc.Log.Info("agent.llm.retro_captured",
+		"session_id", c.SessionID,
+		"model", prompt.Model,
+		"bytes", len(prompt.System)+len(prompt.User),
+		"fallback_reason", FallbackNoBackend,
+	)
+}
+
+// claimSession records sessionID as captured and reports whether THIS call won
+// the claim (i.e. the session had not been captured yet). Mutex-guarded for the
+// exactly-once guarantee.
+func (rc *RetroCoordinator) claimSession(sessionID string) bool {
+	rc.mu.Lock()
+	defer rc.mu.Unlock()
+	if rc.lastSession == sessionID {
+		return false
+	}
+	rc.lastSession = sessionID
+	return true
+}
+
+// retroPromptAttrs bundles the inputs for the single retro span-attribute
+// builder, mirroring llmPromptAttrs.
+type retroPromptAttrs struct {
+	prompt     llm.RetroPrompt
+	sessionID  string
+	objectives map[string]float64
+	allowed    []string
+}
+
+// retroPromptAttributes is the SOLE builder of the agent.llm.retro span attribute
+// set (#844), mirroring llmPromptAttributes. Every emission routes through it so
+// the schema is complete and consistent on every emission:
+//
+//   - gen_ai.operation.name = "chat"        (semconv)
+//   - gen_ai.request.model  = <model flag>  (semconv)
+//   - gen_ai.output.type    = "json"        (semconv key; JSON per RESPONSE CONTRACT)
+//   - agent.mode            = "retro"
+//   - agent.objectives      = sorted "k=v" weights (summarizeObjectives)
+//   - interventions.allowed = the allow-list summary (allowedSummary)
+//   - session.id            = the finished session's id
+//   - llm.retro.system / llm.retro.user = the FULL prompt text (uncapped)
+//   - llm.retro.bytes       = len(system)+len(user)
+//   - inference.configured  = <model flag>
+//   - inference.used        = "none"   (see DIVERGENCE below)
+//   - inference.fallback_reason = "no_backend_available"
+//
+// DIVERGENCE from the in-game capture: inference.used is "none", NOT "rules".
+// The in-game path falls back to the rules engine, so "rules" is the honest
+// answer for "what decided this cycle". A retrospective has NO rules fallback —
+// nothing runs in place of the offline analyst at game end, so claiming "rules"
+// would be a lie. "none" (DefaultInference) is the honest value: no inference of
+// any kind ran. #741's backend will supply used="llm" once it answers.
+func retroPromptAttributes(in retroPromptAttrs) []attribute.KeyValue {
+	system := in.prompt.System
+	user := in.prompt.User
+	return []attribute.KeyValue{
+		// GenAI semantic conventions for the request the agent would have sent.
+		semconv.GenAIOperationNameChat,
+		semconv.GenAIRequestModel(in.prompt.Model),
+		genAIOutputTypeJSON,
+		// Agent attribution (same vocabulary as the in-game capture / decision span).
+		attribute.String(AttrMode, retroModeValue),
+		attribute.String(AttrObjectives, summarizeObjectives(in.objectives)),
+		attribute.String(AttrInterventionsAllowed, allowedSummary(in.allowed)),
+		attribute.String("session.id", in.sessionID),
+		// The captured prompt: full text (uncapped) plus its size.
+		attribute.String(AttrLLMRetroSystem, system),
+		attribute.String(AttrLLMRetroUser, user),
+		attribute.Int(AttrLLMRetroBytes, len(system)+len(user)),
+		// Inference attribution: the prompt was captured, but no backend ran and
+		// there is no rules fallback for a retrospective, so used="none".
+		attribute.String(AttrInferenceConfigured, in.prompt.Model),
+		attribute.String(AttrInferenceUsed, DefaultInference),
+		attribute.String(AttrInferenceFallback, FallbackNoBackend),
+	}
+}
+
+// compile-time guard: RetroCoordinator.OnGameEnd matches the store hook signature.
+var _ func(gamecontext.GameContext) = (*RetroCoordinator)(nil).OnGameEnd

--- a/services/agent/decision/retro_capture_test.go
+++ b/services/agent/decision/retro_capture_test.go
@@ -1,0 +1,155 @@
+package decision
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"github.com/joustmania/agent/flags"
+	"github.com/joustmania/agent/gamecontext"
+)
+
+// retroSnapshot is a representative llm-mode snapshot for the retro capture tests.
+func retroFlagSnapshot() flags.Snapshot {
+	return flags.Snapshot{
+		Enabled:              true,
+		Mode:                 "llm",
+		Objectives:           map[string]float64{"endurance": 0.7, "chaos": 0.3},
+		Capability:           flags.Capability{Model: "phi4-mini"},
+		InterventionsAllowed: []string{"noop", "grant_shield"},
+	}
+}
+
+// recordingRetro builds a RetroCoordinator with a recording tracer and the given
+// flag snapshot.
+func recordingRetro(t *testing.T, snap flags.Snapshot) (*RetroCoordinator, *tracetest.SpanRecorder) {
+	t.Helper()
+	sr := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+	rc := NewRetroCoordinator(&settableFlags{snap: snap}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	rc.Tracer = tp.Tracer("test")
+	return rc, sr
+}
+
+// endedSession is a finished-game GameContext: GameActive false, a session id, an
+// elimination sequence, and a survivor.
+func endedSession() gamecontext.GameContext {
+	active := false
+	dur := 90.0
+	return gamecontext.GameContext{
+		SessionID: "session-7",
+		Session: gamecontext.SessionSignals{
+			GameActive:          &active,
+			DurationSeconds:     &dur,
+			EliminationSequence: []string{"BB:22"},
+		},
+		Players: map[string]*gamecontext.PlayerSignals{
+			"AA:11": {Serial: "AA:11"},
+			"BB:22": {Serial: "BB:22"},
+		},
+	}
+}
+
+// TestRetroCapture_EmitsSpan: a normal game end emits exactly one agent.llm.retro
+// span with non-empty prompt text.
+func TestRetroCapture_EmitsSpan(t *testing.T) {
+	rc, sr := recordingRetro(t, retroFlagSnapshot())
+	rc.OnGameEnd(endedSession())
+
+	spans := spansByName(sr.Ended(), SpanLLMRetro)
+	if len(spans) != 1 {
+		t.Fatalf("agent.llm.retro spans = %d, want 1", len(spans))
+	}
+	if v, ok := attrValue(spans[0], AttrLLMRetroSystem); !ok || v.AsString() == "" {
+		t.Error("llm.retro.system must be present and non-empty")
+	}
+	if v, ok := attrValue(spans[0], AttrLLMRetroUser); !ok || v.AsString() == "" {
+		t.Error("llm.retro.user must be present and non-empty")
+	}
+}
+
+// TestRetroCapture_SchemaComplete: every attribute of the agent.llm.retro schema
+// is present, with inference.used == "none" (the documented divergence — no rules
+// fallback for a retrospective).
+func TestRetroCapture_SchemaComplete(t *testing.T) {
+	rc, sr := recordingRetro(t, retroFlagSnapshot())
+	rc.OnGameEnd(endedSession())
+
+	span := spansByName(sr.Ended(), SpanLLMRetro)[0]
+	wantStr := map[string]string{
+		"gen_ai.operation.name":  "chat",
+		"gen_ai.request.model":   "phi4-mini",
+		"gen_ai.output.type":     "json",
+		AttrMode:                 "retro",
+		AttrObjectives:           "chaos=0.3,endurance=0.7",
+		AttrInterventionsAllowed: "noop,grant_shield",
+		"session.id":             "session-7",
+		AttrInferenceConfigured:  "phi4-mini",
+		AttrInferenceUsed:        DefaultInference, // "none", NOT "rules"
+		AttrInferenceFallback:    FallbackNoBackend,
+	}
+	for key, expected := range wantStr {
+		if v, ok := attrValue(span, key); !ok || v.AsString() != expected {
+			t.Errorf("attr %s = %q (present=%v), want %q", key, v.AsString(), ok, expected)
+		}
+	}
+	// Explicit divergence guard: never "rules" on a retro span.
+	if v, _ := attrValue(span, AttrInferenceUsed); v.AsString() == InferenceRules {
+		t.Errorf("inference.used = %q, must NOT be %q for a retrospective", v.AsString(), InferenceRules)
+	}
+	// llm.retro.bytes equals the combined length of the two prompt texts.
+	sys, _ := attrValue(span, AttrLLMRetroSystem)
+	usr, _ := attrValue(span, AttrLLMRetroUser)
+	wantBytes := int64(len(sys.AsString()) + len(usr.AsString()))
+	if v, ok := attrValue(span, AttrLLMRetroBytes); !ok || v.AsInt64() != wantBytes {
+		t.Errorf("llm.retro.bytes = %d, want %d", v.AsInt64(), wantBytes)
+	}
+}
+
+// TestRetroCapture_ExactlyOncePerSession: the same SessionID twice emits ONE
+// span; a new SessionID emits a second.
+func TestRetroCapture_ExactlyOncePerSession(t *testing.T) {
+	rc, sr := recordingRetro(t, retroFlagSnapshot())
+
+	rc.OnGameEnd(endedSession())
+	rc.OnGameEnd(endedSession()) // same session-7: deduped
+	if n := len(spansByName(sr.Ended(), SpanLLMRetro)); n != 1 {
+		t.Fatalf("agent.llm.retro spans = %d, want 1 (same session deduped)", n)
+	}
+
+	next := endedSession()
+	next.SessionID = "session-8"
+	rc.OnGameEnd(next)
+	if n := len(spansByName(sr.Ended(), SpanLLMRetro)); n != 2 {
+		t.Fatalf("agent.llm.retro spans = %d, want 2 (new session)", n)
+	}
+}
+
+// TestRetroCapture_SkipsActiveGame: a snapshot still reporting GameActive=true
+// emits nothing (defensive — only end-of-game captures).
+func TestRetroCapture_SkipsActiveGame(t *testing.T) {
+	rc, sr := recordingRetro(t, retroFlagSnapshot())
+	c := endedSession()
+	active := true
+	c.Session.GameActive = &active
+	rc.OnGameEnd(c)
+	if n := len(spansByName(sr.Ended(), SpanLLMRetro)); n != 0 {
+		t.Errorf("agent.llm.retro spans = %d, want 0 for an active game", n)
+	}
+}
+
+// TestRetroCapture_SkipsEmptySession: an empty SessionID emits nothing.
+func TestRetroCapture_SkipsEmptySession(t *testing.T) {
+	rc, sr := recordingRetro(t, retroFlagSnapshot())
+	c := endedSession()
+	c.SessionID = ""
+	rc.OnGameEnd(c)
+	if n := len(spansByName(sr.Ended(), SpanLLMRetro)); n != 0 {
+		t.Errorf("agent.llm.retro spans = %d, want 0 for an empty session id", n)
+	}
+}

--- a/services/agent/gamecontext/store.go
+++ b/services/agent/gamecontext/store.go
@@ -40,6 +40,17 @@ type Store struct {
 	// recognized signals anyway, the skip is cheap defense-in-depth against a
 	// self-ingestion feedback loop. Set once before serving; not mutex-guarded.
 	ownService string
+
+	// OnGameEnd, when non-nil, is fired EXACTLY ONCE on the GameActive true->false
+	// transition (#844 post-game retrospective), with a pre-reset GameContext
+	// snapshot — the EliminationSequence and SessionID are still intact. Set once
+	// before serving; nil disables the hook (behavior-neutral). It is invoked
+	// AFTER the store mutex is released (never under s.mu) so the callback may read
+	// the store / build telemetry without a re-entrancy deadlock.
+	//
+	// NOTE (#845): this is the minimal additive hook the retrospective needs.
+	// Issue #845 rewrites this file's lifecycle handling; keep this diff tiny.
+	OnGameEnd func(GameContext)
 }
 
 // SetOwnService records the agent's own OTEL service name so the extractors
@@ -224,8 +235,12 @@ func (s *Store) SetGameMode(mode string) {
 // synthetic SessionID, clears per-game state). A true->false transition opens
 // the grace window by recording endedAt.
 func (s *Store) SetGameActive(active bool) {
+	// endSnapshot is captured under the lock on a true->false transition and the
+	// OnGameEnd callback is fired with it AFTER the mutex is released (never under
+	// s.mu — the callback must be free to read the store without re-entrancy).
+	var endSnapshot *GameContext
+
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	prev := false
 	if s.ctx.Session.GameActive != nil {
 		prev = *s.ctx.Session.GameActive
@@ -242,8 +257,17 @@ func (s *Store) SetGameActive(active bool) {
 		s.endedAt = time.Time{}
 	case prev && !active:
 		s.endedAt = s.now()
+		if s.OnGameEnd != nil {
+			snap := s.snapshotLocked() // pre-reset state: SessionID + sequence intact
+			endSnapshot = &snap
+		}
 	}
 	s.touchSession()
+	s.mu.Unlock()
+
+	if endSnapshot != nil {
+		s.OnGameEnd(*endSnapshot)
+	}
 }
 
 // AdoptSessionID overrides the synthetic SessionID with a real game_id label.
@@ -323,7 +347,13 @@ func (s *Store) appendElimination(serial string) {
 func (s *Store) Snapshot() GameContext {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	return s.snapshotLocked()
+}
 
+// snapshotLocked is the body of Snapshot; the caller must hold s.mu. It is shared
+// by Snapshot() and by SetGameActive's game-end hook so both produce an identical
+// deep-enough copy without re-acquiring the mutex.
+func (s *Store) snapshotLocked() GameContext {
 	out := s.ctx
 	out.Players = make(map[string]*PlayerSignals, len(s.ctx.Players))
 	for serial, p := range s.ctx.Players {

--- a/services/agent/gamecontext/store_test.go
+++ b/services/agent/gamecontext/store_test.go
@@ -109,6 +109,69 @@ func TestStore_SnapshotIsolation(t *testing.T) {
 	}
 }
 
+// TestStore_OnGameEnd_FiresOnceWithPreResetState: the hook fires exactly once on
+// the GameActive true->false transition, with the elimination sequence and
+// SessionID still intact (the snapshot is taken before any session reset).
+func TestStore_OnGameEnd_FiresOnceWithPreResetState(t *testing.T) {
+	s := NewStore(time.Hour, time.Hour, nil)
+	var got []GameContext
+	s.OnGameEnd = func(c GameContext) { got = append(got, c) }
+
+	s.SetGameActive(true) // false->true: no fire
+	s.SetEliminationOrder("BB:22", 0)
+	s.SetEliminationOrder("CC:33", 1)
+	sessionID := s.Snapshot().SessionID
+
+	s.SetGameActive(false) // true->false: fire once
+
+	if len(got) != 1 {
+		t.Fatalf("OnGameEnd fired %d times, want 1", len(got))
+	}
+	end := got[0]
+	if end.SessionID != sessionID || end.SessionID == "" {
+		t.Errorf("snapshot SessionID = %q, want pre-reset %q", end.SessionID, sessionID)
+	}
+	wantSeq := []string{"BB:22", "CC:33"}
+	if len(end.Session.EliminationSequence) != len(wantSeq) {
+		t.Fatalf("elimination sequence = %v, want %v", end.Session.EliminationSequence, wantSeq)
+	}
+	for i, s := range wantSeq {
+		if end.Session.EliminationSequence[i] != s {
+			t.Errorf("elimination[%d] = %q, want %q", i, end.Session.EliminationSequence[i], s)
+		}
+	}
+	// The transition is also visible in the snapshot: GameActive is already false.
+	if end.Session.GameActive == nil || *end.Session.GameActive {
+		t.Error("snapshot GameActive should be false (post-transition, pre-reset)")
+	}
+}
+
+// TestStore_OnGameEnd_NotOnStartOrRepeatedFalse: the hook does not fire on
+// false->true (game start) nor on a repeated false->false call.
+func TestStore_OnGameEnd_NotOnStartOrRepeatedFalse(t *testing.T) {
+	s := NewStore(time.Hour, time.Hour, nil)
+	fires := 0
+	s.OnGameEnd = func(GameContext) { fires++ }
+
+	s.SetGameActive(true) // false->true
+	if fires != 0 {
+		t.Fatalf("fired on game start, want 0 (got %d)", fires)
+	}
+	s.SetGameActive(false) // true->false: 1
+	s.SetGameActive(false) // false->false: no additional fire
+	if fires != 1 {
+		t.Fatalf("OnGameEnd fired %d times, want 1 (no repeated-false fire)", fires)
+	}
+}
+
+// TestStore_OnGameEnd_NilHookSafe: a nil hook is the disabled default and must
+// not panic on a true->false transition.
+func TestStore_OnGameEnd_NilHookSafe(t *testing.T) {
+	s := NewStore(time.Hour, time.Hour, nil)
+	s.SetGameActive(true)
+	s.SetGameActive(false) // must not panic with OnGameEnd == nil
+}
+
 func TestStore_ConcurrencySmoke(t *testing.T) {
 	s := NewStore(time.Hour, time.Hour, nil)
 	var wg sync.WaitGroup

--- a/services/agent/llm/retro.go
+++ b/services/agent/llm/retro.go
@@ -1,0 +1,198 @@
+package llm
+
+// retro.go builds the POST-GAME retrospective prompt (#844): the prompt the
+// agent would send to an offline LLM analyst when a game ENDS, asking it to
+// suggest calibration tweaks for the NEXT game. It is the sibling of the in-game
+// builder in prompt.go and shares its helpers (floatPtrOrUnknown,
+// summarizeObjectives, joinInterventions, stringOrUnknown, the `unknown`
+// literal) and its determinism contract:
+//
+//   - No wall-clock reads — RetroInput.Now is injected.
+//   - No randomness.
+//   - Players are sorted by serial; no map-iteration-order dependence.
+//   - Floats render at fixed precision (floatPtrOrUnknown's 2 decimals).
+//
+// The same RetroInput (with a fixed Now) always yields a byte-identical
+// RetroPrompt. Unlike Build, there is NO Variant: the offline analyst makes a
+// handful of human-reviewed recommendations, so there is no in-game
+// aggressiveness dial.
+//
+// Capture-first, like #739: nothing calls a backend yet. decision/retro_capture.go
+// records the built prompt on an `agent.llm.retro` span for offline replay; a
+// follow-up wires a real backend once the fallback chain (#741) exists.
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/joustmania/agent/flags"
+	"github.com/joustmania/agent/gamecontext"
+)
+
+// RetroPrompt is the System/User prompt pair the agent would send to the offline
+// analyst at game end, plus the capability model flag for attribution. There is
+// deliberately no Variant: a post-game analyst has no in-game aggressiveness
+// variant.
+type RetroPrompt struct {
+	System string // role + calibration surface + policy + response contract
+	User   string // serialized full-session summary
+	Model  string // capability model flag (attribution only)
+}
+
+// RetroInput is everything BuildRetro needs to render a RetroPrompt at game end.
+type RetroInput struct {
+	Snapshot flags.Snapshot
+	Context  gamecontext.GameContext
+	Now      time.Time // injected for determinism — BuildRetro must never read the wall clock
+}
+
+// Calibration-surface flag names the analyst may suggest. These are the #766
+// calibration flags read at game INIT (docs/research/722-intervention-surface.md
+// §11) — NOT the in-game intervention allow-list. They are listed here once so
+// the System prompt and the contract-presence test share a single source.
+const (
+	calibDifficultyFactor = "global_difficulty_factor"
+	calibPacingProfile    = "pacing_profile"
+	calibThresholdTable   = "threshold_table"
+	calibObjectiveVariant = "objective_variant"
+)
+
+// BuildRetro renders the deterministic retrospective prompt for one finished
+// session. The same RetroInput (with a fixed Now) always yields a byte-identical
+// RetroPrompt.
+func BuildRetro(in RetroInput) RetroPrompt {
+	return RetroPrompt{
+		System: buildRetroSystem(),
+		User:   buildRetroUser(in.Context, in.Now),
+		Model:  in.Snapshot.Capability.Model,
+	}
+}
+
+// buildRetroSystem renders the System prompt: the post-game analyst role, the
+// calibration surface as the suggestion vocabulary, the smallest-change policy,
+// and the JSON response contract. It takes no input — the calibration surface is
+// fixed, so the System prompt is constant (the session evidence lives in User).
+func buildRetroSystem() string {
+	return `You are the JoustMania post-game analyst. A physical movement party game has just
+ended. You receive a full session summary and must suggest CALIBRATION TWEAKS that
+would make the NEXT game more fun. You are NOT controlling a live game — you make
+at most a handful of recommendations, which a human reviews. Suggestions are
+RECORDED ONLY and never auto-applied.
+
+CALIBRATION SURFACE — you may ONLY suggest changes to these flags. Each is read at
+game INIT:
+
+  ` + calibDifficultyFactor + `   (float, ~0.5..1.5; 1.0 = current) — scales overall
+                             movement demand for the next game.
+  ` + calibPacingProfile + `             (enum: "relaxed" | "standard" | "intense") — the
+                             music-schedule preset that shapes round tempo.
+  ` + calibThresholdTable + `            (named death/warning threshold table, e.g.
+                             "easy" | "standard" | "hard").
+  ` + calibObjectiveVariant + `          (enum: endurance | balanced | accelerate | chaos) —
+                             the session goal weighting for the next game.
+
+POLICY: suggest the SMALLEST change that addresses an observed problem. If the
+session looked healthy, return an empty suggestions list. Do not invent flags
+outside the calibration surface.
+
+RESPONSE CONTRACT — reply with EXACTLY ONE JSON object, no prose, matching:
+{
+  "session_assessment": "<one short sentence: how did this game go?>",
+  "suggestions": [
+    {
+      "flag": "<one of: ` + calibDifficultyFactor + `, ` + calibPacingProfile + `, ` + calibThresholdTable + `, ` + calibObjectiveVariant + `>",
+      "value": "<the suggested value as a string>",
+      "reason": "<one short sentence tying the change to session evidence>"
+    }
+  ]
+}
+If no tweak is warranted, return "suggestions": [].`
+}
+
+// buildRetroUser renders the User message: the session header, the derived
+// outcome (duration, final active players, elimination order, winner), and the
+// per-player end-state sorted by serial. Now is rendered as the captured_at
+// timestamp in UTC RFC3339.
+func buildRetroUser(ctx gamecontext.GameContext, now time.Time) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "SESSION RETROSPECTIVE (session=%s, mode=%s, captured_at=%s)\n",
+		ctx.SessionID, stringOrUnknown(ctx.Session.GameMode), now.UTC().Format(time.RFC3339))
+
+	serials := sortedSerials(ctx.Players)
+	winner := winnerSerial(serials, ctx.Session.EliminationSequence)
+
+	b.WriteString("\nOutcome:\n")
+	fmt.Fprintf(&b, "  duration_seconds: %s\n", floatPtrOrUnknown(ctx.Session.DurationSeconds))
+	fmt.Fprintf(&b, "  final_active_players: %s\n", intPtrOrUnknown(ctx.Session.ActivePlayerCount))
+	fmt.Fprintf(&b, "  elimination_order: [%s]\n", strings.Join(ctx.Session.EliminationSequence, ", "))
+	fmt.Fprintf(&b, "  winner: %s\n", winner)
+
+	b.WriteString("\nPlayers (sorted by serial; \"unknown\" = signal never observed):\n")
+	if len(ctx.Players) == 0 {
+		b.WriteString("  (none)")
+		return b.String()
+	}
+
+	lines := make([]string, 0, len(serials))
+	for _, serial := range serials {
+		p := ctx.Players[serial]
+		lines = append(lines, fmt.Sprintf(
+			"  %s: outcome=%s battery_pct=%s skill=%s movement_intensity=%s movement_variance=%s",
+			serial,
+			playerOutcome(serial, ctx.Session.EliminationSequence),
+			floatPtrOrUnknown(p.BatteryPct),
+			floatPtrOrUnknown(p.SkillLevel),
+			floatPtrOrUnknown(p.MovementIntensity),
+			floatPtrOrUnknown(p.MovementVariance),
+		))
+	}
+	b.WriteString(strings.Join(lines, "\n"))
+	return b.String()
+}
+
+// sortedSerials returns the player serials sorted ascending. Sorting (not map
+// order) is what makes the prompt deterministic.
+func sortedSerials(players map[string]*gamecontext.PlayerSignals) []string {
+	serials := make([]string, 0, len(players))
+	for serial := range players {
+		serials = append(serials, serial)
+	}
+	sort.Strings(serials)
+	return serials
+}
+
+// playerOutcome derives a player's end-of-game outcome from its position in the
+// elimination sequence: the first serial eliminated is "eliminated #1", the
+// second "eliminated #2", and so on. A serial absent from the sequence survived
+// the game and renders "survivor".
+func playerOutcome(serial string, eliminationSequence []string) string {
+	for i, s := range eliminationSequence {
+		if s == serial {
+			return fmt.Sprintf("eliminated #%d", i+1)
+		}
+	}
+	return "survivor"
+}
+
+// winnerSerial returns the sole survivor's serial — a player present in the
+// roster but absent from the elimination sequence — when EXACTLY one player
+// survived. Zero survivors (everyone eliminated) or more than one survivor both
+// render the "unknown" literal: there is no single, unambiguous winner.
+func winnerSerial(serials, eliminationSequence []string) string {
+	eliminated := make(map[string]bool, len(eliminationSequence))
+	for _, s := range eliminationSequence {
+		eliminated[s] = true
+	}
+	var survivors []string
+	for _, s := range serials {
+		if !eliminated[s] {
+			survivors = append(survivors, s)
+		}
+	}
+	if len(survivors) == 1 {
+		return survivors[0]
+	}
+	return unknown
+}

--- a/services/agent/llm/retro_test.go
+++ b/services/agent/llm/retro_test.go
@@ -1,0 +1,258 @@
+package llm
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/joustmania/agent/flags"
+	"github.com/joustmania/agent/gamecontext"
+)
+
+// retroSnapshot is the shared flag snapshot for the retro golden scenarios. Only
+// the capability model is read by BuildRetro (no variant), so the rest is
+// representative but unused.
+func retroSnapshot() flags.Snapshot {
+	return flags.Snapshot{
+		Mode: "llm",
+		Objectives: map[string]float64{
+			"balanced":  0.7,
+			"chaos":     0.1,
+			"endurance": 0.1,
+		},
+		Capability: flags.Capability{Model: "phi4-mini"},
+	}
+}
+
+// retroThreePlayers: two eliminations and one survivor (the winner). Mixes real
+// and never-observed signals like the in-game three-player context.
+func retroThreePlayers() gamecontext.GameContext {
+	return gamecontext.GameContext{
+		SessionID: "session-7",
+		Session: gamecontext.SessionSignals{
+			DurationSeconds:     fptr(132.0),
+			ActivePlayerCount:   iptr(1),
+			GameActive:          bptr(false),
+			GameMode:            sptr("ffa"),
+			EliminationSequence: []string{"BB:22", "CC:33"},
+		},
+		Players: map[string]*gamecontext.PlayerSignals{
+			"AA:11": {
+				Serial:            "AA:11",
+				MovementIntensity: fptr(1.25),
+				MovementVariance:  fptr(0.40),
+				BatteryPct:        fptr(72),
+				SkillLevel:        fptr(0.8),
+				Active:            bptr(true),
+			},
+			"BB:22": {
+				Serial:            "BB:22",
+				MovementIntensity: fptr(0.10),
+				MovementVariance:  fptr(0.05),
+				BatteryPct:        fptr(40),
+				SkillLevel:        fptr(0.3),
+				Active:            bptr(false),
+			},
+			// Eliminated player with all signals never observed.
+			"CC:33": {Serial: "CC:33"},
+		},
+	}
+}
+
+type retroCase struct {
+	name     string
+	snapshot flags.Snapshot
+	context  gamecontext.GameContext
+}
+
+func retroCases() []retroCase {
+	return []retroCase{
+		{
+			name:     "retro_3players",
+			snapshot: retroSnapshot(),
+			context:  retroThreePlayers(),
+		},
+		{
+			// All players eliminated -> no survivor -> winner unknown.
+			name:     "retro_all_eliminated",
+			snapshot: retroSnapshot(),
+			context: gamecontext.GameContext{
+				SessionID: "session-9",
+				Session: gamecontext.SessionSignals{
+					DurationSeconds:     fptr(60.0),
+					ActivePlayerCount:   iptr(0),
+					GameActive:          bptr(false),
+					GameMode:            sptr("joust"),
+					EliminationSequence: []string{"AA:11", "BB:22"},
+				},
+				Players: map[string]*gamecontext.PlayerSignals{
+					"AA:11": {Serial: "AA:11", BatteryPct: fptr(30), SkillLevel: fptr(0.5)},
+					"BB:22": {Serial: "BB:22", BatteryPct: fptr(25), SkillLevel: fptr(0.4)},
+				},
+			},
+		},
+		{
+			// No players, nil session signals: every field renders "unknown"/[].
+			name:     "retro_empty",
+			snapshot: retroSnapshot(),
+			context: gamecontext.GameContext{
+				SessionID: "session-1",
+				Players:   map[string]*gamecontext.PlayerSignals{},
+			},
+		},
+		{
+			// One survivor (winner) but every player signal never observed.
+			name:     "retro_unknown_signals",
+			snapshot: retroSnapshot(),
+			context: gamecontext.GameContext{
+				SessionID: "session-0",
+				Session: gamecontext.SessionSignals{
+					EliminationSequence: []string{"ZZ:99"},
+				},
+				Players: map[string]*gamecontext.PlayerSignals{
+					"ZZ:99": {Serial: "ZZ:99"},
+					"YY:88": {Serial: "YY:88"},
+				},
+			},
+		},
+	}
+}
+
+// renderRetroGolden serializes a RetroPrompt into the golden-file layout.
+func renderRetroGolden(p RetroPrompt) string {
+	var b strings.Builder
+	b.WriteString("=== MODEL ===\n")
+	b.WriteString(p.Model)
+	b.WriteString("\n=== SYSTEM ===\n")
+	b.WriteString(p.System)
+	b.WriteString("\n=== USER ===\n")
+	b.WriteString(p.User)
+	b.WriteString("\n")
+	return b.String()
+}
+
+func TestRetroGolden(t *testing.T) {
+	for _, tc := range retroCases() {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got := renderRetroGolden(BuildRetro(RetroInput{
+				Snapshot: tc.snapshot,
+				Context:  tc.context,
+				Now:      fixedNow,
+			}))
+			path := filepath.Join("testdata", tc.name+".golden")
+			if *update {
+				if err := os.WriteFile(path, []byte(got), 0o644); err != nil {
+					t.Fatalf("write golden: %v", err)
+				}
+				return
+			}
+			want, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read golden (run with -update to create): %v", err)
+			}
+			if got != string(want) {
+				t.Errorf("retro prompt mismatch for %s\n--- got ---\n%s\n--- want ---\n%s", tc.name, got, want)
+			}
+		})
+	}
+}
+
+// TestPlayerOutcome covers the elimination-position derivation: the first
+// eliminated serial is "eliminated #1", an absent serial is a "survivor".
+func TestPlayerOutcome(t *testing.T) {
+	seq := []string{"BB:22", "CC:33"}
+	cases := map[string]string{
+		"BB:22": "eliminated #1",
+		"CC:33": "eliminated #2",
+		"AA:11": "survivor", // never eliminated
+	}
+	for serial, want := range cases {
+		if got := playerOutcome(serial, seq); got != want {
+			t.Errorf("playerOutcome(%q) = %q, want %q", serial, got, want)
+		}
+	}
+	// Empty sequence: everyone is a survivor.
+	if got := playerOutcome("AA:11", nil); got != "survivor" {
+		t.Errorf("playerOutcome with no eliminations = %q, want survivor", got)
+	}
+}
+
+// TestWinnerSerial: exactly one survivor wins; zero or multiple survivors -> unknown.
+func TestWinnerSerial(t *testing.T) {
+	t.Run("sole survivor wins", func(t *testing.T) {
+		if got := winnerSerial([]string{"AA:11", "BB:22", "CC:33"}, []string{"BB:22", "CC:33"}); got != "AA:11" {
+			t.Errorf("winner = %q, want AA:11", got)
+		}
+	})
+	t.Run("all eliminated -> unknown", func(t *testing.T) {
+		if got := winnerSerial([]string{"AA:11", "BB:22"}, []string{"AA:11", "BB:22"}); got != unknown {
+			t.Errorf("winner = %q, want unknown", got)
+		}
+	})
+	t.Run("multiple survivors -> unknown", func(t *testing.T) {
+		if got := winnerSerial([]string{"AA:11", "BB:22", "CC:33"}, []string{"CC:33"}); got != unknown {
+			t.Errorf("winner = %q, want unknown", got)
+		}
+	})
+	t.Run("no players -> unknown", func(t *testing.T) {
+		if got := winnerSerial(nil, nil); got != unknown {
+			t.Errorf("winner = %q, want unknown", got)
+		}
+	})
+}
+
+// TestRetroDeterminism: identical input yields byte-identical output regardless
+// of player map insertion order.
+func TestRetroDeterminism(t *testing.T) {
+	in := RetroInput{
+		Snapshot: retroSnapshot(),
+		Context:  retroThreePlayers(),
+		Now:      fixedNow,
+	}
+	first := BuildRetro(in)
+	second := BuildRetro(in)
+	if first != second {
+		t.Fatalf("non-deterministic BuildRetro:\n%+v\n%+v", first, second)
+	}
+}
+
+// TestRetroContractKeys: the System prompt names every response-contract key and
+// every calibration flag, so it cannot drift from the documented surface.
+func TestRetroContractKeys(t *testing.T) {
+	sys := BuildRetro(RetroInput{Snapshot: retroSnapshot(), Context: retroThreePlayers(), Now: fixedNow}).System
+	for _, key := range []string{"session_assessment", "suggestions", "flag", "value", "reason"} {
+		if !strings.Contains(sys, `"`+key+`"`) {
+			t.Errorf("system prompt missing response-contract key %q", key)
+		}
+	}
+	for _, flag := range []string{
+		calibDifficultyFactor, calibPacingProfile, calibThresholdTable, calibObjectiveVariant,
+	} {
+		if !strings.Contains(sys, flag) {
+			t.Errorf("system prompt missing calibration flag %q", flag)
+		}
+	}
+}
+
+// TestRetroEmptyPlayers: a session with no players renders the "(none)" marker
+// and an unknown winner.
+func TestRetroEmptyPlayers(t *testing.T) {
+	user := BuildRetro(RetroInput{
+		Snapshot: retroSnapshot(),
+		Context:  gamecontext.GameContext{SessionID: "s"},
+		Now:      fixedNow,
+	}).User
+	for _, want := range []string{
+		"duration_seconds: unknown",
+		"final_active_players: unknown",
+		"elimination_order: []",
+		"winner: unknown",
+		"(none)",
+	} {
+		if !strings.Contains(user, want) {
+			t.Errorf("missing %q in:\n%s", want, user)
+		}
+	}
+}

--- a/services/agent/llm/testdata/retro_3players.golden
+++ b/services/agent/llm/testdata/retro_3players.golden
@@ -1,0 +1,50 @@
+=== MODEL ===
+phi4-mini
+=== SYSTEM ===
+You are the JoustMania post-game analyst. A physical movement party game has just
+ended. You receive a full session summary and must suggest CALIBRATION TWEAKS that
+would make the NEXT game more fun. You are NOT controlling a live game — you make
+at most a handful of recommendations, which a human reviews. Suggestions are
+RECORDED ONLY and never auto-applied.
+
+CALIBRATION SURFACE — you may ONLY suggest changes to these flags. Each is read at
+game INIT:
+
+  global_difficulty_factor   (float, ~0.5..1.5; 1.0 = current) — scales overall
+                             movement demand for the next game.
+  pacing_profile             (enum: "relaxed" | "standard" | "intense") — the
+                             music-schedule preset that shapes round tempo.
+  threshold_table            (named death/warning threshold table, e.g.
+                             "easy" | "standard" | "hard").
+  objective_variant          (enum: endurance | balanced | accelerate | chaos) —
+                             the session goal weighting for the next game.
+
+POLICY: suggest the SMALLEST change that addresses an observed problem. If the
+session looked healthy, return an empty suggestions list. Do not invent flags
+outside the calibration surface.
+
+RESPONSE CONTRACT — reply with EXACTLY ONE JSON object, no prose, matching:
+{
+  "session_assessment": "<one short sentence: how did this game go?>",
+  "suggestions": [
+    {
+      "flag": "<one of: global_difficulty_factor, pacing_profile, threshold_table, objective_variant>",
+      "value": "<the suggested value as a string>",
+      "reason": "<one short sentence tying the change to session evidence>"
+    }
+  ]
+}
+If no tweak is warranted, return "suggestions": [].
+=== USER ===
+SESSION RETROSPECTIVE (session=session-7, mode=ffa, captured_at=2026-06-05T12:30:00Z)
+
+Outcome:
+  duration_seconds: 132.00
+  final_active_players: 1
+  elimination_order: [BB:22, CC:33]
+  winner: AA:11
+
+Players (sorted by serial; "unknown" = signal never observed):
+  AA:11: outcome=survivor battery_pct=72.00 skill=0.80 movement_intensity=1.25 movement_variance=0.40
+  BB:22: outcome=eliminated #1 battery_pct=40.00 skill=0.30 movement_intensity=0.10 movement_variance=0.05
+  CC:33: outcome=eliminated #2 battery_pct=unknown skill=unknown movement_intensity=unknown movement_variance=unknown

--- a/services/agent/llm/testdata/retro_all_eliminated.golden
+++ b/services/agent/llm/testdata/retro_all_eliminated.golden
@@ -1,0 +1,49 @@
+=== MODEL ===
+phi4-mini
+=== SYSTEM ===
+You are the JoustMania post-game analyst. A physical movement party game has just
+ended. You receive a full session summary and must suggest CALIBRATION TWEAKS that
+would make the NEXT game more fun. You are NOT controlling a live game — you make
+at most a handful of recommendations, which a human reviews. Suggestions are
+RECORDED ONLY and never auto-applied.
+
+CALIBRATION SURFACE — you may ONLY suggest changes to these flags. Each is read at
+game INIT:
+
+  global_difficulty_factor   (float, ~0.5..1.5; 1.0 = current) — scales overall
+                             movement demand for the next game.
+  pacing_profile             (enum: "relaxed" | "standard" | "intense") — the
+                             music-schedule preset that shapes round tempo.
+  threshold_table            (named death/warning threshold table, e.g.
+                             "easy" | "standard" | "hard").
+  objective_variant          (enum: endurance | balanced | accelerate | chaos) —
+                             the session goal weighting for the next game.
+
+POLICY: suggest the SMALLEST change that addresses an observed problem. If the
+session looked healthy, return an empty suggestions list. Do not invent flags
+outside the calibration surface.
+
+RESPONSE CONTRACT — reply with EXACTLY ONE JSON object, no prose, matching:
+{
+  "session_assessment": "<one short sentence: how did this game go?>",
+  "suggestions": [
+    {
+      "flag": "<one of: global_difficulty_factor, pacing_profile, threshold_table, objective_variant>",
+      "value": "<the suggested value as a string>",
+      "reason": "<one short sentence tying the change to session evidence>"
+    }
+  ]
+}
+If no tweak is warranted, return "suggestions": [].
+=== USER ===
+SESSION RETROSPECTIVE (session=session-9, mode=joust, captured_at=2026-06-05T12:30:00Z)
+
+Outcome:
+  duration_seconds: 60.00
+  final_active_players: 0
+  elimination_order: [AA:11, BB:22]
+  winner: unknown
+
+Players (sorted by serial; "unknown" = signal never observed):
+  AA:11: outcome=eliminated #1 battery_pct=30.00 skill=0.50 movement_intensity=unknown movement_variance=unknown
+  BB:22: outcome=eliminated #2 battery_pct=25.00 skill=0.40 movement_intensity=unknown movement_variance=unknown

--- a/services/agent/llm/testdata/retro_empty.golden
+++ b/services/agent/llm/testdata/retro_empty.golden
@@ -1,0 +1,48 @@
+=== MODEL ===
+phi4-mini
+=== SYSTEM ===
+You are the JoustMania post-game analyst. A physical movement party game has just
+ended. You receive a full session summary and must suggest CALIBRATION TWEAKS that
+would make the NEXT game more fun. You are NOT controlling a live game — you make
+at most a handful of recommendations, which a human reviews. Suggestions are
+RECORDED ONLY and never auto-applied.
+
+CALIBRATION SURFACE — you may ONLY suggest changes to these flags. Each is read at
+game INIT:
+
+  global_difficulty_factor   (float, ~0.5..1.5; 1.0 = current) — scales overall
+                             movement demand for the next game.
+  pacing_profile             (enum: "relaxed" | "standard" | "intense") — the
+                             music-schedule preset that shapes round tempo.
+  threshold_table            (named death/warning threshold table, e.g.
+                             "easy" | "standard" | "hard").
+  objective_variant          (enum: endurance | balanced | accelerate | chaos) —
+                             the session goal weighting for the next game.
+
+POLICY: suggest the SMALLEST change that addresses an observed problem. If the
+session looked healthy, return an empty suggestions list. Do not invent flags
+outside the calibration surface.
+
+RESPONSE CONTRACT — reply with EXACTLY ONE JSON object, no prose, matching:
+{
+  "session_assessment": "<one short sentence: how did this game go?>",
+  "suggestions": [
+    {
+      "flag": "<one of: global_difficulty_factor, pacing_profile, threshold_table, objective_variant>",
+      "value": "<the suggested value as a string>",
+      "reason": "<one short sentence tying the change to session evidence>"
+    }
+  ]
+}
+If no tweak is warranted, return "suggestions": [].
+=== USER ===
+SESSION RETROSPECTIVE (session=session-1, mode=unknown, captured_at=2026-06-05T12:30:00Z)
+
+Outcome:
+  duration_seconds: unknown
+  final_active_players: unknown
+  elimination_order: []
+  winner: unknown
+
+Players (sorted by serial; "unknown" = signal never observed):
+  (none)

--- a/services/agent/llm/testdata/retro_unknown_signals.golden
+++ b/services/agent/llm/testdata/retro_unknown_signals.golden
@@ -1,0 +1,49 @@
+=== MODEL ===
+phi4-mini
+=== SYSTEM ===
+You are the JoustMania post-game analyst. A physical movement party game has just
+ended. You receive a full session summary and must suggest CALIBRATION TWEAKS that
+would make the NEXT game more fun. You are NOT controlling a live game — you make
+at most a handful of recommendations, which a human reviews. Suggestions are
+RECORDED ONLY and never auto-applied.
+
+CALIBRATION SURFACE — you may ONLY suggest changes to these flags. Each is read at
+game INIT:
+
+  global_difficulty_factor   (float, ~0.5..1.5; 1.0 = current) — scales overall
+                             movement demand for the next game.
+  pacing_profile             (enum: "relaxed" | "standard" | "intense") — the
+                             music-schedule preset that shapes round tempo.
+  threshold_table            (named death/warning threshold table, e.g.
+                             "easy" | "standard" | "hard").
+  objective_variant          (enum: endurance | balanced | accelerate | chaos) —
+                             the session goal weighting for the next game.
+
+POLICY: suggest the SMALLEST change that addresses an observed problem. If the
+session looked healthy, return an empty suggestions list. Do not invent flags
+outside the calibration surface.
+
+RESPONSE CONTRACT — reply with EXACTLY ONE JSON object, no prose, matching:
+{
+  "session_assessment": "<one short sentence: how did this game go?>",
+  "suggestions": [
+    {
+      "flag": "<one of: global_difficulty_factor, pacing_profile, threshold_table, objective_variant>",
+      "value": "<the suggested value as a string>",
+      "reason": "<one short sentence tying the change to session evidence>"
+    }
+  ]
+}
+If no tweak is warranted, return "suggestions": [].
+=== USER ===
+SESSION RETROSPECTIVE (session=session-0, mode=unknown, captured_at=2026-06-05T12:30:00Z)
+
+Outcome:
+  duration_seconds: unknown
+  final_active_players: unknown
+  elimination_order: [ZZ:99]
+  winner: YY:88
+
+Players (sorted by serial; "unknown" = signal never observed):
+  YY:88: outcome=survivor battery_pct=unknown skill=unknown movement_intensity=unknown movement_variance=unknown
+  ZZ:99: outcome=eliminated #1 battery_pct=unknown skill=unknown movement_intensity=unknown movement_variance=unknown

--- a/services/agent/main.go
+++ b/services/agent/main.go
@@ -290,6 +290,15 @@ func main() {
 	infraLoop.SetGate(func(snap infracontext.InfraContext, now time.Time) bool {
 		return gate.ShouldEvaluateInfra(snap, now, infraControllerTTL)
 	})
+	// Post-game retrospective (#844): on the GameActive true->false transition the
+	// store fires OnGameEnd with a pre-reset snapshot, and the RetroCoordinator
+	// captures the prompt the agent would send to an offline analyst on a dedicated
+	// agent.llm.retro span (capture-first, exactly once per session). It is wired
+	// AFTER the loop and deliberately does NOT touch the loop, the gate, or the rate
+	// limiter — a retrospective never consumes the in-game intervention budget.
+	retro := decision.NewRetroCoordinator(agentFlags, logger)
+	store.OnGameEnd = retro.OnGameEnd
+
 	pipe := newPipeline(store, loop, lifecycle.PlayerTTL).withInfra(infraStore, infraLoop)
 
 	grpcServer := grpc.NewServer()

--- a/services/agent/scripts/replay-prompt.sh
+++ b/services/agent/scripts/replay-prompt.sh
@@ -25,6 +25,11 @@
 # manual eyeball. It only invokes the CLI; #741 (resolve_backend) will wire a
 # real backend and #742 settles Claude auth (Claude Max sub, no API key — the
 # `claude` CLI headless path is the current candidate).
+#
+# It ALSO replays post-game `agent.llm.retro` spans (#844) identically: copy the
+# `llm.retro.system` / `llm.retro.user` attribute values out of an
+# `agent.llm.retro` span (instead of llm.prompt.system/user) into the two files
+# and run the same way.
 
 set -euo pipefail
 


### PR DESCRIPTION
## What & why

When a game **ends**, the agent has the richest data it will ever have (full
elimination sequence, final duration, skill spread) and its suggestions —
calibration tweaks — take effect at the *next* game's init. This adds a
**post-game analyst** path that builds a retrospective prompt and **captures**
it on a dedicated `agent.llm.retro` span (capture-first, identical to the #739
spike — no backend called yet). Stacked on PR #842.

## Trigger design

On the `GameActive` true→false transition the `gamecontext.Store` fires a new
**`OnGameEnd`** hook with a **pre-reset** snapshot (`SessionID` +
`EliminationSequence` intact), invoked **after** the store mutex is released (no
re-entrancy). `decision.RetroCoordinator.OnGameEnd` consumes it: it builds
`llm.BuildRetro(...)` and emits the span via the sole builder
`retroPromptAttributes` (schema-complete every emission).

## Attribution divergence: `inference.used = "none"`

The in-game capture records `"rules"` because it falls back to the rules engine.
A retrospective has **no** rules fallback — nothing runs in place of the analyst
at game end — so `"rules"` would be a lie. The honest value is `"none"`
(`DefaultInference`); #741 supplies `"llm"` once a backend answers.

## Exactly-once

Two layers: the store fires only on the true→false edge (not on start, not on a
repeated `false`), and the coordinator dedupes on `SessionID`. Same id twice →
one span; new id → a second.

## No intervention-budget interaction

The coordinator **never** touches `gate.ShouldEvaluate`, the `Loop`, or the rate
limiter — no code path from a retrospective to the limiter. Structural guarantee,
not a convention. Flags evaluated with `context.Background()` (no inbound RPC
context at game end → standalone span).

## Minimal store diff for #845

`gamecontext/store.go` will be rewritten by #845. The hook here is deliberately
minimal/additive: one `OnGameEnd` field, a `snapshotLocked()` helper factored out
of `Snapshot()`, and a few lines in the existing true→false branch.
`SetGameActive`'s signature is unchanged; a code comment records the constraint.

## Suggestion contract → calibration surface (#766)

`session_assessment` + `suggestions[]` of `{flag, value, reason}`, with `flag`
constrained to `global_difficulty_factor` / `pacing_profile` / `threshold_table`
/ `objective_variant` (read at init). Recorded only, never auto-applied.

## Tests

`go test ./...`, `go vet ./...`, `go build ./...`, `gofmt -l .` all green
(incl. `-race`). New: retro golden tests (4 scenarios) + determinism +
contract-presence + `TestPlayerOutcome`/`TestWinnerSerial`; store hook
fires-once/not-on-start/nil-safe; coordinator emits/schema-complete/exactly-once/
skips-active/skips-empty.

Closes #844.

🤖 Generated with [Claude Code](https://claude.com/claude-code)