### PR TITLE
feat(agent): bounded per-game rolling narrative for LLM prompts (#916)

### DIFF
--- a/services/agent/gamecontext/model.go
+++ b/services/agent/gamecontext/model.go
@@ -90,4 +90,13 @@ type GameContext struct {
 	Session   SessionSignals
 	Players   map[string]*PlayerSignals
 	UpdatedAt time.Time
+
+	// Timeline is a bounded, oldest-first slice of the partition's recent rolling
+	// narrative (#916): periodic state deltas, eliminations, and session phase
+	// transitions, each timestamped. It is a SNAPSHOT copy of the Store's ring
+	// buffer taken in Snapshot(), so it shares no backing array with the live ring
+	// and is safe to render after later Store mutations. nil when nothing has been
+	// recorded yet. The llm package renders it into a compact timeline section in
+	// both the in-game prompt (#739) and the retro (#844) via RenderTimeline.
+	Timeline []TimelineEvent
 }

--- a/services/agent/gamecontext/multiplexer_test.go
+++ b/services/agent/gamecontext/multiplexer_test.go
@@ -350,3 +350,55 @@ func TestMux_SpanRouting(t *testing.T) {
 		t.Error("P2 bled into game-A")
 	}
 }
+
+// TestMux_TimelineIsolation verifies the #916 rolling narrative is per-partition:
+// two concurrent games accumulate independent timelines, and one game's
+// eliminations/state deltas never appear in the other's. This is the per-game
+// isolation acceptance criterion — the timeline lives on the per-game Store, so
+// it inherits the multiplexer's partition isolation for free.
+func TestMux_TimelineIsolation(t *testing.T) {
+	clk := &muxClock{t: time.Unix(1000, 0)}
+	mux := newTestMux(clk, time.Hour, time.Hour, nil, nil)
+
+	// Game A: start + two distinct intensities (state deltas) + an elimination.
+	mux.ApplyMetrics(gameActiveFor("game-A", 1))
+	mux.ApplyMetrics(playerIntensityFor("PA", "game-A", 1.0))
+	mux.ApplyMetrics(playerIntensityFor("PA", "game-A", 2.0))
+
+	// Game B: start only.
+	mux.ApplyMetrics(gameActiveFor("game-B", 1))
+
+	a, _ := mux.Snapshot("game-A")
+	b, _ := mux.Snapshot("game-B")
+
+	if len(a.Timeline) <= len(b.Timeline) {
+		t.Fatalf("game-A timeline (%d) should be richer than game-B's (%d)", len(a.Timeline), len(b.Timeline))
+	}
+	// Game B saw only its start phase.
+	if len(b.Timeline) != 1 || b.Timeline[0].Kind != EventPhase {
+		t.Errorf("game-B timeline = %v, want a single phase:start", b.Timeline)
+	}
+	// Game A's narrative must carry a phase and at least one state delta and NOT
+	// have leaked into B (already asserted by B having exactly its own one entry).
+	var sawState bool
+	for _, e := range a.Timeline {
+		if e.Kind == EventStateDelta {
+			sawState = true
+		}
+	}
+	if !sawState {
+		t.Error("game-A timeline missing its state deltas")
+	}
+
+	// Evicting game-A (after its end + grace) must not touch game-B's narrative.
+	mux.ApplyMetrics(gameActiveFor("game-A", 0)) // end A
+	clk.advance(2 * time.Hour)
+	mux.EvictStale() // A drained + removed; B still active
+	if _, ok := mux.Snapshot("game-A"); ok {
+		t.Fatal("game-A partition should be evicted")
+	}
+	b2, okB := mux.Snapshot("game-B")
+	if !okB || len(b2.Timeline) != 1 {
+		t.Errorf("game-B timeline disturbed by game-A eviction: ok=%v timeline=%v", okB, b2.Timeline)
+	}
+}

