### PR TITLE
refactor(audio): replace pydub with miniaudio for music decoding

### DIFF
--- a/docs/AUDIO.md
+++ b/docs/AUDIO.md
@@ -64,7 +64,7 @@ Voice selection is configured in Settings (admin mode or settings service).
 
 **Recommended:** WAV files (44.1 kHz, 16-bit, stereo)
 
-**Supported with conversion overhead:** MP3, FLAC, OGG (converted via pydub)
+**Supported with conversion overhead:** MP3, FLAC, OGG (decoded via miniaudio)
 
 For best performance, use WAV files. Other formats require runtime conversion which adds latency.
 

--- a/services/audio/Dockerfile
+++ b/services/audio/Dockerfile
@@ -24,7 +24,6 @@ ARG TARGETARCH
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libasound2-data \
     libasound2 \
-    ffmpeg \
     && rm -rf /var/lib/apt/lists/* \
     && mkdir /extra-libs \
     && if [ "$TARGETARCH" = "arm64" ]; then \
@@ -33,12 +32,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
          LIB_DIR=/usr/lib/x86_64-linux-gnu; \
        fi \
     && cp "$LIB_DIR"/libasound.so* /extra-libs/ \
-    # Copy all shared libraries needed by ffmpeg/ffprobe (discovered via ldd)
-    # This auto-resolves all transitive deps (libavcodec, libavformat, libx264, etc.)
-    && ldd /usr/bin/ffmpeg /usr/bin/ffprobe \
-       | awk '/=>/ && $3 != "" {print $3}' \
-       | sort -u \
-       | while read -r lib; do cp -n "$lib" /extra-libs/ 2>/dev/null || true; done \
     && mkdir -p /extra-etc \
     && grep -E "^(root|audio):" /etc/group > /extra-etc/group
 
@@ -87,12 +80,8 @@ WORKDIR /app
 # Copy grpc-health-probe from official multi-arch image
 COPY --from=ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.52 /ko-app/grpc-health-probe /bin/grpc_health_probe
 
-# Copy system shared libraries (ALSA + ffmpeg deps for miniaudio/pyalsaaudio/pydub)
+# Copy system shared libraries (ALSA for miniaudio/pyalsaaudio)
 COPY --from=system-libs /extra-libs/ /usr/lib/
-
-# Copy ffmpeg/ffprobe binaries (required by pydub for OGG audio decoding)
-COPY --from=system-libs /usr/bin/ffmpeg /usr/bin/ffmpeg
-COPY --from=system-libs /usr/bin/ffprobe /usr/bin/ffprobe
 
 # Copy ALSA configuration files (required for PCM device resolution)
 COPY --from=system-libs /usr/share/alsa/ /usr/share/alsa/

--- a/services/audio/music_player.py
+++ b/services/audio/music_player.py
@@ -20,9 +20,9 @@ import wave
 from multiprocessing import Array, Process, Value
 from sys import platform
 
+import miniaudio
 import numpy as np
 import resampy
-from pydub import AudioSegment
 
 logger = logging.getLogger(__name__)
 
@@ -72,11 +72,19 @@ def _load_song_from_pattern(pattern: str) -> bytes | None:
     for song_path in files:
         try:
             logger.info(f"Loading music: {song_path}")
-            segment = AudioSegment.from_file(song_path)
-            segment = segment.set_channels(2).set_frame_rate(44100).set_sample_width(2)
+            decoded = miniaudio.decode_file(
+                song_path,
+                output_format=miniaudio.SampleFormat.SIGNED16,
+                nchannels=2,
+                sample_rate=44100,
+            )
 
             buf = io.BytesIO()
-            segment.export(buf, format="wav")
+            with wave.open(buf, "wb") as wf:
+                wf.setnchannels(2)
+                wf.setsampwidth(2)
+                wf.setframerate(44100)
+                wf.writeframes(decoded.samples.tobytes())
             wav_bytes = buf.getvalue()
             logger.info(f"Music loaded: {song_path} ({len(wav_bytes)} bytes)")
             return wav_bytes

--- a/services/audio/pyproject.toml
+++ b/services/audio/pyproject.toml
@@ -15,7 +15,6 @@ dependencies = [
     "resampy>=0.4.0",
     "numba>=0.59.0",  # Required for Python 3.11+ compatibility
     "numpy>=1.24.0",
-    "pydub>=0.25.0",
     "pyalsaaudio>=0.11.0; sys_platform == 'linux'",
 
     # gRPC

--- a/services/audio/tests/test_music_player.py
+++ b/services/audio/tests/test_music_player.py
@@ -2,8 +2,12 @@
 Unit tests for music_player module extracted helper functions.
 """
 
+import array
+import io
+import wave
 from unittest.mock import MagicMock, patch
 
+import miniaudio
 import numpy as np
 import pytest
 
@@ -290,6 +294,13 @@ class TestWriteSamples:
         assert device.write.call_count == 1
 
 
+def _mock_decoded_sound(num_frames: int = 64):
+    """Build a mock miniaudio.DecodedSoundFile with silent stereo int16 samples."""
+    decoded = MagicMock()
+    decoded.samples = array.array("h", [0] * (num_frames * 2))
+    return decoded
+
+
 class TestLoadSongFromPattern:
     """Tests for _load_song_from_pattern."""
 
@@ -299,40 +310,46 @@ class TestLoadSongFromPattern:
         assert result is None
 
     def test_loads_matching_file(self):
-        mock_segment = MagicMock()
-        mock_segment.set_channels.return_value = mock_segment
-        mock_segment.set_frame_rate.return_value = mock_segment
-        mock_segment.set_sample_width.return_value = mock_segment
-
-        # Mock export to write fake WAV bytes
-        def fake_export(buf, **_kwargs):
-            buf.write(b"RIFF_fake_wav_data")
-
-        mock_segment.export.side_effect = fake_export
-
         with (
             patch("services.audio.music_player.glob.glob", return_value=["/music/song1.ogg"]),
-            patch("services.audio.music_player.AudioSegment.from_file", return_value=mock_segment),
+            patch("services.audio.music_player.miniaudio.decode_file", return_value=_mock_decoded_sound()),
         ):
             result = _load_song_from_pattern("/music/*.ogg")
 
         assert result is not None
         assert isinstance(result, bytes)
         assert len(result) > 0
+        # Output is a valid WAV: stereo, 16-bit, 44100 Hz
+        with wave.open(io.BytesIO(result), "rb") as wf:
+            assert wf.getnchannels() == 2
+            assert wf.getsampwidth() == 2
+            assert wf.getframerate() == 44100
+            assert wf.getnframes() == 64
+
+    def test_decodes_to_target_format(self):
+        """decode_file is asked for stereo 16-bit 44100 Hz output."""
+        with (
+            patch("services.audio.music_player.glob.glob", return_value=["/music/song1.ogg"]),
+            patch(
+                "services.audio.music_player.miniaudio.decode_file", return_value=_mock_decoded_sound()
+            ) as mock_decode,
+        ):
+            _load_song_from_pattern("/music/*.ogg")
+
+        mock_decode.assert_called_once_with(
+            "/music/song1.ogg",
+            output_format=miniaudio.SampleFormat.SIGNED16,
+            nchannels=2,
+            sample_rate=44100,
+        )
 
     def test_shuffles_files_before_loading(self):
-        mock_segment = MagicMock()
-        mock_segment.set_channels.return_value = mock_segment
-        mock_segment.set_frame_rate.return_value = mock_segment
-        mock_segment.set_sample_width.return_value = mock_segment
-        mock_segment.export.side_effect = lambda buf, **_kwargs: buf.write(b"wav")
-
         files = ["/music/a.ogg", "/music/b.ogg", "/music/c.ogg"]
 
         with (
             patch("services.audio.music_player.glob.glob", return_value=files),
             patch("services.audio.music_player.random.shuffle") as mock_shuffle,
-            patch("services.audio.music_player.AudioSegment.from_file", return_value=mock_segment),
+            patch("services.audio.music_player.miniaudio.decode_file", return_value=_mock_decoded_sound()),
         ):
             _load_song_from_pattern("/music/*.ogg")
 
@@ -340,17 +357,11 @@ class TestLoadSongFromPattern:
 
     def test_skips_broken_file_and_loads_next(self):
         """If first file fails to decode, tries the next one."""
-        mock_segment = MagicMock()
-        mock_segment.set_channels.return_value = mock_segment
-        mock_segment.set_frame_rate.return_value = mock_segment
-        mock_segment.set_sample_width.return_value = mock_segment
-        mock_segment.export.side_effect = lambda buf, **_kwargs: buf.write(b"wav")
-
         with (
             patch("services.audio.music_player.glob.glob", return_value=["/music/bad.ogg", "/music/good.ogg"]),
             patch(
-                "services.audio.music_player.AudioSegment.from_file",
-                side_effect=[Exception("decode error"), mock_segment],
+                "services.audio.music_player.miniaudio.decode_file",
+                side_effect=[miniaudio.DecodeError("decode error"), _mock_decoded_sound()],
             ),
         ):
             result = _load_song_from_pattern("/music/*.ogg")
@@ -361,7 +372,10 @@ class TestLoadSongFromPattern:
         """Returns None if every file in the glob fails to decode."""
         with (
             patch("services.audio.music_player.glob.glob", return_value=["/music/a.ogg", "/music/b.ogg"]),
-            patch("services.audio.music_player.AudioSegment.from_file", side_effect=Exception("decode error")),
+            patch(
+                "services.audio.music_player.miniaudio.decode_file",
+                side_effect=miniaudio.DecodeError("decode error"),
+            ),
         ):
             result = _load_song_from_pattern("/music/*.ogg")
 

--- a/uv.lock
+++ b/uv.lock
@@ -427,7 +427,6 @@ dependencies = [
     { name = "opentelemetry-instrumentation-grpc" },
     { name = "psutil" },
     { name = "pyalsaaudio", marker = "sys_platform == 'linux'" },
-    { name = "pydub" },
     { name = "resampy" },
 ]
 
@@ -453,7 +452,6 @@ requires-dist = [
     { name = "opentelemetry-instrumentation-grpc", specifier = ">=0.49b0" },
     { name = "psutil", specifier = ">=5.9.0" },
     { name = "pyalsaaudio", marker = "sys_platform == 'linux'", specifier = ">=0.11.0" },
-    { name = "pydub", specifier = ">=0.25.0" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.23.0" },
     { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=4.1.0" },
@@ -1214,15 +1212,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fe/cf/d2d3b9f5699fb1e4615c8e32ff220203e43b248e1dfcc6736ad9057731ca/pycparser-2.23.tar.gz", hash = "sha256:78816d4f24add8f10a06d6f05b4d424ad9e96cfebf68a4ddc99c65c0720d00c2", size = 173734, upload-time = "2025-09-09T13:23:47.91Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/e3/59cd50310fc9b59512193629e1984c1f95e5c8ae6e5d8c69532ccc65a7fe/pycparser-2.23-py3-none-any.whl", hash = "sha256:e5c6e8d3fbad53479cab09ac03729e0a9faf2bee3db8208a550daf5af81a5934", size = 118140, upload-time = "2025-09-09T13:23:46.651Z" },
-]
-
-[[package]]
-name = "pydub"
-version = "0.25.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fe/9a/e6bca0eed82db26562c73b5076539a4a08d3cffd19c3cc5913a3e61145fd/pydub-0.25.1.tar.gz", hash = "sha256:980a33ce9949cab2a569606b65674d748ecbca4f0796887fd6f46173a7b0d30f", size = 38326, upload-time = "2021-03-10T02:09:54.659Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a6/53/d78dc063216e62fc55f6b2eebb447f6a4b0a59f55c8406376f76bf959b08/pydub-0.25.1-py2.py3-none-any.whl", hash = "sha256:65617e33033874b59d87db603aa1ed450633288aefead953b30bded59cb599a6", size = 32327, upload-time = "2021-03-10T02:09:53.503Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

`pydub` imports the stdlib `audioop` module, which was **removed in Python 3.13** (PEP 594) — this is what's failing the `audio checks` and `Integration Tests` jobs on the Python upgrade PR #866 (`ModuleNotFoundError: No module named 'audioop'`).

Rather than shimming with `audioop-lts`, this drops `pydub` entirely:

- pydub is unmaintained (last release 2021)
- The audio service already uses **miniaudio** for sound effects, and miniaudio decodes OGG Vorbis natively — all 297 music assets are `.ogg`
- pydub was the sole reason **ffmpeg/ffprobe + their ldd-discovered shared libs** were baked into the distroless image; those are removed too

## Changes

- `music_player.py`: `_load_song_from_pattern` decodes via `miniaudio.decode_file` (stereo/16-bit/44.1kHz, same target format as before) and builds WAV bytes with the stdlib `wave` module
- `pyproject.toml` + `uv.lock`: drop `pydub`
- `Dockerfile`: remove ffmpeg/ffprobe install, ldd lib harvesting, and runtime COPYs
- Tests updated to mock `miniaudio.decode_file`; added assertions that output is a valid stereo/16-bit/44.1kHz WAV and that decode is requested in the target format

## Verification

- All 229 audio unit tests pass
- Decoded a real `assets/Joust/sounds/*.ogg` through the new path end-to-end: valid WAV, `channels=2 width=2 rate=44100`
- `make lint` clean

Unblocks #866.

🤖 Generated with [Claude Code](https://claude.com/claude-code)