### PR TITLE
feat(lib): flag-evaluation fallback visibility — WARN + flag_eval_errors_total (#921)

### DIFF
--- a/lib/feature_flags.py
+++ b/lib/feature_flags.py
@@ -24,9 +24,35 @@ from openfeature.contrib.hook.opentelemetry import TracingHook
 from openfeature.contrib.provider.flagd import FlagdProvider
 from openfeature.contrib.provider.flagd.config import ResolverType
 from openfeature.evaluation_context import EvaluationContext
+from openfeature.flag_evaluation import FlagEvaluationDetails, Reason
 from openfeature.transaction_context import ContextVarsTransactionContextPropagator
 
+from lib.flag_eval_visibility import record_flag_fallback
+
 logger = logging.getLogger(__name__)
+
+
+def _report_details_error(flag_key: str, details: FlagEvaluationDetails) -> bool:
+    """Surface a non-raising error resolution and report it if present.
+
+    OpenFeature's ``get_*_details`` never raises for a resolution error
+    (TYPE_MISMATCH, FLAG_NOT_FOUND, PROVIDER_NOT_READY, ...): it returns the
+    default value with ``reason == Reason.ERROR`` and a populated
+    ``error_code``. The old value-only getters could not see these, so they
+    surfaced as silent defaults (#921). Returns True when an error reason was
+    found (and reported via :func:`record_flag_fallback`).
+    """
+    if details.reason == Reason.ERROR:
+        error_code = getattr(details.error_code, "value", None) or str(details.error_code or "ERROR")
+        record_flag_fallback(flag_key, error_code, details.error_message or "")
+        return True
+    return False
+
+
+def _report_exception(flag_key: str, exc: Exception) -> None:
+    """Report a raised evaluation exception as a fallback, classified by type."""
+    record_flag_fallback(flag_key, type(exc).__name__, str(exc))
+
 
 # Track initialized domains to avoid re-initialization
 _initialized_domains: set[str] = set()
@@ -218,11 +244,14 @@ def read_object_flag(domain: str, flag_key: str, default: dict, game_id: str | N
     try:
         init_flag_domain(domain)
         client = get_flag_client(domain)
-        value = client.get_object_value(flag_key, default, _calibration_context(game_id))
-        # get_object_value may return the default sentinel itself; either is fine.
+        details = client.get_object_details(flag_key, default, _calibration_context(game_id))
+        if _report_details_error(flag_key, details):
+            return default
+        value = details.value
+        # The resolved value may still be the default sentinel; either is fine.
         return value if isinstance(value, dict) else default
     except Exception as e:
-        logger.warning(f"read_object_flag({domain!r}, {flag_key!r}) failed, using default: {e}")
+        _report_exception(flag_key, e)
         return default
 
 
@@ -249,10 +278,13 @@ def read_object_flag_variant(domain: str, flag_key: str, targeting_key: str, def
     try:
         init_flag_domain(domain)
         client = get_flag_client(domain)
-        value = client.get_object_value(flag_key, default, EvaluationContext(targeting_key=targeting_key))
+        details = client.get_object_details(flag_key, default, EvaluationContext(targeting_key=targeting_key))
+        if _report_details_error(flag_key, details):
+            return default
+        value = details.value
         return value if isinstance(value, dict) else default
     except Exception as e:
-        logger.warning(f"read_object_flag_variant({domain!r}, {flag_key!r}, {targeting_key!r}) failed: {e}")
+        _report_exception(flag_key, e)
         return default
 
 
@@ -285,13 +317,16 @@ def read_float_flag(domain: str, flag_key: str, default: float, game_id: str | N
         # resolver returns TYPE_MISMATCH for get_object_value() on a numeric
         # flag, silently dropping every calibration override to its default
         # (e.g. the tournament/fight_club CI variants never took effect, #903).
-        value = client.get_float_value(flag_key, default, _calibration_context(game_id))
+        details = client.get_float_details(flag_key, default, _calibration_context(game_id))
+        if _report_details_error(flag_key, details):
+            return default
+        value = details.value
         # bool is a subclass of int/float; reject it as a numeric flag value.
         if isinstance(value, bool) or not isinstance(value, (int, float)):
             return default
         return float(value)
     except Exception as e:
-        logger.warning(f"read_float_flag({domain!r}, {flag_key!r}) failed, using default: {e}")
+        _report_exception(flag_key, e)
         return default
 
 
@@ -317,10 +352,13 @@ def read_string_flag(domain: str, flag_key: str, default: str) -> str:
     try:
         init_flag_domain(domain)
         client = get_flag_client(domain)
-        value = client.get_string_value(flag_key, default, EvaluationContext())
+        details = client.get_string_details(flag_key, default, EvaluationContext())
+        if _report_details_error(flag_key, details):
+            return default
+        value = details.value
         return value if isinstance(value, str) else default
     except Exception as e:
-        logger.warning(f"read_string_flag({domain!r}, {flag_key!r}) failed, using default: {e}")
+        _report_exception(flag_key, e)
         return default
 
 
@@ -350,7 +388,10 @@ def read_int_flag(domain: str, flag_key: str, default: int, game_id: str | None 
         # silently falling back to the default (#903). Read as a float first so
         # whole-number variants stored as floats (e.g. 2.0) still resolve, then
         # apply the integral-only coercion below.
-        value = client.get_float_value(flag_key, float(default), _calibration_context(game_id))
+        details = client.get_float_details(flag_key, float(default), _calibration_context(game_id))
+        if _report_details_error(flag_key, details):
+            return default
+        value = details.value
         if isinstance(value, bool):
             return default
         if isinstance(value, int):
@@ -359,7 +400,7 @@ def read_int_flag(domain: str, flag_key: str, default: int, game_id: str | None 
             return int(value)
         return default
     except Exception as e:
-        logger.warning(f"read_int_flag({domain!r}, {flag_key!r}) failed, using default: {e}")
+        _report_exception(flag_key, e)
         return default
 
 

--- a/lib/flag_eval_visibility.py
+++ b/lib/flag_eval_visibility.py
@@ -1,0 +1,120 @@
+"""Visibility for feature-flag evaluation fallbacks (Issue #921).
+
+The typed getters in :mod:`lib.feature_flags` return a hardcoded default on
+*any* failure. Two failure shapes are easy to miss:
+
+1. **Raised exceptions** — provider init blew up, network died, etc. These are
+   caught by ``except Exception`` in the getters.
+2. **Silent error reasons** — OpenFeature's ``get_*_value`` convenience methods
+   never raise; a TYPE_MISMATCH on a numeric flag, a top-level LIST flag read
+   over the RPC resolver, or a protobuf gencode mismatch all come back as the
+   *default value* with ``reason == Reason.ERROR`` and a populated
+   ``error_code``. The old code only inspected the returned value, so these
+   surfaced as mysteriously-default behavior ("silent-defaults failure mode").
+
+This module gives both shapes a single visible treatment:
+
+* a WARN log, **rate-limited to once per (flag_key, reason)** so a hot read
+  loop cannot spam the log, and
+* a ``flag_eval_errors_total{flag_key, reason}`` counter (via
+  :mod:`lib.otel_metrics`, per the metrics conventions) so a dashboard/alert
+  can see the rate within seconds.
+
+**Startup grace:** during normal startup the provider is briefly not READY, so
+``PROVIDER_NOT_READY`` (and the closely related ``PROVIDER_FATAL`` while the
+in-process engine is still loading) are *expected* and must not produce WARN
+spam or trip an alert. We suppress logging+metrics for those reasons for a
+short grace window measured from first import of this module (process start).
+After the window, a still-not-ready provider is a real problem and becomes
+visible like any other fallback.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from threading import Lock
+
+from lib.otel_metrics import Counter
+
+logger = logging.getLogger(__name__)
+
+# flag_eval_errors_total{flag_key, reason}: every fallback to a default that was
+# caused by an error (raised exception OR error-reason resolution) bumps this.
+# `reason` classifies the failure: an OpenFeature ErrorCode (TYPE_MISMATCH,
+# FLAG_NOT_FOUND, PROVIDER_NOT_READY, ...) or an exception class name.
+flag_eval_errors_total = Counter(
+    "flag_eval_errors_total",
+    "Feature-flag evaluations that fell back to their default due to an error",
+    labelnames=["flag_key", "reason"],
+)
+
+# Grace window (seconds) from process start during which provider-not-ready
+# style failures are treated as normal startup races: no WARN, no metric.
+# Overridable via env so an operator can widen it on a slow host.
+_STARTUP_GRACE_SECONDS = float(os.environ.get("FLAG_EVAL_STARTUP_GRACE_SECONDS", "15"))
+
+# Monotonic timestamp of module import ~= process start.
+_PROCESS_START = time.monotonic()
+
+# Error reasons considered "still warming up" and therefore suppressed during
+# the startup grace window only.
+_STARTUP_GRACE_REASONS = frozenset({"PROVIDER_NOT_READY", "PROVIDER_FATAL"})
+
+# Remembered (flag_key, reason) pairs already warned about, so each distinct
+# failure logs at WARN exactly once for the life of the process. The counter
+# still increments every time, so rate/alerting is unaffected.
+_warned_keys: set[tuple[str, str]] = set()
+_warned_lock = Lock()
+
+
+def _in_startup_grace() -> bool:
+    """True while we are still inside the post-start grace window."""
+    return (time.monotonic() - _PROCESS_START) < _STARTUP_GRACE_SECONDS
+
+
+def reset_for_tests() -> None:
+    """Reset the once-per-key warn memory. Test-only helper."""
+    with _warned_lock:
+        _warned_keys.clear()
+
+
+def record_flag_fallback(flag_key: str, reason: str, detail: str = "") -> None:
+    """Record that a flag evaluation fell back to its default due to an error.
+
+    Increments ``flag_eval_errors_total{flag_key, reason}`` and emits a WARN log
+    the first time each ``(flag_key, reason)`` pair is seen. Provider-not-ready
+    style reasons are suppressed entirely (no log, no metric) while inside the
+    startup grace window, so normal startup races stay quiet.
+
+    Args:
+        flag_key: The flag whose evaluation fell back to its default.
+        reason: A short classification — an OpenFeature ErrorCode value
+            (e.g. ``"TYPE_MISMATCH"``) or an exception class name
+            (e.g. ``"RuntimeError"``).
+        detail: Optional human-readable detail appended to the WARN log only.
+    """
+    # Swallow startup races: a not-ready provider during the grace window is
+    # expected and must not warn or feed the alert.
+    if reason in _STARTUP_GRACE_REASONS and _in_startup_grace():
+        logger.debug("flag '%s' fallback during startup grace (reason=%s); suppressed", flag_key, reason)
+        return
+
+    flag_eval_errors_total.labels(flag_key=flag_key, reason=reason).inc()
+
+    key = (flag_key, reason)
+    with _warned_lock:
+        already_warned = key in _warned_keys
+        if not already_warned:
+            _warned_keys.add(key)
+
+    if not already_warned:
+        suffix = f": {detail}" if detail else ""
+        logger.warning(
+            "Feature flag '%s' fell back to its default (reason=%s)%s. "
+            "This is logged once per (flag_key, reason); see flag_eval_errors_total for the rate.",
+            flag_key,
+            reason,
+            suffix,
+        )

--- a/lib/otel_metrics.py
+++ b/lib/otel_metrics.py
@@ -26,7 +26,7 @@ import os
 import time
 from collections.abc import Sequence
 from contextlib import contextmanager
-from threading import Lock
+from threading import Lock, RLock
 from typing import Any
 
 from opentelemetry import metrics
@@ -42,7 +42,16 @@ logger = logging.getLogger(__name__)
 _meter: metrics.Meter | None = None
 _initialized = False
 _pending_metrics: list[LabeledMetric] = []
-_init_lock = Lock()
+# Reentrant: init_metrics() holds this lock while it lazily reads the export
+# interval from flagd, and that import chain (lib.feature_flags ->
+# lib.flag_eval_visibility) can construct a module-level Counter, which calls
+# _register_pending() and re-acquires this same lock on the same thread (#921).
+# A plain Lock would self-deadlock — observed as audio hanging before its gRPC
+# server bound :50056 and failing its healthcheck. RLock makes that nested
+# acquire safe; the re-entered _register_pending sees _initialized is still
+# False (set only after the interval read returns) and queues the Counter into
+# _pending_metrics, which init_metrics then initializes once the meter exists.
+_init_lock = RLock()
 _test_mode = False
 
 

--- a/lib/tests/conftest.py
+++ b/lib/tests/conftest.py
@@ -1,0 +1,9 @@
+"""Shared test fixtures for lib unit tests.
+
+Disables OTEL telemetry and metrics so unit tests never attempt OTLP exports
+(see .claude/rules/development.md).
+"""
+
+from lib.otel_metrics import disable_metrics_for_tests
+
+disable_metrics_for_tests()

--- a/lib/tests/test_feature_flags.py
+++ b/lib/tests/test_feature_flags.py
@@ -15,16 +15,24 @@ from lib.feature_flags import (
 )
 
 
+def _ok_details(value):
+    """Build a successful FlagEvaluationDetails carrying ``value``."""
+    from openfeature.flag_evaluation import FlagEvaluationDetails, Reason
+
+    return FlagEvaluationDetails(flag_key="k", value=value, reason=Reason.STATIC)
+
+
 def _mock_flag_value(value):
     """Patch init/get_flag_client so the domain client returns ``value``.
 
-    Numeric flags are read via the typed ``get_float_value`` getter (#903:
+    Numeric flags are read via the typed ``get_float_details`` getter (#903:
     ``get_object_value`` is TYPE_MISMATCH for numbers under the flagd RPC
-    resolver); the post-read type checks remain as defense-in-depth, so the
-    mock still feeds arbitrary values through the float getter.
+    resolver; #921 switched to the ``_details`` API to surface those reasons);
+    the post-read type checks remain as defense-in-depth, so the mock still
+    feeds arbitrary values through the float getter.
     """
     client = MagicMock()
-    client.get_float_value.return_value = value
+    client.get_float_details.return_value = _ok_details(value)
     return (
         patch("lib.feature_flags.init_flag_domain"),
         patch("lib.feature_flags.get_flag_client", return_value=client),
@@ -76,9 +84,9 @@ def test_read_int_flag_fails_safe_on_exception():
 
 
 def _mock_string_flag_value(value):
-    """Patch init/get_flag_client so the client's get_string_value returns ``value``."""
+    """Patch init/get_flag_client so the client's get_string_details returns ``value``."""
     client = MagicMock()
-    client.get_string_value.return_value = value
+    client.get_string_details.return_value = _ok_details(value)
     return (
         patch("lib.feature_flags.init_flag_domain"),
         patch("lib.feature_flags.get_flag_client", return_value=client),
@@ -329,12 +337,13 @@ class _GameIdAwareClient:
         self.experiment_value = experiment_value
         self.seen_contexts = []
 
-    def get_object_value(self, _key, default, ctx):
+    def get_object_details(self, _key, default, ctx):
+        from openfeature.flag_evaluation import FlagEvaluationDetails, Reason
+
         self.seen_contexts.append(ctx)
         attrs = getattr(ctx, "attributes", None) or {}
-        if attrs.get("gameId") == self.experiment_id:
-            return self.experiment_value
-        return self.baseline
+        value = self.experiment_value if attrs.get("gameId") == self.experiment_id else self.baseline
+        return FlagEvaluationDetails(flag_key=_key, value=value, reason=Reason.STATIC)
 
 
 def _mock_client(client):
@@ -377,19 +386,162 @@ def test_read_object_flag_targeted_variant_for_matching_game():
 
 def test_read_float_flag_threads_gameid_context():
     client = MagicMock()
-    client.get_float_value.return_value = 4.0
+    client.get_float_details.return_value = _ok_details(4.0)
     init_p, get_p = _mock_client(client)
     with init_p, get_p:
         assert read_float_flag("game", "death_grace_period_seconds", 1.0, game_id="game_x") == 4.0
-    ctx = client.get_float_value.call_args[0][2]
+    ctx = client.get_float_details.call_args[0][2]
     assert ctx.attributes["gameId"] == "game_x"
 
 
 def test_read_int_flag_threads_gameid_context():
     client = MagicMock()
-    client.get_float_value.return_value = 3
+    client.get_float_details.return_value = _ok_details(3)
     init_p, get_p = _mock_client(client)
     with init_p, get_p:
         assert read_int_flag("game", "zombie.initial_count", 1, game_id="game_y") == 3
-    ctx = client.get_float_value.call_args[0][2]
+    ctx = client.get_float_details.call_args[0][2]
     assert ctx.attributes["gameId"] == "game_y"
+
+
+# --------------------------------------------------------------------------- #
+# Flag-evaluation fallback visibility (#921): WARN + flag_eval_errors_total
+# --------------------------------------------------------------------------- #
+import pytest  # noqa: E402
+
+import lib.flag_eval_visibility as vis  # noqa: E402
+
+
+@pytest.fixture
+def fresh_visibility():
+    """Reset the once-per-key warn memory and force us out of startup grace."""
+    vis.reset_for_tests()
+    # Push process-start far enough back that the grace window has elapsed, so
+    # provider-not-ready style reasons are NOT suppressed by default.
+    original = vis._PROCESS_START
+    vis._PROCESS_START = original - (vis._STARTUP_GRACE_SECONDS + 100)
+    yield
+    vis._PROCESS_START = original
+    vis.reset_for_tests()
+
+
+def _error_details(error_code, value):
+    """Build a FlagEvaluationDetails carrying a non-raising error resolution."""
+    from openfeature.flag_evaluation import FlagEvaluationDetails, Reason
+
+    return FlagEvaluationDetails(
+        flag_key="k",
+        value=value,
+        reason=Reason.ERROR,
+        error_code=error_code,
+        error_message="boom",
+    )
+
+
+def _mock_float_details(details):
+    client = MagicMock()
+    client.get_float_details.return_value = details
+    return (
+        patch("lib.feature_flags.init_flag_domain"),
+        patch("lib.feature_flags.get_flag_client", return_value=client),
+    )
+
+
+def test_type_mismatch_is_visible_and_counted(fresh_visibility):  # noqa: ARG001 - fixture dependency
+    """A non-raising TYPE_MISMATCH resolution -> default, WARN, counter bump."""
+    from openfeature.exception import ErrorCode
+
+    init_p, get_p = _mock_float_details(_error_details(ErrorCode.TYPE_MISMATCH, 1.0))
+    with patch("lib.feature_flags.record_flag_fallback") as rec, init_p, get_p:
+        assert read_float_flag("game", "death_grace_period_seconds", 1.0) == 1.0
+    rec.assert_called_once()
+    assert rec.call_args[0][0] == "death_grace_period_seconds"
+    assert rec.call_args[0][1] == "TYPE_MISMATCH"
+
+
+def test_exception_is_reported_with_type_name(fresh_visibility):  # noqa: ARG001 - fixture dependency
+    with (
+        patch("lib.feature_flags.init_flag_domain", side_effect=RuntimeError("nope")),
+        patch("lib.feature_flags.record_flag_fallback") as rec,
+    ):
+        assert read_float_flag("game", "k", 2.5) == 2.5
+    rec.assert_called_once()
+    assert rec.call_args[0][0] == "k"
+    assert rec.call_args[0][1] == "RuntimeError"
+
+
+def test_record_warns_once_per_key_but_counts_every_time(fresh_visibility):  # noqa: ARG001 - fixture dependency
+    with (
+        patch("lib.flag_eval_visibility.flag_eval_errors_total") as counter,
+        patch.object(vis.logger, "warning") as warn,
+    ):
+        vis.record_flag_fallback("flagA", "TYPE_MISMATCH")
+        vis.record_flag_fallback("flagA", "TYPE_MISMATCH")
+        vis.record_flag_fallback("flagA", "TYPE_MISMATCH")
+    # WARN exactly once for the repeated (flag, reason) pair...
+    assert warn.call_count == 1
+    # ...but the counter increments on every call.
+    assert counter.labels.call_count == 3
+    counter.labels.assert_called_with(flag_key="flagA", reason="TYPE_MISMATCH")
+
+
+def test_record_warns_again_for_different_reason(fresh_visibility):  # noqa: ARG001 - fixture dependency
+    with (
+        patch("lib.flag_eval_visibility.flag_eval_errors_total"),
+        patch.object(vis.logger, "warning") as warn,
+    ):
+        vis.record_flag_fallback("flagA", "TYPE_MISMATCH")
+        vis.record_flag_fallback("flagA", "FLAG_NOT_FOUND")
+    assert warn.call_count == 2
+
+
+def test_startup_grace_suppresses_provider_not_ready():
+    """Within the grace window, PROVIDER_NOT_READY must not warn or count."""
+    vis.reset_for_tests()
+    # Force "just started": process start = now.
+    original = vis._PROCESS_START
+    import time as _time
+
+    vis._PROCESS_START = _time.monotonic()
+    try:
+        with (
+            patch("lib.flag_eval_visibility.flag_eval_errors_total") as counter,
+            patch.object(vis.logger, "warning") as warn,
+        ):
+            vis.record_flag_fallback("flagX", "PROVIDER_NOT_READY")
+        warn.assert_not_called()
+        counter.labels.assert_not_called()
+    finally:
+        vis._PROCESS_START = original
+        vis.reset_for_tests()
+
+
+def test_startup_grace_does_not_suppress_after_window(fresh_visibility):  # noqa: ARG001 - fixture dependency
+    """After the grace window, PROVIDER_NOT_READY becomes a real, visible error."""
+    with (
+        patch("lib.flag_eval_visibility.flag_eval_errors_total") as counter,
+        patch.object(vis.logger, "warning") as warn,
+    ):
+        vis.record_flag_fallback("flagX", "PROVIDER_NOT_READY")
+    warn.assert_called_once()
+    counter.labels.assert_called_once_with(flag_key="flagX", reason="PROVIDER_NOT_READY")
+
+
+def test_grace_window_never_suppresses_type_mismatch():
+    """TYPE_MISMATCH is a real bug even during startup; never suppressed."""
+    vis.reset_for_tests()
+    original = vis._PROCESS_START
+    import time as _time
+
+    vis._PROCESS_START = _time.monotonic()  # just started
+    try:
+        with (
+            patch("lib.flag_eval_visibility.flag_eval_errors_total") as counter,
+            patch.object(vis.logger, "warning") as warn,
+        ):
+            vis.record_flag_fallback("flagY", "TYPE_MISMATCH")
+        warn.assert_called_once()
+        counter.labels.assert_called_once()
+    finally:
+        vis._PROCESS_START = original
+        vis.reset_for_tests()

--- a/lib/tests/test_otel_metrics.py
+++ b/lib/tests/test_otel_metrics.py
@@ -334,6 +334,45 @@ class TestInitMetricsWithMock:
         assert gauge._instrument_initialized is True
         assert counter._instrument_initialized is True
 
+    @patch("lib.otel_metrics.OTLPMetricExporter")
+    @patch("lib.otel_metrics.PeriodicExportingMetricReader")
+    @patch("lib.otel_metrics.MeterProvider")
+    @patch("lib.otel_metrics.metrics")
+    def test_init_metrics_metric_created_during_init_does_not_deadlock(
+        self, mock_metrics, mock_provider, mock_reader, mock_exporter
+    ):
+        """A metric constructed *while* init_metrics holds the init lock must not deadlock.
+
+        Regression for #921: when ``export_interval_ms`` is None, init_metrics()
+        reads the interval from flagd while holding ``_init_lock``. That read
+        imports ``lib.feature_flags`` -> ``lib.flag_eval_visibility``, whose
+        module-level ``flag_eval_errors_total = Counter(...)`` calls
+        ``_register_pending()`` and re-acquires the same lock on the same
+        thread. With a plain Lock this self-deadlocked and audio hung before
+        binding its gRPC port; ``_init_lock`` must be reentrant.
+        """
+        mock_meter = MagicMock()
+        mock_metrics.get_meter.return_value = mock_meter
+
+        created: list[otel_metrics.Counter] = []
+
+        def make_metric_during_init(_service_name):
+            # Mirror the real side effect: a module-level Counter is constructed
+            # during the in-lock interval read, re-entering _register_pending.
+            created.append(otel_metrics.Counter("created_during_init_total", "Test", ["reason"]))
+            return 1000
+
+        with patch.object(otel_metrics, "_get_export_interval_ms", side_effect=make_metric_during_init):
+            # export_interval_ms=None forces the flagd read path that re-enters the lock.
+            # If the lock were non-reentrant this call would hang forever.
+            otel_metrics.init_metrics(export_interval_ms=None)
+
+        assert otel_metrics._initialized is True
+        # The metric created mid-init must have been picked up and initialized.
+        assert len(created) == 1
+        assert created[0]._instrument_initialized is True
+        assert len(otel_metrics._pending_metrics) == 0
+
 
 class TestMetricNoLabels:
     """Tests for metrics without labels."""

--- a/services/grafana/dashboards/feature-flags.json
+++ b/services/grafana/dashboards/feature-flags.json
@@ -450,6 +450,212 @@
         }
       ],
       "type": "table"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 24
+      },
+      "id": 10,
+      "panels": [],
+      "title": "Evaluation Fallbacks (#921)",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Rate at which feature flags fall back to their hardcoded default due to an error (TYPE_MISMATCH, PARSE_ERROR, PROVIDER_NOT_READY, exception, ...). Sustained nonzero means overrides are being silently ignored.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0.001
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 25
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (flag_key, reason) (rate(flag_eval_errors_total[1m]))",
+          "legendFormat": "{{flag_key}} ({{reason}})",
+          "refId": "A"
+        }
+      ],
+      "title": "Flag Fallback Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Total fallback count per (flag_key, reason) since process start.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Fallbacks"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 25
+      },
+      "id": 12,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "11.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (flag_key, reason) (flag_eval_errors_total)",
+          "format": "table",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Flag Fallback Counts",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "indexByName": {},
+            "renameByName": {
+              "flag_key": "Flag Key",
+              "reason": "Reason"
+            }
+          }
+        }
+      ],
+      "type": "table"
     }
   ],
   "refresh": "5s",

