### PR TITLE
fix(agent): interventions.json corruption recovery — detect, self-heal, alert (#924)

### DIFF
--- a/docs/agent-act-runbook.md
+++ b/docs/agent-act-runbook.md
@@ -271,6 +271,74 @@ budget is too low for the demo. Raise `policy.max_interventions_per_minute` to
 
 ---
 
+## Recovery — interventions file corruption (#924)
+
+The agent applies decisions by an **in-place** read-modify-write of
+`/etc/flagd/interventions.json` (no temp+rename — rename triggers EBUSY on the
+docker bind mount flagd watches). A crash, an out-of-disk, or a concurrent
+truncation mid-write can leave **invalid JSON**. flagd then rejects the *whole*
+flag set and every intervention **silently falls back to its default** — no
+write error is raised, so the legacy `agent_intervention_writes_total{result="error"}`
+alert does **not** catch a previously-poisoned file.
+
+### Built-in self-heal (automatic, no operator action)
+
+The agent repairs corruption on its own:
+
+1. **Validate-after-write** — after each write, the agent re-reads and re-parses
+   the file. If it no longer parses, the agent **restores the last-known-good
+   snapshot** (the bytes it read at the top of that write cycle, which parsed)
+   in place, and the `Apply` records `result=error`.
+2. **Startup self-heal** — on agent start (when `AGENT_INTERVENTIONS_ENABLED=true`),
+   the agent validates the file and, if it is missing or unparseable, writes a
+   **neutral document** (every flag at its neutral `defaultVariant`, empty
+   targeting, no agent-driven variants — embedded in the agent binary, so it is
+   always a complete, valid schema with no game effect).
+
+Both paths increment **`agent_intervention_file_corruption_total{phase=write|startup}`**
+and log `agent.intervention_file_corrupt` (with `phase`, `path`, the parse
+`error`, and the `action` taken).
+
+### Signal & alert
+
+> **Why an agent-side counter, not a flagd metric?** flagd (scraped on
+> `flagd:8014`) surfaces config-source **parse failures via logs only** — it
+> exposes no scrapable sync/parse-failure counter. The agent, by contrast,
+> *detects and heals* the corruption directly, so an agent-side counter is the
+> fast, reliable, test-coverable signal.
+
+Alert: **`AgentInterventionFileCorruption`** (`services/prometheus/alerts.yml`,
+severity `critical`) fires immediately on any increase of
+`agent_intervention_file_corruption_total`. A single corruption already defaults
+every intervention until healed, so it pages without a `for:` delay.
+
+### When the alert fires
+
+1. **Confirm it self-healed.** The agent log shows `agent.intervention_file_corrupt`
+   followed by the restore. Check the file parses:
+   ```bash
+   docker compose exec flagd sh -c 'cat /etc/flagd/interventions.json' | python3 -m json.tool >/dev/null && echo OK
+   ```
+   flagd hot-reloads the repaired file within ~100 ms–1 s; interventions resume.
+2. **If it keeps firing** the underlying cause persists (agent crash-looping
+   mid-write, disk full, or an external writer racing the agent — the agent must
+   be the *sole* writer). Check `df -h` on the host, `docker compose logs agent`
+   for restart loops, and confirm nothing else writes the bind-mounted file.
+3. **Manual restore (last resort).** Re-seed the file from the canonical schema
+   in the repo and restart the agent (which re-validates on startup):
+   ```bash
+   cp services/flagd/interventions.json /path/to/bind-mount/interventions.json
+   docker compose up -d --no-deps agent
+   ```
+   The neutral document the agent writes is byte-identical to
+   `services/flagd/interventions.json`, so this just makes the heal explicit.
+
+The corruption is recovered automatically; the alert exists so an operator
+**investigates the root cause** (why did a write get poisoned?), not so they have
+to hand-repair the file.
+
+---
+
 ## See also
 
 - [Agent README](../services/agent/README.md) — four-layer model, span schema, action sink

--- a/services/agent/actions/heal.go
+++ b/services/agent/actions/heal.go
@@ -1,0 +1,72 @@
+package actions
+
+import (
+	"context"
+	_ "embed"
+	"errors"
+	"fmt"
+	"os"
+)
+
+// neutralInterventions is the canonical, fully-neutral interventions document
+// (every flag at its neutral defaultVariant, empty targeting, no agent-driven
+// "active" variants). It is a byte-for-byte copy of services/flagd/
+// interventions.json and is the self-heal target when the on-disk file is found
+// unparseable. Embedding it means the agent can always restore a VALID, complete
+// schema with no game effect even when the on-disk file has been poisoned and no
+// last-known-good is in memory (e.g. corrupt before the first write).
+//
+//go:embed neutral_interventions.json
+var neutralInterventions []byte
+
+// NeutralDocument returns a copy of the embedded neutral interventions document.
+// Exposed for tests asserting the self-heal target is valid.
+func NeutralDocument() []byte {
+	out := make([]byte, len(neutralInterventions))
+	copy(out, neutralInterventions)
+	return out
+}
+
+// HealIfCorrupt validates the interventions file at startup and self-heals it to
+// the neutral document if it is missing or unparseable (#924). A poisoned file
+// makes flagd reject the whole flag set, silently falling EVERY intervention back
+// to its safe default — so the agent proactively repairs it before its first
+// write rather than waiting for an operator.
+//
+// It returns:
+//   - healed=false, err=nil   when the file already parses (no action taken);
+//   - healed=true,  err=nil   when a corrupt/missing file was replaced with the
+//     neutral document and agent_intervention_file_corruption_total{phase=
+//     "startup"} was incremented;
+//   - healed=false, err!=nil  when the file is corrupt AND the neutral write
+//     itself failed (the agent should still start — log and continue).
+//
+// Safe for concurrent use; it takes the same mutex the write path uses.
+func (w *Writer) HealIfCorrupt(ctx context.Context) (healed bool, err error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	raw, readErr := os.ReadFile(w.path)
+	if readErr == nil {
+		_, readErr = parseDoc(raw)
+		if readErr == nil {
+			return false, nil // already valid; leave any operator/agent state intact
+		}
+	} else if !errors.Is(readErr, os.ErrNotExist) {
+		// A read error other than "missing" (e.g. permission) is not something we
+		// can heal by writing; surface it so startup can log and continue.
+		return false, fmt.Errorf("read interventions file %q for startup validation: %w", w.path, readErr)
+	}
+
+	w.recordCorruption(ctx, phaseStartup)
+	w.log.Error("agent.intervention_file_corrupt",
+		"phase", phaseStartup,
+		"path", w.path,
+		"error", readErr,
+		"action", "writing neutral document")
+
+	if werr := w.writeInPlace(NeutralDocument()); werr != nil {
+		return false, fmt.Errorf("self-heal interventions file %q: %w", w.path, werr)
+	}
+	return true, nil
+}

--- a/services/agent/actions/heal_test.go
+++ b/services/agent/actions/heal_test.go
@@ -1,0 +1,170 @@
+package actions
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/joustmania/agent/decision"
+)
+
+// parses reports whether the file at path is a valid interventions document.
+func parses(t *testing.T, path string) bool {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %q: %v", path, err)
+	}
+	_, err = parseDoc(raw)
+	return err == nil
+}
+
+// TestNeutralDocument_IsValid asserts the embedded self-heal target parses and
+// carries every flag the writer drives, so a heal never produces a half-schema.
+func TestNeutralDocument_IsValid(t *testing.T) {
+	doc, err := parseDoc(NeutralDocument())
+	if err != nil {
+		t.Fatalf("embedded neutral document does not parse: %v", err)
+	}
+	for _, key := range []string{
+		flagMusicTempoOverride, flagGlobalSensitivityOverride,
+		flagPlayerSensitivityFactor, flagShieldSeconds, flagVolumeOverride,
+		flagGlobalDifficultyFactor, flagPacingProfile, flagEliminatePlayer,
+		flagRevivePlayer, flagAudioCue, flagControllerEffect, flagEndGame,
+	} {
+		if _, err := doc.flag(key); err != nil {
+			t.Errorf("neutral document missing flag %q: %v", key, err)
+		}
+	}
+}
+
+// TestValidateAfterWrite_RestoresLastKnownGood is the core chaos case: the file
+// on disk is poisoned (truncated) after a write, and validate-after-write
+// restores the last-known-good bytes and increments the corruption counter
+// (phase=write).
+func TestValidateAfterWrite_RestoresLastKnownGood(t *testing.T) {
+	w, path, reader := newMeteredWriter(t)
+
+	// lastGood is the pristine fixture currently on disk (it parses).
+	lastGood, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+
+	// Simulate a crash/concurrent truncation between write and re-read.
+	if err := os.WriteFile(path, []byte(`{"flags": `), 0o644); err != nil {
+		t.Fatalf("truncate file: %v", err)
+	}
+	if parses(t, path) {
+		t.Fatal("precondition: truncated file should not parse")
+	}
+
+	verr := w.validateAfterWrite(lastGood)
+	if verr == nil {
+		t.Fatal("validateAfterWrite returned nil, want corruption error")
+	}
+	if !parses(t, path) {
+		t.Fatal("file still corrupt after validateAfterWrite; last-known-good not restored")
+	}
+
+	got := corruptionByPhase(t, reader)
+	if got[phaseWrite] != 1 {
+		t.Errorf("corruption{phase=write} = %d, want 1", got[phaseWrite])
+	}
+}
+
+// TestApply_ProducesValidFile is the happy path: a normal Apply leaves the file
+// parseable and records no corruption.
+func TestApply_ProducesValidFile(t *testing.T) {
+	w, path, reader := newMeteredWriter(t)
+
+	if err := w.Apply(context.Background(), decision.Decision{
+		Intervention: decision.InterventionAdjustMusicTempo,
+	}); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if !parses(t, path) {
+		t.Fatal("file does not parse after a normal Apply")
+	}
+	if got := corruptionByPhase(t, reader); len(got) != 0 {
+		t.Errorf("unexpected corruption recorded on happy path: %v", got)
+	}
+}
+
+// TestHealIfCorrupt_TruncatedFile is the startup chaos case: the file is
+// truncated before the agent starts; HealIfCorrupt restores a valid neutral
+// document and increments the corruption counter (phase=startup).
+func TestHealIfCorrupt_TruncatedFile(t *testing.T) {
+	w, path, reader := newMeteredWriter(t)
+
+	if err := os.WriteFile(path, []byte("{ this is not json"), 0o644); err != nil {
+		t.Fatalf("truncate file: %v", err)
+	}
+
+	healed, err := w.HealIfCorrupt(context.Background())
+	if err != nil {
+		t.Fatalf("HealIfCorrupt: %v", err)
+	}
+	if !healed {
+		t.Fatal("HealIfCorrupt reported healed=false, want true for corrupt file")
+	}
+	if !parses(t, path) {
+		t.Fatal("file still corrupt after HealIfCorrupt")
+	}
+	if got := corruptionByPhase(t, reader); got[phaseStartup] != 1 {
+		t.Errorf("corruption{phase=startup} = %d, want 1", got[phaseStartup])
+	}
+}
+
+// TestHealIfCorrupt_ValidFileIsNoop asserts a valid file is left untouched and no
+// corruption is recorded (the agent must not clobber operator/agent state).
+func TestHealIfCorrupt_ValidFileIsNoop(t *testing.T) {
+	w, path, reader := newMeteredWriter(t)
+
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+
+	healed, err := w.HealIfCorrupt(context.Background())
+	if err != nil {
+		t.Fatalf("HealIfCorrupt: %v", err)
+	}
+	if healed {
+		t.Fatal("HealIfCorrupt healed a valid file; want no-op")
+	}
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read after: %v", err)
+	}
+	if string(before) != string(after) {
+		t.Error("HealIfCorrupt mutated a valid file")
+	}
+	if got := corruptionByPhase(t, reader); len(got) != 0 {
+		t.Errorf("unexpected corruption recorded on valid file: %v", got)
+	}
+}
+
+// TestHealIfCorrupt_MissingFile heals a missing file to the neutral document
+// (the bind mount could be empty on a fresh deploy).
+func TestHealIfCorrupt_MissingFile(t *testing.T) {
+	w, path, reader := newMeteredWriter(t)
+
+	if err := os.Remove(path); err != nil {
+		t.Fatalf("remove file: %v", err)
+	}
+
+	healed, err := w.HealIfCorrupt(context.Background())
+	if err != nil {
+		t.Fatalf("HealIfCorrupt: %v", err)
+	}
+	if !healed {
+		t.Fatal("HealIfCorrupt did not heal a missing file")
+	}
+	if !parses(t, path) {
+		t.Fatal("missing file not restored to a valid document")
+	}
+	if got := corruptionByPhase(t, reader); got[phaseStartup] != 1 {
+		t.Errorf("corruption{phase=startup} = %d, want 1", got[phaseStartup])
+	}
+}

