### PR TITLE
feat(agent): LLM call gating — eligibility, cadence, global budget (#847)

### DIFF
--- a/services/agent/decision/attribution_test.go
+++ b/services/agent/decision/attribution_test.go
@@ -25,6 +25,10 @@ func recordingLoop(t *testing.T, snap flags.Snapshot, out []Decision) (*Loop, *t
 	l.Tracer = tp.Tracer("test")
 	l.Rules = fakeRules{out: out}
 	l.Actions = &fakeSink{}
+	// Inject a fresh global LLM budget (#847) so the gate's budget layer can admit
+	// an llm-mode cycle; without it a nil budget would gate every llm attempt and
+	// the capture-path tests (which assert the ALLOWED behavior) would never fire.
+	l.SetLLMBudget(NewLLMBudget())
 	return l, sr
 }
 
@@ -192,6 +196,14 @@ func TestInferenceAttribution_LLMFallback(t *testing.T) {
 				Capability:           flags.Capability{Model: "phi4-mini"},
 				InterventionsAllowed: []string{"play_audio_cue"},
 				Policy:               flags.Policy{MaxInterventionsPerMinute: 10},
+				// Gate-ALLOWED config (#847): the llm case asserts the unchanged
+				// no_backend_available fallback, which only holds when the gate admits —
+				// so this game kind ("") is eligible, no cadence floor, ample budget.
+				LLMGate: flags.LLMGate{
+					EligibleGameKinds:    []string{""},
+					MinDecisionInterval:  0,
+					MaxRequestsPerMinute: 100,
+				},
 			}
 			l, sr := recordingLoop(t, snap, []Decision{{Intervention: "play_audio_cue"}})
 

--- a/services/agent/decision/decision.go
+++ b/services/agent/decision/decision.go
@@ -44,6 +44,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
+	otelmetric "go.opentelemetry.io/otel/metric"
 	semconv "go.opentelemetry.io/otel/semconv/v1.34.0"
 	"go.opentelemetry.io/otel/trace"
 
@@ -178,6 +179,28 @@ type Loop struct {
 	// lastLayer is the most recent fully-evaluated LayerState, retained so #729
 	// (span attribution) and tests can read the per-cycle layer snapshot.
 	lastLayer LayerState
+
+	// --- LLM call gate (#847) ---
+	// llmGate guards the per-game cadence state of the gate. It is separate from mu
+	// because the cadence read-modify-write happens inside decide(), which mu does
+	// not span; the lighter lock avoids holding the loop's main mutex across the
+	// budget check and rules evaluation.
+	llmGate sync.Mutex
+	// lastLLMAttempt is the time this game's most recent LLM attempt was ADMITTED
+	// by the gate (passed eligibility + cadence + budget). The per-game cadence
+	// layer compares the next cycle against it. Per-Loop = per-game (#845): each
+	// game has its own cadence clock. Zero value = no attempt yet (first eligible
+	// cycle always passes cadence).
+	lastLLMAttempt time.Time
+	// budget is the GLOBAL per-minute LLM request cap shared across ALL loops
+	// (#847). It is injected via SetLLMBudget from the one instance main.go
+	// constructs and closes over in the Loop factory, so concurrent games draw down
+	// a single budget. Nil until injected; a nil budget gates every llm attempt
+	// with llm_budget_exhausted (fail-closed: no shared cap means no llm).
+	budget *llmBudget
+	// llmGated counts gated llm cycles (agent_llm_gated_total{reason=...}). Defaults
+	// to a no-op so a Loop built without metrics wiring still works.
+	llmGated otelmetric.Int64Counter
 }
 
 // NewLoop builds a Loop with the no-op rules/actions stubs, the global tracer,
@@ -199,8 +222,16 @@ func NewLoop(flagSource FlagSource, log *slog.Logger) *Loop {
 		Tracer:   otel.Tracer(instrumentationName),
 		now:      time.Now,
 		throttle: DefaultThrottleInterval,
+		llmGated: defaultLLMGatedCounter(),
 	}
 }
+
+// SetLLMBudget injects the GLOBAL per-minute LLM request budget (#847). main.go
+// constructs ONE budget and calls this on every Loop the factory builds, so all
+// per-game loops share a single budget instance and 4 concurrent games can never
+// collectively exceed llm.max_requests_per_minute. Not safe to call concurrently
+// with OnEvaluate — set it during construction, before the loop serves.
+func (l *Loop) SetLLMBudget(b *llmBudget) { l.budget = b }
 
 // SetThrottle overrides the log/span throttle interval. It is read once at
 // startup from decision.throttle_seconds (#766 F5); a non-positive value leaves
@@ -282,7 +313,7 @@ func (l *Loop) OnEvaluate(ctx context.Context, c gamecontext.GameContext, trig E
 		)
 	}
 
-	decisions := l.decide(ctx, snapshot, c, emit)
+	decisions := l.decide(ctx, snapshot, c, emit, &state)
 
 	// Lift the cycle-level fitness evaluation the engine just computed onto the
 	// LayerState so it rides the decision span as fitness.evaluated (#731). Read