--- a/services/prometheus/alerts.yml
+++ b/services/prometheus/alerts.yml
@@ -124,6 +124,21 @@ groups:
           summary: "Intervention handlers are failing"
           description: "Dispatched intervention handlers raised at {{ $value }}/s for 2+ minutes (block_reason=handler_error)."
 
+      # Feature-flag evaluation visibility (#921)
+      - alert: FlagEvaluationFallbacks
+        expr: sum by (flag_key, reason) (rate(flag_eval_errors_total[5m])) > 0
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Feature flag '{{ $labels.flag_key }}' falling back to default ({{ $labels.reason }})"
+          description: >-
+            Flag '{{ $labels.flag_key }}' has been resolving to its hardcoded default at
+            {{ $value }}/s for 5+ minutes (reason={{ $labels.reason }}). A TYPE_MISMATCH or
+            PARSE_ERROR means a flag/getter type mismatch; a sustained PROVIDER_NOT_READY past
+            the startup grace window means the flagd provider is unreachable. Overrides are
+            being silently ignored.
+
       - alert: AgentInterventionWriteFailures
         expr: sum(rate(agent_intervention_writes_total{result="error"}[5m])) > 0
         for: 2m


### PR DESCRIPTION
Closes #921.

## Problem
The typed getters in `lib/feature_flags.py` returned their hardcoded default on **any** failure. Critically, OpenFeature's `get_*_value` convenience methods **never raise** — a TYPE_MISMATCH on a numeric flag, a top-level LIST flag read over the RPC resolver, or a protobuf gencode mismatch all come back as the *default value* with `reason=ERROR` + an `error_code`. The old `except Exception` path could not see those, so they manifested as a "silent-defaults failure mode" (overrides mysteriously ignored, no log, no metric).