--- a/services/agent/gamecontext/store.go
+++ b/services/agent/gamecontext/store.go
@@ -21,6 +21,14 @@ type Store struct {
 	sessionSeq int
 	endedAt    time.Time // when GameActive went true->false; starts the grace window
 
+	// history is the bounded per-partition rolling narrative (#916): a fixed-
+	// capacity ring buffer of timestamped state deltas, eliminations, and phase
+	// transitions. It is guarded by s.mu (no second lock) and lives ON the Store,
+	// so it is automatically per-partition (#845) and evicted with the partition.
+	// Reset on session-grace exit so a finished game's narrative never bleeds into
+	// the next session on the same partition.
+	history timeline
+
 	// deathCounts tracks the last game_player_deaths_total per serial, so the
 	// fallback elimination source can detect increases.
 	deathCounts map[string]float64
@@ -71,6 +79,7 @@ func NewStore(playerTTL, sessionGrace time.Duration, now func() time.Time) *Stor
 		ctx: GameContext{
 			Players: make(map[string]*PlayerSignals),
 		},
+		history:      newTimeline(),
 		deathCounts:  make(map[string]float64),
 		elimOrder:    make(map[string]int),
 		disconnected: make(map[string]bool),
@@ -107,6 +116,67 @@ func (s *Store) touchSession() {
 
 func ptr[T any](v T) *T { return &v }
 
+// recordStateDelta appends a periodic state-delta entry to the rolling narrative
+// (#916), but ONLY when a tracked session aggregate (active player count or mean
+// movement intensity) CHANGED versus the last recorded delta. Dedupe is the
+// linchpin of the bound: live signals arrive at up to 60Hz, so appending one per
+// signal would churn the 64-entry ring in a second and bury eliminations/phase
+// changes. Recording only on change keeps the narrative a TREND log. Caller holds
+// s.mu.
+func (s *Store) recordStateDelta() {
+	active := s.ctx.Session.ActivePlayerCount
+	mean := s.meanIntensityLocked()
+
+	if intPtrEqual(active, s.history.lastActivePlayers) && floatPtrEqual(mean, s.history.lastMeanIntensity) {
+		return // nothing the narrative tracks changed; don't churn the ring
+	}
+	s.history.lastActivePlayers = active
+	s.history.lastMeanIntensity = mean
+	s.history.append(TimelineEvent{
+		At:            s.now(),
+		Kind:          EventStateDelta,
+		ActivePlayers: active,
+		MeanIntensity: mean,
+	})
+}
+
+// meanIntensityLocked returns the mean of all observed player MovementIntensity
+// values as the session's aggregate "energy", or nil when no player has reported
+// intensity yet. It is the one fitness-style aggregate the Store can compute from
+// what it already holds; richer fitness evaluations (skill gap, variance) are the
+// decision engine's, and are layered in via AppendInterventionEvent's sibling
+// seam if/when needed (#916). Caller holds s.mu.
+func (s *Store) meanIntensityLocked() *float64 {
+	var sum float64
+	var n int
+	for _, p := range s.ctx.Players {
+		if p.MovementIntensity != nil {
+			sum += *p.MovementIntensity
+			n++
+		}
+	}
+	if n == 0 {
+		return nil
+	}
+	return ptr(sum / float64(n))
+}
+
+// intPtrEqual / floatPtrEqual compare two pointers by VALUE, treating two nils as
+// equal and a nil-vs-set pair as unequal — the change test recordStateDelta needs.
+func intPtrEqual(a, b *int) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return *a == *b
+}
+
+func floatPtrEqual(a, b *float64) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return *a == *b
+}
+
 // SetPlayerIntensity records movement intensity, creating the player on demand.
 func (s *Store) SetPlayerIntensity(serial string, v float64) {
 	s.mu.Lock()
@@ -114,6 +184,9 @@ func (s *Store) SetPlayerIntensity(serial string, v float64) {
 	p := s.player(serial)
 	p.MovementIntensity = ptr(v)
 	s.touch(p)
+	// A movement-intensity change can move the session mean — record a state delta
+	// (deduped) so the narrative captures the energy trend (#916).
+	s.recordStateDelta()
 }
 
 // SetPlayerVariance records movement variance, creating the player on demand.
@@ -220,6 +293,7 @@ func (s *Store) SetActivePlayerCount(n int) {
 	defer s.mu.Unlock()
 	s.ctx.Session.ActivePlayerCount = ptr(n)
 	s.touchSession()
+	s.recordStateDelta() // active-count change is a first-class narrative trend (#916)
 }
 
 // SetGameMode records the current game mode.
@@ -255,8 +329,16 @@ func (s *Store) SetGameActive(active bool) {
 		s.ctx.Session.DurationSeconds = nil
 		s.elimOrder = make(map[string]int)
 		s.endedAt = time.Time{}
+		// New session: clear the prior game's narrative and open the new one with a
+		// "start" phase event (#916). Reset here (not only on grace exit) so a
+		// back-to-back restart cannot carry the previous game's trend.
+		s.history.reset()
+		s.history.append(TimelineEvent{At: s.now(), Kind: EventPhase, Detail: "start"})
 	case prev && !active:
 		s.endedAt = s.now()
+		// Game end is the final phase transition; record it BEFORE the snapshot so
+		// the OnGameEnd retro (#844) sees a narrative ending in "end" (#916).
+		s.history.append(TimelineEvent{At: s.now(), Kind: EventPhase, Detail: "end"})
 		if s.OnGameEnd != nil {
 			snap := s.snapshotLocked() // pre-reset state: SessionID + sequence intact
 			endSnapshot = &snap
@@ -322,7 +404,19 @@ func (s *Store) RecordDeathTotal(serial string, total float64) {
 func (s *Store) SetEliminationOrder(serial string, order int) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	_, alreadyKnown := s.elimOrder[serial]
 	s.elimOrder[serial] = order
+	// Narrate each serial's elimination exactly once, the first time this preferred
+	// source reports it (a repeat report only re-sorts) (#916). Record with the
+	// reported 1-based order so the narrative matches the rebuilt sequence below.
+	if !alreadyKnown {
+		s.history.append(TimelineEvent{
+			At:     s.now(),
+			Kind:   EventElimination,
+			Serial: serial,
+			Order:  order,
+		})
+	}
 	serials := make([]string, 0, len(s.elimOrder))
 	for k := range s.elimOrder {
 		serials = append(serials, k)
@@ -332,6 +426,32 @@ func (s *Store) SetEliminationOrder(serial string, order int) {
 	})
 	s.ctx.Session.EliminationSequence = serials
 	s.touchSession()
+}
+
+// AppendInterventionEvent records a dispatched OR blocked intervention in the
+// rolling narrative (#916). It is the CLEAN SEAM the decision Loop can call after
+// it decides an intervention's outcome (runDecision knows dispatched vs blocked),
+// since the Loop and the Store are separate objects: the receiver pipeline holds
+// both (mux.Snapshot's Store and loops.For's Loop), so a follow-up can thread the
+// per-game Store's AppendInterventionEvent into the action path without a second
+// global structure.
+//
+// DEFERRED (#916): the first cut wires only what the Store itself observes (state
+// deltas, eliminations, phase). Intervention-event capture needs the receiver to
+// hand the partition's Store to the Loop (or the action sink) so this method is
+// reached on each decision; that plumbing is left for a follow-up so this PR stays
+// a tight, well-tested first cut. The seam is intentionally present and unit-tested
+// so the follow-up is a wiring change, not a redesign.
+func (s *Store) AppendInterventionEvent(intervention, serial string, blocked bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.history.append(TimelineEvent{
+		At:      s.now(),
+		Kind:    EventIntervention,
+		Detail:  intervention,
+		Serial:  serial,
+		Blocked: blocked,
+	})
 }
 
 // RecordElimination is the span-event confirmation path; it appends the serial
@@ -352,6 +472,14 @@ func (s *Store) appendElimination(serial string) {
 	}
 	s.ctx.Session.EliminationSequence = append(s.ctx.Session.EliminationSequence, serial)
 	s.touchSession()
+	// Record the elimination in the rolling narrative with its 1-based order (#916),
+	// so the timeline carries WHEN each player dropped out, not just the final order.
+	s.history.append(TimelineEvent{
+		At:     s.now(),
+		Kind:   EventElimination,
+		Serial: serial,
+		Order:  len(s.ctx.Session.EliminationSequence),
+	})
 }
 
 // Snapshot returns a deep-enough copy of the context: a fresh Players map with
@@ -378,6 +506,11 @@ func (s *Store) snapshotLocked() GameContext {
 		copy(seq, s.ctx.Session.EliminationSequence)
 		out.Session.EliminationSequence = seq
 	}
+	// Carry a fresh, oldest-first copy of the rolling narrative on the snapshot
+	// (#916). events() allocates a new slice sharing no backing array with the
+	// ring, so a later append never mutates a handed-out snapshot — the same
+	// shared-nothing guarantee the Players/EliminationSequence copies give.
+	out.Timeline = s.history.events()
 	return out
 }
 
@@ -426,5 +559,9 @@ func (s *Store) EvictStale() {
 		s.elimOrder = make(map[string]int)
 		s.endedAt = time.Time{}
 		s.ctx.UpdatedAt = now
+		// Drop the finished game's narrative along with the rest of its
+		// session-scoped state (#916): the ring buffer is evicted with the session
+		// so a new game on this partition starts with an empty timeline.
+		s.history.reset()
 	}
 }