@@ -355,11 +386,96 @@ func (l *Loop) setLastLayer(state LayerState) {
 // yet (#741). The "rules" path and any unrecognized mode go straight to rules.
 // emit is this cycle's shared throttle decision (from OnEvaluate); the capture
 // span/log only fire when it is true.
-func (l *Loop) decide(ctx context.Context, snapshot flags.Snapshot, c gamecontext.GameContext, emit bool) []Decision {
-	if snapshot.Mode == "llm" && emit {
-		l.captureLLMPrompt(ctx, snapshot, c)
+//
+// The LLM call gate (#847) sits in FRONT of the prompt build/capture: an llm-mode
+// cycle first passes the three-layer gate (eligibility -> cadence -> budget). When
+// the gate DENIES, the cycle records the specific gate fallback_reason on the
+// LayerState, increments agent_llm_gated_total, and does NOT build or capture the
+// prompt (no token burn, even the prompt serialization is skipped). When the gate
+// ALLOWS, current behavior is unchanged: the prompt is captured and the cycle
+// falls back to rules with no_backend_available. Either way the rules engine still
+// runs (the gate only guards the LLM ATTEMPT, never the deterministic fallback).
+func (l *Loop) decide(ctx context.Context, snapshot flags.Snapshot, c gamecontext.GameContext, emit bool, state *LayerState) []Decision {
+	if snapshot.Mode == "llm" {
+		// Resolve the gate BEFORE any prompt work so a gated cycle never serializes
+		// a prompt it will not send. The reason rides the decision span (#729) via
+		// state.LLMFallbackReason regardless of whether emit fired this cycle, so a
+		// gated cycle is attributable even when the throttled capture span is silent.
+		reason := l.gateLLM(ctx, snapshot, c)
+		state.LLMFallbackReason = reason
+		// Only an ALLOWED attempt (empty reason) captures the prompt; the capture is
+		// still throttle-gated by emit so steady-state load emits at most one span
+		// per interval, exactly as before #847.
+		if reason == "" && emit {
+			l.captureLLMPrompt(ctx, snapshot, c)
+		}
 	}
 	return l.Rules.Evaluate(ctx, c)
+}
+
+// gateLLM runs the three-layer LLM call gate (#847) for this cycle and returns the
+// fallback_reason: "" when the gate ADMITS the attempt (the cycle may capture the
+// prompt and, until a backend exists, falls back to rules with
+// no_backend_available), or the specific gate reason when DENIED. Layers are
+// checked in this exact order — eligibility, then cadence, then budget — so the
+// cheapest, most-decisive check short-circuits first and a denied attempt never
+// charges a later layer (e.g. an ineligible shadow game never touches the global
+// budget). Every denial increments agent_llm_gated_total{reason=...}.
+//
+// Cadence and budget are charged ONLY on admission: lastLLMAttempt advances and a
+// budget slot is consumed exactly when the attempt passes all three layers, so a
+// cycle blocked by a later layer does not perturb an earlier layer's state.
+func (l *Loop) gateLLM(ctx context.Context, snapshot flags.Snapshot, c gamecontext.GameContext) string {
+	now := l.now
+	if now == nil {
+		now = time.Now
+	}
+
+	// Layer 1 — Eligibility: which game kinds may use llm at all. A kind not in
+	// llm.eligible_game_kinds (default ["real"], so shadow games are rules-only,
+	// #838) is gated here and never considers cadence or budget.
+	if !snapshot.LLMGate.EligibleFor(c.GameKind) {
+		l.recordGated(ctx, FallbackNotEligible)
+		return FallbackNotEligible
+	}
+
+	// Layers 2 & 3 are charged together under llmGate so the cadence read and the
+	// lastLLMAttempt write are atomic with respect to concurrent Export handlers
+	// for THIS game (per-game state), and so an admitted attempt advances cadence
+	// and consumes a budget slot as one unit.
+	l.llmGate.Lock()
+	defer l.llmGate.Unlock()
+
+	// Layer 2 — Cadence (per game): at most one attempt per game per
+	// llm.min_decision_interval_seconds. A zero lastLLMAttempt (no prior attempt)
+	// always passes. A non-positive interval disables the cadence floor.
+	t := now()
+	interval := snapshot.LLMGate.MinDecisionInterval
+	if interval > 0 && !l.lastLLMAttempt.IsZero() && t.Sub(l.lastLLMAttempt) < interval {
+		l.recordGated(ctx, FallbackInterval)
+		return FallbackInterval
+	}
+
+	// Layer 3 — Global budget: one shared cap across ALL games. A nil budget
+	// (never injected) fails closed — no shared cap means no llm. The budget is
+	// charged here, last, so an attempt blocked by cadence above never draws it
+	// down.
+	if l.budget == nil || !l.budget.allow(t, snapshot.LLMGate.MaxRequestsPerMinute) {
+		l.recordGated(ctx, FallbackBudgetExhausted)
+		return FallbackBudgetExhausted
+	}
+
+	// Admitted: advance this game's cadence clock. The budget slot was consumed by
+	// the allow() call above. This is the ONLY path that does not return a reason.
+	l.lastLLMAttempt = t
+	return ""
+}
+
+// recordGated increments the agent_llm_gated_total counter for one gated llm cycle,
+// labeled by the fallback reason (#847 acceptance #6). The counter is never nil
+// (NewLoop seeds a no-op), so this is always safe to call.
+func (l *Loop) recordGated(ctx context.Context, reason string) {
+	l.llmGated.Add(ctx, 1, otelmetric.WithAttributes(attribute.String("reason", reason)))
 }
 
 // captureLLMPrompt builds the prompt the agent would send this cycle and records
@@ -625,7 +741,25 @@ func layerStateAttributes(state *LayerState) []attribute.KeyValue {
 	if mode == "" {
 		mode = DefaultMode
 	}
-	inferenceUsed, fallback := inferenceAttribution(mode)
+	// Inference attribution. For the llm path the fallback_reason is the PER-CYCLE
+	// gate outcome the loop resolved this cycle (#847): llm_not_eligible /
+	// llm_interval / llm_budget_exhausted when gated, or no_backend_available when
+	// the gate ADMITTED the attempt but no backend exists yet. The static
+	// inferenceAttribution is kept only as the fallback for the historical case
+	// where the cycle did not run the gate (state.LLMFallbackReason empty on an llm
+	// cycle would be an admitted-but-unrecorded path; we default it to
+	// no_backend_available to preserve the pre-#847 contract). mode=rules has no
+	// fallback reason, unchanged.
+	var inferenceUsed, fallback string
+	if mode == "llm" {
+		inferenceUsed = InferenceRules
+		fallback = state.LLMFallbackReason
+		if fallback == "" {
+			fallback = FallbackNoBackend
+		}
+	} else {
+		inferenceUsed, fallback = inferenceAttribution(mode)
+	}
 	attrs := []attribute.KeyValue{
 		// Existence layer.
 		attribute.Bool(AttrEnabled, state.Enabled),

--- a/services/agent/decision/layerstate.go
+++ b/services/agent/decision/layerstate.go
@@ -56,6 +56,15 @@ type LayerState struct {
 	Model         string
 	PromptVariant string
 
+	// LLMFallbackReason is the inference.fallback_reason this cycle's llm path
+	// resolved to (#847). It is the PER-CYCLE replacement for the static
+	// inferenceAttribution: when mode=="llm" the loop sets it to the gate outcome
+	// (FallbackNotEligible / FallbackInterval / FallbackBudgetExhausted when gated,
+	// FallbackNoBackend when the gate ALLOWED and the cycle fell back for lack of a
+	// backend), and layerStateAttributes lifts it onto the decision span. Empty on
+	// the rules path (mode!="llm"), where there is no fallback reason at all.
+	LLMFallbackReason string
+
 	// --- Permission layer ---
 	InterventionsAllowed      []string
 	PolicyBatteryThreshold    int

--- a/services/agent/decision/llm_capture_test.go
+++ b/services/agent/decision/llm_capture_test.go
@@ -22,6 +22,15 @@ func llmSnapshot() flags.Snapshot {
 			"noop", "grant_shield", "play_audio_cue",
 		},
 		Policy: flags.Policy{MaxInterventionsPerMinute: 100},
+		// The capture tests exercise the gate-ALLOWED path, so the LLM gate (#847)
+		// must admit: eligible for the kinds these tests use ("" and "real"), no
+		// cadence floor, and a generous global budget. recordingLoop injects the
+		// shared budget instance (the field below only sets the per-cycle cap).
+		LLMGate: flags.LLMGate{
+			EligibleGameKinds:    []string{"", "real", "shadow"},
+			MinDecisionInterval:  0,
+			MaxRequestsPerMinute: 1000,
+		},
 	}
 }
 

--- a/services/agent/decision/llm_gate_test.go
+++ b/services/agent/decision/llm_gate_test.go
@@ -1,0 +1,355 @@
+package decision
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"github.com/joustmania/agent/flags"
+	"github.com/joustmania/agent/gamecontext"
+)
+
+// gateSnapshot is an llm-mode snapshot whose gate config the test sets explicitly.
+// It is eligible for nothing by default — each test supplies its own LLMGate.
+func gateSnapshot(gate flags.LLMGate) flags.Snapshot {
+	return flags.Snapshot{
+		Enabled:              true,
+		Mode:                 "llm",
+		Objectives:           map[string]float64{"endurance": 1.0},
+		Capability:           flags.Capability{Model: "phi4-mini", PromptVariant: "balanced"},
+		InterventionsAllowed: []string{"noop", "grant_shield"},
+		Policy:               flags.Policy{MaxInterventionsPerMinute: 100},
+		LLMGate:              gate,
+	}
+}
+
+// gatedByReason collects the agent_llm_gated_total counter into a reason->count map.
+func gatedByReason(t *testing.T, reader *metric.ManualReader) map[string]int64 {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("collect metrics: %v", err)
+	}
+	out := map[string]int64{}
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != "agent_llm_gated_total" {
+				continue
+			}
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			if !ok {
+				t.Fatalf("expected Sum[int64], got %T", m.Data)
+			}
+			for _, dp := range sum.DataPoints {
+				reason, _ := dp.Attributes.Value("reason")
+				out[reason.AsString()] = dp.Value
+			}
+		}
+	}
+	return out
+}
+
+// gateLoop builds a Loop wired with a recording tracer, a metered gate counter,
+// a fixed clock, the given shared budget, and a fixed-decision rules engine so a
+// decision span always emits (lets us read inference.fallback_reason back). It
+// returns the loop, span recorder, and metric reader.
+func gateLoop(t *testing.T, snap flags.Snapshot, budget *llmBudget, clock *time.Time) (*Loop, *tracetest.SpanRecorder, *metric.ManualReader) {
+	t.Helper()
+	sr := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+
+	reader := metric.NewManualReader()
+	mp := metric.NewMeterProvider(metric.WithReader(reader))
+
+	l := NewLoop(&settableFlags{snap: snap}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	l.Tracer = tp.Tracer("test")
+	l.Rules = fakeRules{out: []Decision{{Intervention: "grant_shield", Reason: "x"}}}
+	l.Actions = &fakeSink{}
+	l.llmGated = newLLMGatedCounter(mp)
+	l.SetLLMBudget(budget)
+	// A fixed clock drives cadence/budget windows deterministically and keeps the
+	// capture throttle open across the test's cycles.
+	l.now = func() time.Time { return *clock }
+	return l, sr, reader
+}
+
+// fallbackOnDecision reads inference.fallback_reason off the single decision span.
+func fallbackOnDecision(t *testing.T, sr *tracetest.SpanRecorder) string {
+	t.Helper()
+	decs := spansByName(sr.Ended(), SpanDecision)
+	if len(decs) != 1 {
+		t.Fatalf("agent.decision spans = %d, want 1", len(decs))
+	}
+	v, ok := attrValue(decs[0], AttrInferenceFallback)
+	if !ok {
+		t.Fatal("inference.fallback_reason missing on decision span")
+	}
+	return v.AsString()
+}
+
+// --- Acceptance #2: shadow games produce zero llm attempts with default flags ---
+
+// TestGate_ShadowGameNotEligible: a shadow game under the default ["real"]
+// eligibility never captures a prompt; the decision span carries llm_not_eligible
+// and the gated counter increments for that reason.
+func TestGate_ShadowGameNotEligible(t *testing.T) {
+	clock := time.Unix(1000, 0)
+	// Default-equivalent gate: eligible only for "real".
+	snap := gateSnapshot(flags.LLMGate{
+		EligibleGameKinds:    []string{"real"},
+		MinDecisionInterval:  10 * time.Second,
+		MaxRequestsPerMinute: 6,
+	})
+	l, sr, reader := gateLoop(t, snap, NewLLMBudget(), &clock)
+
+	l.OnEvaluate(context.Background(), gamecontext.GameContext{SessionID: "s1", GameKind: "shadow"}, testTrigger())
+
+	// NO prompt capture for an ineligible game.
+	if n := len(spansByName(sr.Ended(), SpanLLMPrompt)); n != 0 {
+		t.Errorf("agent.llm.prompt spans = %d, want 0 for an ineligible shadow game", n)
+	}
+	if got := fallbackOnDecision(t, sr); got != FallbackNotEligible {
+		t.Errorf("inference.fallback_reason = %q, want %q", got, FallbackNotEligible)
+	}
+	if got := gatedByReason(t, reader); got[FallbackNotEligible] != 1 {
+		t.Errorf("agent_llm_gated_total{reason=%s} = %d, want 1", FallbackNotEligible, got[FallbackNotEligible])
+	}
+}
+
+// --- Acceptance #1 + #4: ordering and per-reason fallback attribution ---
+
+// TestGate_EligibleAllowsAndCaptures: an eligible real game with budget available
+// passes the gate — the prompt is captured and the fallback is the unchanged
+// no_backend_available (gate ALLOWED).
+func TestGate_EligibleAllowsAndCaptures(t *testing.T) {
+	clock := time.Unix(1000, 0)
+	snap := gateSnapshot(flags.LLMGate{
+		EligibleGameKinds:    []string{"real"},
+		MinDecisionInterval:  10 * time.Second,
+		MaxRequestsPerMinute: 6,
+	})
+	l, sr, reader := gateLoop(t, snap, NewLLMBudget(), &clock)
+
+	l.OnEvaluate(context.Background(), gamecontext.GameContext{SessionID: "s1", GameKind: "real"}, testTrigger())
+
+	if n := len(spansByName(sr.Ended(), SpanLLMPrompt)); n != 1 {
+		t.Errorf("agent.llm.prompt spans = %d, want 1 (gate admitted)", n)
+	}
+	if got := fallbackOnDecision(t, sr); got != FallbackNoBackend {
+		t.Errorf("inference.fallback_reason = %q, want %q (allowed, no backend)", got, FallbackNoBackend)
+	}
+	if got := gatedByReason(t, reader); len(got) != 0 {
+		t.Errorf("agent_llm_gated_total has entries %v, want none (nothing gated)", got)
+	}
+}
+
+// TestGate_CadenceBlocksSecondAttempt: a second attempt for the same game within
+// the cadence interval is gated llm_interval — and does NOT capture a prompt.
+func TestGate_CadenceBlocksSecondAttempt(t *testing.T) {
+	clock := time.Unix(1000, 0)
+	snap := gateSnapshot(flags.LLMGate{
+		EligibleGameKinds:    []string{"real"},
+		MinDecisionInterval:  10 * time.Second,
+		MaxRequestsPerMinute: 100,
+	})
+	l, sr, reader := gateLoop(t, snap, NewLLMBudget(), &clock)
+	ctx := gamecontext.GameContext{SessionID: "s1", GameKind: "real"}
+
+	// First attempt admitted.
+	l.OnEvaluate(context.Background(), ctx, testTrigger())
+	// Second attempt 3s later — inside the 10s cadence floor.
+	clock = clock.Add(3 * time.Second)
+	l.OnEvaluate(context.Background(), ctx, testTrigger())
+
+	if n := len(spansByName(sr.Ended(), SpanLLMPrompt)); n != 1 {
+		t.Errorf("agent.llm.prompt spans = %d, want 1 (second blocked by cadence)", n)
+	}
+	if got := gatedByReason(t, reader); got[FallbackInterval] != 1 {
+		t.Errorf("agent_llm_gated_total{reason=%s} = %d, want 1", FallbackInterval, got[FallbackInterval])
+	}
+
+	// Once the interval elapses, the next attempt is admitted again.
+	clock = clock.Add(10 * time.Second)
+	l.OnEvaluate(context.Background(), ctx, testTrigger())
+	if n := len(spansByName(sr.Ended(), SpanLLMPrompt)); n != 2 {
+		t.Errorf("agent.llm.prompt spans = %d, want 2 (cadence elapsed, re-admitted)", n)
+	}
+}
+
+// TestGate_BudgetExhausted: with no cadence floor, a single game exhausts the
+// global budget; the next attempt is gated llm_budget_exhausted.
+func TestGate_BudgetExhausted(t *testing.T) {
+	clock := time.Unix(1000, 0)
+	snap := gateSnapshot(flags.LLMGate{
+		EligibleGameKinds:    []string{"real"},
+		MinDecisionInterval:  0, // no cadence floor
+		MaxRequestsPerMinute: 2,
+	})
+	l, _, reader := gateLoop(t, snap, NewLLMBudget(), &clock)
+	ctx := gamecontext.GameContext{SessionID: "s1", GameKind: "real"}
+
+	l.OnEvaluate(context.Background(), ctx, testTrigger()) // 1 admitted
+	l.OnEvaluate(context.Background(), ctx, testTrigger()) // 2 admitted
+	l.OnEvaluate(context.Background(), ctx, testTrigger()) // 3 -> budget exhausted
+
+	if got := gatedByReason(t, reader); got[FallbackBudgetExhausted] != 1 {
+		t.Errorf("agent_llm_gated_total{reason=%s} = %d, want 1", FallbackBudgetExhausted, got[FallbackBudgetExhausted])
+	}
+}
+
+// TestGate_OrderEligibilityFirst: an ineligible game NEVER touches cadence or the
+// budget — even with a zero budget, the reason is llm_not_eligible (the first
+// layer short-circuits), and the shared budget admits a later eligible game fully.
+func TestGate_OrderEligibilityFirst(t *testing.T) {
+	clock := time.Unix(1000, 0)
+	shared := NewLLMBudget()
+	snap := gateSnapshot(flags.LLMGate{
+		EligibleGameKinds:    []string{"real"},
+		MinDecisionInterval:  0,
+		MaxRequestsPerMinute: 1, // tiny budget
+	})
+	l, sr, reader := gateLoop(t, snap, shared, &clock)
+
+	// Ineligible shadow game: gated at layer 1, budget untouched.
+	l.OnEvaluate(context.Background(), gamecontext.GameContext{SessionID: "s1", GameKind: "shadow"}, testTrigger())
+	if got := gatedByReason(t, reader); got[FallbackNotEligible] != 1 || got[FallbackBudgetExhausted] != 0 {
+		t.Errorf("gated map = %v, want only llm_not_eligible (eligibility short-circuits before budget)", got)
+	}
+	// The eligible real game can still spend the single budget slot. Advance the
+	// clock past the capture throttle (the shadow cycle consumed this interval's
+	// slot) so the admitted real cycle actually emits its capture span.
+	if n := len(spansByName(sr.Ended(), SpanLLMPrompt)); n != 0 {
+		t.Fatalf("unexpected prompt capture before eligible attempt")
+	}
+	clock = clock.Add(2 * time.Second)
+	l.OnEvaluate(context.Background(), gamecontext.GameContext{SessionID: "s1", GameKind: "real"}, testTrigger())
+	if n := len(spansByName(sr.Ended(), SpanLLMPrompt)); n != 1 {
+		t.Errorf("agent.llm.prompt spans = %d, want 1 (real game spends the budget the shadow game never touched)", n)
+	}
+}
+
+// --- Acceptance #5: flags hot-reload (tightening the budget mid-session) ---
+
+// TestGate_BudgetHotReload: a budget admitted under a generous cap is denied on
+// the next cycle once the flag tightens below the in-window count — proving the
+// cap is read live per cycle, never cached.
+func TestGate_BudgetHotReload(t *testing.T) {
+	clock := time.Unix(1000, 0)
+	fl := &settableFlags{snap: gateSnapshot(flags.LLMGate{
+		EligibleGameKinds:    []string{"real"},
+		MinDecisionInterval:  0,
+		MaxRequestsPerMinute: 5,
+	})}
+	sr := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+	reader := metric.NewManualReader()
+	mp := metric.NewMeterProvider(metric.WithReader(reader))
+	l := NewLoop(fl, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	l.Tracer = tp.Tracer("test")
+	l.Rules = fakeRules{out: []Decision{{Intervention: "grant_shield"}}}
+	l.Actions = &fakeSink{}
+	l.llmGated = newLLMGatedCounter(mp)
+	l.SetLLMBudget(NewLLMBudget())
+	l.now = func() time.Time { return clock }
+	ctx := gamecontext.GameContext{SessionID: "s1", GameKind: "real"}
+
+	// Two admissions under cap 5 (advance past the 1s capture throttle between them,
+	// staying well inside the 1-minute budget window so both stay counted).
+	l.OnEvaluate(context.Background(), ctx, testTrigger())
+	clock = clock.Add(2 * time.Second)
+	l.OnEvaluate(context.Background(), ctx, testTrigger())
+	if n := len(spansByName(sr.Ended(), SpanLLMPrompt)); n != 2 {
+		t.Fatalf("agent.llm.prompt spans = %d, want 2 under cap 5", n)
+	}
+	// Tighten the budget flag to 2 (== current window count): the very next cycle
+	// is gated, proving the cap is read live (the budget window still holds 2).
+	tightened := fl.snap
+	tightened.LLMGate.MaxRequestsPerMinute = 2
+	fl.snap = tightened
+	clock = clock.Add(2 * time.Second)
+	l.OnEvaluate(context.Background(), ctx, testTrigger())
+	if got := gatedByReason(t, reader); got[FallbackBudgetExhausted] != 1 {
+		t.Errorf("agent_llm_gated_total{reason=%s} = %d, want 1 after mid-session tighten", FallbackBudgetExhausted, got[FallbackBudgetExhausted])
+	}
+}
+
+// --- Acceptance #3: 4 concurrent games share one global budget ---
+
+// TestGate_SharedBudgetAcrossLoops: four separate Loops (four games) all wired to
+// ONE shared budget never admit more than max_requests_per_minute combined. The
+// capture span is throttle-gated, so admissions are counted as (total cycles -
+// gated denials) via a SHARED metric reader, not by capture-span count.
+func TestGate_SharedBudgetAcrossLoops(t *testing.T) {
+	clock := time.Unix(1000, 0)
+	const cap = 6
+	const games = 4
+	const cyclesPerGame = 10
+	shared := NewLLMBudget()
+
+	// One shared meter provider so the gated counter aggregates across all loops.
+	reader := metric.NewManualReader()
+	mp := metric.NewMeterProvider(metric.WithReader(reader))
+	sharedCounter := newLLMGatedCounter(mp)
+
+	makeLoop := func() *Loop {
+		snap := gateSnapshot(flags.LLMGate{
+			EligibleGameKinds:    []string{"real"},
+			MinDecisionInterval:  0, // no cadence floor: the budget is the sole constraint
+			MaxRequestsPerMinute: cap,
+		})
+		l := NewLoop(&settableFlags{snap: snap}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+		l.Tracer = sdktrace.NewTracerProvider().Tracer("test")
+		l.Rules = fakeRules{out: nil} // idle: gate runs, no decision spans
+		l.Actions = &fakeSink{}
+		l.llmGated = sharedCounter
+		l.SetLLMBudget(shared)
+		l.now = func() time.Time { return clock }
+		return l
+	}
+
+	loops := make([]*Loop, games)
+	for i := range loops {
+		loops[i] = makeLoop()
+	}
+
+	var wg sync.WaitGroup
+	for i := range loops {
+		l := loops[i]
+		gameID := "game-" + string(rune('A'+i))
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for c := 0; c < cyclesPerGame; c++ {
+				l.OnEvaluate(context.Background(),
+					gamecontext.GameContext{SessionID: gameID, GameKind: "real"}, testTrigger())
+			}
+		}()
+	}
+	wg.Wait()
+
+	// admitted = total cycles - gated denials. With no cadence and a budget of cap,
+	// every denial is llm_budget_exhausted, so admitted must equal exactly cap and
+	// can never exceed it.
+	gated := gatedByReason(t, reader)
+	totalGated := gated[FallbackBudgetExhausted] + gated[FallbackInterval] + gated[FallbackNotEligible]
+	admitted := int64(games*cyclesPerGame) - totalGated
+	if admitted > cap {
+		t.Errorf("total admitted LLM attempts across %d games = %d, want <= %d (shared budget)", games, admitted, cap)
+	}
+	if admitted != cap {
+		t.Errorf("total admitted = %d, want exactly %d (budget fully spent, never exceeded)", admitted, cap)
+	}
+	if gated[FallbackInterval] != 0 || gated[FallbackNotEligible] != 0 {
+		t.Errorf("unexpected non-budget gating: %v (only budget should gate here)", gated)
+	}
+}

--- a/services/agent/decision/llmbudget.go
+++ b/services/agent/decision/llmbudget.go
@@ -1,0 +1,80 @@
+package decision
+
+import (
+	"sync"
+	"time"
+)
+
+// llmbudget.go is the GLOBAL per-minute request cap for the LLM call gate (#847,
+// the third and last gate layer). Where decision/ratelimit.go's weighted
+// rateLimiter is the PER-GAME intervention-dispatch budget (one per Loop, see
+// loopset.go), this limiter is a SINGLE shared instance across ALL per-game loops:
+// it caps the total number of LLM requests the whole agent issues per minute,
+// regardless of how many concurrent games are running (#845). The shared instance
+// is constructed once in main.go and closed over by the Loop factory, so 4
+// concurrent eligible games draw down ONE budget and can never collectively exceed
+// llm.max_requests_per_minute.
+//
+// It mirrors rateLimiter's sliding-window + mutex pattern, but the cost model is
+// simpler: each admitted LLM attempt is ONE request (unit weight), not a weighted
+// intervention. The budget is therefore a plain per-minute count, not a weight sum.
+
+// llmBudgetWindow is the trailing window over which the global request cap
+// applies, mirroring rateWindow. One minute, matching llm.max_requests_per_minute.
+const llmBudgetWindow = time.Minute
+
+// llmBudget is the global, concurrency-safe, sliding-window request counter for
+// the LLM gate's budget layer (#847). It admits LLM attempts until the count of
+// admissions within the trailing one-minute window reaches maxPerMinute, then
+// denies further ones (it does not queue). Older admissions are pruned on each
+// call, so the budget replenishes as the window slides. Safe for concurrent use:
+// the per-game Export handler goroutines all call allow on the one shared instance.
+type llmBudget struct {
+	mu      sync.Mutex
+	entries []time.Time
+}
+
+// NewLLMBudget builds an empty global LLM request budget. The cap is NOT stored on
+// the budget — it is passed to allow on every call (read from the live
+// llm.max_requests_per_minute flag each cycle), so tightening the flag mid-session
+// takes effect on the very next admission with no reconstruction (acceptance #5).
+//
+// Exported because main.go constructs the ONE shared instance and injects it into
+// every per-game Loop via SetLLMBudget, so all loops share a single global cap.
+func NewLLMBudget() *llmBudget { return &llmBudget{} }
+
+// allow reports whether an LLM attempt fits within the global budget at time now.
+// When it fits, the admission is recorded and true is returned; when the window
+// already holds maxPerMinute admissions, nothing is recorded and false is returned
+// (the attempt is gated with llm_budget_exhausted). A maxPerMinute <= 0 admits
+// nothing (fully closed) — the safe reading of a zero/negative cap.
+//
+// The cap is a parameter, not state, so the SAME budget instance honors a
+// per-cycle flag value: lowering max_requests_per_minute immediately tightens the
+// next call without losing the window history.
+func (b *llmBudget) allow(now time.Time, maxPerMinute int) bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.prune(now)
+	if maxPerMinute <= 0 {
+		return false
+	}
+	if len(b.entries) >= maxPerMinute {
+		return false
+	}
+	b.entries = append(b.entries, now)
+	return true
+}
+
+// prune drops admissions older than the trailing window ending at now. Caller
+// holds b.mu. Mirrors rateLimiter.prune.
+func (b *llmBudget) prune(now time.Time) {
+	cutoff := now.Add(-llmBudgetWindow)
+	kept := b.entries[:0]
+	for _, at := range b.entries {
+		if at.After(cutoff) {
+			kept = append(kept, at)
+		}
+	}
+	b.entries = kept
+}

--- a/services/agent/decision/llmbudget_test.go
+++ b/services/agent/decision/llmbudget_test.go
@@ -1,0 +1,72 @@
+package decision
+
+import (
+	"testing"
+	"time"
+)
+
+// TestLLMBudget_AdmitsUpToCap: the budget admits exactly maxPerMinute requests in
+// one window, then denies.
+func TestLLMBudget_AdmitsUpToCap(t *testing.T) {
+	b := NewLLMBudget()
+	now := time.Unix(1000, 0)
+	const cap = 6
+	for i := 0; i < cap; i++ {
+		if !b.allow(now, cap) {
+			t.Fatalf("request %d should be admitted within cap %d", i+1, cap)
+		}
+	}
+	if b.allow(now, cap) {
+		t.Errorf("request %d admitted, want denied (cap %d exhausted)", cap+1, cap)
+	}
+}
+
+// TestLLMBudget_ZeroCapDeniesAll: a cap of 0 (or negative) admits nothing — the
+// fully-closed safe reading.
+func TestLLMBudget_ZeroCapDeniesAll(t *testing.T) {
+	b := NewLLMBudget()
+	now := time.Unix(1000, 0)
+	if b.allow(now, 0) {
+		t.Error("cap 0 admitted, want denied")
+	}
+	if b.allow(now, -1) {
+		t.Error("negative cap admitted, want denied")
+	}
+}
+
+// TestLLMBudget_WindowSlides: admissions older than the one-minute window are
+// pruned, so the budget replenishes as time passes.
+func TestLLMBudget_WindowSlides(t *testing.T) {
+	b := NewLLMBudget()
+	t0 := time.Unix(1000, 0)
+	const cap = 2
+	if !b.allow(t0, cap) || !b.allow(t0, cap) {
+		t.Fatal("first two admissions should succeed")
+	}
+	if b.allow(t0, cap) {
+		t.Fatal("third admission at t0 should be denied")
+	}
+	// Advance just past the window: the two t0 entries fall out, budget reopens.
+	later := t0.Add(llmBudgetWindow + time.Second)
+	if !b.allow(later, cap) {
+		t.Error("admission after window slide should succeed (entries pruned)")
+	}
+}
+
+// TestLLMBudget_LiveCapTightening: lowering the cap mid-window takes effect on the
+// next call against the SAME instance, without losing window history (#847 #5).
+func TestLLMBudget_LiveCapTightening(t *testing.T) {
+	b := NewLLMBudget()
+	now := time.Unix(1000, 0)
+	// Admit 3 under a generous cap.
+	for i := 0; i < 3; i++ {
+		if !b.allow(now, 10) {
+			t.Fatalf("admission %d under cap 10 should succeed", i+1)
+		}
+	}
+	// Tighten the cap below the current window count: the next call is denied
+	// immediately, even though no time passed.
+	if b.allow(now, 3) {
+		t.Error("admission under tightened cap 3 (window already holds 3) should be denied")
+	}
+}

--- a/services/agent/decision/metrics.go
+++ b/services/agent/decision/metrics.go
@@ -1,0 +1,40 @@
+package decision
+
+import (
+	"go.opentelemetry.io/otel"
+	otelmetric "go.opentelemetry.io/otel/metric"
+	metricnoop "go.opentelemetry.io/otel/metric/noop"
+)
+
+// metrics.go holds the decision loop's OTel instruments. Today that is the LLM
+// call-gate counter (#847); the audit trace (#724) carries the rest of the
+// loop's observability as spans.
+
+// decisionMeterName scopes the decision loop's OTel instruments, mirroring
+// actions/writer.go's meterName convention (module path + package).
+const decisionMeterName = "github.com/joustmania/agent/decision"
+
+// newLLMGatedCounter builds the agent_llm_gated_total counter from the given meter
+// provider. It is incremented once per gated llm cycle, labeled reason=<fallback
+// reason> (llm_not_eligible / llm_interval / llm_budget_exhausted), so the gate's
+// effect is observable per layer (#847 acceptance #6). An instrument-creation
+// error yields a no-op counter so the Loop always has a usable instrument and
+// tests that never wire a real meter provider still work — mirrors
+// actions.newWritesCounter.
+func newLLMGatedCounter(mp otelmetric.MeterProvider) otelmetric.Int64Counter {
+	c, err := mp.Meter(decisionMeterName).Int64Counter(
+		"agent_llm_gated_total",
+		otelmetric.WithDescription("Total LLM decision cycles denied by the call gate, labeled by fallback reason (#847)"),
+	)
+	if err != nil {
+		c, _ = metricnoop.NewMeterProvider().Meter(decisionMeterName).Int64Counter("agent_llm_gated_total")
+	}
+	return c
+}
+
+// defaultLLMGatedCounter is the no-op fallback counter a Loop uses until one is
+// injected (NewLoop wires the global meter provider; tests may leave it). It keeps
+// the gate-increment path nil-safe without every test having to set a counter.
+func defaultLLMGatedCounter() otelmetric.Int64Counter {
+	return newLLMGatedCounter(otel.GetMeterProvider())
+}

--- a/services/agent/decision/retro_capture.go
+++ b/services/agent/decision/retro_capture.go
@@ -8,6 +8,7 @@ import (
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	otelmetric "go.opentelemetry.io/otel/metric"
 	semconv "go.opentelemetry.io/otel/semconv/v1.34.0"
 	"go.opentelemetry.io/otel/trace"
 
@@ -23,9 +24,19 @@ import (
 // capture, no backend is called yet — this is capture-first.
 //
 // STRUCTURAL GUARANTEE: the coordinator never touches gate.ShouldEvaluate, the
-// decision Loop, or the rate limiter. A retrospective therefore cannot consume
-// the in-game intervention budget — there is simply no code path from here to the
-// limiter. This is a deliberate isolation, not just a convention.
+// decision Loop, or the per-game intervention rate limiter. A retrospective
+// therefore cannot consume the in-game INTERVENTION budget (decision/ratelimit.go)
+// — there is simply no code path from here to it.
+//
+// LLM BUDGET (#847): a retrospective IS one LLM request, so it MUST draw from the
+// same GLOBAL llm.max_requests_per_minute budget the in-game gate uses (#844 +
+// #847 acceptance #7). The coordinator therefore takes the one shared *llmBudget
+// (injected via SetLLMBudget from main.go, the same instance every per-game Loop
+// holds). When the budget is exhausted at game end the retro is GATED: it records
+// agent_llm_gated_total{reason=llm_budget_exhausted} and captures nothing — a
+// retrospective cannot blow the global LLM cap. NOTE the retro is intentionally
+// NOT subject to the eligibility or cadence layers: it is a once-per-session,
+// game-kind-agnostic offline analysis, so only the global budget bounds it.
 
 // SpanLLMRetro is the post-game retrospective capture span (#844): emitted once
 // per session at game end, carrying the prompt the agent would send to an offline
@@ -78,6 +89,15 @@ type RetroCoordinator struct {
 	// now is injectable for tests; nil uses time.Now.
 	now func() time.Time
 
+	// budget is the GLOBAL per-minute LLM request budget (#847), shared with every
+	// per-game Loop. A retro draws one slot from it; a nil budget means the retro is
+	// ungated by the global cap (used by tests / single-purpose wiring that does not
+	// share a budget — capture proceeds as before #847). Injected via SetLLMBudget.
+	budget *llmBudget
+	// llmGated counts gated retro captures (agent_llm_gated_total{reason=...}),
+	// sharing the in-game counter name. Defaults to a no-op so tests need not wire it.
+	llmGated otelmetric.Int64Counter
+
 	// mu guards the captured-session dedupe state.
 	mu sync.Mutex
 	// captured is the set of recently captured SessionIDs (membership = already
@@ -104,8 +124,15 @@ func NewRetroCoordinator(flagSource FlagSource, log *slog.Logger) *RetroCoordina
 		Flags:    flagSource,
 		now:      time.Now,
 		captured: make(map[string]struct{}),
+		llmGated: defaultLLMGatedCounter(),
 	}
 }
+
+// SetLLMBudget injects the shared GLOBAL LLM request budget (#847 acceptance #7)
+// so a retrospective draws one slot from the SAME per-minute cap the in-game gate
+// uses. main.go passes the one instance every per-game Loop also holds. Not safe
+// to call concurrently with OnGameEnd — set it during construction.
+func (rc *RetroCoordinator) SetLLMBudget(b *llmBudget) { rc.budget = b }
 
 // OnGameEnd is the gamecontext.Store.OnGameEnd callback. It captures the
 // retrospective prompt for a finished session exactly once. It is defensive:
@@ -131,8 +158,24 @@ func (rc *RetroCoordinator) OnGameEnd(c gamecontext.GameContext) {
 	// Evaluate flags with a background context: there is no inbound RPC context at
 	// game end, so the retro span is a standalone root (intentional — it is not a
 	// child of any Export). The flag source falls back to safe defaults if flagd is
-	// unreachable, identical to the in-game path.
+	// unreachable, identical to the in-game path. Evaluated up front so the budget
+	// gate below reads the same live llm.max_requests_per_minute the capture would.
 	snapshot := rc.Flags.Evaluate(context.Background())
+
+	// Global LLM budget gate (#847 acceptance #7): a retrospective is one LLM
+	// request, so it must fit the shared per-minute cap the in-game gate honors.
+	// When a budget is wired and exhausted, the retro is GATED — record the gated
+	// metric and capture nothing (no prompt build, no span). A nil budget (tests /
+	// unshared wiring) skips this check, preserving pre-#847 behavior.
+	if rc.budget != nil && !rc.budget.allow(now(), snapshot.LLMGate.MaxRequestsPerMinute) {
+		rc.llmGated.Add(context.Background(), 1,
+			otelmetric.WithAttributes(attribute.String("reason", FallbackBudgetExhausted)))
+		rc.Log.Info("agent.llm.retro_gated",
+			"session_id", c.SessionID,
+			"fallback_reason", FallbackBudgetExhausted,
+		)
+		return
+	}
 
 	prompt := llm.BuildRetro(llm.RetroInput{
 		Snapshot: snapshot,

--- a/services/agent/decision/retro_capture_test.go
+++ b/services/agent/decision/retro_capture_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"log/slog"
 	"testing"
+	"time"
 
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
@@ -71,6 +72,55 @@ func TestRetroCapture_EmitsSpan(t *testing.T) {
 	}
 	if v, ok := attrValue(spans[0], AttrLLMRetroUser); !ok || v.AsString() == "" {
 		t.Error("llm.retro.user must be present and non-empty")
+	}
+}
+
+// TestRetroCapture_DrawsFromGlobalBudget: a retro is one LLM request and draws
+// from the SAME shared budget the in-game gate uses (#847 acceptance #7). When the
+// budget is exhausted, the retro is GATED: no agent.llm.retro span is emitted.
+func TestRetroCapture_DrawsFromGlobalBudget(t *testing.T) {
+	snap := retroFlagSnapshot()
+	snap.LLMGate = flags.LLMGate{MaxRequestsPerMinute: 1}
+
+	rc, sr := recordingRetro(t, snap)
+	budget := NewLLMBudget()
+	rc.SetLLMBudget(budget)
+	now := time.Unix(1000, 0)
+	rc.now = func() time.Time { return now }
+
+	// Pre-spend the single budget slot, mimicking an in-game LLM attempt this minute.
+	if !budget.allow(now, 1) {
+		t.Fatal("pre-spend of the single budget slot should succeed")
+	}
+
+	rc.OnGameEnd(endedSession())
+	if n := len(spansByName(sr.Ended(), SpanLLMRetro)); n != 0 {
+		t.Errorf("agent.llm.retro spans = %d, want 0 (budget exhausted, retro gated)", n)
+	}
+}
+
+// TestRetroCapture_CapturesWhenBudgetAvailable: with a budget wired and a free
+// slot, the retro captures normally AND consumes one budget slot.
+func TestRetroCapture_CapturesWhenBudgetAvailable(t *testing.T) {
+	snap := retroFlagSnapshot()
+	snap.LLMGate = flags.LLMGate{MaxRequestsPerMinute: 2}
+
+	rc, sr := recordingRetro(t, snap)
+	budget := NewLLMBudget()
+	rc.SetLLMBudget(budget)
+	now := time.Unix(1000, 0)
+	rc.now = func() time.Time { return now }
+
+	rc.OnGameEnd(endedSession())
+	if n := len(spansByName(sr.Ended(), SpanLLMRetro)); n != 1 {
+		t.Errorf("agent.llm.retro spans = %d, want 1 (budget available)", n)
+	}
+	// The retro consumed one of the two slots; only one remains.
+	if !budget.allow(now, 2) {
+		t.Error("one budget slot should remain after the retro")
+	}
+	if budget.allow(now, 2) {
+		t.Error("budget should be exhausted after retro + one more (cap 2)")
 	}
 }
 

--- a/services/agent/decision/telemetry.go
+++ b/services/agent/decision/telemetry.go
@@ -142,6 +142,23 @@ const (
 	// #741's resolve_backend() will supply the real reason (and used="llm") once a
 	// backend answers; until then every llm cycle reports this single reason.
 	FallbackNoBackend = "no_backend_available"
+	// LLM call-gate fallback reasons (#847). When the three-layer gate denies an
+	// llm cycle, the cycle falls back to the rules engine WITHOUT building or
+	// capturing the prompt, and the decision span's inference.fallback_reason
+	// carries the specific gate reason instead of FallbackNoBackend — every
+	// skipped LLM call is attributable in Jaeger. They are evaluated in order:
+	// eligibility, then cadence, then budget.
+	//
+	// FallbackNotEligible: the game's kind is not in llm.eligible_game_kinds (e.g.
+	// a shadow game under the default ["real"] list) — the cycle never even
+	// considers the cadence/budget layers.
+	FallbackNotEligible = "llm_not_eligible"
+	// FallbackInterval: the per-game cadence floor (llm.min_decision_interval_seconds)
+	// has not elapsed since this game's last admitted llm attempt.
+	FallbackInterval = "llm_interval"
+	// FallbackBudgetExhausted: the global per-minute request budget
+	// (llm.max_requests_per_minute, shared across all games) is full this window.
+	FallbackBudgetExhausted = "llm_budget_exhausted"
 	// DefaultObjectives until the objectives flag schema exists (#725).
 	DefaultObjectives = "unset"
 	// UnrestrictedAllowed is the interventions.allowed summary while the

--- a/services/agent/flags/flags.go
+++ b/services/agent/flags/flags.go
@@ -36,6 +36,14 @@ const (
 	keyMovementVarianceWindow    = "policy.movement_variance_window"
 	keyMaxInterventionsPerMinute = "policy.max_interventions_per_minute"
 
+	// LLM call gate (#847). The three-layer, flag-controlled gate in FRONT of
+	// every LLM decision attempt (#739), so the llm path can never burn tokens
+	// uncontrolled. All three are read EVERY cycle (never cached) so tightening
+	// the budget mid-session takes effect on the very next decision.
+	keyLLMEligibleGameKinds   = "llm.eligible_game_kinds"
+	keyLLMMinDecisionInterval = "llm.min_decision_interval_seconds"
+	keyLLMMaxRequestsPerMin   = "llm.max_requests_per_minute"
+
 	// Fitness thresholds (#731). The game-objective fitness flags.
 	keyEnduranceMinSessionSeconds  = "fitness.endurance.min_session_seconds"
 	keyBalancedMaxSkillGap         = "fitness.balanced.max_skill_gap"
@@ -77,6 +85,19 @@ const (
 	DefaultMovementVarianceWindow = 10
 	// DefaultMaxInterventionsPerMinute is the weighted per-minute budget.
 	DefaultMaxInterventionsPerMinute = 2
+
+	// LLM call-gate defaults (#847), mirroring the services/flagd/agent.json
+	// defaultVariants. These are the fail-closed safe values when flagd is
+	// unreachable: a missing control plane gates the llm path conservatively
+	// rather than letting it fire uncontrolled.
+
+	// DefaultLLMMinDecisionIntervalSeconds is the per-game cadence floor: at most
+	// one LLM attempt per game per this interval (llm.min_decision_interval_seconds).
+	DefaultLLMMinDecisionIntervalSeconds = 10.0
+	// DefaultLLMMaxRequestsPerMinute is the GLOBAL per-minute request cap across
+	// ALL games combined (llm.max_requests_per_minute). Each admitted LLM attempt
+	// is one request; defaults to 6/min total regardless of game count.
+	DefaultLLMMaxRequestsPerMinute = 6
 
 	// Fitness threshold defaults (#731), mirroring the services/flagd/agent.json
 	// defaultVariants. Applied when flagd is unreachable or a flag is undefined.
@@ -135,6 +156,16 @@ func defaultObjectives() map[string]float64 {
 	return map[string]float64{"endurance": 1.0}
 }
 
+// defaultLLMEligibleGameKinds is the fallback eligibility list for the LLM gate
+// (#847). Returned as a fresh slice each call so callers can never mutate the
+// shared default. Fail-closed here means defaulting to ["real"] — shadow games
+// stay rules-only (#838) — NOT empty: an empty list would also be safe (it
+// disables llm entirely), but ["real"] matches the agent.json schema default and
+// keeps real games eligible when flagd is unreachable.
+func defaultLLMEligibleGameKinds() []string {
+	return []string{"real"}
+}
+
 // Evaluator is the subset of the OpenFeature client the wrapper needs. The real
 // flagd-backed *openfeature.Client satisfies it, as does a client built over the
 // in-memory provider in tests.
@@ -167,6 +198,46 @@ type Policy struct {
 	MovementVarianceWindow int
 	// MaxInterventionsPerMinute is the weighted per-minute dispatch budget.
 	MaxInterventionsPerMinute int
+}
+
+// LLMGate is the three-layer call gate in FRONT of every LLM decision attempt
+// (#847), evaluated EVERY cycle (never cached) so a mid-session tightening takes
+// effect on the next decision. The gate sits before the #739 prompt build/capture:
+// when it denies, the cycle records the layer's fallback_reason and does NOT burn
+// the (future) backend or even build the prompt. Layers are checked in order:
+//
+//	Eligibility — which game kinds may use llm at all (EligibleGameKinds)
+//	Cadence     — per-game floor between llm attempts (MinDecisionInterval)
+//	Budget      — global per-minute request cap across all games (MaxRequestsPerMinute)
+//
+// Eligibility lives in the snapshot but is enforced against GameContext.GameKind;
+// cadence is per-game state on the Loop; the budget is one shared limiter across
+// all loops (see decision/loopset.go + main.go wiring).
+type LLMGate struct {
+	// EligibleGameKinds is the set of GameContext.GameKind values that may use the
+	// llm path. A kind not in this list gates with llm_not_eligible. Default
+	// ["real"] keeps shadow games rules-only (#838).
+	EligibleGameKinds []string
+	// MinDecisionInterval is the per-game cadence floor: at most one LLM attempt
+	// per game per interval. A cycle within the interval of the game's last
+	// attempt gates with llm_interval. Default 10s.
+	MinDecisionInterval time.Duration
+	// MaxRequestsPerMinute is the GLOBAL request budget across all games combined.
+	// Each admitted attempt is one request; an attempt that would exceed the cap
+	// gates with llm_budget_exhausted. Default 6/min.
+	MaxRequestsPerMinute int
+}
+
+// EligibleFor reports whether the given game kind may use the llm path. An empty
+// eligibility list admits nothing (every kind gated) — the safe reading of an
+// explicitly-empty allow-list, symmetrical with InterventionsAllowed.
+func (g LLMGate) EligibleFor(gameKind string) bool {
+	for _, k := range g.EligibleGameKinds {
+		if k == gameKind {
+			return true
+		}
+	}
+	return false
 }
 
 // Fitness is the fitness-threshold half of the objective layer (#731): the
@@ -272,6 +343,9 @@ type Snapshot struct {
 	InterventionsAllowed []string
 	// Policy holds the numeric permission-layer constraints.
 	Policy Policy
+	// LLMGate holds the three-layer LLM call gate (#847): eligibility, per-game
+	// cadence, and the global per-minute request budget.
+	LLMGate LLMGate
 	// Fitness holds the per-objective fitness thresholds (#731).
 	Fitness Fitness
 	// BluetoothFitness holds the infrastructure fitness thresholds (#735).
@@ -321,6 +395,7 @@ func (f *Flags) Evaluate(ctx context.Context) Snapshot {
 			MovementVarianceWindow:    f.intFlag(ctx, keyMovementVarianceWindow, DefaultMovementVarianceWindow),
 			MaxInterventionsPerMinute: f.intFlag(ctx, keyMaxInterventionsPerMinute, DefaultMaxInterventionsPerMinute),
 		},
+		LLMGate: f.llmGate(ctx),
 		Fitness: Fitness{
 			EnduranceMinSessionSeconds:     f.intFlag(ctx, keyEnduranceMinSessionSeconds, DefaultEnduranceMinSessionSeconds),
 			BalancedMaxSkillGap:            f.floatFlag(ctx, keyBalancedMaxSkillGap, DefaultBalancedMaxSkillGap),
@@ -424,6 +499,42 @@ func (f *Flags) interventionsAllowed(ctx context.Context) []string {
 	if !ok {
 		f.log.Warn("flags.interventions_allowed had unexpected shape, blocking all", "value", raw)
 		return nil
+	}
+	return list
+}
+
+// llmGate resolves the three LLM-call-gate flags (#847) for one cycle. Each falls
+// back to its safe default on any error, so a down control plane gates the llm
+// path conservatively rather than firing uncontrolled.
+//
+// flagd gotcha: the numeric flags must use the TYPED getters. A numeric flag read
+// through ObjectValue resolves as a silent TYPE_MISMATCH default (the in-process
+// resolver returns the flag's typed value only via the matching getter), so the
+// interval goes through floatFlag (float seconds -> time.Duration, reusing the
+// durationFlag helper) and the budget through intFlag.
+func (f *Flags) llmGate(ctx context.Context) LLMGate {
+	return LLMGate{
+		EligibleGameKinds:    f.eligibleGameKinds(ctx),
+		MinDecisionInterval:  f.durationFlag(ctx, keyLLMMinDecisionInterval, DefaultLLMMinDecisionIntervalSeconds),
+		MaxRequestsPerMinute: f.intFlag(ctx, keyLLMMaxRequestsPerMin, DefaultLLMMaxRequestsPerMinute),
+	}
+}
+
+// eligibleGameKinds resolves the llm.eligible_game_kinds array into []string. The
+// flag's variants are JSON arrays, surfaced as []any of strings (same shape as
+// interventions_allowed). On any error or unparseable shape it falls back to the
+// default ["real"] — fail-closed to shadow-games-rules-only, NOT to empty, which
+// would disable llm entirely.
+func (f *Flags) eligibleGameKinds(ctx context.Context) []string {
+	raw, err := f.client.ObjectValue(ctx, keyLLMEligibleGameKinds, defaultLLMEligibleGameKinds(), openfeature.EvaluationContext{})
+	if err != nil {
+		f.log.Debug("flags.llm.eligible_game_kinds fell back to default", "error", err)
+		return defaultLLMEligibleGameKinds()
+	}
+	list, ok := toStringSlice(raw)
+	if !ok {
+		f.log.Warn("flags.llm.eligible_game_kinds had unexpected shape, using default", "value", raw)
+		return defaultLLMEligibleGameKinds()
 	}
 	return list
 }

--- a/services/agent/flags/flags_test.go
+++ b/services/agent/flags/flags_test.go
@@ -302,6 +302,83 @@ func TestEvaluate_UnexpectedObjectShapeFallsBack(t *testing.T) {
 	}
 }
 
+// TestEvaluate_LLMGate_FlagdShape: the three #847 gate flags resolve through the
+// typed getters into the LLMGate struct. eligible_game_kinds is an array object,
+// min_decision_interval_seconds is float seconds -> Duration, max_requests_per_minute
+// is an int.
+func TestEvaluate_LLMGate_FlagdShape(t *testing.T) {
+	stub := stubEvaluator{
+		objects: map[string]any{
+			keyLLMEligibleGameKinds: []any{"real", "shadow"},
+		},
+		floats: map[string]float64{keyLLMMinDecisionInterval: 30},
+		ints:   map[string]int64{keyLLMMaxRequestsPerMin: 12},
+	}
+	got := New(stub, nil).Evaluate(context.Background()).LLMGate
+	if !reflect.DeepEqual(got.EligibleGameKinds, []string{"real", "shadow"}) {
+		t.Errorf("EligibleGameKinds = %v, want [real shadow]", got.EligibleGameKinds)
+	}
+	if got.MinDecisionInterval != 30*time.Second {
+		t.Errorf("MinDecisionInterval = %v, want 30s", got.MinDecisionInterval)
+	}
+	if got.MaxRequestsPerMinute != 12 {
+		t.Errorf("MaxRequestsPerMinute = %d, want 12", got.MaxRequestsPerMinute)
+	}
+}
+
+// TestEvaluate_LLMGate_Defaults: with no flags defined, the gate falls back to the
+// fail-closed schema defaults — eligible only for ["real"], 10s cadence, 6/min.
+func TestEvaluate_LLMGate_Defaults(t *testing.T) {
+	got := New(stubEvaluator{}, nil).Evaluate(context.Background()).LLMGate
+	if !reflect.DeepEqual(got.EligibleGameKinds, []string{"real"}) {
+		t.Errorf("EligibleGameKinds = %v, want default [real]", got.EligibleGameKinds)
+	}
+	if got.MinDecisionInterval != time.Duration(DefaultLLMMinDecisionIntervalSeconds*float64(time.Second)) {
+		t.Errorf("MinDecisionInterval = %v, want %ds", got.MinDecisionInterval, int(DefaultLLMMinDecisionIntervalSeconds))
+	}
+	if got.MaxRequestsPerMinute != DefaultLLMMaxRequestsPerMinute {
+		t.Errorf("MaxRequestsPerMinute = %d, want %d", got.MaxRequestsPerMinute, DefaultLLMMaxRequestsPerMinute)
+	}
+}
+
+// TestEvaluate_LLMGate_BadEligibilityShapeFallsBack: an unparseable
+// eligible_game_kinds value falls back to ["real"], NOT empty (fail-closed to
+// shadow-rules-only, not to llm-disabled).
+func TestEvaluate_LLMGate_BadEligibilityShapeFallsBack(t *testing.T) {
+	stub := stubEvaluator{objects: map[string]any{
+		keyLLMEligibleGameKinds: map[string]any{"unexpected": true},
+	}}
+	got := New(stub, nil).Evaluate(context.Background()).LLMGate
+	if !reflect.DeepEqual(got.EligibleGameKinds, []string{"real"}) {
+		t.Errorf("EligibleGameKinds = %v, want default [real] on bad shape", got.EligibleGameKinds)
+	}
+}
+
+// TestLLMGate_EligibleFor: membership test, including the empty-list-admits-nothing
+// reading.
+func TestLLMGate_EligibleFor(t *testing.T) {
+	g := LLMGate{EligibleGameKinds: []string{"real"}}
+	if !g.EligibleFor("real") {
+		t.Error("EligibleFor(real) = false, want true")
+	}
+	if g.EligibleFor("shadow") {
+		t.Error("EligibleFor(shadow) = true, want false")
+	}
+	empty := LLMGate{}
+	if empty.EligibleFor("real") {
+		t.Error("empty eligibility list admitted a kind, want none admitted")
+	}
+}
+
+func TestDefaultLLMEligibleGameKindsIsCopied(t *testing.T) {
+	a := defaultLLMEligibleGameKinds()
+	a[0] = "mutated"
+	b := defaultLLMEligibleGameKinds()
+	if b[0] != "real" {
+		t.Errorf("defaultLLMEligibleGameKinds shared state: got %v", b[0])
+	}
+}
+
 func TestDefaultObjectivesIsCopied(t *testing.T) {
 	// Mutating one default must not leak into the next call's default.
 	a := defaultObjectives()

--- a/services/agent/main.go
+++ b/services/agent/main.go
@@ -253,6 +253,13 @@ func main() {
 	//     keyed by the decision's target), so one Writer is closed over by every loop.
 	//   - SHARED flag source (agentFlags) and tracer: stateless / concurrency-safe.
 	sharedSink := actionSink(logger) // nil leaves the loop's default NoopActions in place
+	// Shared GLOBAL LLM request budget (#847, the gate's third layer). Constructed
+	// ONCE here and injected into every per-game Loop below, so all concurrent
+	// games draw down a SINGLE per-minute request cap (llm.max_requests_per_minute)
+	// — 4 idle shadow games plus a real game can never collectively exceed it. The
+	// per-game cadence + eligibility layers live on each Loop; only the budget is
+	// shared across loops.
+	sharedLLMBudget := decision.NewLLMBudget()
 	probeDecisions := strings.EqualFold(getEnv("AGENT_PROBE_DECISIONS", ""), "true")
 	if probeDecisions {
 		slog.Warn("Probe decisions enabled (demo/verification mode)",
@@ -266,6 +273,10 @@ func main() {
 		// Throttle for the evaluate log line / agent.disabled span is read-at-startup
 		// from decision.throttle_seconds (#766 F5).
 		loop.SetThrottle(lifecycle.DecisionThrottle)
+		// Inject the SHARED global LLM request budget (#847) so every per-game loop
+		// references the same instance: the gate's eligibility + cadence layers are
+		// per-loop, but the budget layer is one global cap across all games.
+		loop.SetLLMBudget(sharedLLMBudget)
 		// The objective-weighted rules engine (#726) is the active default, built
 		// FRESH per loop (see the factory doc above). Its objective weights are driven
 		// live from the `objectives` flag each cycle; policy/fitness run on
@@ -331,6 +342,10 @@ func main() {
 	// coordinator; it dedupes by SessionID across all partitions, so interleaved
 	// game-ends each capture exactly once (see retro_capture.go's bounded dedupe).
 	retro := decision.NewRetroCoordinator(agentFlags, logger)
+	// A retrospective is one LLM request, so it draws from the SAME shared global
+	// budget the in-game gate uses (#847 acceptance #7): inject the one instance the
+	// per-game loops also hold, so a retro at game end cannot blow the per-minute cap.
+	retro.SetLLMBudget(sharedLLMBudget)
 
 	// GameContext multiplexer (#845 PR B): one Store partition per game_id, plus the
 	// fallback partition "" for unlabeled signals (zero-regression — single-game

--- a/services/flagd/agent.json
+++ b/services/flagd/agent.json
@@ -140,6 +140,33 @@
       },
       "defaultVariant": "default"
     },
+    "llm.eligible_game_kinds": {
+      "state": "ENABLED",
+      "variants": {
+        "none": [],
+        "real_only": ["real"],
+        "real_and_shadow": ["real", "shadow"]
+      },
+      "defaultVariant": "real_only"
+    },
+    "llm.min_decision_interval_seconds": {
+      "state": "ENABLED",
+      "variants": {
+        "fast": 5,
+        "default": 10,
+        "slow": 30
+      },
+      "defaultVariant": "default"
+    },
+    "llm.max_requests_per_minute": {
+      "state": "ENABLED",
+      "variants": {
+        "conservative": 3,
+        "default": 6,
+        "aggressive": 12
+      },
+      "defaultVariant": "default"
+    },
     "fitness.endurance.min_session_seconds": {
       "state": "ENABLED",
       "variants": {


### PR DESCRIPTION
Part of #847. Adds a three-layer, flag-controlled gate in FRONT of every LLM decision attempt (#739), so the future llm path can never burn tokens uncontrolled. Prerequisite of #739.

## Scope

A gate evaluated EVERY cycle (never cached), in this exact order, all flagd-driven and hot-reloaded:

| Layer | Flag (`agent.json`) | Default | fallback_reason when gated |
|---|---|---|---|
| Eligibility | `llm.eligible_game_kinds` | `["real"]` | `llm_not_eligible` |
| Cadence (per game) | `llm.min_decision_interval_seconds` | `10` | `llm_interval` |
| Global budget | `llm.max_requests_per_minute` | `6` | `llm_budget_exhausted` |

- **Gate DENIED**: the cycle does NOT build/capture the prompt (no token burn, no serialization), records the specific reason on the decision span's `inference.fallback_reason`, and increments `agent_llm_gated_total{reason=...}`. The rules engine still runs (the gate only guards the LLM *attempt*).
- **Gate ALLOWED**: unchanged behavior — capture prompt -> rules fallback with `no_backend_available`.
- The per-cycle resolved fallback reason now flows onto the decision span via a new `LayerState.LLMFallbackReason` field (replacing the static `inferenceAttribution` for mode=`llm`); mode=`rules` is unchanged.

### Wiring
- New `llmBudget` (global, sliding 1-min window, mutex-guarded, unit-cost-per-request) mirrors `decision/ratelimit.go`. Constructed ONCE in `main.go` and injected into every per-game `Loop` (and the retro coordinator) via `SetLLMBudget`, so all concurrent games share one cap.
- Per-game cadence (`lastLLMAttempt`) lives on the `Loop`.
- New `flags.LLMGate` struct populated in `Flags.Evaluate`; numeric flags use the typed getters (float seconds -> Duration, int budget); eligibility array uses `ObjectValue`/`toStringSlice`, fail-closed to `["real"]`.
- New `agent_llm_gated_total` counter (no-op default so existing Loop tests need no wiring).
- **#844 retrospective** is one LLM request and now draws from the SAME shared global budget; an exhausted budget at game end gates the retro (no span).

## Acceptance criteria

- [x] No LLM attempt without passing eligibility -> cadence -> budget, in order
- [x] Shadow games produce zero LLM attempts with default flags (`TestGate_ShadowGameNotEligible`)
- [x] 4 concurrent eligible games never exceed `max_requests_per_minute` combined (`TestGate_SharedBudgetAcrossLoops`)
- [x] Every gated decision carries the correct `inference.fallback_reason` (`TestGate_*`)
- [x] Flags hot-reload: tightening the budget mid-session takes effect next decision (`TestGate_BudgetHotReload`)
- [x] Gate state observable: `agent_llm_gated_total{reason=...}` increments per gated cycle
- [x] Retro draws from the same global budget (`TestRetroCapture_DrawsFromGlobalBudget`)

## Out of scope (per #847, not built)
Significance-triggered escalation; the real LLM backend call (#739); prompt variants (#740).

## Verification
`gofmt -l .` clean, `go vet ./...`, `go build ./...`, `go test -race ./...` all green from `services/agent/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)