--- a/services/agent/actions/metrics_test.go
+++ b/services/agent/actions/metrics_test.go
@@ -32,12 +32,41 @@ func newMeteredWriter(t *testing.T) (*Writer, string, *metric.ManualReader) {
 	mp := metric.NewMeterProvider(metric.WithReader(reader))
 
 	w := &Writer{
-		path:   path,
-		log:    slog.New(slog.NewTextHandler(os.Stderr, nil)),
-		nonce:  newNonceGen(),
-		writes: newWritesCounter(mp),
+		path:       path,
+		log:        slog.New(slog.NewTextHandler(os.Stderr, nil)),
+		nonce:      newNonceGen(),
+		writes:     newWritesCounter(mp),
+		corruption: newCorruptionCounter(mp),
 	}
 	return w, path, reader
+}
+
+// corruptionByPhase collects the manual reader and returns a phase->value map for
+// the agent_intervention_file_corruption_total counter (empty when not yet
+// recorded).
+func corruptionByPhase(t *testing.T, reader *metric.ManualReader) map[string]int64 {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("collect metrics: %v", err)
+	}
+	out := map[string]int64{}
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != "agent_intervention_file_corruption_total" {
+				continue
+			}
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			if !ok {
+				t.Fatalf("expected Sum[int64], got %T", m.Data)
+			}
+			for _, dp := range sum.DataPoints {
+				phase, _ := dp.Attributes.Value("phase")
+				out[phase.AsString()] = dp.Value
+			}
+		}
+	}
+	return out
 }
 
 // writesByResult collects the manual reader and returns a result->value map for

