### PR TITLE
test(integration): deflake headless lifecycle tests

### DIFF
--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -472,6 +472,68 @@ async def list_games(game_client) -> list:
     return list(response.games)
 
 
+async def wait_until_running(
+    game_client,
+    game_ids: set[str],
+    timeout: float = 10.0,
+    poll_interval: float = 0.3,
+) -> set[str]:
+    """Poll ListGames until every id in ``game_ids`` is RUNNING.
+
+    ``start_game_headless`` returns on the first start event — which can be
+    ``game_starting``, i.e. while the session is still STARTING (countdown).
+    A one-shot RUNNING assert right after it is therefore a race; under
+    parallel CI load the STARTING window stretches well past it (#897).
+
+    Args:
+        game_client: GameCoordinator gRPC client.
+        game_ids: The game ids that must all reach RUNNING.
+        timeout: Max seconds to poll before giving up.
+        poll_interval: Delay between ListGames polls.
+
+    Returns:
+        The set of RUNNING game ids from the final poll (callers assert on it
+        for a failure message that shows what WAS running).
+    """
+    deadline = asyncio.get_running_loop().time() + timeout
+    while True:
+        running = {
+            g.game_id
+            for g in await list_games(game_client)
+            if g.state == game_coordinator_pb2.GameState.RUNNING
+        }
+        if game_ids <= running or asyncio.get_running_loop().time() > deadline:
+            return running
+        await asyncio.sleep(poll_interval)
+
+
+async def describe_game_state(game_client, game_id: str) -> str:
+    """Best-effort one-line description of a session's live state for failures.
+
+    Reports the ListGames state plus per-player team/alive from GetGameState,
+    e.g. ``RUNNING players={'MOCK1': 'team=0 alive', ...}`` — or ``not listed
+    (session retired)`` when the id is gone. Never raises: diagnostics must not
+    mask the assertion they decorate (#897).
+    """
+    try:
+        states = {g.game_id: g.state for g in await list_games(game_client)}
+        if game_id not in states:
+            return "not listed (session retired)"
+        desc = game_coordinator_pb2.GameState.Name(states[game_id])
+        response = await game_client.GetGameState(
+            game_coordinator_pb2.GetGameStateRequest(game_id=game_id)
+        )
+        if response.success:
+            players = {
+                p.serial: f"team={p.team} {'alive' if p.alive else 'dead'}"
+                for p in response.game_info.players
+            }
+            desc += f" players={players}"
+        return desc
+    except Exception as exc:  # noqa: BLE001 - diagnostics are best-effort
+        return f"unavailable ({exc})"
+
+
 _LIVE_GAME_STATES = (
     game_coordinator_pb2.GameState.STARTING,
     game_coordinator_pb2.GameState.RUNNING,

--- a/tests/integration/test_concurrent_games.py
+++ b/tests/integration/test_concurrent_games.py
@@ -40,6 +40,7 @@ from tests.integration.helpers import (
     start_game_headless,
     start_game_via_menu,
     wait_for_lobby_colors,
+    wait_until_running,
 )
 
 
@@ -94,13 +95,7 @@ async def test_two_concurrent_headless_games(docker_compose, headless_cleanup):
         # when its loop publishes game_started — poll instead of a fixed sleep
         # (a one-shot at 1.0s flaked on CI once the start path grew the #837
         # shadow_policy flag read).
-        deadline = asyncio.get_running_loop().time() + 10.0
-        running: set = set()
-        while True:
-            running = _running_ids(await list_games(game_client))
-            if {game_id_a, game_id_b} <= running or asyncio.get_running_loop().time() > deadline:
-                break
-            await asyncio.sleep(0.3)
+        running = await wait_until_running(game_client, {game_id_a, game_id_b})
         assert game_id_a in running, f"{game_id_a} not RUNNING in {running}"
         assert game_id_b in running, f"{game_id_b} not RUNNING in {running}"
 
@@ -345,8 +340,11 @@ async def test_headless_natural_end_then_restart(docker_compose, headless_cleanu
 
         assert game_id_2 != game_id_1, "restart must get a fresh game_id"
 
-        games = await list_games(game_client)
-        assert game_id_2 in _running_ids(games), "restarted game should be RUNNING"
+        # Poll: start_game_headless returns on game_starting, so the session
+        # may still be STARTING (countdown) here — a one-shot assert raced on
+        # CI under parallel load (#897).
+        running = await wait_until_running(game_client, {game_id_2})
+        assert game_id_2 in running, f"restarted game should be RUNNING, got {running}"
 
         await force_end_game_by_id(game_client, game_id_2)
         await second_collector.wait_for_any_event(

--- a/tests/integration/test_parallel_lifecycle.py
+++ b/tests/integration/test_parallel_lifecycle.py
@@ -43,6 +43,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
 
 from tests.integration.helpers import (
     build_start_config,
+    describe_game_state,
     end_fight_club_game,
     end_swapper_game,
     end_tournament_game,
@@ -155,8 +156,9 @@ _SPECS = {
     # so wait it out before driving the win condition (caught in CI).
     "JoustRandomTeams": ModeSpec("JoustRandomTeams", 4, end_team, 20, pre_end_delay=6.5),
     # Swapper's death-swap end sequence (delay=0.3/swap) can exceed 15s under
-    # 4-way parallel load on a loaded CI runner (one timeout observed).
-    "Swapper": ModeSpec("Swapper", 4, end_swapper, 25),
+    # 4-way parallel load on a loaded CI runner; 25s also timed out on CI
+    # (#897), so give the post-convergence end path generous headroom.
+    "Swapper": ModeSpec("Swapper", 4, end_swapper, 40),
     "Zombies": ModeSpec("Zombies", 4, end_zombies, 15),
     "NonStop": ModeSpec("NonStop", 2, end_force, 15),
     "Traitor": ModeSpec("Traitor", 4, end_force, 15),
@@ -263,7 +265,16 @@ async def _run_mode_headless(docker_compose, spec: ModeSpec, tag: str) -> None:
 
         # The mode's terminal event must arrive for this game_id. (Force-end
         # strategies already triggered it; awaiting it is still correct.)
-        await collector.wait_for_any_event(_TERMINAL_EVENTS, timeout=spec.timeout)
+        # On timeout, attach the session's live state so the failure says
+        # WHICH way it broke: still RUNNING = the game never reached its win
+        # condition (frame starvation / end strategy bug); ENDED/ENDING = the
+        # game finished but the event never reached the collector; absent =
+        # session retired without the collector seeing the event (#897).
+        try:
+            await collector.wait_for_any_event(_TERMINAL_EVENTS, timeout=spec.timeout)
+        except TimeoutError as exc:
+            state = await describe_game_state(game_client, game_id)
+            raise TimeoutError(f"{exc} (session state: {state})") from exc
     except Exception as exc:  # noqa: BLE001 - re-raise tagged with the mode name
         raise AssertionError(f"[{spec.mode}] headless lifecycle failed: {exc}") from exc
     finally:


### PR DESCRIPTION
## Summary

Fixes the two integration-test flakes documented in #897, observed back-to-back on PR #896 (each test passed in the run where the other failed):

### 1. STARTING/RUNNING race in `test_headless_natural_end_then_restart`

`start_game_headless` returns on the **first** start event — which can be `game_starting`, i.e. while the session is still STARTING (countdown). The restart test then asserted RUNNING with a one-shot `ListGames`, racing the countdown under CI load. `test_two_concurrent_headless_games` already solved this with an inline poll (its comment records the same flake from #837); this PR extracts that into a `wait_until_running()` helper and uses it at both sites.

### 2. Swapper terminal-event budget too tight in `fast-batch`

`test_parallel_mode_lifecycle[fast-batch]` runs 4 modes concurrently on a 2-core runner; Swapper's post-convergence end path blew through its 25s budget (the in-file comment already flagged it "can exceed 15s under load"). Widened to 40s.

### 3. Diagnostics for the next flake

`wait_for_any_event` checks buffered events first, so the Swapper timeout means `game_ended` genuinely never arrived within the budget — but CI logs couldn't tell us *why*. New `describe_game_state()` helper attaches the session's live state + player teams to terminal-event timeout failures, distinguishing:
- still `RUNNING` → game never reached its win condition (frame starvation / end-path stall)
- `ENDED`/`ENDING` → game finished but event delivery to the collector lagged
- not listed → session retired without the collector seeing the event

It's exception-safe (best-effort) so diagnostics can never mask the original failure.

## Verification

All affected tests pass locally against the dev-mounted stack:

```
test_two_concurrent_headless_games PASSED
test_headless_natural_end_then_restart PASSED
test_parallel_mode_lifecycle[slow-batch] PASSED
test_parallel_mode_lifecycle[fast-batch] PASSED
4 passed in 169.37s
```

`make lint` clean.

Closes #897

🤖 Generated with [Claude Code](https://claude.com/claude-code)