### PR TITLE
docs: issue-tracking workflow — assign on work start, manual close on merge

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,16 @@ When resuming from a previous session, ask the user to confirm the current task 
 
 Always create a feature branch before making changes. Never commit directly to main. Verify current branch with `git branch --show-current` before starting work.
 
+## Issue Tracking
+
+When work on a GitHub issue starts (implementation begun or a background agent launched), assign the issue to the repository owner so in-flight work is visible at a glance:
+
+```bash
+gh issue edit <NUMBER> --add-assignee aepfli
+```
+
+When the implementing PR merges, close the issue manually with a comment referencing the PR and what was delivered — PR bodies in this repo use "Part of #N" phrasing without `closes` keywords, so issues never auto-close.
+
 ## Quick Reference
 
 ```bash


### PR DESCRIPTION
Persists today's working agreement into the checked-in agent instructions (CLAUDE.md), so every session and background agent follows it:

- **On work start** (implementation or agent launch): `gh issue edit <N> --add-assignee aepfli` — assignment marks in-flight work
- **On merge**: close the issue manually with a PR-reference comment (PR bodies here use "Part of #N" without `closes` keywords, so auto-close never fires — this has required manual closes for every issue in M6)

Also mirrored in session memory; this PR makes it tool-agnostic and durable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)