### PR TITLE
chore: remove unused pyyaml dependency (#322)

### DIFF
--- a/services/controller_manager/pyproject.toml
+++ b/services/controller_manager/pyproject.toml
@@ -8,9 +8,6 @@ dependencies = [
     "joustmania-proto",
     "joustmania-lib",
 
-    # Core dependencies
-    "pyyaml>=6.0",
-
     # Platform-specific dependencies
     "dbus-fast>=2.0.0; sys_platform == 'linux'",  # Async D-Bus for BlueZ
     "hidapi>=0.14.0",  # Required by bt_discovery for HID device enumeration

--- a/services/game_coordinator/pyproject.toml
+++ b/services/game_coordinator/pyproject.toml
@@ -8,9 +8,6 @@ dependencies = [
     "joustmania-proto",
     "joustmania-lib",
 
-    # Core dependencies
-    "pyyaml>=6.0",
-
     # gRPC
     "grpcio>=1.70.0",
     "grpcio-health-checking>=1.70.0",

--- a/services/menu/pyproject.toml
+++ b/services/menu/pyproject.toml
@@ -8,9 +8,6 @@ dependencies = [
     "joustmania-proto",
     "joustmania-lib",
 
-    # Core dependencies
-    "pyyaml>=6.0",
-
     # gRPC
     "grpcio>=1.70.0",
     "grpcio-health-checking>=1.70.0",

--- a/uv.lock
+++ b/uv.lock
@@ -463,7 +463,6 @@ dependencies = [
     { name = "opentelemetry-instrumentation-grpc" },
     { name = "prometheus-client" },
     { name = "psutil" },
-    { name = "pyyaml" },
     { name = "uvloop", marker = "sys_platform == 'linux'" },
 ]
 
@@ -491,7 +490,6 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.23.0" },
     { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=4.1.0" },
-    { name = "pyyaml", specifier = ">=6.0" },
     { name = "uvloop", marker = "sys_platform == 'linux'", specifier = ">=0.19.0" },
 ]
 provides-extras = ["test"]
@@ -511,7 +509,6 @@ dependencies = [
     { name = "opentelemetry-instrumentation-grpc" },
     { name = "prometheus-client" },
     { name = "psutil" },
-    { name = "pyyaml" },
 ]
 
 [package.optional-dependencies]
@@ -536,7 +533,6 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.23.0" },
     { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=4.1.0" },
-    { name = "pyyaml", specifier = ">=6.0" },
 ]
 provides-extras = ["test"]
 
@@ -625,7 +621,6 @@ dependencies = [
     { name = "opentelemetry-exporter-otlp" },
     { name = "opentelemetry-instrumentation-grpc" },
     { name = "psutil" },
-    { name = "pyyaml" },
 ]
 
 [package.optional-dependencies]
@@ -649,7 +644,6 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.23.0" },
     { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=4.1.0" },
-    { name = "pyyaml", specifier = ">=6.0" },
 ]
 provides-extras = ["test"]
 


### PR DESCRIPTION
## Summary

Removes the unused `pyyaml>=6.0` direct dependency from three Python services:
- `services/controller_manager/pyproject.toml`
- `services/menu/pyproject.toml`
- `services/game_coordinator/pyproject.toml`

This is the remaining cleanup item of #322. The redis removal (#901) and Python standardization (#866) already covered the rest of that issue.

## Evidence

`pyyaml` is declared as a direct dependency but is never used. Grepping all three services (including tests) for `import yaml` / `from yaml` / `yaml.` returns **no matches** — the only references are in `pyproject.toml` and in generated `*.egg-info` metadata (which is gitignored). There are also no `.yaml`/`.yml` config files loaded at runtime within these services.

`pyyaml` still appears in `uv.lock` as a transitive dependency of another package, which is expected and harmless.

## Verification

- `uv lock` regenerated (workspace-level lock; the three `specifier = ">=6.0"` direct-dep entries are removed)
- Unit tests pass for all three services:
  - controller_manager: 643 passed
  - menu: 358 passed
  - game_coordinator: 931 passed
- `make lint`: All checks passed

Closes #322

🤖 Generated with [Claude Code](https://claude.com/claude-code)