### PR TITLE
chore: post-#846 reconciliation — lift provider cap, drop obsolete filter (#843)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -59,9 +59,9 @@
       "groupName": "github actions"
     },
     {
-      "description": "Every flagd provider release >= 0.3.0 breaks the flagSetId-per-domain selector architecture against the compose-pinned flagd v0.13.2 (silent fallback to defaults — verified 0.4.1 and 0.5.0 on PR #840 CI; 0.3.0 drops RPC-resolver selector support entirely). Lift only via the coordinated provider+flagd-image upgrade in issue #843.",
-      "matchPackageNames": ["openfeature-provider-flagd"],
-      "allowedVersions": "<0.3.0"
+      "description": "flagd image + flagd providers must move TOGETHER (flag-set selector coupling, #843: providers >= 0.3.0 silently default against flagd < flagd-selector-header support). Group them so Renovate proposes coordinated bumps; the integration suite is the gate (silent-defaults failure mode).",
+      "matchPackageNames": ["openfeature-provider-flagd", "/^ghcr\\.io\\/open-feature\\/flagd$/", "/go-sdk-contrib\\/providers\\/flagd/"],
+      "groupName": "flagd + providers (coordinated)"
     },
     {
       "description": "Majors need explicit approval via the dependency dashboard",

--- a/tests/integration/test_rollout_plumbing.py
+++ b/tests/integration/test_rollout_plumbing.py
@@ -182,13 +182,6 @@ def _poll_until(predicate, timeout: float = RESOLVE_TIMEOUT_SECONDS, rewrite=Non
 
 
 @pytest.mark.asyncio
-# Known upstream bug in openfeature-provider-flagd 0.2.7 (test-only RPC
-# resolver): the event-listener thread dies with KeyError 'data' when a
-# data-less stream message arrives during teardown (flagd reload racing
-# provider.shutdown()). Fixed upstream in 0.3.0, but providers >= 0.3.0 break
-# our flagSetId selector architecture — see #843 for the coordinated upgrade
-# that removes this filter. Benign here: resolution already succeeded.
-@pytest.mark.filterwarnings("ignore::pytest.PytestUnhandledThreadExceptionWarning")
 async def test_rollout_write_shape_resolves_via_live_flagd(rollout_file, docker_compose):
     """The agent's rollout write shape (strategy=progressive, target_backend flip,
     current_controller_count variant flip along the ladder) is schema-valid and


### PR DESCRIPTION
Follow-up to the merged #846 (flagd v0.16 + provider upgrades) reconciling the artifacts #840 added for the pre-upgrade world:

- **renovate.json**: the `allowedVersions: <0.3.0` cap on `openfeature-provider-flagd` now contradicts the shipped 0.5.0. Replaced with a **coordinated group rule** (flagd image + Python provider + Go provider in one group) so future Renovate bumps move them together — the silent-defaults coupling (#843) remains, it's just at a new floor. Timely now that Renovate is active.
- **test_rollout_plumbing.py**: removed the `filterwarnings` for the 0.2.7 dead-listener bug — fixed upstream as of the shipped 0.5.0.
- **Rust checklist item from #843 verified**: selector-less evaluation against flagd v0.16.0 returns real configured values for flagSetId-scoped flags (`grpc_rpc_spans` from observability.json → `true`/`enabled`) — rust-hid's selector-less RPC reads are safe; its `open-feature-flagd` 0.1.0 crate is already the newest release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)