--- a/services/agent/actions/neutral_interventions.json
+++ b/services/agent/actions/neutral_interventions.json
@@ -1,0 +1,116 @@
+{
+  "metadata": {
+    "flagSetId": "interventions"
+  },
+  "flags": {
+    "music_tempo_override": {
+      "state": "ENABLED",
+      "variants": {
+        "none": 0,
+        "slow": 1.0,
+        "medium": 1.15,
+        "fast": 1.3
+      },
+      "defaultVariant": "none"
+    },
+    "global_sensitivity_override": {
+      "state": "ENABLED",
+      "variants": {
+        "none": -1,
+        "ultra_slow": 0,
+        "slow": 1,
+        "medium": 2,
+        "fast": 3,
+        "ultra_fast": 4
+      },
+      "defaultVariant": "none"
+    },
+    "player_sensitivity_factor": {
+      "state": "ENABLED",
+      "variants": {
+        "default": 1.0,
+        "protect": 0.7,
+        "handicap": 1.5
+      },
+      "defaultVariant": "default",
+      "targeting": {}
+    },
+    "shield_seconds": {
+      "state": "ENABLED",
+      "variants": {
+        "none": 0,
+        "short": 3,
+        "default": 5,
+        "long": 10
+      },
+      "defaultVariant": "none",
+      "targeting": {}
+    },
+    "volume_override": {
+      "state": "ENABLED",
+      "variants": {
+        "none": -1,
+        "quiet": 0.3,
+        "normal": 0.7,
+        "loud": 1.0
+      },
+      "defaultVariant": "none"
+    },
+    "global_difficulty_factor": {
+      "state": "ENABLED",
+      "variants": {
+        "default": 1.0,
+        "easier": 0.5,
+        "easy": 0.75,
+        "hard": 1.5,
+        "harder": 2.0
+      },
+      "defaultVariant": "default"
+    },
+    "pacing_profile": {
+      "state": "ENABLED",
+      "variants": {
+        "none": "none",
+        "default": "default",
+        "calm": "calm",
+        "frantic": "frantic"
+      },
+      "defaultVariant": "none"
+    },
+    "eliminate_player": {
+      "state": "ENABLED",
+      "variants": {
+        "none": ""
+      },
+      "defaultVariant": "none"
+    },
+    "revive_player": {
+      "state": "ENABLED",
+      "variants": {
+        "none": ""
+      },
+      "defaultVariant": "none"
+    },
+    "audio_cue": {
+      "state": "ENABLED",
+      "variants": {
+        "none": ""
+      },
+      "defaultVariant": "none"
+    },
+    "controller_effect": {
+      "state": "ENABLED",
+      "variants": {
+        "none": ""
+      },
+      "defaultVariant": "none"
+    },
+    "end_game": {
+      "state": "ENABLED",
+      "variants": {
+        "none": ""
+      },
+      "defaultVariant": "none"
+    }
+  }
+}

