### PR TITLE
fix(agent): dedupe elimination narration across both source paths (#916)

### DIFF
--- a/services/agent/gamecontext/store.go
+++ b/services/agent/gamecontext/store.go
@@ -404,12 +404,30 @@ func (s *Store) RecordDeathTotal(serial string, total float64) {
 func (s *Store) SetEliminationOrder(serial string, order int) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	_, alreadyKnown := s.elimOrder[serial]
+	_, inOrderMap := s.elimOrder[serial]
 	s.elimOrder[serial] = order
-	// Narrate each serial's elimination exactly once, the first time this preferred
-	// source reports it (a repeat report only re-sorts) (#916). Record with the
-	// reported 1-based order so the narrative matches the rebuilt sequence below.
-	if !alreadyKnown {
+	// Narrate each serial's elimination exactly ONCE — but across BOTH dedupe
+	// stores. This preferred source dedupes on the elimOrder map (inOrderMap); the
+	// death/span fallback path (appendElimination) narrates through
+	// EliminationSequence membership. The two never cross-check, so without the
+	// sequence guard below a serial the death/span path already narrated would get
+	// a SECOND elimination line here (#916). Latent today — the
+	// game_player_elimination_order producer is unshipped, so only the death/span
+	// path fires — but armed the moment that metric ships alongside the death/span
+	// signals, so we close it now. The reverse order is already safe: once this
+	// method rebuilds EliminationSequence below, a later appendElimination finds the
+	// serial present and returns early. Record with the reported 1-based order so
+	// the narrative matches the rebuilt sequence.
+	alreadyNarrated := inOrderMap
+	if !alreadyNarrated {
+		for _, existing := range s.ctx.Session.EliminationSequence {
+			if existing == serial {
+				alreadyNarrated = true // the death/span path already narrated it
+				break
+			}
+		}
+	}
+	if !alreadyNarrated {
 		s.history.append(TimelineEvent{
 			At:     s.now(),
 			Kind:   EventElimination,

--- a/services/agent/gamecontext/store_test.go
+++ b/services/agent/gamecontext/store_test.go
@@ -283,6 +283,50 @@ func TestStore_TimelinePhaseStartEnd(t *testing.T) {
 	}
 }
 
+// TestStore_TimelineEliminationNoDoubleNarration verifies a serial is narrated as
+// eliminated exactly ONCE regardless of which order the death/span path
+// (RecordElimination) and the preferred order source (SetEliminationOrder) report
+// it. The two paths dedupe on different stores (EliminationSequence vs elimOrder),
+// so without the cross-store guard the order source emits a second elimination
+// line for a serial the death/span path already narrated (#916).
+func TestStore_TimelineEliminationNoDoubleNarration(t *testing.T) {
+	count := func(s *Store) int {
+		n := 0
+		for _, e := range s.Snapshot().Timeline {
+			if e.Kind == EventElimination && e.Serial == "A" {
+				n++
+			}
+		}
+		return n
+	}
+
+	// The buggy direction: death/span narrates + adds to EliminationSequence, then
+	// the order source reports the same serial (elimOrder did not yet know it).
+	t.Run("span_then_order", func(t *testing.T) {
+		clk := &clock{t: time.Unix(0, 0)}
+		s := NewStore(time.Hour, time.Hour, clk.now)
+		s.RecordElimination("A")
+		clk.advance(time.Second)
+		s.SetEliminationOrder("A", 1)
+		if n := count(s); n != 1 {
+			t.Fatalf("elimination lines for A = %d, want 1 (no double-narration)", n)
+		}
+	})
+
+	// The reverse direction was already safe (the rebuilt sequence dedupes the later
+	// append); assert it so the invariant is documented from both sides.
+	t.Run("order_then_span", func(t *testing.T) {
+		clk := &clock{t: time.Unix(0, 0)}
+		s := NewStore(time.Hour, time.Hour, clk.now)
+		s.SetEliminationOrder("A", 1)
+		clk.advance(time.Second)
+		s.RecordElimination("A")
+		if n := count(s); n != 1 {
+			t.Fatalf("elimination lines for A = %d, want 1 (no double-narration)", n)
+		}
+	})
+}
+
 // TestStore_TimelineEvictedOnGrace verifies the narrative is cleared with the
 // rest of the session-scoped state on grace exit (#916 eviction).
 func TestStore_TimelineEvictedOnGrace(t *testing.T) {


### PR DESCRIPTION
## What

Follow-up correctness fix for #916 (the rolling game narrative merged in #934). Found by sub-agent review of #934 *after* it had already squash-merged, so it needs its own PR.

`SetEliminationOrder` (the preferred `game_player_elimination_order` source) deduped elimination narration on the `elimOrder` map, while `appendElimination` (the death/span fallback path) deduped on `EliminationSequence` membership. The two paths never cross-checked, so a serial the death/span path already narrated got a **second** elimination line when the order source later reported it (empirically reproducible: 2 lines for one serial).

Latent on `main` today — the `game_player_elimination_order` producer is unshipped, so only the death/span path fires — but armed the moment that metric ships alongside the death/span signals. Fixing now since the trap is easy to forget later.

## Change

- `SetEliminationOrder` now guards narration on `EliminationSequence` membership in addition to the `elimOrder` map, so the two source paths can't each narrate the same serial.
- New `TestStore_TimelineEliminationNoDoubleNarration` asserting exactly one elimination line for **both** report orderings (span-then-order, the buggy direction, and order-then-span, already safe).

## Verification

`gofmt -l .` clean, `go vet ./...`, `go test -race ./...` all green (9 packages).

Part of #916.

🤖 Generated with [Claude Code](https://claude.com/claude-code)