### PR TITLE
chore: remove unused redis from stack

### DIFF
--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -41,8 +41,6 @@ services:
     privileged: false
     # Override depends_on to remove rust-hid and python-hid (hardware profile, not available in CI)
     depends_on: !override
-      redis:
-        condition: service_healthy
       flagd:
         condition: service_started
     environment: !override

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -8,7 +8,7 @@
 #   docker compose -f docker-compose.yml -f docker-compose.override.yml -f docker-compose.dev.yml up -d
 #
 # Note: Only Python application services are mounted. Infrastructure
-# services (redis, prometheus, grafana, etc.) and non-Python services
+# services (prometheus, grafana, etc.) and non-Python services
 # (connect-proxy, dashboard) are unchanged.
 #
 # After changing code, restart the affected service to pick up changes:

--- a/docker-compose.lite.yml
+++ b/docker-compose.lite.yml
@@ -12,21 +12,6 @@
 # Use IMAGE_TAG environment variable to specify version (default: latest)
 
 services:
-  # Redis for pub/sub messaging (lightweight)
-  redis:
-    image: redis:8.8-alpine
-    container_name: joustmania-redis
-    expose:
-      - "6379"
-    networks:
-      - joustmania
-    healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
-      interval: 5s
-      timeout: 5s
-      retries: 3
-      start_period: 2s
-
   # flagd for feature flag evaluation
   flagd:
     image: ghcr.io/open-feature/flagd:v0.16.0
@@ -90,8 +75,6 @@ services:
       - /dev:/dev:rslave
       - controller-names:/app/data
     depends_on:
-      redis:
-        condition: service_healthy
       flagd:
         condition: service_started
     restart: unless-stopped
@@ -139,8 +122,6 @@ services:
     environment:
       - OTEL_SDK_DISABLED=true
     depends_on:
-      redis:
-        condition: service_healthy
       flagd:
         condition: service_started
     networks:
@@ -170,8 +151,6 @@ services:
       - ./services/flagd/game.json:/etc/flagd/game.json
       - ./services/flagd/user.json:/etc/flagd/user.json
     depends_on:
-      redis:
-        condition: service_healthy
       flagd:
         condition: service_started
     networks:
@@ -270,5 +249,4 @@ networks:
     name: joustmania-network
 
 volumes:
-  redis-data:
   controller-names:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,29 +36,6 @@ x-logging: &default-logging
     labels: "com.docker.compose.service,com.docker.compose.image"
 
 services:
-  # Redis for pub/sub messaging
-  redis:
-    image: redis:8.8-alpine
-    container_name: joustmania-redis
-    # Port 6379 exposed only within Docker network (no host binding)
-    expose:
-      - "6379"
-    networks:
-      - joustmania
-    restart: unless-stopped
-    healthcheck:
-      test: [ "CMD", "redis-cli", "ping" ]
-      interval: 2s
-      timeout: 2s
-      retries: 3
-      start_period: 1s
-    deploy:
-      resources:
-        limits:
-          memory: 128m
-          cpus: '0.25'
-    logging: *default-logging
-
   # flagd for feature flag evaluation
   flagd:
     image: ghcr.io/open-feature/flagd:v0.16.0
@@ -227,8 +204,6 @@ services:
       - PYTHON_HID_HOST=python-hid
       - PYTHON_HID_PORT=50059
     depends_on:
-      redis:
-        condition: service_healthy
       flagd:
         condition: service_started
       rust-hid:
@@ -371,8 +346,6 @@ services:
       - OTEL_RESOURCE_ATTRIBUTES=host.name=${JOUSTMANIA_HOST:-joustmania}
       - SERVICE_VERSION=${IMAGE_TAG:-dev}
     depends_on:
-      redis:
-        condition: service_healthy
       flagd:
         condition: service_started
     networks:
@@ -414,8 +387,6 @@ services:
     volumes:
       - ./services/flagd:/etc/flagd
     depends_on:
-      redis:
-        condition: service_healthy
       flagd:
         condition: service_started
     networks:
@@ -458,8 +429,6 @@ services:
       - FLAGD_PORT=8015
       - ALSA_CARD=auto  # Auto-detect sound card; set to card number (e.g. "1") to override
     depends_on:
-      redis:
-        condition: service_healthy
       flagd:
         condition: service_started
     networks:
@@ -769,7 +738,6 @@ networks:
     name: joustmania-network
 
 volumes:
-  redis-data:
   prometheus-data:
   victoria-metrics-data:
   grafana-data:

--- a/docs/CANARY_RUNBOOK.md
+++ b/docs/CANARY_RUNBOOK.md
@@ -412,8 +412,6 @@ controller-manager:
   depends_on:
     rust-hid:
       condition: service_healthy
