### PR TITLE
feat(agent): inference availability checking and fallback chain (#741)

### DIFF
--- a/services/agent/decision/attribution_test.go
+++ b/services/agent/decision/attribution_test.go
@@ -175,6 +175,43 @@ func TestDisabledSpan_Throttled(t *testing.T) {
 	}
 }
 
+// TestDisabledSpan_LLMModeNoFallbackReason: when the kill switch is off
+// (enabled=false) in llm mode, the disabled span reports inference.used=rules and
+// inference.fallback_reason="" — NOT a fallback reason. The disabled path
+// short-circuits before decide()/resolve_backend run, so no inference was
+// attempted and there is nothing to fall back FROM (#741). This locks the #741
+// attribution change: pre-#741 the static inferenceAttribution(mode) stamped
+// no_backend_available here even though the agent was off; now the resolved
+// LayerState (decide never ran) honestly carries an empty fallback reason.
+func TestDisabledSpan_LLMModeNoFallbackReason(t *testing.T) {
+	snap := flags.Snapshot{
+		Enabled:    false,
+		Mode:       "llm",
+		Capability: flags.Capability{Model: "claude", PromptVariant: "balanced"},
+	}
+	l, sr := recordingLoop(t, snap, []Decision{{Intervention: "play_audio_cue"}})
+
+	l.OnEvaluate(context.Background(), gamecontext.GameContext{SessionID: "s1"}, testTrigger())
+
+	disabled := spansByName(sr.Ended(), SpanDisabled)
+	if len(disabled) != 1 {
+		t.Fatalf("disabled spans = %d, want 1", len(disabled))
+	}
+	d := disabled[0]
+	if v, ok := attrValue(d, AttrMode); !ok || v.AsString() != "llm" {
+		t.Errorf("agent.mode = %q, want llm", v.AsString())
+	}
+	if v, ok := attrValue(d, AttrInferenceUsed); !ok || v.AsString() != InferenceRules {
+		t.Errorf("inference.used = %q, want %q (nothing decided; rules floor)", v.AsString(), InferenceRules)
+	}
+	if v, ok := attrValue(d, AttrInferenceFallback); !ok || v.AsString() != "" {
+		t.Errorf("inference.fallback_reason = %q, want \"\" (agent off, no inference attempted)", v.AsString())
+	}
+	if v, ok := attrValue(d, AttrInferenceConfigured); !ok || v.AsString() != "claude" {
+		t.Errorf("inference.configured = %q, want claude (capability still recorded)", v.AsString())
+	}
+}
+
 // TestInferenceAttribution_LLMFallback: mode=llm records the fallback to rules
 // with a reason; mode=rules records no fallback. Path-agnostic per #729 §5.
 func TestInferenceAttribution_LLMFallback(t *testing.T) {

--- a/services/agent/decision/decision.go
+++ b/services/agent/decision/decision.go
@@ -198,6 +198,16 @@ type Loop struct {
 	// a single budget. Nil until injected; a nil budget gates every llm attempt
 	// with llm_budget_exhausted (fail-closed: no shared cap means no llm).
 	budget *llmBudget
+
+	// resolver is the SHARED inference fallback-chain resolver (#741), injected via
+	// SetResolver from the one instance main.go constructs (one availability cache
+	// for the whole agent, like budget). On a gate-ADMITTED llm cycle the loop calls
+	// resolver.resolve(model) to determine WHICH tier would serve, recording it as
+	// inference.used and any degradation as inference.fallback_reason. Nil until
+	// injected; a nil resolver means the cycle reports inference.used="rules" with
+	// FallbackNoBackend (no resolver = no llm tier known = rules decides), preserving
+	// the pre-#741 admitted-but-no-backend contract.
+	resolver *Resolver
 	// llmGated counts gated llm cycles (agent_llm_gated_total{reason=...}). Defaults
 	// to a no-op so a Loop built without metrics wiring still works.
 	llmGated otelmetric.Int64Counter
@@ -232,6 +242,14 @@ func NewLoop(flagSource FlagSource, log *slog.Logger) *Loop {
 // collectively exceed llm.max_requests_per_minute. Not safe to call concurrently
 // with OnEvaluate — set it during construction, before the loop serves.
 func (l *Loop) SetLLMBudget(b *llmBudget) { l.budget = b }
+
+// SetResolver injects the SHARED inference fallback-chain resolver (#741). main.go
+// constructs ONE Resolver (one availability cache + one background probe ticker for
+// the whole agent) and calls this on every Loop the factory builds, so all per-game
+// loops resolve against the same availability picture — mirroring SetLLMBudget. Not
+// safe to call concurrently with OnEvaluate — set it during construction, before
+// the loop serves.
+func (l *Loop) SetResolver(r *Resolver) { l.resolver = r }
 
 // SetThrottle overrides the log/span throttle interval. It is read once at
 // startup from decision.throttle_seconds (#766 F5); a non-positive value leaves
@@ -402,12 +420,33 @@ func (l *Loop) decide(ctx context.Context, snapshot flags.Snapshot, c gamecontex
 		// state.LLMFallbackReason regardless of whether emit fired this cycle, so a
 		// gated cycle is attributable even when the throttled capture span is silent.
 		reason := l.gateLLM(ctx, snapshot, c)
-		state.LLMFallbackReason = reason
-		// Only an ALLOWED attempt (empty reason) captures the prompt; the capture is
-		// still throttle-gated by emit so steady-state load emits at most one span
-		// per interval, exactly as before #847.
-		if reason == "" && emit {
-			l.captureLLMPrompt(ctx, snapshot, c)
+		if reason != "" {
+			// Gate DENIED (#847): keep the gate's behavior EXACTLY — inference.used
+			// stays "rules" (the newLayerState default) and inference.fallback_reason
+			// carries the gate reason. resolve_backend (#741) does NOT run: there is no
+			// point resolving a tier for an attempt that will not be made, and we must
+			// not override the gate's attribution. No prompt capture, no tier consumed.
+			state.LLMFallbackReason = reason
+		} else {
+			// Gate ADMITTED: now (and only now) resolve WHICH inference tier would serve
+			// this decision (#741). The resolver reads its cached availability — cheap,
+			// no network on the hot path. The resolved tier becomes inference.used and
+			// any degradation becomes inference.fallback_reason:
+			//   - configured tier reachable -> used=<tier>,        fallback=""
+			//   - a lower tier serves        -> used=<lower tier>,  fallback=endpoint_unreachable
+			//   - whole chain unreachable    -> used="rules",       fallback=no_backend_available
+			// Until #739 a "reachable" tier does not actually decide — the rules engine
+			// below still produces the Decision — so inference.used honestly reflects WHO
+			// #739 WILL call, with fallback="" meaning "this is the tier #739 would use".
+			res := l.resolveBackend(snapshot.Capability.Model)
+			state.InferenceUsed = res.Used
+			state.LLMFallbackReason = res.FallbackReason
+			// Only an ADMITTED attempt captures the prompt; the capture is still
+			// throttle-gated by emit so steady-state load emits at most one span per
+			// interval, exactly as before #847.
+			if emit {
+				l.captureLLMPrompt(ctx, snapshot, c)
+			}
 		}
 	}
 	return l.Rules.Evaluate(ctx, c)
@@ -469,6 +508,20 @@ func (l *Loop) gateLLM(ctx context.Context, snapshot flags.Snapshot, c gameconte
 	// the allow() call above. This is the ONLY path that does not return a reason.
 	l.lastLLMAttempt = t
 	return ""
+}
+
+// resolveBackend walks the inference fallback chain (#741) for an ADMITTED llm
+// cycle and returns the resolved tier plus any degradation reason. A nil resolver
+// (never injected) fails to the honest default: inference.used="rules" with
+// no_backend_available — no resolver means no llm tier is known, so the rules
+// engine decides, exactly the admitted-but-no-backend contract that held before
+// #741. With a resolver it delegates to resolver.resolve, which reads the cached
+// availability (no probe on the hot path).
+func (l *Loop) resolveBackend(configuredModel string) Resolution {
+	if l.resolver == nil {
+		return Resolution{Used: InferenceRules, FallbackReason: FallbackNoBackend}
+	}
+	return l.resolver.resolve(configuredModel)
 }
 
 // recordGated increments the agent_llm_gated_total counter for one gated llm cycle,
@@ -733,30 +786,36 @@ func decisionAttributes(state *LayerState, d Decision, blocked bool, reason Bloc
 // onto a span verbatim — the heart of #729. It is path-agnostic (rules and the
 // M4 llm path converge on the same LayerState) and used by both the live
 // decision span and the disabled kill-switch span. Inference attribution is
-// derived from the mode: configured = the capability model flag, used = the
-// engine that actually ran (rules until M4), fallback_reason set only when
-// mode=llm fell back.
+// derived from the mode: configured = the capability model flag, used = the tier
+// resolve_backend resolved (#741, rules on the rules path), fallback_reason set
+// only when mode=llm degraded.
 func layerStateAttributes(state *LayerState) []attribute.KeyValue {
 	mode := state.Mode
 	if mode == "" {
 		mode = DefaultMode
 	}
-	// Inference attribution. For the llm path the fallback_reason is the PER-CYCLE
-	// gate outcome the loop resolved this cycle (#847): llm_not_eligible /
-	// llm_interval / llm_budget_exhausted when gated, or no_backend_available when
-	// the gate ADMITTED the attempt but no backend exists yet. The static
-	// inferenceAttribution is kept only as the fallback for the historical case
-	// where the cycle did not run the gate (state.LLMFallbackReason empty on an llm
-	// cycle would be an admitted-but-unrecorded path; we default it to
-	// no_backend_available to preserve the pre-#847 contract). mode=rules has no
-	// fallback reason, unchanged.
+	// Inference attribution (#741 makes used/fallback HONEST). On the llm path:
+	//   - inference.used is the tier resolve_backend resolved this cycle
+	//     (state.InferenceUsed): a real tier when the gate admitted and a tier was
+	//     reachable, or "rules" when the gate denied / the whole chain was unreachable.
+	//     The newLayerState default is already "rules", so a gate-denied cycle (where
+	//     the loop never overwrote it) correctly reports rules — matching #847's "used
+	//     stays rules when gated" contract WITHOUT a special case here.
+	//   - inference.fallback_reason is the PER-CYCLE reason: a #847 gate reason
+	//     (llm_not_eligible / llm_interval / llm_budget_exhausted) when gated, the #741
+	//     resolve reason (endpoint_unreachable when a lower tier serves) when admitted-
+	//     and-degraded, or no_backend_available when admitted but nothing was reachable.
+	//     An empty reason on an admitted, configured-tier-reachable cycle is correct and
+	//     left empty (configured == used, no degradation) — we no longer force
+	//     no_backend_available, because a reachable tier has no fallback.
+	// mode=rules has no fallback reason and reports used=rules, unchanged.
 	var inferenceUsed, fallback string
 	if mode == "llm" {
-		inferenceUsed = InferenceRules
-		fallback = state.LLMFallbackReason
-		if fallback == "" {
-			fallback = FallbackNoBackend
+		inferenceUsed = state.InferenceUsed
+		if inferenceUsed == "" {
+			inferenceUsed = InferenceRules
 		}
+		fallback = state.LLMFallbackReason
 	} else {
 		inferenceUsed, fallback = inferenceAttribution(mode)
 	}
@@ -788,13 +847,14 @@ func layerStateAttributes(state *LayerState) []attribute.KeyValue {
 	return attrs
 }
 
-// inferenceAttribution maps the decision mode to the inference.used /
-// inference.fallback_reason pair. In the #739 spike, mode=llm captures the
-// prompt (see captureLLMPrompt) but no inference backend is wired, so it falls
-// back to the rules engine recording FallbackNoBackend; mode=rules (and any
-// unknown mode) runs rules with no fallback. inference.configured is the model
-// flag, set by the caller. Path-agnostic: #741's resolve_backend() will supply
-// the real reason and return ("llm", "") once a backend answers.
+// inferenceAttribution maps a NON-llm decision mode to the inference.used /
+// inference.fallback_reason pair: rules (and any unknown mode) run the rules
+// engine with no fallback reason. Since #741 wired resolve_backend, the llm path
+// no longer flows through here — layerStateAttributes reads the per-cycle resolved
+// tier (state.InferenceUsed) and reason (state.LLMFallbackReason) directly — so
+// this helper handles only the rules/unknown branch. It is retained (rather than
+// inlined) so the rules-path attribution has a single named source, and the
+// mode=="llm" guard stays defensive in case a caller routes an llm mode here.
 func inferenceAttribution(mode string) (used, fallbackReason string) {
 	if mode == "llm" {
 		return InferenceRules, FallbackNoBackend

--- a/services/agent/decision/layerstate.go
+++ b/services/agent/decision/layerstate.go
@@ -57,13 +57,31 @@ type LayerState struct {
 	PromptVariant string
 
 	// LLMFallbackReason is the inference.fallback_reason this cycle's llm path
-	// resolved to (#847). It is the PER-CYCLE replacement for the static
-	// inferenceAttribution: when mode=="llm" the loop sets it to the gate outcome
-	// (FallbackNotEligible / FallbackInterval / FallbackBudgetExhausted when gated,
-	// FallbackNoBackend when the gate ALLOWED and the cycle fell back for lack of a
-	// backend), and layerStateAttributes lifts it onto the decision span. Empty on
-	// the rules path (mode!="llm"), where there is no fallback reason at all.
+	// resolved to (#847 + #741). It is the PER-CYCLE replacement for the static
+	// inferenceAttribution. On an llm cycle the loop sets it to, in order of
+	// precedence:
+	//   - the #847 gate reason (FallbackNotEligible / FallbackInterval /
+	//     FallbackBudgetExhausted) when the gate DENIED — resolve_backend never runs;
+	//   - the #741 resolve_backend reason when the gate ADMITTED: "" when the
+	//     configured tier is reachable, FallbackEndpointUnreachable when a LOWER tier
+	//     serves, or FallbackNoBackend when the whole chain is unreachable and rules
+	//     decided.
+	// layerStateAttributes lifts it onto the decision span. Empty on the rules path
+	// (mode!="llm"), where there is no fallback reason at all.
 	LLMFallbackReason string
+
+	// InferenceUsed is inference.used this cycle: the tier resolve_backend (#741)
+	// determined WOULD serve the decision — claude/copilot via "cloud", "gemma3:4b",
+	// "phi4-mini", or InferenceRules ("rules") when the gate denied, the chain was
+	// unreachable, or the mode is rules. Defaulted to InferenceRules by newLayerState
+	// so a cycle that never resolves a backend (rules mode, gate-denied llm) honestly
+	// reports rules. The loop overwrites it with the resolved tier ONLY on a
+	// gate-admitted llm cycle. layerStateAttributes emits it verbatim as
+	// inference.used, replacing the static inferenceAttribution(mode) value (#847's
+	// inference.used was always InferenceRules; #741 makes it honest). Until #739 a
+	// "reachable" tier does NOT actually decide — the rules engine still produces the
+	// Decision — so this reflects WHO #739 WILL call, not who decided this cycle.
+	InferenceUsed string
 
 	// --- Permission layer ---
 	InterventionsAllowed      []string
@@ -91,11 +109,15 @@ type LayerState struct {
 // are filled in as decisions are processed.
 func newLayerState(s flags.Snapshot) LayerState {
 	return LayerState{
-		Enabled:                   s.Enabled,
-		Mode:                      s.Mode,
-		Objectives:                s.Objectives,
-		Model:                     s.Capability.Model,
-		PromptVariant:             s.Capability.PromptVariant,
+		Enabled:       s.Enabled,
+		Mode:          s.Mode,
+		Objectives:    s.Objectives,
+		Model:         s.Capability.Model,
+		PromptVariant: s.Capability.PromptVariant,
+		// inference.used defaults to rules (#741): a cycle that never resolves a
+		// backend (rules mode, or a gate-denied llm cycle) honestly reports rules. The
+		// loop overwrites this only on a gate-admitted llm cycle with the resolved tier.
+		InferenceUsed:             InferenceRules,
 		InterventionsAllowed:      s.InterventionsAllowed,
 		PolicyBatteryThreshold:    s.Policy.BatteryThreshold,
 		PolicyMovementVarianceWin: s.Policy.MovementVarianceWindow,

--- a/services/agent/decision/probe_backend.go
+++ b/services/agent/decision/probe_backend.go
@@ -1,0 +1,92 @@
+package decision
+
+import (
+	"context"
+	"net"
+	"time"
+)
+
+// probe_backend.go is the PRODUCTION inference probe (#741): a Backend whose
+// reachability is a bounded TCP dial to a tier's endpoint. It is the only real
+// (network-touching) Backend; tests use a fake that implements the same interface
+// with no I/O (see resolver_test.go). The dial is intentionally minimal — a
+// successful TCP connect is "reachable enough" for #741, which only needs to know
+// WHICH tier #739 would call. #739 will replace this with a real model-health
+// check (e.g. an Ollama /api/tags or a cloud auth ping) once a backend call exists;
+// until then a TCP connect is the honest, dependency-free liveness signal, and in
+// dev every endpoint is unreachable so the chain degrades to rules exactly as #741
+// requires.
+
+// probeDialTimeout bounds a single tier's availability dial. It is short because
+// the probe runs on the background refresh ticker, not the decision hot path, but
+// a hung dial would still delay the whole refresh sweep (tiers are probed
+// sequentially), so each is capped. 2s tolerates a slow-but-present endpoint
+// without letting an unplugged one stall the sweep for long.
+const probeDialTimeout = 2 * time.Second
+
+// Endpoints carries the dial addresses for the three llm tiers (#741). main.go
+// fills them from env with the documented defaults; an empty address makes that
+// tier permanently unreachable (the probe short-circuits to false), which is the
+// correct behavior when a tier is not configured (e.g. no Jetson on the network).
+type Endpoints struct {
+	// Cloud is the cloud inference endpoint (claude/copilot, #742). Credential-
+	// blocked today, so there is no sensible dev default — empty unless configured,
+	// which keeps the cloud tier permanently unreachable and the chain degrades past
+	// it. main.go reads AGENT_CLOUD_ENDPOINT.
+	Cloud string
+	// Jetson is gemma3:4b's host:port on the Jetson (#738). Default
+	// "jetson:11434" (the Ollama port) — unresolvable in dev, so the tier is
+	// unreachable and the chain degrades to localhost. main.go reads AGENT_JETSON_ENDPOINT.
+	Jetson string
+	// Localhost is phi4-mini's host:port on the local box (#739). Default
+	// "localhost:11434" (Ollama) — also unreachable in dev unless a model server is
+	// actually running locally. main.go reads AGENT_LOCALHOST_ENDPOINT.
+	Localhost string
+}
+
+// endpointBackend is the production Backend: a named tier whose Available is a
+// bounded TCP dial of addr. An empty addr is permanently unreachable.
+type endpointBackend struct {
+	name string
+	addr string
+	// dial is the dialer seam. Production uses net.Dialer.DialContext; it is a field
+	// so a future test of the real backend (not the resolver) could stub it, mirroring
+	// the Backend interface's own test seam. Nil means "use the default dialer".
+	dial func(ctx context.Context, addr string) (net.Conn, error)
+}
+
+// newEndpointBackend builds a production probe for one tier. An empty addr yields a
+// backend that is always unreachable (Available short-circuits false) — the correct
+// state for an unconfigured tier (no cloud credentials, no Jetson on the LAN).
+func newEndpointBackend(name, addr string) *endpointBackend {
+	return &endpointBackend{name: name, addr: addr}
+}
+
+func (e *endpointBackend) Name() string { return e.name }
+
+// Available dials the tier's endpoint with a bounded timeout and reports whether
+// the connect succeeded. An empty addr is unreachable without dialing. The
+// connection is closed immediately — this is a liveness probe, not a session.
+// Honors ctx (cancellation / deadline) via DialContext, layered under the per-dial
+// timeout so the sweep is bounded even with a background ctx that never cancels.
+func (e *endpointBackend) Available(ctx context.Context) bool {
+	if e.addr == "" {
+		return false
+	}
+	dialCtx, cancel := context.WithTimeout(ctx, probeDialTimeout)
+	defer cancel()
+
+	dial := e.dial
+	if dial == nil {
+		var d net.Dialer
+		dial = func(ctx context.Context, addr string) (net.Conn, error) {
+			return d.DialContext(ctx, "tcp", addr)
+		}
+	}
+	conn, err := dial(dialCtx, e.addr)
+	if err != nil {
+		return false
+	}
+	_ = conn.Close()
+	return true
+}

--- a/services/agent/decision/resolver.go
+++ b/services/agent/decision/resolver.go
@@ -1,0 +1,269 @@
+package decision
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// resolver.go is the inference availability checker and fallback chain (#741).
+// It answers ONE question per decision cycle, cheaply: given the configured model
+// flag, WHICH inference tier would serve this decision right now? It walks a fixed
+// chain of tiers from the configured model down to the always-available rules
+// engine, returning the first reachable tier — so the agent uses whatever
+// intelligence is reachable and degrades gracefully to rules when nothing is:
+//
+//	configured model (claude | copilot)   -> cloud tier      [agent.model flag]
+//	    ↓ unreachable
+//	gemma3:4b on Jetson                    -> jetson tier
+//	    ↓ unreachable
+//	phi4-mini on localhost                 -> localhost tier
+//	    ↓ unreachable
+//	rules engine                           -> always available; the system ALWAYS decides
+//
+// CRITICAL — this is the ABSTRACTION + resolver + attribution, NOT the call. There
+// is no real backend yet: #739 implements the actual llm_decide call, Jetson #738
+// and cloud #742 are hardware/credential-blocked. So a "reachable" tier here means
+// "this is who #739 WILL call once it lands" — the rules engine still produces the
+// Decision until then. The resolver's job is solely to make inference.used /
+// inference.fallback_reason HONEST on every decision span (#741 acceptance #3): it
+// reports the tier that WOULD serve, and the fallback_reason explaining any
+// degradation, while decide() keeps running the deterministic rules engine.
+//
+// Coordination with the #847 call gate: the gate decides WHETHER to attempt llm
+// (eligibility -> cadence -> budget); the resolver decides WHICH tier would serve.
+// decide() runs the gate FIRST and only resolves a backend when the gate ADMITS —
+// there is no point resolving a tier for an attempt that will not be made. See
+// decision.go's decide() for the exact ordering.
+//
+// Availability is checked PERIODICALLY and CACHED between checks (#741 acceptance
+// #2): a per-decision resolve reads the cache only (a cheap mutex-guarded slice
+// read), never a live probe. A background ticker re-probes every tier on an
+// interval, so an unplugged tier degrades within one interval and a recovered tier
+// is climbed back to within one interval (#741 acceptance #4/#5). This keeps the
+// hot decision path off the network entirely while still tracking reality.
+
+// Inference tier identifiers, used as inference.used on the decision span (#741).
+// Each names a distinct rung of the fallback chain. The local-model and cloud
+// names match the agent.model flag vocabulary so a configured model maps onto its
+// tier (resolveTierFromModel). InferenceRules (telemetry.go) is the bottom rung —
+// always available — and is reused as the chain's terminal value.
+const (
+	// TierCloud is the configured cloud model (claude or copilot via the agent.model
+	// flag) — the top of the chain. Its reachability is the network reachability of
+	// the cloud inference endpoint (#742, credential-blocked today, so unreachable in
+	// dev and the chain degrades past it).
+	TierCloud = "cloud"
+	// TierGemma is gemma3:4b on the Jetson (#738, hardware-blocked today). Named by
+	// the model so a `model=gemma3:4b` flag selects it as the chain top.
+	TierGemma = "gemma3:4b"
+	// TierPhi is phi4-mini on localhost (#739 will run it here first). It is the
+	// default-model tier (flags.DefaultModel == "phi4-mini") and the lowest LLM rung
+	// above the rules engine.
+	TierPhi = "phi4-mini"
+)
+
+// cloudModels are the agent.model flag values that name the cloud tier. A model
+// flag of "claude" or "copilot" puts the cloud tier at the TOP of the chain; any
+// other recognized local model (gemma3:4b, phi4-mini) starts the chain lower, and
+// an unrecognized model is treated as the cloud tier (start at the top and let the
+// chain degrade) so a typo or a future model name never silently skips tiers.
+var cloudModels = map[string]struct{}{
+	"claude":  {},
+	"copilot": {},
+}
+
+// DefaultProbeInterval is how often the resolver re-probes every tier's
+// availability in the background (#741). It is the cache TTL: an unplugged tier is
+// noticed, and a recovered tier is climbed back to, within at most this interval.
+// A const (not a flag) keeps #741 simple — availability cadence is an operational
+// constant, not a per-game tunable; main.go may override it via NewResolver's
+// interval argument if an env knob is ever wanted. Chosen at 15s as a balance
+// between detecting an unplugged Jetson promptly and not hammering endpoints.
+const DefaultProbeInterval = 15 * time.Second
+
+// Backend is one rung of the inference fallback chain: a named tier whose
+// reachability can be probed. The rules engine is NOT a Backend — it is the
+// implicit, always-available terminal rung the resolver returns when every
+// Backend is unreachable, so it never needs a probe.
+//
+// Available is the INJECTION SEAM for tests (#741 acceptance #2/#4/#5): production
+// wiring uses a real network probe (endpointBackend), tests use a counting/flippable
+// fake so availability is deterministic and no test ever touches the network. It
+// takes a context so a real probe can honor a dial timeout / cancellation.
+type Backend interface {
+	// Name is the tier identifier recorded as inference.used (e.g. "phi4-mini").
+	Name() string
+	// Available reports whether this tier is reachable right now. It is called
+	// ONLY by the resolver's background refresh, never on the decision hot path —
+	// the resolver caches the result. A real probe should be cheap and bounded
+	// (a short-timeout dial), but even a slow one cannot stall a decision because
+	// decisions read the cache.
+	Available(ctx context.Context) bool
+}
+
+// Resolver holds the ordered inference chain and a periodically-refreshed
+// availability cache (#741). It is SHARED across all per-game Loops (one cache for
+// the whole agent, like the global llmBudget): main.go constructs ONE Resolver and
+// injects it into every Loop via SetResolver, so all concurrent games see the same
+// availability picture and a single ticker re-probes for all of them. It is safe
+// for concurrent use — resolve() is called from the concurrent Export handler
+// goroutines, and the background refresh writes the cache under the same mutex.
+type Resolver struct {
+	// chain is the ordered tier list, TOP (cloud) to BOTTOM (lowest llm rung). It is
+	// immutable after construction; resolve() walks it from the configured-model
+	// index downward. The rules engine is the implicit terminal rung below it.
+	chain []Backend
+
+	// mu guards available. The decision hot path takes it for a cheap read; the
+	// background refresh takes it for the write. Held only around the slice copy /
+	// map write, never across a probe (probes run before the lock is taken).
+	mu sync.Mutex
+	// available is the cached reachability per tier name, refreshed by the
+	// background ticker (refresh) or an explicit Refresh. A tier absent from the map
+	// (before the first refresh) reads as unreachable — fail-safe: until we have
+	// probed, assume nothing is reachable and serve from rules.
+	available map[string]bool
+
+	interval time.Duration
+	now      func() time.Time
+}
+
+// NewResolver builds a Resolver over the given ordered chain (top tier first) with
+// the given background re-probe interval (DefaultProbeInterval when non-positive).
+// The cache starts EMPTY — every tier reads as unreachable until the first refresh,
+// so a resolve() before Start (or before the first tick) honestly bottoms out at
+// rules rather than optimistically claiming a tier is up. Call Start to begin the
+// background refresh, or Refresh once synchronously (tests do the latter for
+// determinism).
+func NewResolver(chain []Backend, interval time.Duration) *Resolver {
+	if interval <= 0 {
+		interval = DefaultProbeInterval
+	}
+	return &Resolver{
+		chain:     chain,
+		available: make(map[string]bool),
+		interval:  interval,
+		now:       time.Now,
+	}
+}
+
+// DefaultChain is the production inference chain (#741), top tier first: cloud
+// (claude/copilot, #742), then gemma3:4b on the Jetson (#738), then phi4-mini on
+// localhost (#739). Each tier probes a TCP endpoint; in dev every endpoint is
+// unreachable, so the chain degrades to rules — which is exactly the standalone,
+// no-Jetson-no-cloud behavior #741 requires. main.go reads the endpoint addresses
+// from env (sensible defaults documented on the Endpoints fields).
+func DefaultChain(eps Endpoints) []Backend {
+	return []Backend{
+		newEndpointBackend(TierCloud, eps.Cloud),
+		newEndpointBackend(TierGemma, eps.Jetson),
+		newEndpointBackend(TierPhi, eps.Localhost),
+	}
+}
+
+// resolveTierFromModel maps the configured agent.model flag to the index of the
+// chain tier it selects as the TOP of the walk. claude/copilot -> the cloud tier
+// (index 0); gemma3:4b -> the Jetson tier; phi4-mini -> the localhost tier; any
+// unrecognized model -> the top (cloud), so a future/misspelled model starts high
+// and degrades through every rung rather than silently skipping the chain. It
+// returns the chain index to start resolving from.
+func (r *Resolver) resolveTierFromModel(model string) int {
+	if _, isCloud := cloudModels[model]; isCloud {
+		return 0
+	}
+	// A local model name selects its own tier as the chain top. Match by the tier's
+	// Name(), which equals the model string for the local rungs (gemma3:4b, phi4-mini).
+	for i, b := range r.chain {
+		if b.Name() == model {
+			return i
+		}
+	}
+	// Unrecognized: start at the top and let the chain degrade.
+	return 0
+}
+
+// Resolution is the outcome of one resolve() call (#741): the tier that would
+// serve this decision and, when it is NOT the configured tier, why it degraded.
+type Resolution struct {
+	// Used is the resolved tier name recorded as inference.used: a tier from the
+	// chain when one at/below the configured model is reachable, else InferenceRules
+	// when the whole chain is unreachable and it bottoms out at the rules engine.
+	Used string
+	// FallbackReason is inference.fallback_reason: "" when the configured tier
+	// itself is reachable (no degradation), FallbackEndpointUnreachable when a LOWER
+	// tier serves (a higher one was unreachable), or FallbackNoBackend when the whole
+	// chain is unreachable and only rules remain. It composes with the #847 gate
+	// reason in decide(): the gate reason wins when the gate DENIED; this reason is
+	// only consulted on an ADMITTED cycle.
+	FallbackReason string
+}
+
+// resolve walks the chain from the configured model's tier downward and returns
+// the first reachable tier, reading the cache ONLY (no probe — #741 acceptance #2,
+// the hot path never touches the network). When the configured tier is reachable
+// the resolution carries no fallback_reason; when a LOWER tier serves the reason is
+// endpoint_unreachable (a higher tier was down); when the whole chain is unreachable
+// it bottoms out at the rules engine with no_backend_available. Concurrency-safe:
+// the cache read is mutex-guarded.
+func (r *Resolver) resolve(configuredModel string) Resolution {
+	start := r.resolveTierFromModel(configuredModel)
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for i := start; i < len(r.chain); i++ {
+		if r.available[r.chain[i].Name()] {
+			reason := ""
+			// A tier BELOW the configured one means a higher tier was unreachable —
+			// honestly attribute the degradation. The configured tier serving itself
+			// carries no reason (configured == used).
+			if i > start {
+				reason = FallbackEndpointUnreachable
+			}
+			return Resolution{Used: r.chain[i].Name(), FallbackReason: reason}
+		}
+	}
+	// Whole chain unreachable: the rules engine is the always-available terminal
+	// rung. no_backend_available reconciles with #847's existing use of the same
+	// constant for the gate-admitted-but-no-backend case — both mean "the llm path
+	// was wanted but nothing answered, so rules decided".
+	return Resolution{Used: InferenceRules, FallbackReason: FallbackNoBackend}
+}
+
+// Refresh probes every tier ONCE and updates the cache (#741). The background
+// ticker calls it on each tick; tests call it directly for deterministic, single-
+// threaded refreshes (no goroutine, no clock). Probes run OUTSIDE the lock so a
+// slow/blocking probe never stalls a concurrent resolve() on the hot path — only
+// the final cache write takes the mutex. ctx bounds the probes (cancellation /
+// dial timeout); a cancelled ctx still writes whatever results completed.
+func (r *Resolver) Refresh(ctx context.Context) {
+	next := make(map[string]bool, len(r.chain))
+	for _, b := range r.chain {
+		next[b.Name()] = b.Available(ctx)
+	}
+	r.mu.Lock()
+	r.available = next
+	r.mu.Unlock()
+}
+
+// Start launches the background re-probe loop and returns immediately (#741). It
+// probes ONCE synchronously first so the cache is populated before the agent
+// serves its first decision (otherwise the first interval would resolve to rules
+// even with a reachable tier), then re-probes every interval until ctx is
+// cancelled. main.go calls this once on the shared Resolver during startup; it
+// must not be called twice on the same Resolver.
+func (r *Resolver) Start(ctx context.Context) {
+	r.Refresh(ctx) // prime the cache before the first decision
+	go func() {
+		ticker := time.NewTicker(r.interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				r.Refresh(ctx)
+			}
+		}
+	}()
+}

--- a/services/agent/decision/resolver.go
+++ b/services/agent/decision/resolver.go
@@ -116,8 +116,8 @@ type Resolver struct {
 	chain []Backend
 
 	// mu guards available. The decision hot path takes it for a cheap read; the
-	// background refresh takes it for the write. Held only around the slice copy /
-	// map write, never across a probe (probes run before the lock is taken).
+	// background refresh takes it for the write. Held only around the map read and
+	// write, never across a probe (probes run before the lock is taken).
 	mu sync.Mutex
 	// available is the cached reachability per tier name, refreshed by the
 	// background ticker (refresh) or an explicit Refresh. A tier absent from the map
@@ -246,15 +246,20 @@ func (r *Resolver) Refresh(ctx context.Context) {
 	r.mu.Unlock()
 }
 
-// Start launches the background re-probe loop and returns immediately (#741). It
-// probes ONCE synchronously first so the cache is populated before the agent
-// serves its first decision (otherwise the first interval would resolve to rules
-// even with a reachable tier), then re-probes every interval until ctx is
-// cancelled. main.go calls this once on the shared Resolver during startup; it
+// Start launches the background re-probe loop and returns immediately (#741). The
+// FIRST probe runs INSIDE the goroutine, not synchronously, so agent startup is
+// never blocked waiting on optional inference endpoints: a black-holed Jetson or
+// cloud endpoint would otherwise stall the server's readiness by up to the dial
+// timeout per tier. Until that first probe completes the cache is empty and
+// resolve() serves from rules — the fail-safe floor — which is harmless here:
+// nothing consults the resolver before then (the #847 cadence floor delays the
+// first LLM attempt, and #739, the actual call, is not wired yet), so the brief
+// rules window costs nothing. After priming it re-probes every interval until ctx
+// is cancelled. main.go calls this once on the shared Resolver during startup; it
 // must not be called twice on the same Resolver.
 func (r *Resolver) Start(ctx context.Context) {
-	r.Refresh(ctx) // prime the cache before the first decision
 	go func() {
+		r.Refresh(ctx) // prime the cache in the background, off the startup path
 		ticker := time.NewTicker(r.interval)
 		defer ticker.Stop()
 		for {

--- a/services/agent/decision/resolver_attribution_test.go
+++ b/services/agent/decision/resolver_attribution_test.go
@@ -1,0 +1,262 @@
+package decision
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel/sdk/metric"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"github.com/joustmania/agent/flags"
+	"github.com/joustmania/agent/gamecontext"
+)
+
+// resolver_attribution_test.go drives the #741 resolver through the FULL decision
+// loop (OnEvaluate) so the inference attribution triple — inference.configured,
+// inference.used, inference.fallback_reason — is asserted exactly as it lands on
+// the agent.decision span, and the coordination with the #847 gate is verified
+// end-to-end (gate first; resolve only on admission).
+
+// resolverLoop builds a Loop wired with a recording tracer, a metered gate
+// counter, a fixed clock, a freshly-refreshed resolver, and a fixed-decision rules
+// engine so a decision span always emits. The snapshot's model selects the chain
+// top. Returns the loop, span recorder, and the three flippable backends.
+func resolverLoop(t *testing.T, snap flags.Snapshot, cloud, gemma, phi bool, clock *time.Time) (*Loop, *tracetest.SpanRecorder, *fakeBackend, *fakeBackend, *fakeBackend) {
+	t.Helper()
+	sr := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+
+	r, c, g, p := chainBackends(cloud, gemma, phi)
+	r.Refresh(context.Background())
+
+	reader := metric.NewManualReader()
+	mp := metric.NewMeterProvider(metric.WithReader(reader))
+
+	l := NewLoop(&settableFlags{snap: snap}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	l.Tracer = tp.Tracer("test")
+	l.Rules = fakeRules{out: []Decision{{Intervention: "grant_shield", Reason: "x"}}}
+	l.Actions = &fakeSink{}
+	l.llmGated = newLLMGatedCounter(mp)
+	l.SetLLMBudget(NewLLMBudget())
+	l.SetResolver(r)
+	l.now = func() time.Time { return *clock }
+	return l, sr, c, g, p
+}
+
+// llmGateAdmit is an llm-mode snapshot whose #847 gate always admits (eligible for
+// the test's game kind, no cadence floor, generous budget), with the given model
+// selecting the resolver's chain top.
+func llmGateAdmit(model string) flags.Snapshot {
+	return flags.Snapshot{
+		Enabled:              true,
+		Mode:                 "llm",
+		Objectives:           map[string]float64{"endurance": 1.0},
+		Capability:           flags.Capability{Model: model, PromptVariant: "balanced"},
+		InterventionsAllowed: []string{"grant_shield"},
+		Policy:               flags.Policy{MaxInterventionsPerMinute: 100},
+		LLMGate: flags.LLMGate{
+			EligibleGameKinds:    []string{"real"},
+			MinDecisionInterval:  0,
+			MaxRequestsPerMinute: 100,
+		},
+	}
+}
+
+// inferenceTriple reads the three inference attributes off the single decision span.
+func inferenceTriple(t *testing.T, sr *tracetest.SpanRecorder) (configured, used, fallback string) {
+	t.Helper()
+	decs := spansByName(sr.Ended(), SpanDecision)
+	if len(decs) != 1 {
+		t.Fatalf("agent.decision spans = %d, want 1", len(decs))
+	}
+	cfg, _ := attrValue(decs[0], AttrInferenceConfigured)
+	u, _ := attrValue(decs[0], AttrInferenceUsed)
+	fb, ok := attrValue(decs[0], AttrInferenceFallback)
+	if !ok {
+		t.Fatal("inference.fallback_reason missing on decision span")
+	}
+	return cfg.AsString(), u.AsString(), fb.AsString()
+}
+
+// --- Acceptance #3: all three attributes present, including when configured == used ---
+
+// TestAttribution_ConfiguredEqualsUsed: a reachable configured tier reports
+// inference.used == the configured tier and an EMPTY fallback_reason (no
+// degradation), with inference.configured = the model flag. All three present.
+func TestAttribution_ConfiguredEqualsUsed(t *testing.T) {
+	clock := time.Unix(1000, 0)
+	// model=claude -> cloud tier; cloud up -> configured == used, no fallback.
+	l, sr, _, _, _ := resolverLoop(t, llmGateAdmit("claude"), true, true, true, &clock)
+
+	l.OnEvaluate(context.Background(), gamecontext.GameContext{SessionID: "s1", GameKind: "real"}, testTrigger())
+
+	configured, used, fallback := inferenceTriple(t, sr)
+	if configured != "claude" {
+		t.Errorf("inference.configured = %q, want claude", configured)
+	}
+	if used != TierCloud {
+		t.Errorf("inference.used = %q, want %q (configured tier reachable)", used, TierCloud)
+	}
+	if fallback != "" {
+		t.Errorf("inference.fallback_reason = %q, want empty (configured == used)", fallback)
+	}
+}
+
+// TestAttribution_DegradesToLowerTier: cloud configured but down -> a lower tier
+// serves, inference.used = that tier and fallback_reason = endpoint_unreachable.
+func TestAttribution_DegradesToLowerTier(t *testing.T) {
+	clock := time.Unix(1000, 0)
+	// model=claude (cloud), cloud DOWN, gemma up -> used=gemma3:4b, endpoint_unreachable.
+	l, sr, _, _, _ := resolverLoop(t, llmGateAdmit("claude"), false, true, true, &clock)
+
+	l.OnEvaluate(context.Background(), gamecontext.GameContext{SessionID: "s1", GameKind: "real"}, testTrigger())
+
+	configured, used, fallback := inferenceTriple(t, sr)
+	if configured != "claude" {
+		t.Errorf("inference.configured = %q, want claude", configured)
+	}
+	if used != TierGemma {
+		t.Errorf("inference.used = %q, want %q", used, TierGemma)
+	}
+	if fallback != FallbackEndpointUnreachable {
+		t.Errorf("inference.fallback_reason = %q, want %q", fallback, FallbackEndpointUnreachable)
+	}
+}
+
+// TestAttribution_WholeChainDownBottomsOutAtRules: every tier down -> used=rules,
+// fallback=no_backend_available (the chain bottoms out, the system still decides).
+func TestAttribution_WholeChainDownBottomsOutAtRules(t *testing.T) {
+	clock := time.Unix(1000, 0)
+	l, sr, _, _, _ := resolverLoop(t, llmGateAdmit("claude"), false, false, false, &clock)
+
+	l.OnEvaluate(context.Background(), gamecontext.GameContext{SessionID: "s1", GameKind: "real"}, testTrigger())
+
+	_, used, fallback := inferenceTriple(t, sr)
+	if used != InferenceRules {
+		t.Errorf("inference.used = %q, want %q", used, InferenceRules)
+	}
+	if fallback != FallbackNoBackend {
+		t.Errorf("inference.fallback_reason = %q, want %q", fallback, FallbackNoBackend)
+	}
+}
+
+// --- Acceptance #4 (end-to-end): unplug mid-session, no stalled decisions ---
+
+// TestAttribution_DegradesMidSession: across cycles, flipping the resolver's cache
+// from cloud->gemma->rules changes inference.used each time with no error and a
+// decision span on every cycle (no stall).
+func TestAttribution_DegradesMidSession(t *testing.T) {
+	clock := time.Unix(1000, 0)
+	l, sr, c, g, _ := resolverLoop(t, llmGateAdmit("claude"), true, true, true, &clock)
+	r := l.resolver
+	ctx := gamecontext.GameContext{SessionID: "s1", GameKind: "real"}
+
+	steps := []struct {
+		name     string
+		unplug   func()
+		wantUsed string
+	}{
+		{"cloud up", func() {}, TierCloud},
+		{"unplug cloud", func() { c.set(false); r.Refresh(context.Background()) }, TierGemma},
+		{"unplug gemma", func() { g.set(false); r.Refresh(context.Background()) }, TierPhi},
+	}
+	for i, st := range steps {
+		st.unplug()
+		l.OnEvaluate(context.Background(), ctx, testTrigger())
+		decs := spansByName(sr.Ended(), SpanDecision)
+		if len(decs) != i+1 {
+			t.Fatalf("step %q: decision spans = %d, want %d (no stalled decisions)", st.name, len(decs), i+1)
+		}
+		v, _ := attrValue(decs[i], AttrInferenceUsed)
+		if v.AsString() != st.wantUsed {
+			t.Errorf("step %q: inference.used = %q, want %q", st.name, v.AsString(), st.wantUsed)
+		}
+	}
+}
+
+// --- Acceptance #5 (end-to-end): recovery climbs back up ---
+
+// TestAttribution_RecoversMidSession: with cloud down a cycle serves gemma; after
+// cloud recovers and the cache refreshes, the next cycle reports cloud again.
+func TestAttribution_RecoversMidSession(t *testing.T) {
+	clock := time.Unix(1000, 0)
+	l, sr, c, _, _ := resolverLoop(t, llmGateAdmit("claude"), false, true, true, &clock)
+	r := l.resolver
+	ctx := gamecontext.GameContext{SessionID: "s1", GameKind: "real"}
+
+	l.OnEvaluate(context.Background(), ctx, testTrigger())
+	if v, _ := attrValue(spansByName(sr.Ended(), SpanDecision)[0], AttrInferenceUsed); v.AsString() != TierGemma {
+		t.Fatalf("first cycle used = %q, want %q (cloud down)", v.AsString(), TierGemma)
+	}
+
+	c.set(true)
+	r.Refresh(context.Background())
+	l.OnEvaluate(context.Background(), ctx, testTrigger())
+	decs := spansByName(sr.Ended(), SpanDecision)
+	if v, _ := attrValue(decs[len(decs)-1], AttrInferenceUsed); v.AsString() != TierCloud {
+		t.Errorf("after recovery, used = %q, want %q (climbed back up)", v.AsString(), TierCloud)
+	}
+}
+
+// --- Acceptance #6: gate coordination — a gate-DENIED cycle is NOT overridden ---
+
+// TestAttribution_GateDeniedKeepsGateReason: when the #847 gate DENIES (here:
+// ineligible game kind), inference.used stays "rules" and inference.fallback_reason
+// is the GATE reason (llm_not_eligible) — resolve_backend never runs, so even
+// though the resolver's cloud tier is up, it does NOT override the gate attribution.
+func TestAttribution_GateDeniedKeepsGateReason(t *testing.T) {
+	clock := time.Unix(1000, 0)
+	snap := llmGateAdmit("claude")
+	snap.LLMGate.EligibleGameKinds = []string{"real"} // shadow will be gated
+	// Cloud tier is UP and reachable — if resolve_backend wrongly ran on a denied
+	// cycle it would report cloud; it must not.
+	l, sr, _, _, _ := resolverLoop(t, snap, true, true, true, &clock)
+
+	l.OnEvaluate(context.Background(), gamecontext.GameContext{SessionID: "s1", GameKind: "shadow"}, testTrigger())
+
+	_, used, fallback := inferenceTriple(t, sr)
+	if used != InferenceRules {
+		t.Errorf("inference.used = %q, want %q (gate denied -> rules, resolver must not override)", used, InferenceRules)
+	}
+	if fallback != FallbackNotEligible {
+		t.Errorf("inference.fallback_reason = %q, want %q (the gate reason, not a resolver reason)", fallback, FallbackNotEligible)
+	}
+	// And no prompt was captured (the gate skipped the whole attempt).
+	if n := len(spansByName(sr.Ended(), SpanLLMPrompt)); n != 0 {
+		t.Errorf("agent.llm.prompt spans = %d, want 0 (gate denied)", n)
+	}
+}
+
+// TestAttribution_GateBudgetExhaustedKeepsGateReason: a budget-exhausted cycle
+// (#847 layer 3) likewise keeps used=rules and fallback=llm_budget_exhausted even
+// with a reachable resolver chain.
+func TestAttribution_GateBudgetExhaustedKeepsGateReason(t *testing.T) {
+	clock := time.Unix(1000, 0)
+	snap := llmGateAdmit("claude")
+	snap.LLMGate.MaxRequestsPerMinute = 1 // one slot, then exhausted
+	l, sr, _, _, _ := resolverLoop(t, snap, true, true, true, &clock)
+	ctx := gamecontext.GameContext{SessionID: "s1", GameKind: "real"}
+
+	l.OnEvaluate(context.Background(), ctx, testTrigger()) // admits, spends the slot
+	l.OnEvaluate(context.Background(), ctx, testTrigger()) // budget exhausted
+
+	decs := spansByName(sr.Ended(), SpanDecision)
+	if len(decs) != 2 {
+		t.Fatalf("decision spans = %d, want 2", len(decs))
+	}
+	// First cycle admitted -> resolved cloud. Second gated -> rules + budget reason.
+	if v, _ := attrValue(decs[0], AttrInferenceUsed); v.AsString() != TierCloud {
+		t.Errorf("cycle 1 used = %q, want %q (admitted, cloud reachable)", v.AsString(), TierCloud)
+	}
+	if v, _ := attrValue(decs[1], AttrInferenceUsed); v.AsString() != InferenceRules {
+		t.Errorf("cycle 2 used = %q, want %q (gated)", v.AsString(), InferenceRules)
+	}
+	if v, _ := attrValue(decs[1], AttrInferenceFallback); v.AsString() != FallbackBudgetExhausted {
+		t.Errorf("cycle 2 fallback = %q, want %q", v.AsString(), FallbackBudgetExhausted)
+	}
+}

--- a/services/agent/decision/resolver_test.go
+++ b/services/agent/decision/resolver_test.go
@@ -1,0 +1,249 @@
+package decision
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+// fakeBackend is the test Backend (#741): a named tier whose availability is a
+// flippable atomic flag and whose probe count is recorded, so tests can assert
+// both the resolved tier AND that the probe is NOT called per decision (acceptance
+// #2). It never touches the network. Safe for concurrent use.
+type fakeBackend struct {
+	name   string
+	up     atomic.Bool
+	probes atomic.Int64 // how many times Available was called (probe count)
+}
+
+func newFakeBackend(name string, up bool) *fakeBackend {
+	b := &fakeBackend{name: name}
+	b.up.Store(up)
+	return b
+}
+
+func (b *fakeBackend) Name() string { return b.name }
+
+func (b *fakeBackend) Available(context.Context) bool {
+	b.probes.Add(1)
+	return b.up.Load()
+}
+
+func (b *fakeBackend) set(up bool)       { b.up.Store(up) }
+func (b *fakeBackend) probeCount() int64 { return b.probes.Load() }
+
+// chainBackends builds a fresh test chain (cloud -> gemma3:4b -> phi4-mini) with
+// the given up/down states and returns the resolver plus the individual backends
+// so a test can flip them. The resolver is NOT started (no goroutine); tests call
+// Refresh explicitly for deterministic, single-threaded cache updates.
+func chainBackends(cloud, gemma, phi bool) (*Resolver, *fakeBackend, *fakeBackend, *fakeBackend) {
+	c := newFakeBackend(TierCloud, cloud)
+	g := newFakeBackend(TierGemma, gemma)
+	p := newFakeBackend(TierPhi, phi)
+	r := NewResolver([]Backend{c, g, p}, 0) // 0 -> DefaultProbeInterval (unused; no Start)
+	return r, c, g, p
+}
+
+// --- Acceptance #1: resolution follows the chain order from the configured model ---
+
+// TestResolve_ChainOrderFromConfiguredModel: from each configured model the
+// resolver starts at the right rung and returns the first reachable tier at/below
+// it. A higher-but-unreachable tier is skipped to the next reachable one.
+func TestResolve_ChainOrderFromConfiguredModel(t *testing.T) {
+	tests := []struct {
+		name         string
+		model        string
+		cloud        bool
+		gemma        bool
+		phi          bool
+		wantUsed     string
+		wantFallback string
+	}{
+		{"cloud configured, cloud up", "claude", true, true, true, TierCloud, ""},
+		{"copilot maps to cloud", "copilot", true, false, false, TierCloud, ""},
+		{"cloud down -> gemma", "claude", false, true, true, TierGemma, FallbackEndpointUnreachable},
+		{"cloud+gemma down -> phi", "claude", false, false, true, TierPhi, FallbackEndpointUnreachable},
+		{"gemma configured starts at gemma", "gemma3:4b", true, true, true, TierGemma, ""},
+		{"gemma configured, gemma down -> phi", "gemma3:4b", true, false, true, TierPhi, FallbackEndpointUnreachable},
+		{"gemma configured never climbs to cloud", "gemma3:4b", true, false, false, InferenceRules, FallbackNoBackend},
+		{"phi configured, phi up", "phi4-mini", true, true, true, TierPhi, ""},
+		{"phi configured, phi down -> rules", "phi4-mini", true, true, false, InferenceRules, FallbackNoBackend},
+		{"unknown model starts at top", "mystery-model", true, false, false, TierCloud, ""},
+		{"whole chain down -> rules", "claude", false, false, false, InferenceRules, FallbackNoBackend},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r, _, _, _ := chainBackends(tc.cloud, tc.gemma, tc.phi)
+			r.Refresh(context.Background())
+			res := r.resolve(tc.model)
+			if res.Used != tc.wantUsed {
+				t.Errorf("inference.used = %q, want %q", res.Used, tc.wantUsed)
+			}
+			if res.FallbackReason != tc.wantFallback {
+				t.Errorf("fallback_reason = %q, want %q", res.FallbackReason, tc.wantFallback)
+			}
+		})
+	}
+}
+
+// TestResolve_EmptyCacheBottomsOutAtRules: before any Refresh the cache is empty,
+// so every tier reads as unreachable and resolve honestly returns rules. This is
+// the fail-safe startup state (don't claim a tier is up before probing it).
+func TestResolve_EmptyCacheBottomsOutAtRules(t *testing.T) {
+	r, _, _, _ := chainBackends(true, true, true) // backends "up" but never probed
+	res := r.resolve("claude")
+	if res.Used != InferenceRules || res.FallbackReason != FallbackNoBackend {
+		t.Errorf("pre-refresh resolve = %+v, want rules/%s", res, FallbackNoBackend)
+	}
+}
+
+// --- Acceptance #2: availability cached between checks, NOT probed per decision ---
+
+// TestResolve_CachedNotProbedPerDecision: one Refresh probes each tier exactly
+// once; a thousand resolves after it add ZERO probes — the hot path reads the
+// cache only. This is the core "periodic + cached" guarantee.
+func TestResolve_CachedNotProbedPerDecision(t *testing.T) {
+	r, c, g, p := chainBackends(true, true, true)
+	r.Refresh(context.Background())
+
+	if c.probeCount() != 1 || g.probeCount() != 1 || p.probeCount() != 1 {
+		t.Fatalf("after one Refresh, probe counts = %d/%d/%d, want 1/1/1",
+			c.probeCount(), g.probeCount(), p.probeCount())
+	}
+	for i := 0; i < 1000; i++ {
+		r.resolve("claude")
+	}
+	if c.probeCount() != 1 || g.probeCount() != 1 || p.probeCount() != 1 {
+		t.Errorf("after 1000 resolves, probe counts = %d/%d/%d, want still 1/1/1 (cache read, no probe)",
+			c.probeCount(), g.probeCount(), p.probeCount())
+	}
+	// A second Refresh probes again (periodic re-check), proving probing is the
+	// Refresh's job, not the resolve's.
+	r.Refresh(context.Background())
+	if c.probeCount() != 2 {
+		t.Errorf("cloud probe count after 2nd Refresh = %d, want 2", c.probeCount())
+	}
+}
+
+// --- Acceptance #4: unplug a tier mid-session -> degrade to the next, then rules ---
+
+// TestResolve_DegradesWhenTierUnplugged: with the cloud configured, flipping the
+// reachable cloud down (then gemma, then phi) degrades the resolved tier one rung
+// at a time on each Refresh — no error, every resolve returns a usable tier.
+func TestResolve_DegradesWhenTierUnplugged(t *testing.T) {
+	r, c, g, p := chainBackends(true, true, true)
+	r.Refresh(context.Background())
+	if got := r.resolve("claude"); got.Used != TierCloud {
+		t.Fatalf("initial used = %q, want %q", got.Used, TierCloud)
+	}
+
+	// Unplug cloud: next Refresh degrades to gemma with endpoint_unreachable.
+	c.set(false)
+	r.Refresh(context.Background())
+	if got := r.resolve("claude"); got.Used != TierGemma || got.FallbackReason != FallbackEndpointUnreachable {
+		t.Errorf("after cloud unplug, resolve = %+v, want gemma/%s", got, FallbackEndpointUnreachable)
+	}
+
+	// Unplug gemma too: degrade to phi.
+	g.set(false)
+	r.Refresh(context.Background())
+	if got := r.resolve("claude"); got.Used != TierPhi {
+		t.Errorf("after gemma unplug, used = %q, want %q", got.Used, TierPhi)
+	}
+
+	// Unplug phi: the whole chain is down -> rules, no_backend_available, no error.
+	p.set(false)
+	r.Refresh(context.Background())
+	if got := r.resolve("claude"); got.Used != InferenceRules || got.FallbackReason != FallbackNoBackend {
+		t.Errorf("after full unplug, resolve = %+v, want rules/%s", got, FallbackNoBackend)
+	}
+}
+
+// --- Acceptance #5: recovery — a recovered higher tier is climbed back to ---
+
+// TestResolve_RecoversToHigherTier: with cloud down the resolver serves gemma;
+// when cloud comes back and the cache refreshes, resolve climbs back to cloud.
+func TestResolve_RecoversToHigherTier(t *testing.T) {
+	r, c, _, _ := chainBackends(false, true, true)
+	r.Refresh(context.Background())
+	if got := r.resolve("claude"); got.Used != TierGemma {
+		t.Fatalf("with cloud down, used = %q, want %q", got.Used, TierGemma)
+	}
+
+	// Cloud recovers. BEFORE the next Refresh the cache still says gemma (the
+	// recovery is not seen until we re-probe) — proving the cache governs.
+	c.set(true)
+	if got := r.resolve("claude"); got.Used != TierGemma {
+		t.Errorf("before refresh, used = %q, want still %q (cache not yet refreshed)", got.Used, TierGemma)
+	}
+	// After the periodic re-probe, the higher tier is picked up again.
+	r.Refresh(context.Background())
+	if got := r.resolve("claude"); got.Used != TierCloud || got.FallbackReason != "" {
+		t.Errorf("after recovery refresh, resolve = %+v, want cloud/no-fallback", got)
+	}
+}
+
+// TestResolve_ConcurrentResolveAndRefresh: resolve() runs from many goroutines
+// while Refresh flips availability — the race detector must stay quiet and every
+// resolve returns a valid chain tier or rules (never a torn read).
+func TestResolve_ConcurrentResolveAndRefresh(t *testing.T) {
+	r, c, _, _ := chainBackends(true, true, true)
+	r.Refresh(context.Background())
+
+	valid := map[string]bool{TierCloud: true, TierGemma: true, TierPhi: true, InferenceRules: true}
+	stop := make(chan struct{})
+
+	// Refresher: flip cloud up/down and re-probe until the resolvers signal stop.
+	var refresher sync.WaitGroup
+	refresher.Add(1)
+	go func() {
+		defer refresher.Done()
+		for i := 0; ; i++ {
+			select {
+			case <-stop:
+				return
+			default:
+				c.set(i%2 == 0)
+				r.Refresh(context.Background())
+			}
+		}
+	}()
+
+	// Resolvers: hammer resolve concurrently for a fixed number of iterations.
+	var resolvers sync.WaitGroup
+	for g := 0; g < 8; g++ {
+		resolvers.Add(1)
+		go func() {
+			defer resolvers.Done()
+			for i := 0; i < 2000; i++ {
+				if used := r.resolve("claude").Used; !valid[used] {
+					t.Errorf("resolve returned invalid tier %q", used)
+					return
+				}
+			}
+		}()
+	}
+	resolvers.Wait() // resolvers done -> stop the refresher
+	close(stop)
+	refresher.Wait()
+}
+
+// TestDefaultChain_TierNamesAndOrder: the production chain is cloud -> gemma3:4b
+// -> phi4-mini, in that order, with the documented tier names. Empty endpoints
+// make a tier permanently unreachable without dialing.
+func TestDefaultChain_TierNamesAndOrder(t *testing.T) {
+	chain := DefaultChain(Endpoints{}) // all empty -> all unreachable
+	wantNames := []string{TierCloud, TierGemma, TierPhi}
+	if len(chain) != len(wantNames) {
+		t.Fatalf("chain length = %d, want %d", len(chain), len(wantNames))
+	}
+	for i, b := range chain {
+		if b.Name() != wantNames[i] {
+			t.Errorf("chain[%d] = %q, want %q", i, b.Name(), wantNames[i])
+		}
+		if b.Available(context.Background()) {
+			t.Errorf("chain[%d] (%q) with empty endpoint must be unreachable", i, b.Name())
+		}
+	}
+}

--- a/services/agent/decision/telemetry.go
+++ b/services/agent/decision/telemetry.go
@@ -136,11 +136,14 @@ const (
 	// InferenceRules is inference.used on every cycle until the M4 LLM path
 	// runs: the deterministic rules engine is what actually decided.
 	InferenceRules = "rules"
-	// FallbackNoBackend is inference.fallback_reason when mode=llm is selected and
-	// the loop captures the prompt (#739) but no inference backend is wired yet, so
-	// it falls back to the rules engine. Empty when not applicable (mode=rules).
-	// #741's resolve_backend() will supply the real reason (and used="llm") once a
-	// backend answers; until then every llm cycle reports this single reason.
+	// FallbackNoBackend is inference.fallback_reason when the #847 gate ADMITTED an
+	// llm attempt but resolve_backend (#741) found the WHOLE chain unreachable, so it
+	// bottoms out at the always-available rules engine (inference.used="rules"). It is
+	// the honest "the llm path was wanted but nothing answered" reason — distinct from
+	// FallbackEndpointUnreachable, where a LOWER llm tier still serves. Empty when not
+	// applicable (mode=rules, or a configured-tier-reachable llm cycle). Until #739 a
+	// reachable tier does not actually decide either, but it carries no fallback_reason
+	// (configured == used); only a fully-unreachable chain reports this.
 	FallbackNoBackend = "no_backend_available"
 	// LLM call-gate fallback reasons (#847). When the three-layer gate denies an
 	// llm cycle, the cycle falls back to the rules engine WITHOUT building or
@@ -159,6 +162,15 @@ const (
 	// FallbackBudgetExhausted: the global per-minute request budget
 	// (llm.max_requests_per_minute, shared across all games) is full this window.
 	FallbackBudgetExhausted = "llm_budget_exhausted"
+	// FallbackEndpointUnreachable is the inference.fallback_reason when the #847 gate
+	// ADMITTED an llm attempt but resolve_backend (#741) had to degrade PAST the
+	// configured tier because a higher tier's endpoint was unreachable — a LOWER llm
+	// tier serves instead (e.g. configured=claude but the cloud endpoint is down, so
+	// gemma3:4b or phi4-mini resolves). It is distinct from FallbackNoBackend: this
+	// reason means a real llm tier WILL serve (#739), just not the configured one;
+	// FallbackNoBackend means the WHOLE chain was unreachable and rules decided.
+	// Recorded together with inference.used=<the lower tier> on the decision span.
+	FallbackEndpointUnreachable = "endpoint_unreachable"
 	// DefaultObjectives until the objectives flag schema exists (#725).
 	DefaultObjectives = "unset"
 	// UnrestrictedAllowed is the interventions.allowed summary while the

--- a/services/agent/main.go
+++ b/services/agent/main.go
@@ -260,6 +260,21 @@ func main() {
 	// per-game cadence + eligibility layers live on each Loop; only the budget is
 	// shared across loops.
 	sharedLLMBudget := decision.NewLLMBudget()
+	// Shared inference fallback-chain resolver (#741). Constructed ONCE here with the
+	// real network probes for the three llm tiers (cloud #742, gemma3:4b on Jetson
+	// #738, phi4-mini on localhost #739) and ONE availability cache for the whole
+	// agent, then injected into every per-game Loop below — like the global budget.
+	// In dev every endpoint is unreachable, so resolve_backend honestly degrades the
+	// whole chain to the rules engine; with a tier reachable it reports that tier as
+	// inference.used (who #739 WILL call). Start() launches the background re-probe
+	// ticker (DefaultProbeInterval) and primes the cache before the first decision; it
+	// stops when ctx is cancelled at shutdown.
+	sharedResolver := decision.NewResolver(decision.DefaultChain(decision.Endpoints{
+		Cloud:     getEnv("AGENT_CLOUD_ENDPOINT", ""),                    // #742 credential-blocked: empty = permanently unreachable
+		Jetson:    getEnv("AGENT_JETSON_ENDPOINT", "jetson:11434"),       // #738 Ollama on the Jetson; unresolvable in dev
+		Localhost: getEnv("AGENT_LOCALHOST_ENDPOINT", "localhost:11434"), // #739 Ollama locally; unreachable unless running
+	}), decision.DefaultProbeInterval)
+	sharedResolver.Start(ctx)
 	probeDecisions := strings.EqualFold(getEnv("AGENT_PROBE_DECISIONS", ""), "true")
 	if probeDecisions {
 		slog.Warn("Probe decisions enabled (demo/verification mode)",
@@ -277,6 +292,10 @@ func main() {
 		// references the same instance: the gate's eligibility + cadence layers are
 		// per-loop, but the budget layer is one global cap across all games.
 		loop.SetLLMBudget(sharedLLMBudget)
+		// Inject the SHARED inference resolver (#741): every per-game loop resolves the
+		// fallback chain against the same availability cache, so a gate-admitted llm
+		// cycle reports the honest inference.used tier and any degradation reason.
+		loop.SetResolver(sharedResolver)
 		// The objective-weighted rules engine (#726) is the active default, built
 		// FRESH per loop (see the factory doc above). Its objective weights are driven
 		// live from the `objectives` flag each cycle; policy/fitness run on


### PR DESCRIPTION
Part of #741. Builds the inference availability checker + fallback chain: `resolve_backend()` walks from the configured `agent.model` flag down to the always-available rules engine, so the agent uses whatever intelligence is reachable and degrades gracefully:

```
configured model (claude | copilot)   [agent.model flag]
    ↓ unreachable
gemma3:4b on Jetson                    (#738)
    ↓ unreachable
phi4-mini on localhost                 (#739)
    ↓ unreachable
rules engine                           ← always available; the system ALWAYS decides
```

> **Stacking note:** authored as a stacked diff on top of #847 / PR #938 (`feat/847-llm-call-gating`). #938 squash-merged to main while this was in flight, so this branch was rebased onto main; it now targets `main` directly and builds ON #847's merged gate. No #847 changes appear in this diff.

This is the ABSTRACTION + resolver + attribution + periodic-cached probing. There is **no real backend call yet** — #739 implements `llm_decide`, Jetson #738 and cloud #742 are hardware/credential-blocked. So a "reachable" tier means "this is who #739 WILL call"; the rules engine still produces the Decision until then. The resolver's job is to make `inference.used` / `inference.fallback_reason` HONEST on every decision span.

## What's in it

- **Backend abstraction** (`decision/resolver.go`): a `Backend` interface (`Name()` + `Available(ctx) bool`) per tier, an ordered chain, and a `Resolver` holding a periodically-refreshed availability **cache**. `resolve()` reads the cache only — **no probe on the decision hot path** (acceptance #2). A background ticker (`Start`) re-probes every `DefaultProbeInterval` (15s const), so an unplugged tier degrades and a recovered tier is climbed back to within one interval (acceptance #4/#5). Mutex-guarded for the concurrent Export handlers.
- **Production probe** (`decision/probe_backend.go`): a bounded TCP dial per tier; empty endpoint = permanently unreachable. Injectable via the `Backend` interface so tests use fakes (never the network). #739 swaps the dial for a real model-health check.
- **Honest attribution**: `inference.used` / `inference.fallback_reason` are now the resolved tier and degradation reason, threaded through `LayerState.InferenceUsed` (default `rules`) so `layerStateAttributes` emits the resolved value instead of the static `inferenceAttribution(mode)`. `inference.configured` is the model flag. All three present on every decision span, including when configured == used (fallback_reason `""` then).
- **Gate coordination with #847**: `decide()` runs the gate FIRST; `resolve_backend` runs ONLY when the gate ADMITS. A gate-DENIED cycle keeps #847's behavior **exactly** — `inference.used="rules"`, `inference.fallback_reason`=the gate reason — and the resolver never overrides it or consumes anything. New `FallbackEndpointUnreachable` (`endpoint_unreachable`) reason for "a lower tier serves"; `FallbackNoBackend` reconciled to mean "whole chain unreachable, rules decided".
- **Wiring** (`main.go`): ONE shared `Resolver` (one availability cache for the whole agent, like the global budget) injected into every per-game Loop via `SetResolver`; endpoints read from env (`AGENT_CLOUD_ENDPOINT` / `AGENT_JETSON_ENDPOINT` / `AGENT_LOCALHOST_ENDPOINT`) with documented defaults. In dev every endpoint is unreachable, so the chain degrades to rules — exactly the standalone no-Jetson/no-cloud behavior.

## Acceptance criteria

- [x] Backend resolution follows the documented chain order from the configured model (`TestResolve_ChainOrderFromConfiguredModel`)
- [x] Availability checks run periodically with results cached between checks — probe NOT called per decision (`TestResolve_CachedNotProbedPerDecision`, counting fake)
- [x] All three inference attributes present on every decision span, including configured == used (`TestAttribution_ConfiguredEqualsUsed`)
- [x] Unplugging a tier mid-session degrades to the next, then to rules — no errors, no stalled decisions (`TestResolve_DegradesWhenTierUnplugged`, `TestAttribution_DegradesMidSession`)
- [x] Recovery: a recovered higher tier is climbed back to (`TestResolve_RecoversToHigherTier`, `TestAttribution_RecoversMidSession`)
- [x] Gate coordination: a gate-DENIED cycle keeps the gate reason and used=rules; the resolver does not override it (`TestAttribution_GateDeniedKeepsGateReason`, `TestAttribution_GateBudgetExhaustedKeepsGateReason`)

## Out of scope (per #741)
The actual LLM call / `llm_decide` (#739 — stacks on this next). Real Jetson/cloud backends (#738/#742). Async inference (#917). Prompt variants (#740).

## Verification
`gofmt -l .` clean, `go vet ./...`, `go build ./...`, `go test -race ./...` all green from `services/agent/` (9 packages). `make lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)