--- a/services/agent/gamecontext/store_test.go
+++ b/services/agent/gamecontext/store_test.go
@@ -191,3 +191,148 @@ func TestStore_ConcurrencySmoke(t *testing.T) {
 	}
 	wg.Wait()
 }
+
+// --- #916 rolling-narrative Store integration ---
+
+// timelineKinds extracts the kinds of a snapshot's timeline, in order.
+func timelineKinds(snap GameContext) []TimelineEventKind {
+	out := make([]TimelineEventKind, len(snap.Timeline))
+	for i, e := range snap.Timeline {
+		out[i] = e.Kind
+	}
+	return out
+}
+
+func hasKind(snap GameContext, k TimelineEventKind) bool {
+	for _, e := range snap.Timeline {
+		if e.Kind == k {
+			return true
+		}
+	}
+	return false
+}
+
+// TestStore_TimelineAccumulates checks that the Store records a phase-start, a
+// state delta, and an elimination into the rolling narrative, in observation
+// order, on the partition's snapshot (#916).
+func TestStore_TimelineAccumulates(t *testing.T) {
+	clk := &clock{t: time.Unix(0, 0)}
+	s := NewStore(time.Hour, time.Hour, clk.now)
+
+	s.SetGameActive(true) // phase: start
+	clk.advance(time.Second)
+	s.SetActivePlayerCount(3) // state delta
+	clk.advance(time.Second)
+	s.SetActivePlayerCount(2) // changed -> another state delta
+	clk.advance(time.Second)
+	s.RecordElimination("A") // elimination
+
+	got := timelineKinds(s.Snapshot())
+	want := []TimelineEventKind{EventPhase, EventStateDelta, EventStateDelta, EventElimination}
+	if len(got) != len(want) {
+		t.Fatalf("timeline kinds = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("event[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// TestStore_TimelineStateDeltaDeduped verifies a repeated identical aggregate
+// does NOT churn the ring: only CHANGES are recorded (#916).
+func TestStore_TimelineStateDeltaDeduped(t *testing.T) {
+	clk := &clock{t: time.Unix(0, 0)}
+	s := NewStore(time.Hour, time.Hour, clk.now)
+
+	s.SetActivePlayerCount(3)
+	s.SetActivePlayerCount(3) // identical -> no new entry
+	s.SetActivePlayerCount(3)
+	if n := len(s.Snapshot().Timeline); n != 1 {
+		t.Fatalf("timeline len = %d, want 1 (identical deltas deduped)", n)
+	}
+	s.SetActivePlayerCount(2) // change -> one more
+	if n := len(s.Snapshot().Timeline); n != 2 {
+		t.Fatalf("timeline len = %d, want 2 after a real change", n)
+	}
+}
+
+// TestStore_TimelinePhaseStartEnd checks both phase transitions are recorded,
+// and that a restart clears the prior game's narrative (#916).
+func TestStore_TimelinePhaseStartEnd(t *testing.T) {
+	clk := &clock{t: time.Unix(0, 0)}
+	s := NewStore(time.Hour, time.Hour, clk.now)
+
+	s.SetGameActive(true)
+	s.RecordElimination("A")
+	s.SetGameActive(false) // phase: end
+
+	end := s.Snapshot().Timeline
+	if len(end) == 0 || end[len(end)-1].Kind != EventPhase || end[len(end)-1].Detail != "end" {
+		t.Fatalf("last event = %+v, want a phase:end", end[len(end)-1])
+	}
+
+	// A restart resets the narrative: the prior elimination must be gone.
+	s.SetGameActive(true)
+	restarted := s.Snapshot()
+	if hasKind(restarted, EventElimination) {
+		t.Error("restart did not clear the prior game's elimination from the timeline")
+	}
+	if k := timelineKinds(restarted); len(k) != 1 || k[0] != EventPhase {
+		t.Errorf("after restart timeline = %v, want a single phase:start", k)
+	}
+}
+
+// TestStore_TimelineEvictedOnGrace verifies the narrative is cleared with the
+// rest of the session-scoped state on grace exit (#916 eviction).
+func TestStore_TimelineEvictedOnGrace(t *testing.T) {
+	clk := &clock{t: time.Unix(0, 0)}
+	s := NewStore(time.Hour, 15*time.Second, clk.now)
+
+	s.SetGameActive(true)
+	s.SetActivePlayerCount(3)
+	s.SetGameActive(false)
+
+	clk.advance(16 * time.Second)
+	s.EvictStale()
+
+	if got := s.Snapshot().Timeline; got != nil {
+		t.Fatalf("timeline = %v, want nil after grace eviction", got)
+	}
+}
+
+// TestStore_TimelineCapBounded drives more than capacity of distinct state
+// deltas and confirms the snapshot's timeline never exceeds timelineCap (#916).
+func TestStore_TimelineCapBounded(t *testing.T) {
+	clk := &clock{t: time.Unix(0, 0)}
+	s := NewStore(time.Hour, time.Hour, clk.now)
+
+	s.SetGameActive(true) // 1 phase event
+	for i := 0; i < timelineCap*2; i++ {
+		s.SetActivePlayerCount(i) // each distinct -> a state delta
+	}
+	if n := len(s.Snapshot().Timeline); n != timelineCap {
+		t.Fatalf("timeline len = %d, want capped at %d", n, timelineCap)
+	}
+}
+
+// TestStore_AppendInterventionEvent covers the deferred-seam method: a
+// dispatched and a blocked intervention land in the narrative (#916).
+func TestStore_AppendInterventionEvent(t *testing.T) {
+	clk := &clock{t: time.Unix(0, 0)}
+	s := NewStore(time.Hour, time.Hour, clk.now)
+
+	s.AppendInterventionEvent("set_music_tempo", "", false)
+	s.AppendInterventionEvent("grant_shield", "BB:22", true)
+
+	tl := s.Snapshot().Timeline
+	if len(tl) != 2 {
+		t.Fatalf("timeline len = %d, want 2", len(tl))
+	}
+	if tl[0].Kind != EventIntervention || tl[0].Detail != "set_music_tempo" || tl[0].Blocked {
+		t.Errorf("event[0] = %+v, want dispatched set_music_tempo", tl[0])
+	}
+	if tl[1].Serial != "BB:22" || !tl[1].Blocked {
+		t.Errorf("event[1] = %+v, want blocked grant_shield -> BB:22", tl[1])
+	}
+}

--- a/services/agent/gamecontext/timeline.go
+++ b/services/agent/gamecontext/timeline.go
@@ -1,0 +1,212 @@
+package gamecontext
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// timeline.go is the bounded per-game rolling NARRATIVE (#916). The pre-#916
+// agent kept only a LIVE SNAPSHOT per partition: every signal OVERWRITES the
+// matching GameContext field, so the LLM prompt (#739) and the post-game retro
+// (#844) saw point-in-time state with no trend — "player X has been fading for
+// 90s" or "the last tempo bump changed nothing" were invisible. The project
+// pitch promised "spans aggregated into rolling game narratives"; this is that
+// narrative.
+//
+// It is a FIXED-CAPACITY ring buffer (timelineCap) living ON the Store, so it is
+// automatically per-partition and evicted with the partition (#845): two
+// concurrent games keep two independent timelines, and a drained partition's
+// timeline disappears with its Store. Nothing global is introduced — the ring
+// buffer is just another field guarded by the existing Store mutex.
+//
+// Determinism contract (the prompt golden tests depend on it): entries carry an
+// injected timestamp (Store.now, never time.Now), render in append order, one
+// compact line each, with fixed formatting. The same event stream always renders
+// byte-identically.
+
+// timelineCap is the FIXED ring-buffer capacity per partition (#916). It bounds
+// memory to a constant per game — once full, each append evicts the oldest
+// entry, so the timeline always reflects the most RECENT window of activity.
+// 64 entries comfortably covers the recent narrative the prompt cares about
+// (a few minutes of ~periodic state deltas plus eliminations and phase changes)
+// while keeping the rendered section small enough to stay cheap in the prompt.
+const timelineCap = 64
+
+// TimelineEventKind is the compact, typed category of a narrative entry. Keeping
+// it a small enum (rather than free text) means the renderer can format each
+// kind consistently and a future consumer can filter without string parsing.
+type TimelineEventKind string
+
+const (
+	// EventStateDelta is a periodic snapshot of the session-level aggregates that
+	// matter for trend reasoning (active player count, mean movement intensity).
+	// It is appended only when a tracked aggregate CHANGED versus the last delta,
+	// so a steady game does not fill the ring with identical lines (#916).
+	EventStateDelta TimelineEventKind = "state"
+	// EventElimination records a player leaving the game, with the serial and the
+	// 1-based elimination order — the trend the retro's winner/outcome derivation
+	// already reasons over, now timestamped in the narrative.
+	EventElimination TimelineEventKind = "elimination"
+	// EventPhase records a session phase transition: game start and game end.
+	EventPhase TimelineEventKind = "phase"
+	// EventIntervention records a dispatched OR blocked intervention. The Store
+	// does not observe interventions itself (the decision Loop does); this kind
+	// exists so a clean seam (Store.AppendInterventionEvent) can layer them in
+	// without a second structure. See AppendInterventionEvent / #916 deferral note.
+	EventIntervention TimelineEventKind = "intervention"
+)
+
+// TimelineEvent is one compact, timestamped narrative entry. Payload fields are
+// kind-specific and only the relevant ones are set; the renderer reads exactly
+// the fields its kind defines, so an unset field never leaks into the wrong line.
+type TimelineEvent struct {
+	At   time.Time
+	Kind TimelineEventKind
+
+	// Detail is the kind-specific short payload:
+	//   EventPhase        -> "start" | "end"
+	//   EventElimination  -> the eliminated serial
+	//   EventIntervention -> the intervention id (e.g. "grant_shield")
+	//   EventStateDelta   -> unused (the numeric fields below carry it)
+	Detail string
+
+	// Serial scopes an event to a player when relevant (elimination target, or a
+	// player-targeted intervention); empty for session-scoped events.
+	Serial string
+
+	// Order is the 1-based elimination order for EventElimination; 0 otherwise.
+	Order int
+
+	// ActivePlayers / MeanIntensity carry the EventStateDelta aggregates. Pointers
+	// distinguish "not part of this delta" (nil) from a genuine zero so the
+	// renderer can omit an unobserved aggregate rather than print a misleading 0.
+	ActivePlayers *int
+	MeanIntensity *float64
+
+	// Blocked marks an EventIntervention that a permission gate rejected (true) vs
+	// one that dispatched (false); unused for other kinds.
+	Blocked bool
+}
+
+// timeline is the fixed-capacity ring buffer. It is NOT independently locked:
+// every method is called while the owning Store holds s.mu, so the timeline
+// reuses that mutex (the issue's "reuse the existing mutex" guidance) and adds
+// no second lock to reason about.
+type timeline struct {
+	buf   []TimelineEvent // len == cap once warmed; pre-grown to timelineCap
+	start int             // index of the OLDEST entry within buf
+	size  int             // number of live entries (0..timelineCap)
+
+	// lastActivePlayers / lastMeanIntensity dedupe EventStateDelta: an aggregate
+	// snapshot is only appended when one of these CHANGED, so a steady game does
+	// not churn the ring. They track the last APPENDED delta, not every signal.
+	lastActivePlayers *int
+	lastMeanIntensity *float64
+}
+
+// newTimeline builds an empty ring pre-grown to capacity so appends never
+// allocate after construction (allocation-bounded, per the issue).
+func newTimeline() timeline {
+	return timeline{buf: make([]TimelineEvent, timelineCap)}
+}
+
+// append adds e to the ring, evicting the oldest entry once at capacity. The
+// length stays clamped at timelineCap forever — this is the memory bound.
+func (t *timeline) append(e TimelineEvent) {
+	if t.buf == nil {
+		t.buf = make([]TimelineEvent, timelineCap)
+	}
+	end := (t.start + t.size) % timelineCap
+	t.buf[end] = e
+	if t.size == timelineCap {
+		// Full: overwrite the oldest and advance start so it points at the new
+		// oldest. size stays at cap.
+		t.start = (t.start + 1) % timelineCap
+	} else {
+		t.size++
+	}
+}
+
+// events returns the live entries in append (oldest-first) order as a fresh
+// slice, safe to hand out in a snapshot (it shares no backing array with the
+// ring, so later appends never mutate a returned snapshot).
+func (t *timeline) events() []TimelineEvent {
+	if t.size == 0 {
+		return nil
+	}
+	out := make([]TimelineEvent, t.size)
+	for i := 0; i < t.size; i++ {
+		out[i] = t.buf[(t.start+i)%timelineCap]
+	}
+	return out
+}
+
+// reset clears the ring AND the state-delta dedupe memory. The Store calls this
+// on session reset (grace exit) so a finished game's narrative does not bleed
+// into the next session on the same partition (the lobby persists, but the
+// timeline is session-scoped, matching EliminationSequence).
+func (t *timeline) reset() {
+	t.start = 0
+	t.size = 0
+	t.lastActivePlayers = nil
+	t.lastMeanIntensity = nil
+}
+
+// RenderTimeline formats a slice of timeline events into the compact, one-line
+// per-event section shared by the in-game prompt (#739) and the retro (#844).
+// It is exported so the llm package renders the exact same lines for both
+// prompts from the bounded slice carried on the GameContext snapshot.
+//
+// The reference time `now` makes each line carry a RELATIVE age (e.g. "-12s")
+// rather than an absolute clock, so the narrative reads as "how long ago" and
+// stays stable regardless of the session's wall-clock start. Events are assumed
+// oldest-first (events() order); they render in that order, one per line.
+func RenderTimeline(events []TimelineEvent, now time.Time) []string {
+	lines := make([]string, 0, len(events))
+	for _, e := range events {
+		lines = append(lines, renderEvent(e, now))
+	}
+	return lines
+}
+
+// renderEvent formats one event as "<age> <kind>: <detail>". age is the whole
+// seconds between the event and now, negative for the past (the normal case),
+// so a reader scans "-90s ... -12s ... -0s" as the recent window.
+func renderEvent(e TimelineEvent, now time.Time) string {
+	age := int(e.At.Sub(now).Round(time.Second) / time.Second)
+	prefix := fmt.Sprintf("%+ds", age)
+	switch e.Kind {
+	case EventPhase:
+		return prefix + " phase: " + e.Detail
+	case EventElimination:
+		return fmt.Sprintf("%s elimination: %s (#%d)", prefix, e.Serial, e.Order)
+	case EventIntervention:
+		outcome := "dispatched"
+		if e.Blocked {
+			outcome = "blocked"
+		}
+		if e.Serial != "" {
+			return fmt.Sprintf("%s intervention: %s %s -> %s", prefix, e.Detail, outcome, e.Serial)
+		}
+		return fmt.Sprintf("%s intervention: %s %s", prefix, e.Detail, outcome)
+	case EventStateDelta:
+		return prefix + " state: " + renderStateDelta(e)
+	default:
+		return prefix + " " + string(e.Kind)
+	}
+}
+
+// renderStateDelta formats the aggregates of a state-delta event, omitting any
+// aggregate not part of this delta (nil) so a line never prints a misleading 0.
+func renderStateDelta(e TimelineEvent) string {
+	parts := make([]string, 0, 2)
+	if e.ActivePlayers != nil {
+		parts = append(parts, "active_players="+strconv.Itoa(*e.ActivePlayers))
+	}
+	if e.MeanIntensity != nil {
+		parts = append(parts, "mean_intensity="+strconv.FormatFloat(*e.MeanIntensity, 'f', 2, 64))
+	}
+	return strings.Join(parts, " ")
+}

--- a/services/agent/gamecontext/timeline_test.go
+++ b/services/agent/gamecontext/timeline_test.go
@@ -1,0 +1,174 @@
+package gamecontext
+
+import (
+	"testing"
+	"time"
+)
+
+// Tests for the #916 rolling-narrative ring buffer: accumulation (order),
+// capacity (oldest evicted at cap), the snapshot's shared-nothing copy, reset,
+// and deterministic rendering. These exercise the buffer directly; the
+// Store-level lifecycle (per-partition isolation, session/grace eviction) is
+// covered in store_test.go and multiplexer_test.go.
+
+// kinds extracts the event kinds in order — a compact way to assert accumulation.
+func kinds(events []TimelineEvent) []TimelineEventKind {
+	out := make([]TimelineEventKind, len(events))
+	for i, e := range events {
+		out[i] = e.Kind
+	}
+	return out
+}
+
+func TestTimeline_AppendsInOrder(t *testing.T) {
+	tl := newTimeline()
+	base := time.Unix(0, 0)
+	tl.append(TimelineEvent{At: base, Kind: EventPhase, Detail: "start"})
+	tl.append(TimelineEvent{At: base.Add(time.Second), Kind: EventStateDelta})
+	tl.append(TimelineEvent{At: base.Add(2 * time.Second), Kind: EventElimination, Serial: "A", Order: 1})
+
+	got := tl.events()
+	if len(got) != 3 {
+		t.Fatalf("len = %d, want 3", len(got))
+	}
+	want := []TimelineEventKind{EventPhase, EventStateDelta, EventElimination}
+	for i := range want {
+		if got[i].Kind != want[i] {
+			t.Errorf("event[%d].Kind = %q, want %q", i, got[i].Kind, want[i])
+		}
+	}
+	// Append order is oldest-first.
+	if !got[0].At.Before(got[2].At) {
+		t.Errorf("events not in oldest-first order")
+	}
+}
+
+func TestTimeline_CapacityEvictsOldest(t *testing.T) {
+	tl := newTimeline()
+	base := time.Unix(0, 0)
+	// Append exactly 2x capacity; the first timelineCap entries must be evicted.
+	total := timelineCap * 2
+	for i := 0; i < total; i++ {
+		tl.append(TimelineEvent{At: base.Add(time.Duration(i) * time.Second), Kind: EventStateDelta, Order: i})
+	}
+
+	got := tl.events()
+	if len(got) != timelineCap {
+		t.Fatalf("len = %d, want capped at %d", len(got), timelineCap)
+	}
+	// The oldest surviving entry is index (total - cap); the newest is total-1.
+	if got[0].Order != total-timelineCap {
+		t.Errorf("oldest survivor Order = %d, want %d", got[0].Order, total-timelineCap)
+	}
+	if got[len(got)-1].Order != total-1 {
+		t.Errorf("newest Order = %d, want %d", got[len(got)-1].Order, total-1)
+	}
+	// Ordering across the wrap is still strictly increasing.
+	for i := 1; i < len(got); i++ {
+		if got[i].Order != got[i-1].Order+1 {
+			t.Fatalf("non-contiguous after wrap at %d: %d then %d", i, got[i-1].Order, got[i].Order)
+		}
+	}
+}
+
+func TestTimeline_AtExactlyCapacity(t *testing.T) {
+	tl := newTimeline()
+	base := time.Unix(0, 0)
+	for i := 0; i < timelineCap; i++ {
+		tl.append(TimelineEvent{At: base, Kind: EventStateDelta, Order: i})
+	}
+	got := tl.events()
+	if len(got) != timelineCap {
+		t.Fatalf("len = %d, want %d (nothing evicted at exactly cap)", len(got), timelineCap)
+	}
+	if got[0].Order != 0 {
+		t.Errorf("oldest Order = %d, want 0 (no eviction yet)", got[0].Order)
+	}
+}
+
+func TestTimeline_EmptyEventsIsNil(t *testing.T) {
+	tl := newTimeline()
+	if got := tl.events(); got != nil {
+		t.Errorf("empty timeline events() = %v, want nil", got)
+	}
+}
+
+func TestTimeline_EventsCopyIsIndependent(t *testing.T) {
+	tl := newTimeline()
+	base := time.Unix(0, 0)
+	tl.append(TimelineEvent{At: base, Kind: EventPhase, Detail: "start"})
+
+	snap := tl.events()
+	// A later append must not mutate the previously returned slice.
+	tl.append(TimelineEvent{At: base.Add(time.Second), Kind: EventStateDelta})
+	if len(snap) != 1 {
+		t.Fatalf("handed-out snapshot grew to %d after a later append", len(snap))
+	}
+	if snap[0].Kind != EventPhase {
+		t.Errorf("handed-out snapshot mutated: kind = %q", snap[0].Kind)
+	}
+}
+
+func TestTimeline_ResetClearsBufferAndDedupe(t *testing.T) {
+	tl := newTimeline()
+	tl.append(TimelineEvent{At: time.Unix(0, 0), Kind: EventStateDelta})
+	tl.lastActivePlayers = ptr(3)
+	tl.reset()
+	if got := tl.events(); got != nil {
+		t.Errorf("after reset events() = %v, want nil", got)
+	}
+	if tl.lastActivePlayers != nil {
+		t.Errorf("reset did not clear state-delta dedupe memory")
+	}
+}
+
+func TestRenderTimeline_Deterministic(t *testing.T) {
+	now := time.Date(2026, time.June, 5, 12, 30, 0, 0, time.UTC)
+	events := []TimelineEvent{
+		{At: now.Add(-90 * time.Second), Kind: EventPhase, Detail: "start"},
+		{At: now.Add(-60 * time.Second), Kind: EventStateDelta, ActivePlayers: ptr(3), MeanIntensity: ptr(1.25)},
+		{At: now.Add(-30 * time.Second), Kind: EventElimination, Serial: "AA:11", Order: 1},
+		{At: now.Add(-10 * time.Second), Kind: EventIntervention, Detail: "grant_shield", Serial: "BB:22", Blocked: true},
+		{At: now.Add(-5 * time.Second), Kind: EventIntervention, Detail: "set_music_tempo"},
+	}
+	want := []string{
+		"-90s phase: start",
+		"-60s state: active_players=3 mean_intensity=1.25",
+		"-30s elimination: AA:11 (#1)",
+		"-10s intervention: grant_shield blocked -> BB:22",
+		"-5s intervention: set_music_tempo dispatched",
+	}
+	got := RenderTimeline(events, now)
+	if len(got) != len(want) {
+		t.Fatalf("len = %d, want %d: %v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("line[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+	// Re-render is byte-identical (determinism contract).
+	again := RenderTimeline(events, now)
+	for i := range got {
+		if got[i] != again[i] {
+			t.Errorf("non-deterministic render at %d: %q vs %q", i, got[i], again[i])
+		}
+	}
+}
+
+func TestRenderTimeline_StateDeltaOmitsNilAggregates(t *testing.T) {
+	now := time.Unix(100, 0)
+	// Only ActivePlayers set; MeanIntensity nil must be omitted, not rendered 0.
+	got := RenderTimeline([]TimelineEvent{
+		{At: now.Add(-10 * time.Second), Kind: EventStateDelta, ActivePlayers: ptr(2)},
+	}, now)
+	if len(got) != 1 || got[0] != "-10s state: active_players=2" {
+		t.Errorf("got %v, want a single line omitting the nil mean_intensity", got)
+	}
+}
+
+func TestRenderTimeline_EmptyIsEmptySlice(t *testing.T) {
+	if got := RenderTimeline(nil, time.Now()); len(got) != 0 {
+		t.Errorf("RenderTimeline(nil) = %v, want empty", got)
+	}
+}

--- a/services/agent/llm/prompt.go
+++ b/services/agent/llm/prompt.go
@@ -166,6 +166,8 @@ func buildUser(ctx gamecontext.GameContext, now time.Time) string {
 	fmt.Fprintf(&b, "  game_active: %s\n", boolPtrOrUnknown(ctx.Session.GameActive))
 	fmt.Fprintf(&b, "  elimination_sequence: [%s]\n", strings.Join(ctx.Session.EliminationSequence, ", "))
 
+	writeTimeline(&b, ctx, now)
+
 	b.WriteString("\nPlayers (sorted by serial; \"unknown\" = signal never observed):\n")
 	if len(ctx.Players) == 0 {
 		b.WriteString("  (none)")
@@ -193,6 +195,26 @@ func buildUser(ctx gamecontext.GameContext, now time.Time) string {
 	}
 	b.WriteString(strings.Join(lines, "\n"))
 	return b.String()
+}
+
+// writeTimeline renders the compact RECENT EVENTS section shared by the in-game
+// prompt and the retro (#916): the bounded rolling narrative the GameContext now
+// carries (state deltas, eliminations, phase transitions), one line per event in
+// oldest-first order with a relative age. An empty timeline renders "(none)" so
+// the section is always present and deterministic — the prompt never reads the
+// wall clock; `now` (RenderTimeline's reference) is the injected BuildInput.Now.
+func writeTimeline(b *strings.Builder, ctx gamecontext.GameContext, now time.Time) {
+	b.WriteString("\nRecent events (oldest first; age relative to captured_at):\n")
+	lines := gamecontext.RenderTimeline(ctx.Timeline, now)
+	if len(lines) == 0 {
+		b.WriteString("  (none)\n")
+		return
+	}
+	for _, line := range lines {
+		b.WriteString("  ")
+		b.WriteString(line)
+		b.WriteString("\n")
+	}
 }
 
 // floatPtrOrUnknown renders a *float64 as a 2-decimal fixed string, or the

--- a/services/agent/llm/prompt_test.go
+++ b/services/agent/llm/prompt_test.go
@@ -85,6 +85,26 @@ func threePlayerContext() gamecontext.GameContext {
 	}
 }
 
+// timelineContext is threePlayerContext plus a populated #916 rolling narrative:
+// a start phase, two state deltas, an elimination, and a dispatched + a blocked
+// intervention, all at instants before fixedNow so ages render negative.
+func timelineContext() gamecontext.GameContext {
+	ctx := threePlayerContext()
+	at := func(secsBefore int) time.Time {
+		return fixedNow.Add(time.Duration(-secsBefore) * time.Second)
+	}
+	ctx.Timeline = []gamecontext.TimelineEvent{
+		{At: at(120), Kind: gamecontext.EventPhase, Detail: "start"},
+		{At: at(110), Kind: gamecontext.EventStateDelta, ActivePlayers: iptr(3), MeanIntensity: fptr(0.90)},
+		{At: at(60), Kind: gamecontext.EventStateDelta, ActivePlayers: iptr(3), MeanIntensity: fptr(1.40)},
+		{At: at(45), Kind: gamecontext.EventElimination, Serial: "CC:33", Order: 1},
+		{At: at(40), Kind: gamecontext.EventStateDelta, ActivePlayers: iptr(2)},
+		{At: at(20), Kind: gamecontext.EventIntervention, Detail: "set_music_tempo"},
+		{At: at(5), Kind: gamecontext.EventIntervention, Detail: "grant_shield", Serial: "BB:22", Blocked: true},
+	}
+	return ctx
+}
+
 type goldenCase struct {
 	name     string
 	snapshot flags.Snapshot
@@ -122,6 +142,15 @@ func goldenCases() []goldenCase {
 				},
 				Players: map[string]*gamecontext.PlayerSignals{},
 			},
+		},
+		{
+			// #916: a populated rolling-narrative section. Events are placed at
+			// earlier instants than fixedNow so ages render as negative seconds, in
+			// oldest-first order, mixing every kind including a player-targeted and a
+			// blocked intervention (via the AppendInterventionEvent seam).
+			name:     "timeline_3players",
+			snapshot: baseSnapshot(balancedVariant),
+			context:  timelineContext(),
 		},
 		{
 			name: "all_unknown",

--- a/services/agent/llm/retro.go
+++ b/services/agent/llm/retro.go
@@ -129,6 +129,11 @@ func buildRetroUser(ctx gamecontext.GameContext, now time.Time) string {
 	fmt.Fprintf(&b, "  elimination_order: [%s]\n", strings.Join(ctx.Session.EliminationSequence, ", "))
 	fmt.Fprintf(&b, "  winner: %s\n", winner)
 
+	// The same rolling-narrative section as the in-game prompt (#916): the retro
+	// analyst sees the trend over the whole session (when players faded, when the
+	// game ended), not just the terminal snapshot.
+	writeTimeline(&b, ctx, now)
+
 	b.WriteString("\nPlayers (sorted by serial; \"unknown\" = signal never observed):\n")
 	if len(ctx.Players) == 0 {
 		b.WriteString("  (none)")

--- a/services/agent/llm/retro_test.go
+++ b/services/agent/llm/retro_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/joustmania/agent/flags"
 	"github.com/joustmania/agent/gamecontext"
@@ -61,6 +62,23 @@ func retroThreePlayers() gamecontext.GameContext {
 	}
 }
 
+// retroTimelineContext is retroThreePlayers plus a full-session #916 narrative
+// ending in the "end" phase, as the OnGameEnd snapshot would carry.
+func retroTimelineContext() gamecontext.GameContext {
+	ctx := retroThreePlayers()
+	at := func(secsBefore int) time.Time {
+		return fixedNow.Add(time.Duration(-secsBefore) * time.Second)
+	}
+	ctx.Timeline = []gamecontext.TimelineEvent{
+		{At: at(150), Kind: gamecontext.EventPhase, Detail: "start"},
+		{At: at(140), Kind: gamecontext.EventStateDelta, ActivePlayers: iptr(3), MeanIntensity: fptr(0.80)},
+		{At: at(90), Kind: gamecontext.EventElimination, Serial: "CC:33", Order: 1},
+		{At: at(40), Kind: gamecontext.EventStateDelta, ActivePlayers: iptr(2), MeanIntensity: fptr(0.45)},
+		{At: at(0), Kind: gamecontext.EventPhase, Detail: "end"},
+	}
+	return ctx
+}
+
 type retroCase struct {
 	name     string
 	snapshot flags.Snapshot
@@ -93,6 +111,13 @@ func retroCases() []retroCase {
 					"BB:22": {Serial: "BB:22", BatteryPct: fptr(25), SkillLevel: fptr(0.4)},
 				},
 			},
+		},
+		{
+			// #916: the retro carries the same rolling-narrative section, ending in
+			// the "end" phase transition (the OnGameEnd snapshot includes it).
+			name:     "retro_timeline",
+			snapshot: retroSnapshot(),
+			context:  retroTimelineContext(),
 		},
 		{
 			// No players, nil session signals: every field renders "unknown"/[].

--- a/services/agent/llm/testdata/aggressive_3players.golden
+++ b/services/agent/llm/testdata/aggressive_3players.golden
@@ -37,6 +37,9 @@ Session:
   game_active: true
   elimination_sequence: [CC:33]
 
+Recent events (oldest first; age relative to captured_at):
+  (none)
+
 Players (sorted by serial; "unknown" = signal never observed):
   AA:11: active=true movement_intensity=1.25 movement_variance=0.40 battery_pct=85.00 skill=0.60
   BB:22: active=true movement_intensity=0.00 movement_variance=0.05 battery_pct=15.00 skill=0.30

--- a/services/agent/llm/testdata/all_unknown.golden
+++ b/services/agent/llm/testdata/all_unknown.golden
@@ -37,5 +37,8 @@ Session:
   game_active: unknown
   elimination_sequence: []
 
+Recent events (oldest first; age relative to captured_at):
+  (none)
+
 Players (sorted by serial; "unknown" = signal never observed):
   ZZ:99: active=unknown movement_intensity=unknown movement_variance=unknown battery_pct=unknown skill=unknown

--- a/services/agent/llm/testdata/conservative_3players.golden
+++ b/services/agent/llm/testdata/conservative_3players.golden
@@ -37,6 +37,9 @@ Session:
   game_active: true
   elimination_sequence: [CC:33]
 
+Recent events (oldest first; age relative to captured_at):
+  (none)
+
 Players (sorted by serial; "unknown" = signal never observed):
   AA:11: active=true movement_intensity=1.25 movement_variance=0.40 battery_pct=85.00 skill=0.60
   BB:22: active=true movement_intensity=0.00 movement_variance=0.05 battery_pct=15.00 skill=0.30

--- a/services/agent/llm/testdata/empty_players.golden
+++ b/services/agent/llm/testdata/empty_players.golden
@@ -37,5 +37,8 @@ Session:
   game_active: false
   elimination_sequence: []
 
+Recent events (oldest first; age relative to captured_at):
+  (none)
+
 Players (sorted by serial; "unknown" = signal never observed):
   (none)

--- a/services/agent/llm/testdata/retro_3players.golden
+++ b/services/agent/llm/testdata/retro_3players.golden
@@ -44,6 +44,9 @@ Outcome:
   elimination_order: [BB:22, CC:33]
   winner: AA:11
 
+Recent events (oldest first; age relative to captured_at):
+  (none)
+
 Players (sorted by serial; "unknown" = signal never observed):
   AA:11: outcome=survivor battery_pct=72.00 skill=0.80 movement_intensity=1.25 movement_variance=0.40
   BB:22: outcome=eliminated #1 battery_pct=40.00 skill=0.30 movement_intensity=0.10 movement_variance=0.05

--- a/services/agent/llm/testdata/retro_all_eliminated.golden
+++ b/services/agent/llm/testdata/retro_all_eliminated.golden
@@ -44,6 +44,9 @@ Outcome:
   elimination_order: [AA:11, BB:22]
   winner: unknown
 
+Recent events (oldest first; age relative to captured_at):
+  (none)
+
 Players (sorted by serial; "unknown" = signal never observed):
   AA:11: outcome=eliminated #1 battery_pct=30.00 skill=0.50 movement_intensity=unknown movement_variance=unknown
   BB:22: outcome=eliminated #2 battery_pct=25.00 skill=0.40 movement_intensity=unknown movement_variance=unknown

--- a/services/agent/llm/testdata/retro_empty.golden
+++ b/services/agent/llm/testdata/retro_empty.golden
@@ -44,5 +44,8 @@ Outcome:
   elimination_order: []
   winner: unknown
 
+Recent events (oldest first; age relative to captured_at):
+  (none)
+
 Players (sorted by serial; "unknown" = signal never observed):
   (none)

--- a/services/agent/llm/testdata/retro_timeline.golden
+++ b/services/agent/llm/testdata/retro_timeline.golden
@@ -36,17 +36,22 @@ RESPONSE CONTRACT — reply with EXACTLY ONE JSON object, no prose, matching:
 }
 If no tweak is warranted, return "suggestions": [].
 === USER ===
-SESSION RETROSPECTIVE (session=session-0, kind=unknown, mode=unknown, captured_at=2026-06-05T12:30:00Z)
+SESSION RETROSPECTIVE (session=session-7, kind=real, mode=ffa, captured_at=2026-06-05T12:30:00Z)
 
 Outcome:
-  duration_seconds: unknown
-  final_active_players: unknown
-  elimination_order: [ZZ:99]
-  winner: YY:88
+  duration_seconds: 132.00
+  final_active_players: 1
+  elimination_order: [BB:22, CC:33]
+  winner: AA:11
 
 Recent events (oldest first; age relative to captured_at):
-  (none)
+  -150s phase: start
+  -140s state: active_players=3 mean_intensity=0.80
+  -90s elimination: CC:33 (#1)
+  -40s state: active_players=2 mean_intensity=0.45
+  +0s phase: end
 
 Players (sorted by serial; "unknown" = signal never observed):
-  YY:88: outcome=survivor battery_pct=unknown skill=unknown movement_intensity=unknown movement_variance=unknown
-  ZZ:99: outcome=eliminated #1 battery_pct=unknown skill=unknown movement_intensity=unknown movement_variance=unknown
+  AA:11: outcome=survivor battery_pct=72.00 skill=0.80 movement_intensity=1.25 movement_variance=0.40
+  BB:22: outcome=eliminated #1 battery_pct=40.00 skill=0.30 movement_intensity=0.10 movement_variance=0.05
+  CC:33: outcome=eliminated #2 battery_pct=unknown skill=unknown movement_intensity=unknown movement_variance=unknown

--- a/services/agent/llm/testdata/timeline_3players.golden
+++ b/services/agent/llm/testdata/timeline_3players.golden
@@ -38,7 +38,13 @@ Session:
   elimination_sequence: [CC:33]
 
 Recent events (oldest first; age relative to captured_at):
-  (none)
+  -120s phase: start
+  -110s state: active_players=3 mean_intensity=0.90
+  -60s state: active_players=3 mean_intensity=1.40
+  -45s elimination: CC:33 (#1)
+  -40s state: active_players=2
+  -20s intervention: set_music_tempo dispatched
+  -5s intervention: grant_shield blocked -> BB:22
 
 Players (sorted by serial; "unknown" = signal never observed):
   AA:11: active=true movement_intensity=1.25 movement_variance=0.40 battery_pct=85.00 skill=0.60


### PR DESCRIPTION
## Summary

Part of #916. The agent kept only a **live snapshot** per game — `GameContext` is overwritten per signal, with the elimination sequence the sole retained history — so the in-game prompt (#739) and the post-game retro (#844) saw point-in-time state with no trend. This adds a **bounded per-game-partition rolling narrative** (ring buffer) and surfaces it in both prompt builders.

## Scope

- **`gamecontext/timeline.go`** — a FIXED-capacity (64) ring buffer of timestamped, typed events (`state` / `elimination` / `phase` / `intervention`). It lives ON the per-game `Store`, guarded by the existing Store mutex, so it is automatically **per-partition (#845)** and evicted with the partition. Append past cap evicts the oldest; the snapshot copy shares no backing array with the live ring.
- **`Store`** appends from what it already observes: periodic **state deltas** (active player count, mean movement intensity — deduped so a steady game does not churn the ring), **eliminations** (with 1-based order), and **session phase transitions** (start/end). The narrative is cleared on session restart and on grace eviction, matching `EliminationSequence`'s session scope.
- **`GameContext.Timeline`** carries a bounded, oldest-first snapshot copy, so `llm.Build` / `llm.BuildRetro` stay pure and deterministic (no signature change beyond the field on the context they already receive).
- **`llm/prompt.go` + `llm/retro.go`** render a compact `Recent events` section — one line per event, relative ages — via `gamecontext.RenderTimeline`. Empty timelines render `(none)`.

## Acceptance

1. ✅ Prompt contains a bounded recent-events timeline per game (golden tests `timeline_3players` / `retro_timeline`).
2. ✅ Memory bounded — fixed `timelineCap` (64) ring buffer, oldest evicted at cap.
3. ✅ Per-game isolation preserved — history lives on the per-game Store (multiplexer isolation test).
4. ✅ Unit tests for accumulation, capacity, eviction (session reset + grace + partition removal), isolation, and deterministic rendering.

## Deferred (with rationale)

**Intervention-event capture into the timeline.** The decision `Loop` — not the `Store` — knows the dispatched-vs-blocked outcome, and the two are separate objects. `Store.AppendInterventionEvent(intervention, serial, blocked)` is the clean seam (the receiver pipeline holds both the partition Store and the Loop), and it is implemented + unit-tested here. Wiring it into the per-decision action path is left for a follow-up referencing #916 to keep this PR a tight, well-tested first cut over what the Store already sees. The `intervention` event kind and renderer are already in place, so the follow-up is pure wiring.

## Tests

`gofmt -l` clean, `go vet ./...` clean, `go build ./...` clean, `go test -race ./...` all green from `services/agent`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)