### PR TITLE
fix(tournament): finalize kill-decided matches and fix numeric flag reads (#903)

### DIFF
--- a/lib/feature_flags.py
+++ b/lib/feature_flags.py
@@ -281,7 +281,11 @@ def read_float_flag(domain: str, flag_key: str, default: float, game_id: str | N
     try:
         init_flag_domain(domain)
         client = get_flag_client(domain)
-        value = client.get_object_value(flag_key, default, _calibration_context(game_id))
+        # Number flags must be read with the float getter: the flagd RPC
+        # resolver returns TYPE_MISMATCH for get_object_value() on a numeric
+        # flag, silently dropping every calibration override to its default
+        # (e.g. the tournament/fight_club CI variants never took effect, #903).
+        value = client.get_float_value(flag_key, default, _calibration_context(game_id))
         # bool is a subclass of int/float; reject it as a numeric flag value.
         if isinstance(value, bool) or not isinstance(value, (int, float)):
             return default
@@ -341,7 +345,12 @@ def read_int_flag(domain: str, flag_key: str, default: int, game_id: str | None 
     try:
         init_flag_domain(domain)
         client = get_flag_client(domain)
-        value = client.get_object_value(flag_key, default, _calibration_context(game_id))
+        # Number flags must be read with the integer getter: get_object_value()
+        # returns TYPE_MISMATCH for a numeric flag under the flagd RPC resolver,
+        # silently falling back to the default (#903). Read as a float first so
+        # whole-number variants stored as floats (e.g. 2.0) still resolve, then
+        # apply the integral-only coercion below.
+        value = client.get_float_value(flag_key, float(default), _calibration_context(game_id))
         if isinstance(value, bool):
             return default
         if isinstance(value, int):

--- a/lib/tests/test_feature_flags.py
+++ b/lib/tests/test_feature_flags.py
@@ -16,9 +16,15 @@ from lib.feature_flags import (
 
 
 def _mock_flag_value(value):
-    """Patch init/get_flag_client so the domain client returns ``value``."""
+    """Patch init/get_flag_client so the domain client returns ``value``.
+
+    Numeric flags are read via the typed ``get_float_value`` getter (#903:
+    ``get_object_value`` is TYPE_MISMATCH for numbers under the flagd RPC
+    resolver); the post-read type checks remain as defense-in-depth, so the
+    mock still feeds arbitrary values through the float getter.
+    """
     client = MagicMock()
-    client.get_object_value.return_value = value
+    client.get_float_value.return_value = value
     return (
         patch("lib.feature_flags.init_flag_domain"),
         patch("lib.feature_flags.get_flag_client", return_value=client),
@@ -371,19 +377,19 @@ def test_read_object_flag_targeted_variant_for_matching_game():
 
 def test_read_float_flag_threads_gameid_context():
     client = MagicMock()
-    client.get_object_value.return_value = 4.0
+    client.get_float_value.return_value = 4.0
     init_p, get_p = _mock_client(client)
     with init_p, get_p:
         assert read_float_flag("game", "death_grace_period_seconds", 1.0, game_id="game_x") == 4.0
-    ctx = client.get_object_value.call_args[0][2]
+    ctx = client.get_float_value.call_args[0][2]
     assert ctx.attributes["gameId"] == "game_x"
 
 
 def test_read_int_flag_threads_gameid_context():
     client = MagicMock()
-    client.get_object_value.return_value = 3
+    client.get_float_value.return_value = 3
     init_p, get_p = _mock_client(client)
     with init_p, get_p:
         assert read_int_flag("game", "zombie.initial_count", 1, game_id="game_y") == 3
-    ctx = client.get_object_value.call_args[0][2]
+    ctx = client.get_float_value.call_args[0][2]
     assert ctx.attributes["gameId"] == "game_y"

--- a/services/game_coordinator/games/tournament.py
+++ b/services/game_coordinator/games/tournament.py
@@ -486,8 +486,19 @@ class TournamentGame(BaseGameMode):
                 # No data received, continue loop (check time/completion)
                 pass
 
-        # Finalize match
-        if not match.is_complete and match.winner_serial:
+        # Finalize match. Runs for BOTH ways a match can end:
+        #  - timeout: the loop set winner_serial and broke (is_complete False);
+        #  - kill: _kill_player_impl set winner_serial AND is_complete True.
+        # The previous `not match.is_complete` guard skipped finalization for
+        # kill-decided matches, so their winner was never advanced and the
+        # bracket stalled (no champion, game never ended) — the core #903 bug.
+        # Idempotency: the winner is still FIGHTING until finalize moves it to
+        # WAITING, so this block runs exactly once even if re-entered.
+        winner_still_fighting = (
+            match.winner_serial is not None
+            and self.players[match.winner_serial].tournament_state == TournamentState.FIGHTING
+        )
+        if match.winner_serial and winner_still_fighting:
             match.is_complete = True
 
             # Determine loser
@@ -669,6 +680,18 @@ class TournamentGame(BaseGameMode):
         else:
             self.current_match.winner_serial = self.current_match.player1_serial
 
+        # Mark the loser ELIMINATED immediately so a SECOND near-simultaneous
+        # kill (e.g. a test killing both fighters, or the #757 mock death-hold
+        # firing on both controllers) is rejected by the FIGHTING guard above
+        # and cannot flip the winner back to the player who just lost. Without
+        # this, blind double-kills corrupted the bracket and it never finished.
+        player.tournament_state = TournamentState.ELIMINATED
+        player.alive = False
+
+        # Signal the match loop to stop; finalization (advance winner, emit
+        # match_end, eliminate loser) happens in _run_match, which now runs its
+        # finalize block for kill-decided matches too (it previously only ran on
+        # the timeout path, so kill wins never advanced and the bracket stalled).
         self.current_match.is_complete = True
 
         winner = self.current_match.winner_serial

--- a/services/game_coordinator/tests/test_tournament.py
+++ b/services/game_coordinator/tests/test_tournament.py
@@ -1444,6 +1444,140 @@ class TestGameplayLoop:
 
 
 # ---------------------------------------------------------------------------
+# Full kill-driven bracket (#903 regression coverage)
+# ---------------------------------------------------------------------------
+
+
+class TestFullBracketKillDriven:
+    """End-to-end bracket completion driven by real kills (not timeouts).
+
+    The pre-existing _gameplay_loop tests resolve every match by TIMEOUT
+    (timeout_forever streams + jumped clock), which exercised a different code
+    path than a real match: a kill sets ``match.is_complete`` inside
+    ``_kill_player_impl``, and the old finalize guard ``if not match.is_complete``
+    then SKIPPED winner-advancement, stalling the bracket so no champion ever
+    emerged (the #903 production bug). These tests kill the current match's
+    player every match, so the whole bracket runs through the kill path and must
+    still crown a champion.
+    """
+
+    def _make_game(self, num_controllers: int, game_id: str):
+        mock_cm = MockControllerManagerService(num_controllers=num_controllers, death_schedule={}, max_duration=10.0)
+        event_collector = EventCollector()
+        game = TournamentGame(
+            controller_manager_client=mock_cm,
+            event_publisher=event_collector.publish,
+            audio_client=None,
+            game_id=game_id,
+            invincibility_seconds=0.0,
+        )
+        return game, mock_cm, event_collector
+
+    @pytest.mark.asyncio
+    async def test_kill_driven_bracket_crowns_champion(self):
+        """A 4-player bracket resolved entirely by kills produces one champion."""
+        from unittest.mock import AsyncMock, patch
+
+        game, mock_cm, event_collector = self._make_game(4, "test_kill_bracket")
+        await game._initialize_players_impl(mock_cm.controllers)
+        game._play_sound = AsyncMock()
+        game.running = True
+        game.gameplay_stream = AsyncGameplayStreamMock(timeout_forever=True)
+
+        # Every match: "kill" player1 of the current match the first time the
+        # stream is read, exactly as a real death would (sets winner + complete
+        # via _kill_player_impl). This drives the kill-decided finalize path.
+        async def kill_p1_of_current(_gameplay_data):
+            match = game.current_match
+            if match and not match.is_complete:
+                await game._kill_player_impl(match.player1_serial, accel_mag=5.0)
+
+        game._process_controller_state = kill_p1_of_current
+
+        # read() must return an update carrying at least one controller entry so
+        # the match loop's ``for gameplay_data in update.controllers`` actually
+        # invokes _process_controller_state (an empty update would never kill,
+        # and the match would run to its full timeout).
+        async def read_with_data():
+            from proto import controller_manager_pb2 as cm
+
+            update = cm.GameplayDataUpdate()
+            update.controllers.add(serial="tick")
+            return update
+
+        game.gameplay_stream.read = read_with_data
+
+        with patch(
+            "services.game_coordinator.games.tournament.asyncio.sleep",
+            new_callable=AsyncMock,
+        ):
+            await game._gameplay_loop()
+
+        # Exactly one non-eliminated player remains: the champion-to-be.
+        survivors = [s for s, p in game.players.items() if p.tournament_state != TournamentState.ELIMINATED]
+        assert len(survivors) == 1, f"expected one survivor, got {survivors}"
+
+        # The champion must have won every round (2 rounds for 4 players).
+        champion = game.players[survivors[0]]
+        assert champion.wins == game.total_rounds == 2
+
+        # Every match in the bracket completed (none left dangling) and all
+        # match_end events fired through the kill path (the bug emitted none).
+        assert all(m.is_complete for m in game.bracket)
+        match_ends = event_collector.get_events_of_type("match_end")
+        assert len(match_ends) == 3  # 2 first-round + 1 final
+
+        # The final win condition recognizes the champion.
+        assert await game._check_win_condition() is True
+        assert champion.tournament_state == TournamentState.CHAMPION
+
+    @pytest.mark.asyncio
+    async def test_kill_driven_match_advances_winner(self):
+        """A single kill-decided match advances its winner to round 2.
+
+        Direct regression for the stalled-bracket bug: before the fix, a
+        kill set is_complete=True and the finalize block (which calls
+        _advance_winner) was skipped, so the winner sat in round 1 forever.
+        """
+        from unittest.mock import AsyncMock
+
+        game, mock_cm, _ = self._make_game(4, "test_kill_advance")
+        await game._initialize_players_impl(mock_cm.controllers)
+        game._play_sound = AsyncMock()
+        game.running = True
+        game.gameplay_stream = AsyncGameplayStreamMock(timeout_forever=True)
+
+        first_match = [m for m in game.bracket if m.round_number == 1 and not m.is_bye][0]
+        game.current_match = first_match
+        winner_serial = first_match.player2_serial
+
+        async def kill_p1(_gameplay_data):
+            await game._kill_player_impl(first_match.player1_serial, accel_mag=5.0)
+
+        game._process_controller_state = kill_p1
+
+        async def read_once():
+            from proto import controller_manager_pb2 as cm
+
+            update = cm.GameplayDataUpdate()
+            update.controllers.add(serial="tick")
+            return update
+
+        game.gameplay_stream.read = read_once
+
+        await game._run_match(first_match)
+
+        # Winner advanced to a round-2 match (the finalize ran).
+        round2 = [m for m in game.bracket if m.round_number == 2]
+        assert any(m.player1_serial == winner_serial or m.player2_serial == winner_serial for m in round2), (
+            "kill-decided winner was not advanced to round 2"
+        )
+        assert game.players[winner_serial].round_number == 2
+        assert game.players[winner_serial].tournament_state == TournamentState.WAITING
+        assert game.players[first_match.player1_serial].tournament_state == TournamentState.ELIMINATED
+
+
+# ---------------------------------------------------------------------------
 # _check_win_condition edge cases
 # ---------------------------------------------------------------------------
 

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -1694,49 +1694,117 @@ async def end_fight_club_game(
 
 
 async def end_tournament_game(
-    mock_client, serials: list[str], delay: float = 0.2, invincibility_wait: float = 4.2
+    mock_client,
+    game_client,
+    serials: list[str],
+    game_id: str = "",
+    timeout: float = 45.0,
 ) -> list[str]:
-    """End a Tournament game by running through bracket matches.
+    """Drive a Tournament bracket to completion via state-aware kills.
 
-    Tournament is single-elimination bracket with 1v1 matches.
-    Each match is 22s max with 4s invincibility.
+    Tournament is a single-elimination bracket of 1v1 matches. Only the two
+    FIGHTING players in the *current* match can be eliminated; kills of anyone
+    else are ignored by design, and ``PlayerInfo`` does not expose which two are
+    fighting (no FIGHTING flag). So this loops on the live ``alive`` set instead
+    of guessing match boundaries: each pass kills exactly ONE still-alive player
+    and verifies it registered, then repeats until the game emits its terminal
+    event (i.e. ``GetGameState`` no longer reports RUNNING).
 
-    Strategy: For each round, kill one of the fighters.
-    Continue until only one player remains.
+    Why ONE player per pass (not blind kill-everyone): killing BOTH fighters in
+    the same match within the mock's ~2s held death window corrupts the match —
+    the second death can flip the winner back to the player who just lost — and
+    the bracket never produces a champion. Killing one fighter, waiting for it to
+    register dead, then moving on keeps each match clean.
+
+    Pacing: CI sets match invincibility to 2.0s (start config) and the mock holds
+    death-level acceleration ~1s (#757), so ``kill_player_verified`` re-fires
+    every 1.5s until the kill lands — which naturally clears both windows. The
+    kill registering as ``not alive`` is the signal that match advanced.
 
     Args:
-        mock_client: Mock controller service gRPC client
-        serials: List of all controller serials
-        delay: Delay between kills in seconds
-        invincibility_wait: Time to wait for invincibility to end (default 4.2s)
+        mock_client: Mock controller service gRPC client.
+        game_client: GameCoordinator client (for GetGameState).
+        serials: This game's controller serials (used only as the candidate set).
+        game_id: Target session (empty = primary/legacy).
+        timeout: Max total time to keep driving the bracket.
 
     Returns:
-        List of serials that were killed
+        List of serials that were eliminated (in the order they died).
     """
-    killed = []
-    active_players = list(serials)
-
-    # Run bracket rounds until 1 player left
+    killed: list[str] = []
+    loop = asyncio.get_event_loop()
+    deadline = loop.time() + timeout
     round_num = 0
-    while len(active_players) > 1:
+
+    while True:
+        players = await get_player_states(game_client, game_id=game_id)
+        if players is None:
+            # Game no longer RUNNING -> terminal event fired; bracket finished.
+            return killed
+
+        alive = [s for s, p in players.items() if p.alive]
+        if len(alive) <= 1:
+            # Champion decided (or finalize pending) — let the terminal event land.
+            await asyncio.sleep(0.5)
+            continue
+
+        if loop.time() >= deadline:
+            raise TimeoutError(
+                f"Tournament bracket did not finish within {timeout}s "
+                f"(still alive: {alive})"
+            )
+
         round_num += 1
-        print(f"Tournament round {round_num}, {len(active_players)} players remaining")
-
-        # Wait for invincibility to end
-        await asyncio.sleep(invincibility_wait)
-
-        # Kill first active player (eliminates them)
-        loser = active_players[0]
-        response = await mock_client.SimulateDeath(
-            controller_manager_mock_pb2.DeathRequest(serial=loser)
+        # Eliminate ONE fighter from the current match. We can't see which two
+        # are FIGHTING (PlayerInfo has no such flag), so probe the alive set:
+        # fire at each candidate and watch for a death. Only a FIGHTING player
+        # past its invincibility actually dies; WAITING players ignore the kill,
+        # so we move to the next candidate. Crucially we stop after the FIRST
+        # death so we never kill BOTH fighters in one match (which corrupts it).
+        a_death = await _eliminate_one_fighter(
+            mock_client, game_client, alive, game_id=game_id, deadline=deadline
         )
-        if response.success:
-            killed.append(loser)
-            active_players.remove(loser)
-            print(f"  Eliminated: {loser}")
-        else:
-            print(f"  Failed to eliminate {loser}: {response.error}")
-
-        await asyncio.sleep(delay)
+        if a_death is None:
+            # No candidate died within the probe window. Either the game just
+            # ended, or all alive players are mid-invincibility/between matches;
+            # re-poll and try again until the overall deadline.
+            if await get_player_states(game_client, game_id=game_id) is None:
+                return killed
+            continue
+        killed.append(a_death)
+        print(f"Tournament round {round_num}: eliminated {a_death} ({len(alive)} were alive)")
 
     return killed
+
+
+async def _eliminate_one_fighter(
+    mock_client, game_client, candidates: list[str], game_id: str, deadline: float
+) -> str | None:
+    """Kill exactly one FIGHTING player from ``candidates`` and return its serial.
+
+    Probes candidates round-robin: fires SimulateDeath at one, waits briefly for
+    it to register dead, and on success returns immediately (so the other fighter
+    in that match is never touched). A candidate that won't die in the probe
+    window is WAITING/invincible — skip to the next. Returns None if nobody died
+    before the probe budget or overall deadline expired (caller re-polls/retries).
+    """
+    loop = asyncio.get_event_loop()
+    # One full pass over candidates, re-firing each at >1s spacing (clears the
+    # mock's ~1s death-hold) and giving the kill a moment to register.
+    probe_deadline = min(deadline, loop.time() + 8.0)
+    while loop.time() < probe_deadline:
+        for serial in candidates:
+            await mock_client.SimulateDeath(
+                controller_manager_mock_pb2.DeathRequest(serial=serial)
+            )
+            # Give this kill a beat to register before trying the next candidate.
+            await asyncio.sleep(0.4)
+            players = await get_player_states(game_client, game_id=game_id)
+            if players is None:
+                return None  # game ended
+            dead = [s for s in candidates if s in players and not players[s].alive]
+            if dead:
+                return dead[0]
+        # No death this pass; wait out invincibility/death-hold and re-probe.
+        await asyncio.sleep(1.2)
+    return None

--- a/tests/integration/test_parallel_lifecycle.py
+++ b/tests/integration/test_parallel_lifecycle.py
@@ -105,10 +105,14 @@ async def end_werewolf(mock_client, serials, game_client, game_id) -> None:
 
 
 async def end_tournament(mock_client, serials, game_client, game_id) -> None:
-    """Tournament: run the bracket. CI invincibility=2.0s (set in start config)."""
-    # Pure SimulateDeath-driven (no per-game state query needed): game_id-agnostic.
+    """Tournament: drive the single-elimination bracket to a champion.
+
+    State-aware (game_id-scoped): kills one FIGHTING player per match, verified
+    against GetGameState, until the terminal event. CI uses 6s match / 1s pause
+    flags (game.ci.json) and invincibility=2.0s (start config).
+    """
     await end_tournament_game(
-        mock_client, serials, delay=0.2, invincibility_wait=2.5
+        mock_client, game_client, serials, game_id=game_id, timeout=45.0
     )
 
 
@@ -163,13 +167,14 @@ _SPECS = {
     "NonStop": ModeSpec("NonStop", 2, end_force, 15),
     "Traitor": ModeSpec("Traitor", 4, end_force, 15),
     "Werewolf": ModeSpec("Werewolf", 4, end_werewolf, 20),
-    # Tournament: #899 fixed three stacked crashes (stream init, match
-    # iteration, win effect) — matches now complete, but the full bracket
-    # still does not finish within the batch budget (suspected: ci-variant
-    # match/pause flags not resolving + fixed-rounds kill strategy). DEMOTED
-    # to force-end coverage (start/colors/session routing) until the
-    # end-to-end repair in #903 restores the real bracket strategy.
-    "Tournament": ModeSpec("Tournament", 4, end_force, 15),
+    # Tournament: full single-elimination bracket to a champion (#903). Two
+    # root causes fixed there: (1) numeric calibration flags were read with the
+    # wrong typed getter so the CI match/pause variants silently fell back to
+    # defaults (lib/feature_flags); (2) kill-decided matches skipped finalize so
+    # the winner never advanced and the bracket stalled (tournament.py). The
+    # state-aware end strategy then drives it to completion. Measured ~18-26s of
+    # bracket play locally; 45s terminal-event budget covers parallel CI load.
+    "Tournament": ModeSpec("Tournament", 4, end_tournament, 45),
     "FightClub": ModeSpec("FightClub", 4, end_fight_club, 30),
 }
 


### PR DESCRIPTION
Closes #903. Continuation of the Tournament repair started in #899 (which fixed three stacked crashes but the bracket still never finished in CI).

## Root causes

**1. Numeric calibration flags never resolved** (`lib/feature_flags.py`)

`read_float_flag` / `read_int_flag` used `client.get_object_value()`, which returns **TYPE_MISMATCH for numeric flags under the flagd RPC resolver** — every numeric calibration override silently fell back to its code default. This is exactly why the `tournament.match_seconds=ci(6.0)` / `time_between_matches_seconds=ci(1.0)` variants added in #899 never took effect: matches ran the full 22s default and the bracket blew every CI budget.

Fixed by switching to the typed `get_float_value()` getter (int reads go through float-first so whole-number variants stored as floats still resolve, then keep the integral-only coercion).

Blast radius check: every other numeric flag in `game.ci.json` has a default variant **equal to its code constant** (`death_grace_period_seconds` 0.5, `fight_club.round_seconds` 22.0, `zombie.*`, `nonstop.*`, `werewolf_fraction` 0.44), so only the tournament `ci` variants change behavior — the intended effect.

**2. Kill-decided matches skipped finalization** (`games/tournament.py`)

The finalize guard `if not match.is_complete and match.winner_serial` only ran on the **timeout** path. A real kill sets `is_complete=True` inside `_kill_player_impl`, so kill-decided matches skipped winner-advancement entirely — the winner stayed FIGHTING, the bracket stalled, no champion ever emerged. (All pre-existing unit tests resolved matches by timeout, so this path had zero coverage.)

Finalize now runs for both end paths, idempotent via the winner-still-FIGHTING check. The loser is also marked ELIMINATED immediately in `_kill_player_impl` so a near-simultaneous second kill (mock death-hold #757 firing on both controllers) can't flip the winner back to the player who just lost.

## Tests

- **New `TestFullBracketKillDriven` unit class** — full 4-player bracket resolved entirely through the kill path must crown a champion (the previously-uncovered code path). 59/59 tournament unit tests pass.
- **`end_tournament_game` rewritten state-aware** — kills exactly ONE fighter per match, verified via `GetGameState`, loops until the terminal event instead of fixed rounds. Blind kill-everyone corrupted matches inside the mock's ~1s death-hold window.
- **Tournament restored to the real bracket strategy** in `test_parallel_lifecycle` (demoted to `end_force` in #899 to unblock the merge train).

## Validation

- `make lint` ✅
- Full `make test-dev`: 17/18 — only failure was Swapper in fast-batch (untouched by this diff; reads no numeric flags; documented load-sensitive end sequence). Immediate re-run of both batches: **2/2 green in 1:47**, Tournament slow-batch green twice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)