### PR TITLE
fix(game-coordinator): restore natural music tempo on override revert (#922)

### DIFF
--- a/services/game_coordinator/difficulty_handlers.py
+++ b/services/game_coordinator/difficulty_handlers.py
@@ -7,7 +7,9 @@ intervention flags against the InterventionManager registry built in PR A:
 - ``music_tempo_override``        — N6: the music loop adopts the override tempo
   and suspends its own speed-up/slow-down schedule (resolves the E1 tempo race
   in docs/research/722-intervention-surface.md §3.1); reverting to none (0)
-  resumes the natural schedule from the current state.
+  resumes the natural schedule from the current state via an explicit revert
+  handler (#922 — the manager routes reverts to ``_revert_handlers``, not back to
+  the apply-handler, so the override must be cleared there).
 - ``global_sensitivity_override`` — N2: live update of ``game.sensitivity``,
   consumed next frame by ``_compute_effective_thresholds``; reverting to none
   (-1) restores the sensitivity the game started with.
@@ -73,6 +75,25 @@ async def handle_music_tempo_override(ctx: InterventionContext) -> None:
     else:
         game.tempo_override = None
         logger.info("music_tempo_override: override cleared, natural schedule resumes")
+
+
+async def handle_music_tempo_override_revert(ctx: InterventionContext) -> None:
+    """Clear the music-tempo override when the flag reverts to neutral (0).
+
+    The apply-handler already clears ``game.tempo_override`` for a 0 value, but
+    the manager routes none-value transitions to ``_revert_handlers`` rather than
+    re-invoking the apply-handler, so without this entry a revert would leave
+    ``game.tempo_override`` pinned at the last override and the music loop stuck
+    at that tempo until the game restarts. This restores ``None`` so
+    ``_check_music_speed`` resumes the natural speed-up/slow-down schedule on its
+    next tick.
+    """
+    game = ctx.game
+    if game is None:
+        logger.debug("music_tempo_override: no live game on revert, ignoring")
+        return
+    game.tempo_override = None
+    logger.info("music_tempo_override: reverted, natural schedule resumes")
 
 
 async def handle_global_sensitivity_override(ctx: InterventionContext) -> None:
@@ -234,6 +255,13 @@ def register_difficulty_handlers(manager: InterventionManager) -> None:
     per-flag so the parallel ambience PR (E) appends rather than conflicts.
     """
     manager.register_handler("music_tempo_override", handle_music_tempo_override)
+    # music_tempo_override needs an explicit revert handler (#922): the manager
+    # routes a flag's revert-to-neutral (value 0) to _revert_handlers, NOT back
+    # to the apply-handler, so the apply-handler's "value 0 -> clear" branch never
+    # runs on revert. Without this entry game.tempo_override stays pinned at the
+    # last override and the music loop (_check_music_speed re-reads it every tick)
+    # is stuck at that tempo until the game restarts.
+    manager._revert_handlers["music_tempo_override"] = handle_music_tempo_override_revert
     manager.register_handler("global_sensitivity_override", handle_global_sensitivity_override)
     # player_sensitivity_factor needs the manager (for the reusable targeting
     # helper), so bind it via a small closure.

--- a/services/game_coordinator/interventions.py
+++ b/services/game_coordinator/interventions.py
@@ -439,6 +439,16 @@ class InterventionManager:
         # Optional per-flag handlers run when a state-shaped flag reverts to its
         # neutral value (e.g. volume_override -> default game volume). Additive;
         # absence means "do nothing on revert" (the default for all flags).
+        #
+        # IMPORTANT (#922): a revert-to-neutral is routed HERE, not back to the
+        # flag's apply-handler. So a state flag that mutates live game state on
+        # apply MUST register a revert handler to undo it — the apply-handler's
+        # own "neutral value" branch is never reached on revert. music_tempo_override
+        # is a concrete example: its apply-handler clears game.tempo_override for a
+        # 0 value, but that branch only runs when the value CHANGES TO a non-neutral
+        # value and back via a separate apply; on a genuine revert the dedicated
+        # handle_music_tempo_override_revert (registered in difficulty_handlers.py)
+        # is what actually resets the override.
         self._revert_handlers: dict[str, Handler] = {}
 
         self._lock = threading.RLock()

--- a/services/game_coordinator/tests/test_difficulty_interventions.py
+++ b/services/game_coordinator/tests/test_difficulty_interventions.py
@@ -37,6 +37,7 @@ from lib.types import GameEvent, Sensitivity
 from services.game_coordinator.difficulty_handlers import (
     handle_global_sensitivity_override,
     handle_music_tempo_override,
+    handle_music_tempo_override_revert,
     handle_player_sensitivity_factor,
     register_difficulty_handlers,
 )
@@ -191,6 +192,18 @@ class TestMusicTempoOverride:
         game.change_time = 0.0
         await game._check_music_speed()
         game.audio_client.ChangeTempo.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_revert_handler_clears_override(self):
+        """The dedicated revert handler (#922) clears a stuck override."""
+        game = make_game()
+        game.tempo_override = 1.3
+        await handle_music_tempo_override_revert(make_ctx("music_tempo_override", 0, game))
+        assert game.tempo_override is None
+
+    @pytest.mark.asyncio
+    async def test_revert_handler_no_live_game_is_noop(self):
+        await handle_music_tempo_override_revert(make_ctx("music_tempo_override", 0, None))  # no raise
 
     @pytest.mark.asyncio
     async def test_no_live_game_is_noop(self):
@@ -371,6 +384,9 @@ class TestRegistration:
         assert mgr._handlers["global_sensitivity_override"] is handle_global_sensitivity_override
         # player_sensitivity_factor is bound via closure (not identity-equal).
         assert callable(mgr._handlers["player_sensitivity_factor"])
+        # #922: music_tempo_override needs an explicit revert handler (the manager
+        # routes reverts to _revert_handlers, not back to the apply-handler).
+        assert mgr._revert_handlers["music_tempo_override"] is handle_music_tempo_override_revert
 
     @pytest.mark.asyncio
     @patch("services.game_coordinator.metrics.interventions_total")
@@ -398,6 +414,50 @@ class TestRegistration:
 
         assert game.tempo_override == pytest.approx(1.15)
         assert any(e[0] == GameEvent.AGENT_INTERVENTION and e[1]["blocked"] == "false" for e in events)
+
+    @pytest.mark.asyncio
+    @patch("services.game_coordinator.metrics.interventions_total")
+    async def test_revert_to_neutral_restores_natural_tempo_via_chain(self, _metric):
+        """Acceptance (#922): apply music_tempo_override, then revert the flag to
+        neutral (0) through the manager, and assert the override is cleared so the
+        natural music schedule resumes.
+
+        This exercises the real revert path: the manager routes a revert-to-neutral
+        to ``_revert_handlers``, NOT back to the apply-handler, so without the
+        registered revert handler ``game.tempo_override`` would stay pinned at the
+        override and the music loop would be stuck at that tempo.
+        """
+        game = make_game()
+        events = []
+
+        async def publisher(event_type, data):
+            events.append((event_type, data))
+
+        mgr = InterventionManager(event_publisher=publisher, get_game=lambda: game)
+        mgr._interventions_client = _ScalarFlagClient({"music_tempo_override": 0})
+        mgr._agent_client = _AllowAllAgent()
+        register_difficulty_handlers(mgr)
+        mgr._prime_baseline()
+
+        primary = SessionView(game_id="", game=game, publish=publisher)
+
+        # Apply the override.
+        mgr._interventions_client.values["music_tempo_override"] = 1.15
+        await mgr._evaluate_one(_spec("music_tempo_override"), primary)
+        assert game.tempo_override == pytest.approx(1.15)
+
+        # Revert the flag to its neutral value (0).
+        mgr._interventions_client.values["music_tempo_override"] = 0
+        await mgr._evaluate_one(_spec("music_tempo_override"), primary)
+
+        # Override cleared: the music loop resumes its natural schedule next tick.
+        assert game.tempo_override is None
+
+        # Confirm the schedule actually runs again: force a scheduled change due.
+        game.audio_client.ChangeTempo.reset_mock()
+        game.change_time = 0.0
+        await game._check_music_speed()
+        game.audio_client.ChangeTempo.assert_called_once()
 
 
 class _ScalarFlagClient:


### PR DESCRIPTION
## Finding: revert was BROKEN (not implicit)

Issue #922 asked whether `music_tempo_override` needs an explicit revert handler or relies on an implicit revert. **Verification shows the revert was broken**, not implicit.

### Trace
- The music loop (`games/base.py::_check_music_speed`, called every 100ms by `_music_loop`) **does re-read `game.tempo_override` each tick**:
  - non-`None` → adopt override tempo, suspend schedule (early `return`).
  - `None` → fall through to the natural speed-up/slow-down schedule.
- So clearing `game.tempo_override` to `None` is exactly what resumes the natural schedule.
- **BUT** the apply-handler that clears it is never invoked on revert. In `interventions.py::_evaluate_one`, when a state flag changes to its `none_value` (0 for `music_tempo_override`), the code routes to `_revert_handlers[flag_key]` — it does **NOT** re-invoke the apply-handler. `music_tempo_override` had no `_revert_handlers` entry, so `game.tempo_override` stayed pinned at the last override and the music loop was **stuck at that tempo until game restart**.

The apply-handler's `value == 0 → clear` branch (`difficulty_handlers.py:74`) only ever runs when the flag changes *to* a non-neutral value and back through a fresh apply — never on a genuine revert-to-neutral.

This mirrors exactly how `volume_override`, `global_difficulty_factor`, and `pacing_profile` each register a dedicated revert handler.

## Changes
- Add `handle_music_tempo_override_revert` (clears `game.tempo_override`) and register it in `_revert_handlers["music_tempo_override"]` (`difficulty_handlers.py`).
- Document the `_revert_handlers` contract in `interventions.py` (revert-to-neutral is routed here, not to the apply-handler) and update the module docstring.
- Tests (`test_difficulty_interventions.py`):
  - unit test for the revert handler (clears override; no-op without a live game).
  - **acceptance test**: apply `music_tempo_override` via the chain, revert the flag to neutral (0) through `_evaluate_one`, assert `game.tempo_override` is cleared and the natural schedule resumes (`ChangeTempo` fires once when due).
  - registration test asserts the revert handler is wired.

## Verification of the test
Temporarily removing the new registration makes the end-to-end test fail (`tempo_override` stuck at 1.15), confirming the test catches the original bug.

## Results
- `uv run --extra test pytest tests/test_difficulty_interventions.py` → 24 passed.
- Full intervention suite (4 files) → 96 passed.
- `make lint` → all checks passed.

Closes #922

🤖 Generated with [Claude Code](https://claude.com/claude-code)