### PR TITLE
feat(game_coordinator): game_id labels for agent per-game partitioning (#845)

### DIFF
--- a/services/agent/gamecontext/extract_metrics.go
+++ b/services/agent/gamecontext/extract_metrics.go
@@ -17,7 +17,7 @@ const (
 	metricDuration       = "game_duration_seconds"       // live
 	metricActivePlayers  = "game_active_players"         // live
 	metricGameActive     = "game_active"                 // live
-	metricGameMode       = "current_game_mode"           // live
+	metricGameMode       = "game_current_mode"           // live (coordinator emits game_current_mode; #848)
 	metricDeathsTotal    = "game_player_deaths_total"    // live
 	metricPeakAccel      = "game_player_peak_accel"      // live (game_id carrier)
 

--- a/services/agent/gamecontext/extract_metrics_test.go
+++ b/services/agent/gamecontext/extract_metrics_test.go
@@ -159,7 +159,7 @@ func TestApplyMetrics_SessionScalars(t *testing.T) {
 	// mode with value 0 must be ignored.
 	s2 := newTestStore()
 	if s2.ApplyMetrics(metricsWith(metricGameMode, 0, map[string]string{"mode": "off"})) {
-		t.Fatal("current_game_mode with value 0 should be ignored")
+		t.Fatal("game_current_mode with value 0 should be ignored")
 	}
 }
 

--- a/services/agent/gamecontext/model.go
+++ b/services/agent/gamecontext/model.go
@@ -69,7 +69,7 @@ type SessionSignals struct {
 	GameActive *bool
 
 	// GameMode is the current game mode.
-	// Source: current_game_mode{mode} label (value != 0) (live), or span
+	// Source: game_current_mode{mode} label (value != 0) (live), or span
 	// attribute game.mode.
 	GameMode *string
 

--- a/services/game_coordinator/game_session.py
+++ b/services/game_coordinator/game_session.py
@@ -217,8 +217,8 @@ class GameSession:
                     self.game_state = game_coordinator_pb2.GameState.ENDED
 
                 # Update lifecycle metrics for THIS session's kind (#775).
-                metrics.active_game.labels(game_kind=self.game_kind).set(0)
-                metrics.active_players.labels(game_kind=self.game_kind).set(0)
+                metrics.active_game.labels(game_kind=self.game_kind, game_id=self.game_id).set(0)
+                metrics.active_players.labels(game_kind=self.game_kind, game_id=self.game_id).set(0)
                 if self.is_primary:
                     # players_alive is a single global gauge (not yet per-kind);
                     # only the primary session resets it.
@@ -227,7 +227,7 @@ class GameSession:
                     metrics.games_completed_total.labels(mode=self.game_name, game_kind=self.game_kind).inc()
                 if self.game_start_time:
                     duration = time.time() - self.game_start_time
-                    metrics.game_duration_seconds.labels(game_kind=self.game_kind).set(duration)
+                    metrics.game_duration_seconds.labels(game_kind=self.game_kind, game_id=self.game_id).set(duration)
 
                 # Cleanup channels
                 await self.clients.close()

--- a/services/game_coordinator/games/base.py
+++ b/services/game_coordinator/games/base.py
@@ -689,7 +689,7 @@ class BaseGameMode(ABC):
 
             # Set alive metric for all initialized players (Phase 75: filter dead from dashboard)
             for serial in self.players:
-                metrics.player_alive.labels(serial=serial).set(1)
+                metrics.player_alive.labels(serial=serial, game_id=self.game_id).set(1)
             metrics.players_alive.set(len(self.players))
 
             logger.info(f"Initialized {len(self.players)} players from StartGame RPC")
@@ -1250,13 +1250,19 @@ class BaseGameMode(ABC):
 
         # Emit Prometheus metrics periodically (every ~1 second)
         if player.analytics.sample_count % config.analytics.metrics_emit_interval_frames == 0:
-            metrics.player_accel_magnitude.labels(serial=serial).set(accel_mag)
-            metrics.player_movement_zone.labels(serial=serial).set(zone.value)
+            metrics.player_accel_magnitude.labels(serial=serial, game_id=self.game_id).set(accel_mag)
+            metrics.player_movement_zone.labels(serial=serial, game_id=self.game_id).set(zone.value)
             metrics.player_peak_accel.labels(serial=serial, game_id=self.game_id).set(player.analytics.peak_accel)
-            metrics.player_playstyle.labels(serial=serial).set(player.analytics.get_playstyle().value)
+            metrics.player_playstyle.labels(serial=serial, game_id=self.game_id).set(
+                player.analytics.get_playstyle().value
+            )
             # Intervention observability signals (#730 / #722 §7)
-            metrics.player_movement_variance.labels(serial=serial).set(player.analytics.windowed_variance)
-            metrics.player_skill_level.labels(serial=serial).set(player.analytics.get_skill_level())
+            metrics.player_movement_variance.labels(serial=serial, game_id=self.game_id).set(
+                player.analytics.windowed_variance
+            )
+            metrics.player_skill_level.labels(serial=serial, game_id=self.game_id).set(
+                player.analytics.get_skill_level()
+            )
 
         # Record to histogram for distribution analysis
         metrics.accel_distribution.labels(game_mode=self.get_game_name()).observe(accel_mag)
@@ -1608,7 +1614,7 @@ class BaseGameMode(ABC):
         player.smoothed_accel = 0.0
         player.grace_until = time.time() + grace
 
-        metrics.player_alive.labels(serial=serial).set(1)
+        metrics.player_alive.labels(serial=serial, game_id=self.game_id).set(1)
         alive_count = len([p for p in self.players.values() if p.alive])
         metrics.players_alive.set(alive_count)
 
@@ -1668,7 +1674,7 @@ class BaseGameMode(ABC):
         # Mark player as dead in metrics - dashboard template variables filter
         # on game_player_alive==1 so dead players naturally disappear from panels.
         # Metric removal happens at game end via clear_all_player_analytics().
-        metrics.player_alive.labels(serial=serial).set(0)
+        metrics.player_alive.labels(serial=serial, game_id=self.game_id).set(0)
         alive_count = len([p for p in self.players.values() if p.alive])
         metrics.players_alive.set(alive_count)
 
@@ -2048,6 +2054,11 @@ class BaseGameMode(ABC):
                 "player.team": player.team,
                 "player.color": str(player.color),
                 GAME_MODE_ATTR: self.get_game_name(),
+                # #845: stamp game identity so the agent can attribute a
+                # player_lifecycle span to its game (mirrors game.id/game.kind on
+                # the parent game-session span in game_session.py).
+                "game.id": self.game_id,
+                "game.kind": self.game_kind,
             },
         )
 

--- a/services/game_coordinator/metrics.py
+++ b/services/game_coordinator/metrics.py
@@ -19,7 +19,7 @@ from lib.otel_metrics import Counter, Gauge, Histogram
 active_game = Gauge(
     "game_active",
     "Whether a game is currently running (0=no, 1=yes)",
-    ["game_kind"],
+    ["game_kind", "game_id"],
 )
 
 current_game_mode = Gauge(
@@ -31,7 +31,7 @@ current_game_mode = Gauge(
 game_duration_seconds = Gauge(
     "game_duration_seconds",
     "Duration of current game in seconds",
-    ["game_kind"],
+    ["game_kind", "game_id"],
 )
 
 games_started_total = Counter(
@@ -64,12 +64,12 @@ shadow_games_preempted_total = Counter(
 active_players = Gauge(
     "game_active_players",
     "Number of players currently in game",
-    ["game_kind"],
+    ["game_kind", "game_id"],
 )
 
 players_alive = Gauge("game_players_alive", "Number of players currently alive")
 
-player_deaths_total = Counter("game_player_deaths_total", "Total player deaths", ["mode", "serial"])
+player_deaths_total = Counter("game_player_deaths_total", "Total player deaths", ["mode", "serial", "game_id"])
 
 player_kills_total = Counter("game_player_kills_total", "Total player kills", ["mode", "serial"])
 
@@ -205,13 +205,13 @@ gameplay_stream_reconnects_total = Counter(
 player_accel_magnitude = Gauge(
     "game_player_accel_magnitude",
     "Current acceleration magnitude for player (g-force)",
-    ["serial"],
+    ["serial", "game_id"],
 )
 
 player_movement_zone = Gauge(
     "game_player_movement_zone",
     "Current movement zone (0=still, 1=active, 2=warning, 3=danger)",
-    ["serial"],
+    ["serial", "game_id"],
 )
 
 player_peak_accel = Gauge(
@@ -223,13 +223,13 @@ player_peak_accel = Gauge(
 player_playstyle = Gauge(
     "game_player_playstyle",
     "Player playstyle classification (0=calm, 1=balanced, 2=active, 3=aggressive)",
-    ["serial"],
+    ["serial", "game_id"],
 )
 
 player_alive = Gauge(
     "game_player_alive",
     "Player alive status (1=alive, 0=dead)",
-    ["serial"],
+    ["serial", "game_id"],
 )
 
 # Intervention observability metrics (#730, closes gaps from #722 §7).
@@ -239,14 +239,14 @@ player_movement_variance = Gauge(
     "game_player_movement_variance",
     "Rolling-window variance of acceleration magnitude (g^2). "
     "Near zero indicates a player gaming the EMA by holding still.",
-    ["serial"],
+    ["serial", "game_id"],
 )
 
 player_skill_level = Gauge(
     "game_player_skill_level",
     "Derived player skill level in [0.0, 1.0] (blend of playstyle control and "
     "motion smoothness). Complements game_player_playstyle.",
-    ["serial"],
+    ["serial", "game_id"],
 )
 
 player_elimination_order = Gauge(
@@ -300,26 +300,30 @@ def clear_player_analytics(serial: str, game_id: str = "") -> None:
     Normal player death sets player_alive=0 instead, letting dashboard queries
     filter dead players via game_player_alive==1 in template variables.
     Bulk cleanup at game end uses clear_all_player_analytics().
+
+    The per-player gauges carry both a ``serial`` and a ``game_id`` label (#845),
+    so removal must supply the same tuple the emitter set; ``game_id`` is the
+    ending session's id (mirrors how peak_accel / elimination_order are scoped).
     """
     with suppress(KeyError, ValueError):
-        player_accel_magnitude.remove(serial)
+        player_accel_magnitude.remove(serial, game_id)
 
     with suppress(KeyError, ValueError):
-        player_movement_zone.remove(serial)
+        player_movement_zone.remove(serial, game_id)
 
     with suppress(KeyError, ValueError):
-        player_playstyle.remove(serial)
+        player_playstyle.remove(serial, game_id)
 
     with suppress(KeyError, ValueError):
-        player_movement_variance.remove(serial)
+        player_movement_variance.remove(serial, game_id)
 
     with suppress(KeyError, ValueError):
-        player_skill_level.remove(serial)
+        player_skill_level.remove(serial, game_id)
 
     with suppress(KeyError, ValueError):
-        player_alive.remove(serial)
+        player_alive.remove(serial, game_id)
 
-    # peak_accel and elimination_order have both serial and game_id labels
+    # peak_accel and elimination_order also carry serial + game_id labels.
     if game_id:
         with suppress(KeyError, ValueError):
             player_peak_accel.remove(serial, game_id)

--- a/services/game_coordinator/servicer.py
+++ b/services/game_coordinator/servicer.py
@@ -420,9 +420,9 @@ class GameCoordinatorServicer(game_coordinator_pb2_grpc.GameCoordinatorServiceSe
                     return False, "Game already in progress"
                 logger.warning("Real game lost the admission race to a late shadow; preempting again (#837)")
             # Update lifecycle metrics for this session's kind.
-            metrics.active_game.labels(game_kind=game_kind).set(1)
+            metrics.active_game.labels(game_kind=game_kind, game_id=game_id).set(1)
             metrics.games_started_total.labels(mode=session.game_name, game_kind=game_kind).inc()
-            metrics.active_players.labels(game_kind=game_kind).set(len(session.players))
+            metrics.active_players.labels(game_kind=game_kind, game_id=game_id).set(len(session.players))
 
             # Publish game_start on this session's bus.
             await session.event_bus.publish(

--- a/services/game_coordinator/tests/test_game_id_labels.py
+++ b/services/game_coordinator/tests/test_game_id_labels.py
@@ -1,0 +1,138 @@
+"""
+Tests for the additive ``game_id`` label on live-session and per-player metrics,
+plus ``game.id`` / ``game.kind`` on the player_lifecycle span (#845).
+
+These guarantee the producer side of per-game agent partitioning: every live
+signal the agent routes on is stamped with the emitting session's game_id, so
+concurrent games never blur into one partition.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import pytest_asyncio
+
+# Setup paths for imports
+test_dir = Path(__file__).parent
+service_dir = test_dir.parent
+project_root = service_dir.parent.parent
+sys.path.insert(0, str(project_root))
+sys.path.insert(0, str(test_dir))
+
+from conftest import EventCollector, MockControllerManagerService
+
+from proto import game_coordinator_pb2
+from services.game_coordinator import metrics
+from services.game_coordinator.games.ffa import FFAGame
+
+GAME_ID = "test_labels_001"
+
+
+class MockGameplayStream:
+    async def write(self, message):
+        pass
+
+
+@pytest_asyncio.fixture
+async def ffa_game():
+    """FFA game with 4 initialized players and a known game_id."""
+    mock_cm = MockControllerManagerService(num_controllers=4, death_schedule={}, max_duration=10.0)
+    collector = EventCollector()
+    game = FFAGame(
+        controller_manager_client=mock_cm,
+        event_publisher=collector.publish,
+        audio_client=None,
+        game_id=GAME_ID,
+    )
+    await game._initialize_players_impl(mock_cm.controllers)
+    game.gameplay_stream = MockGameplayStream()
+    return game
+
+
+class TestPerPlayerMetricLabels:
+    @pytest.mark.asyncio
+    async def test_kill_player_stamps_alive_with_game_id(self, ffa_game):
+        game = ffa_game
+        serial = next(iter(game.players))
+
+        with patch("services.game_coordinator.metrics.player_alive") as mock_alive:
+            await game._kill_player(serial, accel_mag=5.0)
+
+        mock_alive.labels.assert_called_with(serial=serial, game_id=GAME_ID)
+        mock_alive.labels.return_value.set.assert_called_with(0)
+
+    @pytest.mark.asyncio
+    async def test_initialize_marks_alive_with_game_id(self):
+        mock_cm = MockControllerManagerService(num_controllers=2, death_schedule={}, max_duration=10.0)
+        collector = EventCollector()
+        game = FFAGame(
+            controller_manager_client=mock_cm,
+            event_publisher=collector.publish,
+            audio_client=None,
+            game_id=GAME_ID,
+            initial_players=[game_coordinator_pb2.Player(serial="p1"), game_coordinator_pb2.Player(serial="p2")],
+        )
+
+        with patch("services.game_coordinator.metrics.player_alive") as mock_alive:
+            # The StartGame-RPC init path sets player_alive=1 per player.
+            await game._initialize_players()
+
+        assert mock_alive.labels.call_args_list, "player_alive never labeled during init"
+        for call in mock_alive.labels.call_args_list:
+            assert call.kwargs["game_id"] == GAME_ID
+        mock_alive.labels.return_value.set.assert_called_with(1)
+
+
+class TestLifecycleSpanGameIdentity:
+    def test_lifecycle_span_carries_game_id_and_kind(self, ffa_game):
+        game = ffa_game
+        game.game_kind = "shadow"
+        serial = next(iter(game.players))
+
+        with patch("services.game_coordinator.games.base.tracer") as mock_tracer:
+            game._create_player_lifecycle_span(serial)
+
+        _, kwargs = mock_tracer.start_span.call_args
+        attrs = kwargs["attributes"]
+        assert attrs["game.id"] == GAME_ID
+        assert attrs["game.kind"] == "shadow"
+        assert attrs["player.serial"] == serial
+
+
+class TestMetricDeclarationsCarryGameId:
+    """The label set on the gauge/counter declarations must include game_id so
+    the agent's extractors can read it (contract for PR A)."""
+
+    def test_live_session_metrics_have_game_id(self):
+        for metric in (metrics.active_game, metrics.active_players, metrics.game_duration_seconds):
+            assert "game_id" in metric.labelnames
+
+    def test_per_player_metrics_have_game_id(self):
+        for metric in (
+            metrics.player_alive,
+            metrics.player_accel_magnitude,
+            metrics.player_movement_zone,
+            metrics.player_playstyle,
+            metrics.player_movement_variance,
+            metrics.player_skill_level,
+            metrics.player_peak_accel,
+            metrics.player_elimination_order,
+            metrics.player_deaths_total,
+        ):
+            assert "game_id" in metric.labelnames
+
+
+class TestCleanupRemovesGameIdScopedSeries:
+    def test_clear_player_analytics_removes_serial_and_game_id_tuple(self):
+        with (
+            patch("services.game_coordinator.metrics.player_alive") as mock_alive,
+            patch("services.game_coordinator.metrics.player_accel_magnitude") as mock_accel,
+            patch("services.game_coordinator.metrics.player_skill_level") as mock_skill,
+        ):
+            metrics.clear_player_analytics("AA:BB:CC", game_id=GAME_ID)
+
+        mock_alive.remove.assert_called_once_with("AA:BB:CC", GAME_ID)
+        mock_accel.remove.assert_called_once_with("AA:BB:CC", GAME_ID)
+        mock_skill.remove.assert_called_once_with("AA:BB:CC", GAME_ID)

--- a/services/game_coordinator/tests/test_game_session.py
+++ b/services/game_coordinator/tests/test_game_session.py
@@ -189,7 +189,7 @@ class TestGameSessionLoop:
         await session._run_game_loop_async()
 
         # active_game/active_players reset to 0 for this session's kind.
-        mock_metrics.active_game.labels.assert_any_call(game_kind=GAME_KIND_PRIMARY)
+        mock_metrics.active_game.labels.assert_any_call(game_kind=GAME_KIND_PRIMARY, game_id="game_abc123")
         mock_metrics.active_game.labels.return_value.set.assert_any_call(0)
         mock_metrics.active_players.labels.return_value.set.assert_any_call(0)
         # players_alive (still a single global gauge) reset only by primary.

--- a/services/game_coordinator/tests/test_servicer_sessions.py
+++ b/services/game_coordinator/tests/test_servicer_sessions.py
@@ -20,7 +20,7 @@ import asyncio
 import os
 import sys
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 import pytest
 
@@ -722,7 +722,7 @@ class TestShadowGameGovernance:
         """Shadow starts label their lifecycle metrics game_kind='shadow'."""
         with _NO_THREAD:
             await servicer._start_game_from_config(_shadow_config(serials=("a1", "a2")), _MockSpan())
-        mock_metrics.active_game.labels.assert_any_call(game_kind="shadow")
+        mock_metrics.active_game.labels.assert_any_call(game_kind="shadow", game_id=ANY)
         mock_metrics.games_started_total.labels.assert_any_call(mode="FFA", game_kind="shadow")
 
     # -- Resource gate ------------------------------------------------------


### PR DESCRIPTION
## Summary

PR 0 of #845: stamp the game_coordinator's **live** telemetry with `game_id` so the agent can partition OBSERVE→DECIDE state per game. Concurrent games (real since the multi-session coordinator, #793/#776) currently blur into one agent partition because the live signals carry no `game_id`. This PR is **additive only** — every existing label (`game_kind`, `serial`, `mode`) is untouched, so dashboards and PromQL queries are unaffected.

Also fixes #848: the agent listened for `current_game_mode` but the coordinator emits `game_current_mode`.

## The label gap this closes (from the planning comment)

| Signal | Before | After |
|---|---|---|
| `game_active`, `game_active_players`, `game_duration_seconds` | `[game_kind]` | `[game_kind, game_id]` |
| `game_player_alive`, `game_player_accel_magnitude`, `game_player_deaths_total` | `[serial]` (+mode) | `+ game_id` |
| `game_player_peak_accel`, `game_player_elimination_order` | `[serial, game_id]` (already) | unchanged |
| `player_lifecycle` span | `player.serial`, `game.mode` | `+ game.id`, `+ game.kind` |

## What gained labels

**Live session gauges** (`game_id` added; declarations in `metrics.py`, emitters in `servicer.py` / `game_session.py`):
- `game_active`, `game_active_players`, `game_duration_seconds`

**Per-player game-scoped metrics** (`game_id` added; emitters in `games/base.py`):
- `game_player_alive`, `game_player_accel_magnitude`, `game_player_movement_zone`, `game_player_playstyle`, `game_player_movement_variance`, `game_player_skill_level`
- `game_player_deaths_total` — label added to the declaration (counter has no in-tree emit site yet; this fixes the contract ahead of PR A)

**Cleanup paths**: `clear_player_analytics` / `clear_session_player_analytics` now remove the `(serial, game_id)` tuple. The deprecated `clear_all_player_analytics` global wipe is label-agnostic (clears all series) and needed no change.

**Span**: `player_lifecycle` now carries `game.id` + `game.kind` (mirrors the parent game-session span in `game_session.py`).

## Cardinality

Bounded by `GAME_MAX_CONCURRENT_GAMES=4` — at most 4 distinct `game_id` values live at once. Per-game_id series are removed at game end via the existing per-session cleanup.

## Zero-dashboard-impact rationale

All changes append a label to existing series; no metric was renamed (#848 is fixed on the agent side) and no existing label was removed. Existing Grafana panels and alert rules select on the labels they already use and continue to match.

## Tests

- New `tests/test_game_id_labels.py` (6 tests): per-player/live-session label emission, span game.id/game.kind, declaration label-set contract, cleanup tuple removal.
- Updated existing assertions in `test_game_session.py` and `test_servicer_sessions.py` for the new label.
- `cd services/game_coordinator && uv run --extra test pytest` → **925 passed**.
- `make lint` → passed.
- Agent #848 fix: `cd services/agent && go build ./... && go test ./...` → all packages pass.
- `make test` (docker integration) **not** run locally — integration CI will cover it.

## Producer contract for agent-side PR A

Signals NOT carrying `game_id` (and why), so PR A's extractors know the boundary:
- `game_players_alive` (single global gauge, not per-session)
- `game_current_mode` / `game_sensitivity` / `game_music_tempo` / `effective_*_threshold` (single-game/primary state gauges)
- `controller_battery_pct` and all controller-manager metrics (out of scope)
- `games_started_total` / `games_completed_total` (lifecycle counters keyed by `mode` + `game_kind`, no per-instance id)

Part of #845. Fixes #848.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