--- a/services/agent/actions/writer.go
+++ b/services/agent/actions/writer.go
@@ -81,6 +81,15 @@ const (
 	resultError = "error"
 )
 
+// Phase label values for agent_intervention_file_corruption_total. A poisoned
+// interventions file is detected either after a write (validate-after-write) or
+// at agent startup (self-heal). Cardinality is bounded to these two values per
+// .claude/rules/development.md.
+const (
+	phaseWrite   = "write"
+	phaseStartup = "startup"
+)
+
 // Per-intervention defaults used when a Decision carries no explicit Value. The
 // rules engine (#726) leaves Value empty today, so these are the contract.
 const (
@@ -107,6 +116,13 @@ type Writer struct {
 	// no-op recorder until initMetrics wires the OTLP exporter.
 	writes otelmetric.Int64Counter
 
+	// corruption counts detected-and-healed interventions-file corruptions
+	// (agent_intervention_file_corruption_total), labeled phase=write|startup.
+	// Incremented when a post-write re-parse fails (last-known-good restored) or
+	// when startup validation finds an unparseable file (neutral document
+	// written). Same no-op-until-wired semantics as writes.
+	corruption otelmetric.Int64Counter
+
 	mu sync.Mutex
 }
 
@@ -119,11 +135,13 @@ func NewWriter(path string, log *slog.Logger) *Writer {
 	if log == nil {
 		log = slog.Default()
 	}
+	mp := otel.GetMeterProvider()
 	return &Writer{
-		path:   path,
-		log:    log,
-		nonce:  newNonceGen(),
-		writes: newWritesCounter(otel.GetMeterProvider()),
+		path:       path,
+		log:        log,
+		nonce:      newNonceGen(),
+		writes:     newWritesCounter(mp),
+		corruption: newCorruptionCounter(mp),
 	}
 }
 
@@ -139,6 +157,20 @@ func newWritesCounter(mp otelmetric.MeterProvider) otelmetric.Int64Counter {
 		// Int64Counter only errors on bad config; fall back to a no-op so callers
 		// never have to nil-check.
 		c, _ = metricnoop.NewMeterProvider().Meter(meterName).Int64Counter("agent_intervention_writes_total")
+	}
+	return c
+}
+
+// newCorruptionCounter builds the agent_intervention_file_corruption_total
+// counter from the given meter provider. An instrument-creation error yields a
+// no-op counter so the Writer always has a usable instrument.
+func newCorruptionCounter(mp otelmetric.MeterProvider) otelmetric.Int64Counter {
+	c, err := mp.Meter(meterName).Int64Counter(
+		"agent_intervention_file_corruption_total",
+		otelmetric.WithDescription("Total interventions-file corruptions detected and self-healed by the agent, labeled by phase (write|startup)"),
+	)
+	if err != nil {
+		c, _ = metricnoop.NewMeterProvider().Meter(meterName).Int64Counter("agent_intervention_file_corruption_total")
 	}
 	return c
 }