## Changes
**`lib/feature_flags.py`**
- Switched every reader (`read_object_flag`, `read_object_flag_variant`, `read_float_flag`, `read_int_flag`, `read_string_flag`) from `get_*_value` to `get_*_details`, so error *reasons* are observable (not just raised exceptions). Behavior is unchanged on the happy path; defaults are still returned on error.
- Both error shapes — a `Reason.ERROR` resolution **and** a raised exception — are routed through `record_flag_fallback`.

**`lib/flag_eval_visibility.py` (new)**
- `flag_eval_errors_total{flag_key, reason}` counter via `lib.otel_metrics` (per the metrics conventions; `_total` suffix). `reason` is the OpenFeature `ErrorCode` (e.g. `TYPE_MISMATCH`, `FLAG_NOT_FOUND`, `PROVIDER_NOT_READY`) or the exception class name.
- WARN log **rate-limited to once per `(flag_key, reason)`** for the life of the process, so a hot read loop cannot spam the log. The counter still increments on every fallback, so the rate/alert is unaffected.
- **Startup grace:** `PROVIDER_NOT_READY` / `PROVIDER_FATAL` are suppressed entirely (no WARN, no metric) for a window after process start (default 15s, `FLAG_EVAL_STARTUP_GRACE_SECONDS`), so normal startup races stay quiet. `TYPE_MISMATCH` and other config errors are **never** suppressed.