-    redis:
-      condition: service_healthy
     flagd:
       condition: service_started
 ```

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -244,7 +244,7 @@ docker compose up -d
 
 ```bash
 # Only infrastructure
-docker compose up -d redis jaeger otel-collector
+docker compose up -d jaeger otel-collector
 
 # Only application services
 docker compose up -d controller-manager game-coordinator menu

--- a/docs/research/722-intervention-surface.md
+++ b/docs/research/722-intervention-surface.md
@@ -369,9 +369,9 @@ defines what "fresh data" means for `ShouldEvaluate`.
 
 Persistence: the `game_id` label (pattern already established by
 `game_player_peak_accel`) keeps per-game history in the TSDB; `PlayerAnalytics`
-already persists end-of-game summaries (incl. `std_accel`) to Redis
-(`analytics.py:319`), so per-game analytics persistence needs no new mechanism —
-only the windowed/derived values above need to be added to the live gauges.
+already computes end-of-game summaries (incl. `std_accel`) (`analytics.py:319`),
+so per-game analytics needs no new mechanism — only the windowed/derived values
+above need to be added to the live gauges.
 
 Cardinality note: `serial` and `game_id` labels are bounded (≤ ~16 controllers,
 games are short); this matches the existing exposure and is safe for
@@ -538,7 +538,7 @@ the `adjust_music_tempo` row (✅ everywhere).
    (`none`/`ambient`/`standard`/`full`) with `ambient` as the rollout default (§6).
 6. **The OBSERVE layer can largely read existing metrics**; five additive
    metrics close the gap to the schema's signal list, and the `game_id` label +
-   existing Redis analytics persistence cover per-game history (§7).
+   existing analytics summaries cover per-game history (§7).
 7. All interventions are assessed against the three policy constraints in §5;
    enforcement must live in the game coordinator's flag-application layer, with
    weighted rate-limit costs rather than a flat count.

--- a/services/controller_manager/pyproject.toml
+++ b/services/controller_manager/pyproject.toml
@@ -19,9 +19,6 @@ dependencies = [
     "grpcio>=1.70.0",
     "grpcio-health-checking>=1.70.0",
 
-    # Redis for pub/sub events
-    "redis>=5.0.0",
-
     # OpenTelemetry
     "opentelemetry-distro>=0.49b0",
     "opentelemetry-exporter-otlp>=1.28.0",

--- a/services/game_coordinator/games/analytics.py
+++ b/services/game_coordinator/games/analytics.py
@@ -416,33 +416,3 @@ class PlayerAnalytics:
                 "samples": [s.to_dict() for s in self.replay_samples],
             }
         )
-
-    async def store_replay_to_redis(
-        self,
-        redis_client,
-        game_id: str,
-        ttl_seconds: int = 3600,
-    ) -> bool:
-        """
-        Store replay data to Redis for later retrieval.
-
-        Args:
-            redis_client: Async Redis client
-            game_id: Unique game identifier
-            ttl_seconds: Time-to-live for the key
-
-        Returns:
-            True if stored successfully, False otherwise
-        """
-        if not self.replay_samples:
-            return False
-
-        try:
-            key = f"replay:{game_id}:{self.serial}"
-            data = self.export_replay_json()
-            await redis_client.setex(key, ttl_seconds, data)
-            logger.debug(f"Stored {len(self.replay_samples)} replay samples to {key}")
-            return True
-        except Exception as e:
-            logger.warning(f"Failed to store replay data: {e}")
-            return False

--- a/services/game_coordinator/runtime_config.py
+++ b/services/game_coordinator/runtime_config.py
@@ -34,7 +34,6 @@ class AnalyticsConfig:
     # Feature toggles
     track_gyro: bool = False  # Track rotation data (increases memory/cpu slightly)
     enable_replay: bool = False  # Store 60Hz samples for replay/testing
-    replay_ttl_seconds: int = 3600  # Redis TTL for replay data (1 hour)
 
     # Zone thresholds (in g-force units, ~4096 raw = 1g). Defaults promoted to
     # the agent domain `perception.zone_*` flags (#766 F4); the values here are

--- a/services/otel-collector/config.dynatrace.yaml
+++ b/services/otel-collector/config.dynatrace.yaml
@@ -35,7 +35,7 @@ receivers:
               replacement: 'process_resident_memory_bytes'
 
   # Filelog receiver — tail Docker container JSON logs for non-OTLP services
-  # (connect-proxy, rust-hid, envoy, flagd, redis, etc.)
+  # (connect-proxy, rust-hid, envoy, flagd, etc.)
   filelog/docker:
     include:
       - /var/lib/docker/containers/*/*-json.log

--- a/services/otel-collector/config.yaml
+++ b/services/otel-collector/config.yaml
@@ -53,7 +53,7 @@ receivers:
             - targets: ['envoy:9901']
 
   # Filelog receiver — tail Docker container JSON logs for non-OTLP services
-  # (connect-proxy, rust-hid, envoy, flagd, redis, etc.)
+  # (connect-proxy, rust-hid, envoy, flagd, etc.)
   filelog/docker:
     include:
       - /var/lib/docker/containers/*/*-json.log