@@ -174,8 +206,26 @@ func (w *Writer) recordWrite(ctx context.Context, result string) {
 	w.writes.Add(ctx, 1, otelmetric.WithAttributes(attribute.String("result", result)))
 }
 
+// recordCorruption increments agent_intervention_file_corruption_total for one
+// detected-and-healed corruption in the given phase (write|startup). The counter
+// is nil only in hand-built test Writers that never reach a corruption path; the
+// nil guard keeps those panic-free.
+func (w *Writer) recordCorruption(ctx context.Context, phase string) {
+	if w.corruption == nil {
+		return
+	}
+	w.corruption.Add(ctx, 1, otelmetric.WithAttributes(attribute.String("phase", phase)))
+}
+
 // edit runs one read-modify-write cycle under the process mutex: read the file,
-// apply fn to the order-preserving document, and write it back in place.
+// apply fn to the order-preserving document, write it back in place, then
+// VALIDATE the write by re-parsing the on-disk bytes. If the file no longer
+// parses (a crash or concurrent truncation poisoned it between write and
+// re-read, or our own marshal somehow produced invalid JSON), the last-known-good
+// snapshot — the `raw` bytes we read at the top of this cycle, which parsed
+// successfully — is restored in place, the corruption counter is incremented,
+// and the original parse error is returned. This keeps flagd from ingesting a
+// poisoned file and falling all interventions back to defaults silently (#924).
 func (w *Writer) edit(fn func(*orderedDoc) error) error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