**Observability**
- `services/grafana/dashboards/feature-flags.json`: new "Evaluation Fallbacks" row — a rate timeseries and a totals table over `flag_eval_errors_total`. A TYPE_MISMATCH is visible on the dashboard within seconds.
- `services/prometheus/alerts.yml`: `FlagEvaluationFallbacks` warns on a sustained nonzero rate (`for: 5m`). Startup races are suppressed at the source, so it does not fire on normal startup.

**Tests** (`lib/tests/test_feature_flags.py`, +`conftest.py`)
- TYPE_MISMATCH (non-raising error resolution) is detected, returns the default, and reports the right `(flag_key, reason)`.
- Exceptions are classified by type name.
- WARN logs exactly once per `(flag_key, reason)` while the counter increments on every call; a different reason re-warns.
- Startup grace suppresses `PROVIDER_NOT_READY` within the window, surfaces it after, and never suppresses `TYPE_MISMATCH`.
- Existing getter tests migrated to the `_details` mock API.

## Test results
- `lib`: 354 passed (30 in `test_feature_flags.py`).
- `game_coordinator` flag suites (threshold/duration/music-window/F6): 80 passed (confirms the lib refactor doesn't disturb callers that patch the `read_*_flag` helpers).
- `make lint`: clean. `alerts.yml` and dashboard JSON validated.

## Acceptance criteria
- ✅ A TYPE_MISMATCH in any service is visible at WARN and on a dashboard within seconds.
- ✅ No alert/log noise during normal startup races (provider-not-ready grace window).

## Deferred — Go agent parity (follow-up)
The issue notes "same treatment in the Go agent flag provider for parity" as secondary. Deferred: the Go `*Value` API in `services/agent/flags/flags.go` **already returns an error** on TYPE_MISMATCH (so the acute silent-defaults problem is Python-specific), and full parity would require plumbing a new OTEL counter through the agent's metrics setup, rate-limited logging, a grace window, and touching ~6 accessor methods + Go tests — a separate, non-trivial change. Recommend a dedicated follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)