--- a/uv.lock
+++ b/uv.lock
@@ -17,15 +17,6 @@ members = [
 ]
 
 [[package]]
-name = "async-timeout"
-version = "5.0.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a5/ae/136395dfbfe00dfc94da3f3e136d0b13f394cba8f4841120e34226265780/async_timeout-5.0.1.tar.gz", hash = "sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3", size = 9274, upload-time = "2024-11-06T16:41:39.6Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fe/ba/e2081de779ca30d473f21f5b30e0e737c438205440784c7dfc81efc2b029/async_timeout-5.0.1-py3-none-any.whl", hash = "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c", size = 6233, upload-time = "2024-11-06T16:41:37.9Z" },
-]
-
-[[package]]
 name = "cachebox"
 version = "5.2.3"
 source = { registry = "https://pypi.org/simple" }
@@ -473,7 +464,6 @@ dependencies = [
     { name = "prometheus-client" },
     { name = "psutil" },
     { name = "pyyaml" },
-    { name = "redis" },
     { name = "uvloop", marker = "sys_platform == 'linux'" },
 ]
 
@@ -502,7 +492,6 @@ requires-dist = [
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.23.0" },
     { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=4.1.0" },
     { name = "pyyaml", specifier = ">=6.0" },
-    { name = "redis", specifier = ">=5.0.0" },
     { name = "uvloop", marker = "sys_platform == 'linux'", specifier = ">=0.19.0" },
 ]
 provides-extras = ["test"]
@@ -1302,18 +1291,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
     { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
     { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
-]
-
-[[package]]
-name = "redis"
-version = "8.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "async-timeout", marker = "python_full_version < '3.11.3'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/53/ae/ed461cca5780b5fc8b9fe8ca0ed98d89508645fb9d880c24cc42c087678f/redis-8.0.0.tar.gz", hash = "sha256:a00c5355432051ac14e593b8b197fc76c887ee12d55a0984f69328a1115fdc49", size = 5101591, upload-time = "2026-05-28T12:45:13.5Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/e3/b519734372d305bd547534a9f32e4ce9f98552af753dce72cf3483a0ff0b/redis-8.0.0-py3-none-any.whl", hash = "sha256:c938c18338585009f0bc310f4c7e4e4b4d37639356c4ac072cedf3af570c8dc7", size = 499870, upload-time = "2026-05-28T12:45:11.697Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Redis was introduced for never-merged **gamer-profile** work. Nothing in the codebase imports, connects to, or otherwise uses it — there is no redis client instantiation, no connection string consumed, and the only code that referenced a redis client was a dead `store_replay_to_redis` method with zero callers. This PR removes redis entirely from the stack.

## Changes

- **docker-compose.yml**: removed the `redis` service, all four `depends_on: redis` references (controller-manager, game-coordinator, menu, audio), and the `redis-data` volume.
- **docker-compose.lite.yml**: removed the `redis` service, its three `depends_on` references, and the `redis-data` volume.
- **docker-compose.ci.yml**: removed redis from the `!override` `depends_on` block.
- **docker-compose.dev.yml**: removed redis from an infra-services comment.
- **services/controller_manager/pyproject.toml**: dropped the `redis>=5.0.0` dependency and its comment; `uv lock` regenerated (removes `redis` and its transitive `async-timeout`).
- **services/game_coordinator/games/analytics.py**: deleted the dead `store_replay_to_redis` method (no callers — verified via grep).
- **services/game_coordinator/runtime_config.py**: removed `replay_ttl_seconds` (only ever referenced by the deleted method). `enable_replay`/`replay_samples` are still live and retained.
- **services/otel-collector/config.yaml & config.dynatrace.yaml**: removed redis from the filelog tailed-containers comment.
- **docs/DEVELOPMENT.md, docs/CANARY_RUNBOOK.md, docs/research/722-intervention-surface.md**: removed redis from example commands / depends_on snippets and corrected a research note that claimed analytics were persisted to redis (they never were — that path was the dead code removed here).

Note: `services/grafana/grafana.ini` matches for "redis" are stock upstream Grafana config comments about Grafana's own remote-cache backend and are unrelated; left untouched.

## Validation

- `make lint` — passed (ruff, all checks)
- `services/game_coordinator` unit tests — 925 passed
- `services/controller_manager` unit tests — 643 passed
- All edited YAML validated with `yaml.safe_load`
- `docker compose -f docker-compose.yml -f docker-compose.override.yml -f docker-compose.ci.yml config -q` — passed (merged compose valid)

🤖 Generated with [Claude Code](https://claude.com/claude-code)