@@ -195,7 +245,35 @@ func (w *Writer) edit(fn func(*orderedDoc) error) error {
 	if err != nil {
 		return err
 	}
-	return w.writeInPlace(out)
+	if err := w.writeInPlace(out); err != nil {
+		return err
+	}
+	return w.validateAfterWrite(raw)
+}
+
+// validateAfterWrite re-reads and re-parses the file just written. On success it
+// returns nil. On failure it restores lastGood (the pre-edit bytes, known to
+// parse), increments agent_intervention_file_corruption_total{phase="write"},
+// logs, and returns the parse error so Apply records result=error. A failure to
+// restore is itself returned (the caller already holds w.mu).
+func (w *Writer) validateAfterWrite(lastGood []byte) error {
+	back, err := os.ReadFile(w.path)
+	if err == nil {
+		_, err = parseDoc(back)
+		if err == nil {
+			return nil // write produced valid JSON
+		}
+	}
+	w.recordCorruption(context.Background(), phaseWrite)
+	w.log.Error("agent.intervention_file_corrupt",
+		"phase", phaseWrite,
+		"path", w.path,
+		"error", err,
+		"action", "restoring last-known-good")
+	if rerr := w.writeInPlace(lastGood); rerr != nil {
+		return fmt.Errorf("interventions file corrupt after write and restore failed: %w (original: %v)", rerr, err)
+	}
+	return fmt.Errorf("interventions file corrupt after write, restored last-known-good: %w", err)
 }
 
 // RevertState flips a session-scoped state flag back to its neutral variant

