### PR TITLE
test(integration): replace fixed settle-sleeps with condition polls (#894)

### DIFF
--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -9,8 +9,11 @@ These helpers provide:
 """
 
 import asyncio
+import contextlib
+import json
 import os
 import sys
+import time
 
 import grpc
 
@@ -26,6 +29,234 @@ from proto import (
     menu_pb2,
     menu_pb2_grpc,
 )
+
+
+# =============================================================================
+# Condition-wait helpers (#894)
+#
+# Replace fixed "write then sleep a constant" settles with condition polls:
+# the old constant becomes the DEADLINE, so the fast path costs ~one poll
+# interval instead of the full constant on every run, and the slow path keeps
+# (or extends) the same upper bound. Generalized from
+# test_rollout_plumbing._poll_until, which proved the shape (incl. the
+# rewrite self-heal) against flagd file-watch reloads under CI load.
+# =============================================================================
+
+# Deadline for a flagd file write to be served via RPC reads. Generous on
+# purpose — it is a worst-case bound, not a paid wait.
+FLAGD_RESOLVE_TIMEOUT_SECONDS = 30.0
+# Cadence for re-applying an idempotent file write while waiting: each
+# re-write touches the file -> fresh inotify event -> flagd reloads,
+# self-healing a missed or coalesced file-watch event (observed under CI load).
+FLAGD_REWRITE_INTERVAL_SECONDS = 2.0
+
+
+def poll_until(
+    predicate,
+    timeout: float = FLAGD_RESOLVE_TIMEOUT_SECONDS,
+    *,
+    interval: float = 0.3,
+    rewrite=None,
+    rewrite_interval: float = FLAGD_REWRITE_INTERVAL_SECONDS,
+) -> bool:
+    """Poll ``predicate()`` until true or ``timeout``; return the final value.
+
+    ``rewrite``, when given, is an IDEMPOTENT re-application of the file write
+    being waited on, re-invoked every ``rewrite_interval`` seconds (see
+    FLAGD_REWRITE_INTERVAL_SECONDS for why).
+    """
+    deadline = time.time() + timeout
+    last_rewrite = time.time()
+    while time.time() < deadline:
+        if predicate():
+            return True
+        if rewrite is not None and time.time() - last_rewrite >= rewrite_interval:
+            rewrite()
+            last_rewrite = time.time()
+        time.sleep(interval)
+    return predicate()
+
+
+async def async_poll_until(
+    predicate,
+    timeout: float = FLAGD_RESOLVE_TIMEOUT_SECONDS,
+    *,
+    interval: float = 0.25,
+    rewrite=None,
+    rewrite_interval: float = FLAGD_REWRITE_INTERVAL_SECONDS,
+) -> bool:
+    """Async twin of :func:`poll_until`. ``predicate`` may be sync (a quick
+    RPC/in-memory check) or a coroutine function; same for ``rewrite``."""
+
+    async def _eval(fn):
+        result = fn()
+        if asyncio.iscoroutine(result):
+            result = await result
+        return result
+
+    loop = asyncio.get_event_loop()
+    deadline = loop.time() + timeout
+    last_rewrite = loop.time()
+    while loop.time() < deadline:
+        if await _eval(predicate):
+            return True
+        if rewrite is not None and loop.time() - last_rewrite >= rewrite_interval:
+            await _eval(rewrite)
+            last_rewrite = loop.time()
+        await asyncio.sleep(interval)
+    return await _eval(predicate)
+
+
+@contextlib.contextmanager
+def flagd_probe_client(docker_compose, flag_set: str, *, resolver: str = "in_process"):
+    """Short-lived OpenFeature client bound to ``flagSetId=<flag_set>`` on the
+    live flagd, for polling that a file write is actually being SERVED — the
+    condition every former RELOAD_SETTLE sleep was waiting on.
+
+    ``resolver``:
+    - ``"in_process"`` (default): the sync-stream engine on port 8015 — the
+      SAME path every service reads flags through (lib/feature_flags), so the
+      probe observes exactly what the services observe. Also the only resolver
+      that can read top-level LIST flags (e.g. ``interventions_allowed``): the
+      RPC resolver's object channel is a protobuf Struct (a map), so a list is
+      TYPE_MISMATCH there — the object-flag sibling of the #903 numeric trap.
+    - ``"rpc"``: the evaluation API on port 8013, for tests whose PURPOSE is
+      probing flagd's server-side rule evaluation. Cache disabled: the RPC
+      LRU can serve the first resolution forever if change-event invalidation
+      doesn't arrive for a selector'd flag set (CI run 27029212634), and
+      settle-polling exists precisely to observe live re-resolution.
+    """
+    from openfeature import api
+    from openfeature.contrib.provider.flagd import FlagdProvider
+    from openfeature.contrib.provider.flagd.config import CacheType, ResolverType
+
+    if resolver == "in_process":
+        provider = FlagdProvider(
+            host=docker_compose.get_service_host("flagd", 8015),
+            port=int(docker_compose.get_service_port("flagd", 8015)),
+            resolver_type=ResolverType.IN_PROCESS,
+            selector=f"flagSetId={flag_set}",
+        )
+    else:
+        provider = FlagdProvider(
+            host=docker_compose.get_service_host("flagd", 8013),
+            port=int(docker_compose.get_service_port("flagd", 8013)),
+            resolver_type=ResolverType.RPC,
+            selector=f"flagSetId={flag_set}",
+            cache=CacheType.DISABLED,
+        )
+    domain = f"it_probe_{flag_set}_{resolver}"
+    api.set_provider(provider, domain=domain)
+    try:
+        yield api.get_client(domain)
+    finally:
+        provider.shutdown()
+
+
+def flag_default_value(doc: dict, flag_key: str):
+    """The value a flag resolves to with an empty context: its defaultVariant's
+    value. Used to derive the expected post-restore canary value from a
+    snapshotted flag-file document."""
+    flag = doc["flags"][flag_key]
+    return flag["variants"][flag["defaultVariant"]]
+
+
+def _resolve_flag_typed(client, flag_key: str, expected, context):
+    """Resolve ``flag_key`` with the getter matching ``expected``'s type.
+
+    Numeric flags MUST use the typed getters — get_object_value() is
+    TYPE_MISMATCH for numbers under the flagd RPC resolver and silently
+    returns the default (#903)."""
+    if isinstance(expected, bool):
+        return client.get_boolean_value(flag_key, not expected, context)
+    if isinstance(expected, str):
+        return client.get_string_value(flag_key, "__unset__", context)
+    if isinstance(expected, (int, float)):
+        return client.get_float_value(flag_key, float("nan"), context)
+    return client.get_object_value(flag_key, None, context)
+
+
+def _flag_values_match(got, expected) -> bool:
+    if isinstance(expected, (int, float)) and not isinstance(expected, bool):
+        try:
+            return abs(float(got) - float(expected)) <= 1e-9
+        except (TypeError, ValueError):
+            return False
+    return got == expected
+
+
+def wait_flag_file_restored(
+    docker_compose,
+    flag_set: str,
+    backup_text: str,
+    mutated_text: str,
+    restore,
+    timeout: float = FLAGD_RESOLVE_TIMEOUT_SECONDS,
+) -> None:
+    """Wait until flagd actually SERVES a restored flag file's baseline (#894).
+
+    Replaces the fixed post-restore settle in snapshot/restore fixtures with a
+    condition poll on exactly the flags the test observably mutated, derived by
+    diffing ``mutated_text`` (the file content just before restore) against
+    ``backup_text`` (the snapshot that was written back):
+
+    - a flag whose empty-context value (defaultVariant's value) differs must
+      serve the baseline value again;
+    - a flag that grew ``agent_<serial>`` targeting variants must resolve to
+      the baseline value FOR THOSE SERIALS again (the ladder is gone);
+    - a flag that grew gameId-scoped branches (recorded in the ``_branches``
+      side-registry by the *_for_game writers) must resolve to the baseline
+      value FOR THOSE (gameId, serial) scopes again.
+
+    ``restore`` re-writes the backup and is used as the poll's rewrite
+    self-heal (fresh inotify event for a missed/coalesced file-watch reload).
+    If the test made no observable mutation there is nothing flagd could serve
+    stale, and this returns immediately.
+
+    Deliberately unchecked: gameId-scoped edge writes that do NOT register in
+    ``_branches`` (e.g. ``write_edge_for_game``). Their targeting only matches
+    the writing test's (now-ended) game_id, so a stale serve resolves to the
+    neutral default for every later game — harmless by the #838 design.
+    """
+    from openfeature.evaluation_context import EvaluationContext
+
+    backup_doc = json.loads(backup_text)
+    mutated_doc = json.loads(mutated_text)
+
+    checks = []  # (flag_key, EvaluationContext, expected_baseline_value)
+    for key, mflag in mutated_doc.get("flags", {}).items():
+        bflag = backup_doc.get("flags", {}).get(key)
+        if bflag is None:
+            continue  # flag added by the test; gone after restore, nothing to read
+        baseline = bflag["variants"][bflag["defaultVariant"]]
+        if not _flag_values_match(mflag["variants"].get(mflag["defaultVariant"]), baseline):
+            checks.append((key, EvaluationContext(), baseline))
+        for vname in mflag["variants"]:
+            if vname.startswith("agent_") and vname not in bflag["variants"]:
+                ctx = EvaluationContext(targeting_key=vname[len("agent_"):])
+                checks.append((key, ctx, baseline))
+        for scope in mflag.get("_branches", {}).values():
+            ctx = EvaluationContext(
+                targeting_key=scope.get("serial"),
+                attributes={"gameId": scope.get("gameId")},
+            )
+            checks.append((key, ctx, baseline))
+
+    if not checks:
+        return
+
+    with flagd_probe_client(docker_compose, flag_set) as client:
+
+        def _served() -> bool:
+            for key, ctx, baseline in checks:
+                if not _flag_values_match(_resolve_flag_typed(client, key, baseline, ctx), baseline):
+                    return False
+            return True
+
+        assert poll_until(_served, timeout, rewrite=restore), (
+            f"flagd did not serve the restored {flag_set} baseline for "
+            f"{[k for k, _, _ in checks]}"
+        )
 
 
 # =============================================================================

--- a/tests/integration/test_f6_flow.py
+++ b/tests/integration/test_f6_flow.py
@@ -155,13 +155,17 @@ async def test_pacing_profile_applies_and_reverts(flag_files, docker_compose, ga
             await _wait_applied_count(1)
 
             # frantic preset (distinct value change) -> a second applied event.
-            await asyncio.sleep(RELOAD_SETTLE_SECONDS)
+            # No settle needed (#894): the applied event above proves the calm
+            # write completed the whole flagd-reload -> coordinator-apply chain,
+            # so the frantic write cannot coalesce with it.
             write_state("pacing_profile", "frantic")
             await _wait_applied_count(2)
 
             applied_after_apply = _applied_count()
 
             # Revert to neutral: revert handler restores init windows, no new event.
+            # Absence assertion — bounded wait by design (#894): there is no
+            # event to wait for when the correct behavior is "no new event".
             write_state("pacing_profile", "none")
             await asyncio.sleep(RELOAD_SETTLE_SECONDS + 1.0)
             applied_after_revert = len(

--- a/tests/integration/test_gameid_intervention_isolation.py
+++ b/tests/integration/test_gameid_intervention_isolation.py
@@ -38,14 +38,17 @@ from proto import game_coordinator_pb2  # noqa: E402
 from tests.integration.helpers import (  # noqa: E402
     GameEventCollector,
     build_start_config,
+    flagd_probe_client,
     force_end_game_by_id,
     get_game_client,
     get_mock_client,
     kill_players_until_one_remains,
     list_games,
+    poll_until,
     setup_mock_controllers,
     start_game_via_menu,
     start_game_headless,
+    wait_flag_file_restored,
     wait_for_lobby_colors,
 )
 
@@ -55,7 +58,6 @@ _FLAGD_DIR = os.path.abspath(
 INTERVENTIONS_PATH = os.path.join(_FLAGD_DIR, "interventions.json")
 AGENT_PATH = os.path.join(_FLAGD_DIR, "agent.json")
 
-RELOAD_SETTLE_SECONDS = 2.0
 APPLY_TIMEOUT_SECONDS = 15.0
 SUITE_RATE_LIMIT_BUDGET = 50
 
@@ -154,16 +156,38 @@ def flag_files(docker_compose):
     with open(AGENT_PATH) as fh:
         agent_backup = fh.read()
 
+    # Pin the budget and wait until flagd actually SERVES it (#894: condition
+    # poll, not a fixed settle).
     set_policy_budget(SUITE_RATE_LIMIT_BUDGET)
-    time.sleep(RELOAD_SETTLE_SECONDS)
+    from openfeature.evaluation_context import EvaluationContext
+
+    with flagd_probe_client(docker_compose, "agent") as client:
+        assert poll_until(
+            lambda: client.get_integer_value(
+                "policy.max_interventions_per_minute", -1, EvaluationContext()
+            )
+            == SUITE_RATE_LIMIT_BUDGET,
+            rewrite=lambda: set_policy_budget(SUITE_RATE_LIMIT_BUDGET),
+        ), "flagd did not serve the pinned suite rate-limit budget"
 
     yield
 
-    with open(INTERVENTIONS_PATH, "w") as fh:
-        fh.write(interventions_backup)
-    with open(AGENT_PATH, "w") as fh:
-        fh.write(agent_backup)
-    time.sleep(RELOAD_SETTLE_SECONDS)
+    def _restore():
+        with open(INTERVENTIONS_PATH, "w") as fh:
+            fh.write(interventions_backup)
+        with open(AGENT_PATH, "w") as fh:
+            fh.write(agent_backup)
+
+    with open(INTERVENTIONS_PATH) as fh:
+        interventions_mutated = fh.read()
+    with open(AGENT_PATH) as fh:
+        agent_mutated = fh.read()
+    _restore()
+    # Wait until flagd serves the restored baselines before the next test (#894).
+    wait_flag_file_restored(
+        docker_compose, "interventions", interventions_backup, interventions_mutated, _restore
+    )
+    wait_flag_file_restored(docker_compose, "agent", agent_backup, agent_mutated, _restore)
 
 
 # =============================================================================

--- a/tests/integration/test_intervention_flow.py
+++ b/tests/integration/test_intervention_flow.py
@@ -49,10 +49,13 @@ from proto import game_coordinator_pb2  # noqa: E402
 
 from tests.integration.helpers import (  # noqa: E402
     GameEventCollector,
+    flagd_probe_client,
     get_game_client,
     get_mock_controller_serials,
+    poll_until,
     setup_mock_controllers,
     start_game_via_menu,
+    wait_flag_file_restored,
 )
 
 # Repo-root-relative path to the bind-mounted flagd config dir. The compose
@@ -62,8 +65,11 @@ _FLAGD_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../serv
 INTERVENTIONS_PATH = os.path.join(_FLAGD_DIR, "interventions.json")
 AGENT_PATH = os.path.join(_FLAGD_DIR, "agent.json")
 
-# flagd debounces file-watch reloads + the game coordinator re-evaluates on the
-# PROVIDER_CONFIGURATION_CHANGED event; give the chain time to converge.
+# Absence window: how long the flagd reload + coordinator re-evaluate chain is
+# given to (not) act before asserting that NOTHING happened. Positive waits are
+# condition polls (#894, see helpers.poll_until); this constant remains ONLY for
+# negative assertions — "the blocked/reverted/re-read write produced no effect"
+# cannot be event-driven, the bounded wait IS the test.
 RELOAD_SETTLE_SECONDS = 2.0
 
 # Mutating a per-player state flag and observing the applied sensitivity_factor
@@ -228,19 +234,40 @@ def flag_files(docker_compose):
     with open(AGENT_PATH) as fh:
         agent_backup = fh.read()
 
-    # Pin the generous budget up front and let flagd reload it before the test
-    # body runs, so the very first intervention write already sees the headroom.
+    # Pin the generous budget up front and wait until flagd actually SERVES it
+    # before the test body runs, so the very first intervention write already
+    # sees the headroom (#894: condition poll, not a fixed settle).
     set_policy_budget(SUITE_RATE_LIMIT_BUDGET)
-    time.sleep(RELOAD_SETTLE_SECONDS)
+    from openfeature.evaluation_context import EvaluationContext
+
+    with flagd_probe_client(docker_compose, "agent") as client:
+        assert poll_until(
+            lambda: client.get_integer_value(
+                "policy.max_interventions_per_minute", -1, EvaluationContext()
+            )
+            == SUITE_RATE_LIMIT_BUDGET,
+            rewrite=lambda: set_policy_budget(SUITE_RATE_LIMIT_BUDGET),
+        ), "flagd did not serve the pinned suite rate-limit budget"
 
     yield
 
-    with open(INTERVENTIONS_PATH, "w") as fh:
-        fh.write(interventions_backup)
-    with open(AGENT_PATH, "w") as fh:
-        fh.write(agent_backup)
-    # Let flagd reload the restored baseline before the next test mutates it.
-    time.sleep(RELOAD_SETTLE_SECONDS)
+    def _restore():
+        with open(INTERVENTIONS_PATH, "w") as fh:
+            fh.write(interventions_backup)
+        with open(AGENT_PATH, "w") as fh:
+            fh.write(agent_backup)
+
+    with open(INTERVENTIONS_PATH) as fh:
+        interventions_mutated = fh.read()
+    with open(AGENT_PATH) as fh:
+        agent_mutated = fh.read()
+    _restore()
+    # Wait until flagd serves the restored baselines (every flag this test
+    # observably mutated) before the next test mutates them (#894).
+    wait_flag_file_restored(
+        docker_compose, "interventions", interventions_backup, interventions_mutated, _restore
+    )
+    wait_flag_file_restored(docker_compose, "agent", agent_backup, agent_mutated, _restore)
 
 
 @pytest.fixture
@@ -332,49 +359,40 @@ async def test_per_player_targeting_resolves_against_live_flagd(flag_files, dock
     resolve correctly via OpenFeature for distinct serials + unknown->default.
     Catches schema/targeting-rule rejections the Go unit tests cannot.
     """
-    from openfeature.contrib.provider.flagd import FlagdProvider
-    from openfeature.contrib.provider.flagd.config import ResolverType
     from openfeature.evaluation_context import EvaluationContext
 
     serial_a, serial_b, unknown = "SER_A", "SER_B", "SER_UNKNOWN"
 
-    # Write two distinct per-serial branches (merged into one if-ladder).
-    write_targeted("player_sensitivity_factor", "default", serial_a, 1.5)
-    write_targeted("player_sensitivity_factor", "default", serial_b, 0.7)
-    time.sleep(RELOAD_SETTLE_SECONDS)
+    def _write_branches():
+        # Write two distinct per-serial branches (merged into one if-ladder).
+        # Idempotent, so it doubles as poll_until's rewrite self-heal.
+        write_targeted("player_sensitivity_factor", "default", serial_a, 1.5)
+        write_targeted("player_sensitivity_factor", "default", serial_b, 0.7)
 
-    host = docker_compose.get_service_host("flagd", 8013)
-    port = int(docker_compose.get_service_port("flagd", 8013))
+    _write_branches()
 
-    provider = FlagdProvider(
-        host=host,
-        port=port,
-        resolver_type=ResolverType.RPC,
-        selector="flagSetId=interventions",
-    )
-    from openfeature import api
+    # resolver="rpc" deliberately: this test's PURPOSE is flagd's server-side
+    # evaluation of the written targeting ladder (in-process would evaluate the
+    # jsonlogic client-side and mask server-side rule rejections).
+    with flagd_probe_client(docker_compose, "interventions", resolver="rpc") as client:
 
-    api.set_provider(provider, domain="it_interventions")
-    client = api.get_client("it_interventions")
+        def _eval(serial: str) -> float:
+            return client.get_float_value(
+                "player_sensitivity_factor", 1.0, EvaluationContext(targeting_key=serial)
+            )
 
-    # Poll: provider connect + flagd reload may lag the file write.
-    def _eval(serial: str) -> float:
-        return client.get_float_value(
-            "player_sensitivity_factor", 1.0, EvaluationContext(targeting_key=serial)
+        # No fixed settle: poll until flagd serves the written ladder (provider
+        # connect + file-watch reload may lag the write), then assert.
+        assert poll_until(
+            lambda: abs(_eval(serial_a) - 1.5) <= 0.01 and abs(_eval(serial_b) - 0.7) <= 0.01,
+            APPLY_TIMEOUT_SECONDS,
+            rewrite=_write_branches,
+        ), (
+            f"ladder did not resolve: serial_a={_eval(serial_a)} (want 1.5), "
+            f"serial_b={_eval(serial_b)} (want 0.7)"
         )
-
-    deadline = time.time() + APPLY_TIMEOUT_SECONDS
-    while time.time() < deadline:
-        if abs(_eval(serial_a) - 1.5) <= 0.01 and abs(_eval(serial_b) - 0.7) <= 0.01:
-            break
-        time.sleep(0.3)
-
-    assert abs(_eval(serial_a) - 1.5) <= 0.01, f"serial_a resolved to {_eval(serial_a)}"
-    assert abs(_eval(serial_b) - 0.7) <= 0.01, f"serial_b resolved to {_eval(serial_b)}"
-    # Unknown serial falls through the if-ladder to the neutral default (1.0).
-    assert abs(_eval(unknown) - 1.0) <= 0.01, f"unknown resolved to {_eval(unknown)}"
-
-    provider.shutdown()
+        # Unknown serial falls through the if-ladder to the neutral default (1.0).
+        assert abs(_eval(unknown) - 1.0) <= 0.01, f"unknown resolved to {_eval(unknown)}"
 
 
 # =============================================================================
@@ -414,6 +432,8 @@ async def test_permission_layer_blocks_disallowed_intervention(flag_files, docke
             )
 
             # Game state unchanged: the blocked intervention never killed anyone.
+            # Absence assertion — kept as a bounded wait by design (#894): there
+            # is no event to wait for when the correct behavior is "nothing".
             await asyncio.sleep(RELOAD_SETTLE_SECONDS)
             assert (await _player(game_client, victim)).alive, (
                 "blocked intervention still killed the player"

--- a/tests/integration/test_parallel_intervention_flow.py
+++ b/tests/integration/test_parallel_intervention_flow.py
@@ -68,6 +68,8 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
 from proto import game_coordinator_pb2  # noqa: E402
 
 from tests.integration.helpers import (  # noqa: E402
+    async_poll_until,
+    flagd_probe_client,
     GameEventCollector,
     build_start_config,
     force_end_game_by_id,
@@ -80,6 +82,7 @@ from tests.integration.helpers import (  # noqa: E402
     verify_controllers_have_color,
 )
 from tests.integration.test_intervention_flow import (  # noqa: E402
+    AGENT_PATH,
     APPLY_TIMEOUT_SECONDS,
     INTERVENTIONS_PATH,
     RELOAD_SETTLE_SECONDS,
@@ -465,6 +468,8 @@ async def _scenario_eliminate_exactly_once(docker_compose, tag: str) -> None:
         applied_after_first = len(_intervention_events(collector, "eliminate_player", blocked="false"))
 
         # Re-read SAME nonce (force reload, value unchanged): no re-apply.
+        # Absence assertion — bounded wait by design (#894): there is no event
+        # to wait for when the correct behavior is "no re-apply".
         rewrite_edge_value_for_game("eliminate_player", game_id, f"{nonce1}:{victim}")
         await asyncio.sleep(RELOAD_SETTLE_SECONDS + 1.0)
         applied_after_reread = len(_intervention_events(collector, "eliminate_player", blocked="false"))
@@ -581,6 +586,8 @@ async def _scenario_global_difficulty(docker_compose, tag: str) -> None:
         applied_after_apply = len(_intervention_events(collector, "adjust_global_difficulty", blocked="false"))
 
         # Revert to neutral 1.0: revert handler runs, no new applied event.
+        # Absence assertion — bounded wait by design (#894): there is no event
+        # to wait for when the correct behavior is "no new event".
         write_state_for_game("global_difficulty_factor", game_id, 1.0, neutral="default")
         await asyncio.sleep(RELOAD_SETTLE_SECONDS + 1.0)
         applied_after_revert = len(_intervention_events(collector, "adjust_global_difficulty", blocked="false"))
@@ -621,9 +628,17 @@ async def _scenario_repeated_writes(docker_compose, tag: str) -> None:
         observed_intermediate = False
         for value in sequence:
             write_targeted_for_game("player_sensitivity_factor", game_id, target, value)
-            await asyncio.sleep(RELOAD_SETTLE_SECONDS)
-            p = await _player(game_client, game_id, target)
-            if p is not None and abs(p.sensitivity_factor - value) <= 0.01:
+
+            # Poll (bounded by the old fixed settle, #894) for THIS value to be
+            # applied; on success move on immediately instead of paying the full
+            # constant. A miss is tolerated by design — under load a write may
+            # be superseded before the coordinator observes it; the asserts
+            # below only require the FINAL value plus >=1 observed intermediate.
+            async def _applied(v=value) -> bool:
+                p = await _player(game_client, game_id, target)
+                return p is not None and abs(p.sensitivity_factor - v) <= 0.01
+
+            if await async_poll_until(_applied, RELOAD_SETTLE_SECONDS):
                 observed_intermediate = True
 
         await _wait_for_sensitivity_factor(game_client, game_id, target, sequence[-1])
@@ -689,8 +704,20 @@ async def test_parallel_interventions(flag_files, docker_compose, headless_clean
     # All batch scenarios share the single global ``interventions_allowed`` flag
     # (not gameId-scopeable); they are all selected to run under ``full``.
     set_interventions_allowed("full")
-    # Let flagd serve the permission flip before any scenario writes.
-    await asyncio.sleep(RELOAD_SETTLE_SECONDS)
+    # Wait until flagd actually SERVES the permission flip before any scenario
+    # writes (#894: condition poll, not a fixed settle).
+    with open(AGENT_PATH) as fh:
+        expected_full = json.load(fh)["flags"]["interventions_allowed"]["variants"]["full"]
+    from openfeature.evaluation_context import EvaluationContext
+
+    with flagd_probe_client(docker_compose, "agent") as flag_client:
+        assert await async_poll_until(
+            lambda: flag_client.get_object_value(
+                "interventions_allowed", None, EvaluationContext()
+            )
+            == expected_full,
+            rewrite=lambda: set_interventions_allowed("full"),
+        ), "flagd did not serve interventions_allowed=full"
 
     # Register tags up front so the fixture sweeps reserved controllers even if a
     # coroutine dies before its own finally-block cleanup runs.

--- a/tests/integration/test_parallel_lifecycle.py
+++ b/tests/integration/test_parallel_lifecycle.py
@@ -57,6 +57,7 @@ from tests.integration.helpers import (
     setup_mock_controllers,
     start_game_headless,
     verify_controllers_have_color,
+    wait_until_running,
 )
 
 # =============================================================================
@@ -262,6 +263,20 @@ async def _run_mode_headless(docker_compose, spec: ModeSpec, tag: str) -> None:
         # transient cap rejections (sibling games in their ENDING window).
         game_id, collector = await _start_headless_with_retry(
             game_client, build_start_config(spec.mode, serials)
+        )
+
+        # The session must actually be RUNNING before the end strategy may
+        # query it: start_game_headless returns on the first start event (can
+        # be game_starting, #897), and the state-driven end strategies treat
+        # "not RUNNING" from GetGameState as "game already ended" and silently
+        # return — leaving a live game with no kills and no terminal event.
+        # That was the recurring [Swapper] fast-batch failure: under load the
+        # strategy's first query landed inside the stretched STARTING window,
+        # zero SimulateDeath calls ever fired, and the batch timed out on a
+        # healthy 2v2 RUNNING game (#894).
+        running = await wait_until_running(game_client, {game_id}, timeout=20.0)
+        assert game_id in running, (
+            f"{spec.mode} game {game_id} never reached RUNNING (running: {sorted(running)})"
         )
 
         # Controllers must get game colors (non-zero LED, per serial via

--- a/tests/integration/test_rollout_plumbing.py
+++ b/tests/integration/test_rollout_plumbing.py
@@ -39,29 +39,26 @@ fixture in test_intervention_flow.py).
 import json
 import os
 import sys
-import time
 
 import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
 
+# All flagd-write waits here are condition polls via helpers.poll_until (#894:
+# the old fixed settles became deadlines). Its generous default deadline and
+# `rewrite` self-heal exist because one CI run (27028642150) showed a
+# defaultVariant flip never resolving within 15s while EARLIER flips on the
+# same file did — a missed/coalesced file-watch reload under load; re-writing
+# the file mid-poll produces a fresh inotify event and self-heals that case.
+from tests.integration.helpers import (  # noqa: E402
+    poll_until,
+    wait_flag_file_restored,
+)
+
 # Repo-root-relative path to the bind-mounted flagd config dir (same dir the
 # intervention-flow tests mutate).
 _FLAGD_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../services/flagd"))
 ROLLOUT_PATH = os.path.join(_FLAGD_DIR, "rollout.json")
-
-# flagd debounces file-watch reloads; the RPC provider also needs a moment to
-# reconnect and re-pull after a reload. Generous so this never flakes under CI
-# load (#805 is a known timing flake on the game path; the rollout path is
-# simpler but we stay conservative).
-RELOAD_SETTLE_SECONDS = 2.0
-# Generous: one CI run (27028642150) showed a defaultVariant flip never resolving
-# within 15s while EARLIER flips on the same file did — a missed/coalesced
-# file-watch reload under load. _poll_until therefore also supports re-writing
-# the file mid-poll (see its `rewrite` param), which produces a fresh inotify
-# event and self-heals that case.
-RESOLVE_TIMEOUT_SECONDS = 30.0
-REWRITE_INTERVAL_SECONDS = 2.0
 
 
 # =============================================================================
@@ -124,10 +121,17 @@ def rollout_file(docker_compose):
 
     yield
 
-    with open(ROLLOUT_PATH, "w") as fh:
-        fh.write(backup)
-    # Let flagd reload the restored baseline before the next test mutates it.
-    time.sleep(RELOAD_SETTLE_SECONDS)
+    with open(ROLLOUT_PATH) as fh:
+        mutated = fh.read()
+
+    def _restore():
+        with open(ROLLOUT_PATH, "w") as fh:
+            fh.write(backup)
+
+    _restore()
+    # Wait until flagd actually SERVES the restored baseline before the next
+    # test mutates it (#894: condition poll instead of a fixed settle).
+    wait_flag_file_restored(docker_compose, "rollout", backup, mutated, _restore)
 
 
 # =============================================================================
@@ -161,26 +165,6 @@ def _rollout_client(docker_compose):
     return api.get_client("it_rollout"), provider
 
 
-def _poll_until(predicate, timeout: float = RESOLVE_TIMEOUT_SECONDS, rewrite=None) -> bool:
-    """Poll predicate() until true or timeout (provider connect + flagd reload may
-    lag the file write). Returns the final predicate value.
-
-    ``rewrite``, when given, is an IDEMPOTENT re-application of the file write
-    being waited on, re-invoked every REWRITE_INTERVAL_SECONDS. Each re-write
-    touches the file → fresh inotify event → flagd reloads, self-healing a
-    missed or coalesced file-watch event (observed under CI load)."""
-    deadline = time.time() + timeout
-    last_rewrite = time.time()
-    while time.time() < deadline:
-        if predicate():
-            return True
-        if rewrite is not None and time.time() - last_rewrite >= REWRITE_INTERVAL_SECONDS:
-            rewrite()
-            last_rewrite = time.time()
-        time.sleep(0.3)
-    return predicate()
-
-
 @pytest.mark.asyncio
 async def test_rollout_write_shape_resolves_via_live_flagd(rollout_file, docker_compose):
     """The agent's rollout write shape (strategy=progressive, target_backend flip,
@@ -198,26 +182,30 @@ async def test_rollout_write_shape_resolves_via_live_flagd(rollout_file, docker_
     # operator-intent + loop would have the file look at the start of an episode.
     set_default_variant("strategy", "progressive")
     set_default_variant("target_backend", "rust")
-    time.sleep(RELOAD_SETTLE_SECONDS)
+    # No settle here: the first poll_until below IS the wait for these writes
+    # to be served (with rewrite self-heal), so a fixed sleep is pure cost.
 
     client, provider = _rollout_client(docker_compose)
     try:
         empty = EvaluationContext()
 
-        # strategy + target_backend resolve as written.
-        assert _poll_until(
+        # strategy + target_backend resolve as written. Both polled: the two
+        # writes are separate file versions, so flagd serving the strategy flip
+        # does NOT prove it loaded the later target_backend write too.
+        assert poll_until(
             lambda: client.get_string_value("strategy", "off", empty) == "progressive",
             rewrite=lambda: set_default_variant("strategy", "progressive"),
         ), f"strategy resolved to {client.get_string_value('strategy', 'off', empty)!r}"
-        assert client.get_string_value("target_backend", "python", empty) == "rust", (
-            "target_backend did not resolve to the written rust"
-        )
+        assert poll_until(
+            lambda: client.get_string_value("target_backend", "python", empty) == "rust",
+            rewrite=lambda: set_default_variant("target_backend", "rust"),
+        ), "target_backend did not resolve to the written rust"
 
         # Walk the expansion ladder: each variant flip resolves to its integer.
         ladder = [("none", 0), ("one", 1), ("three", 3), ("six", 6), ("all", 99)]
         for variant, expected in ladder:
             set_controller_count_variant(variant)
-            assert _poll_until(
+            assert poll_until(
                 lambda e=expected: client.get_integer_value("current_controller_count", -1, empty) == e,
                 rewrite=lambda v=variant: set_controller_count_variant(v),
             ), (
@@ -230,7 +218,7 @@ async def test_rollout_write_shape_resolves_via_live_flagd(rollout_file, docker_
         # Rollback shape: the loop resets current_controller_count to "none" (0) on
         # an allowed rollback — assert that exact flip lands too.
         set_controller_count_variant("none")
-        assert _poll_until(
+        assert poll_until(
             lambda: client.get_integer_value("current_controller_count", -1, empty) == 0,
             rewrite=lambda: set_controller_count_variant("none"),
         ), "rollback-to-none did not resolve to 0"


### PR DESCRIPTION
Part of #894. Serves #770. Sequenced after #838 (merged via #890) per the issue.

Every former `RELOAD_SETTLE` sleep after a flagd file write becomes a **condition wait with the old constant as the deadline, not the paid cost**: the fast path costs ~one poll interval, the slow path keeps (or extends) the same upper bound.

## Measured

Flag-plumbing subset (`rollout or intervention or f6 or gameid`, 11 tests), same machine, both green: **3:44 → 2:29 (−33%)**. Full suite: **18/18 in 5:00** — including the fast-batch that had been failing (see bonus fix below).

## What changed

**New helpers** (`tests/integration/helpers.py`):
- `poll_until` / `async_poll_until` — generalized from `test_rollout_plumbing._poll_until`, including the `rewrite` self-heal (re-write → fresh inotify → flagd reload; missed/coalesced watch events were observed under CI load, run 27028642150).
- `flagd_probe_client(docker_compose, flag_set, resolver="in_process"|"rpc")` — short-lived OpenFeature client for "is flagd actually serving this write" polls. **In-process by default**: it's the same sync-stream path every service reads through, and the only resolver that can read top-level LIST flags — `get_object_value` is TYPE_MISMATCH for a list under the RPC resolver (protobuf Struct is a map), the object-flag sibling of the #903 numeric trap (found when the first conversion attempt polled `interventions_allowed` over RPC and timed out forever). `rpc` (cache disabled, run 27029212634) is opt-in for the one test whose purpose is server-side rule evaluation.
- `wait_flag_file_restored` — teardown polls exactly the flags a test observably mutated, derived by diffing the pre-restore doc against the snapshot: changed defaults, added `agent_*` ladders, and `_branches` gameId scopes. Un-registered gameId edge writes are deliberately unchecked — stale serves are no-ops for any later game_id by the #838 design.

**Conversions**: fixture setup pins + polls the budget flag; teardowns poll the restored baseline; redundant settles deleted where an existing event/poll already proves the condition (rollout test body, f6 calm→frantic after the applied event, targeted-ladder test); the parallel sequence test polls each written value bounded by the old constant.

**Kept (absence windows)**: blocked-intervention, revert-no-new-event, and same-nonce-no-re-apply sleeps stay — a proof of "nothing happened" cannot be event-driven; each site now documents that.

## Bonus: recurring [Swapper] fast-batch failure root-caused (second commit)

It was never an env flake. `_run_mode_headless` ran end strategies without waiting for RUNNING; `start_game_headless` returns on `game_starting` (#897), and the state-driven strategies treat `GetGameState != RUNNING` as "game already ended" and silently return. Under load the first query landed inside the stretched STARTING window → **zero SimulateDeath calls ever fired** (controller-manager mock logs show kills only for the sibling mode's serials; the coordinator shows Swapper init then 40s of silence) → healthy RUNNING 2v2 game, no terminal event, batch timeout. Fixed with the existing `wait_until_running` gate, whose docstring already documented this exact race. This also protects Tournament's state-driven strategy from #909.

## Validation

- `make lint` ✅
- Flag-plumbing subset: 11/11 in 2:29 ✅
- Parallel lifecycle batches: 2/2 ✅ (previously failing fast-batch now passes repeatedly)
- Full `make test-dev`: **18/18 in 5:00** ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)