--- a/services/agent/main.go
+++ b/services/agent/main.go
@@ -260,6 +260,18 @@ func main() {
 	// per-game cadence + eligibility layers live on each Loop; only the budget is
 	// shared across loops.
 	sharedLLMBudget := decision.NewLLMBudget()
+	// Startup self-heal (#924): when the real action sink is enabled, validate the
+	// interventions file and repair a poisoned (unparseable) one to the neutral
+	// document before the first decision cycle. A corrupt file would otherwise make
+	// flagd reject the whole flag set, silently defaulting every intervention. The
+	// heal is best-effort: a failure logs and the agent still starts.
+	if writer, ok := sharedSink.(*actions.Writer); ok {
+		if healed, err := writer.HealIfCorrupt(ctx); err != nil {
+			slog.Error("Interventions file startup self-heal failed (continuing)", "error", err)
+		} else if healed {
+			slog.Warn("Interventions file was corrupt at startup; restored neutral document (#924)")
+		}
+	}
 	probeDecisions := strings.EqualFold(getEnv("AGENT_PROBE_DECISIONS", ""), "true")
 	if probeDecisions {
 		slog.Warn("Probe decisions enabled (demo/verification mode)",

--- a/services/prometheus/alerts.yml
+++ b/services/prometheus/alerts.yml
@@ -132,3 +132,21 @@ groups:
         annotations:
           summary: "Agent cannot write intervention flags"
           description: "The agent ActionSink failed flag-file writes at {{ $value }}/s for 2+ minutes (flagd file unreachable?). The ACT path is degraded."
+
+      # Interventions-file corruption / self-heal (#924). The agent detects a
+      # poisoned (unparseable) interventions.json after a write or at startup and
+      # repairs it (restore last-known-good / write neutral document), emitting
+      # agent_intervention_file_corruption_total{phase=write|startup}. flagd
+      # surfaces config parse failures via logs only (no scrapable counter on
+      # :8014), so this agent-side counter is the fast, reliable signal — a
+      # poisoned file is visible within seconds instead of silently defaulting
+      # every intervention. ANY increase fires immediately (for: 0m) because a
+      # single corruption already kills all interventions until healed.
+      - alert: AgentInterventionFileCorruption
+        expr: sum(increase(agent_intervention_file_corruption_total[5m])) > 0
+        for: 0m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Agent interventions file was corrupt and self-healed"
+          description: "The agent detected a poisoned interventions.json and self-healed it ({{ $value }} event(s) in 5m). flagd would otherwise reject the whole flag set and silently default every intervention. See docs/agent-act-runbook.md → Recovery."


### PR DESCRIPTION
Closes #924

The agent rewrites `/etc/flagd/interventions.json` **in place** (no temp+rename — that EBUSYs on the docker bind mount flagd watches; deliberately kept). A crash or concurrent truncation mid-write can leave invalid JSON; flagd then rejects the whole flag set and **every intervention silently falls back to default**. The existing `agent_intervention_writes_total{result="error"}` alert only catches write *errors*, not a previously-poisoned file.

## Three changes

1. **Validate-after-write** (`actions/writer.go`) — `edit()` re-reads and re-parses the file after every write. On parse failure it restores the **last-known-good** snapshot (the bytes read at the top of that write cycle, known to parse) in place, and the `Apply` records `result=error`. The in-place write is kept (no temp+rename).
2. **Startup self-heal** (`actions/heal.go`, wired in `main.go`) — when the real action sink is enabled, `Writer.HealIfCorrupt` validates the file on start and, if it is missing or unparseable, writes an **embedded neutral document** (every flag at its neutral `defaultVariant`, empty targeting, no agent-driven variants — byte-identical to `services/flagd/interventions.json`, so always a complete, valid schema with no game effect).
3. **Alert** (`services/prometheus/alerts.yml`) — new `AgentInterventionFileCorruption` (critical), fires on any increase of the new counter `agent_intervention_file_corruption_total{phase=write|startup}`.

## Alert signal: agent-side counter (not a flagd metric)

flagd (scraped on `flagd:8014`) surfaces config-source **parse failures via logs only** — it exposes no scrapable sync/parse-failure counter. The agent, by contrast, **detects and heals** the corruption directly, so an agent-side counter is the fast, reliable, test-coverable signal. It fires without a `for:` delay because a single corruption already defaults every intervention until healed.

## Chaos test (`actions/heal_test.go`)

- `TestValidateAfterWrite_RestoresLastKnownGood` — truncate the file after a write → last-known-good restored, `corruption{phase=write}=1`.
- `TestHealIfCorrupt_TruncatedFile` / `_MissingFile` — startup heal writes a valid neutral document, `corruption{phase=startup}=1`.
- `TestHealIfCorrupt_ValidFileIsNoop` — a valid file is left byte-for-byte untouched, no corruption recorded.
- `TestApply_ProducesValidFile` / `TestNeutralDocument_IsValid` — happy path stays valid; the embedded heal target parses and carries every driven flag.

## Verification

- `go build ./...`, `go vet ./...`, `gofmt -l` clean.
- `go test ./...` (full agent suite) and `go test ./actions/... -race` pass.
- `alerts.yml` validated with `yaml.safe_load`.

## Docs

Added a **Recovery — interventions file corruption (#924)** section to `docs/agent-act-runbook.md` (refs #831): self-heal behavior, the signal/alert and why agent-side, and the operator playbook (confirm self-heal → investigate root cause → manual restore as last resort).

🤖 Generated with [Claude Code](https://claude.com/claude-code)