### PR TITLE
feat(interventions): coordinator rate limiter becomes generous global backstop (#919)

### DIFF
--- a/docs/agent-act-runbook.md
+++ b/docs/agent-act-runbook.md
@@ -204,6 +204,37 @@ can verify the trace pipeline without a live game. See the agent README →
 
 ---
 
+## Rate-limit ownership — defense-in-depth contract (#919)
+
+Intervention rate limiting runs in **two layers, in two languages**, with
+**distinct, non-overlapping roles**. They are deliberately *not* two copies of
+the same governor, and they read **different flags** so they cannot silently
+drift (closes bug classes #800/#848):
+
+| Layer | Where | Scope | Reads flag | Role |
+|-------|-------|-------|-----------|------|
+| **Agent (authoritative)** | `services/agent/decision/` — per-game `Loop` in `loopset.go`, limiter in `ratelimit.go` | **Per game** (`game_id`) | `policy.max_interventions_per_minute` | The real governor. Each game gets its **own** weighted per-minute budget; one game exhausting it never starves another. The agent only emits an intervention once its per-game limiter admits it. |
+| **Coordinator (backstop)** | `services/game_coordinator/interventions.py` — `_RateLimiter` | **Process-global** (all games share one) | `policy.coordinator_backstop_per_minute` | A generous global safety net. Caps a *runaway/buggy* agent that floods flag writes far beyond any sane per-game rate. Tuned high enough that normal multi-session traffic never reaches it. |
+
+**The single-owner rule (drift prevention).** Per-game pacing lives in exactly
+**one** place — the agent. The coordinator does **not** re-derive or mirror the
+per-game budget; it owns only the generous global flood ceiling.
+
+- To change how aggressively a single game may be nudged → change
+  `policy.max_interventions_per_minute` (agent, per-game).
+- To move the global flood ceiling → change
+  `policy.coordinator_backstop_per_minute` (coordinator backstop). The default
+  variant (`60`/min) is intentionally far above any legitimate combined traffic;
+  it only trips on an order-of-magnitude-higher, clearly-runaway write rate.
+
+A `decision.block_reason=rate_limit` on an **agent** span means the game's own
+per-game budget is spent (normal pacing). A `block_reason=rate_limited` on a
+**coordinator** `game_interventions_total{blocked="true"}` increment means the
+*global backstop* tripped — that is abnormal and points at a misbehaving agent,
+not at normal play.
+
+---
+
 ## Where to look
 
 | Tool | Path | Use |

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -352,7 +352,8 @@ variants are populated from the #722 research — see
 | `interventions_allowed` | string | `none`, `ambient`, `standard`, `full` | `ambient` | Permitted intervention surface (from #722 §6) |
 | `policy.battery_threshold` | integer | percent | 20 | Battery floor before agent acts |
 | `policy.movement_variance_window` | integer | samples | 10 | Window for movement-variance checks |
-| `policy.max_interventions_per_minute` | integer | count | 2 | Rate cap on interventions |
+| `policy.max_interventions_per_minute` | integer | count | 2 | **Authoritative per-game** rate cap, enforced by the agent (one budget per `game_id`, see [agent runbook → rate-limit ownership](agent-act-runbook.md#rate-limit-ownership--defense-in-depth-contract-919)) |
+| `policy.coordinator_backstop_per_minute` | integer | count | 60 | **Generous global backstop** (#919) for the coordinator `_RateLimiter` — a process-wide flood ceiling across all games, *not* a per-game cap; only trips on a runaway agent |
 
 #### Fitness configuration
 

--- a/services/agent/decision/ratelimit.go
+++ b/services/agent/decision/ratelimit.go
@@ -24,8 +24,18 @@ import (
 //     unified loop *can* see permissions. The engine no longer rate-limits.
 //   - Unknown-intervention cost is #728's medium (1.0). #726 used the hard cost
 //     (2.0) as a fail-safe; the medium default is kept for parity with #728 and
-//     because the game-coordinator flag-application layer (#730) remains the
-//     authoritative backstop for anything mis-weighted here.
+//     because the game-coordinator flag-application layer (#730) remains a
+//     generous GLOBAL backstop that catches anything mis-weighted here.
+//
+// Budget-ownership contract (#919): THIS limiter is the AUTHORITATIVE PER-GAME
+// governor. Each game_id gets its own *Loop with its own rateLimiter (see
+// loopset.go), so one game exhausting policy.max_interventions_per_minute never
+// starves another. The game-coordinator's _RateLimiter
+// (services/game_coordinator/interventions.py) is NOT a second per-game governor:
+// it is a single, deliberately generous, process-global BACKSTOP keyed off a
+// SEPARATE flag (policy.coordinator_backstop_per_minute) that only trips on a
+// runaway agent. The two layers read different flags on purpose so they cannot
+// silently drift (bug classes #800/#848).
 
 // Intervention identifiers — exactly the interventions_allowed vocabulary from
 // the flagd agent schema (services/flagd/agent.json) and the #722 research §6.

--- a/services/flagd/agent.json
+++ b/services/flagd/agent.json
@@ -167,6 +167,15 @@
       },
       "defaultVariant": "default"
     },
+    "policy.coordinator_backstop_per_minute": {
+      "state": "ENABLED",
+      "variants": {
+        "default": 60,
+        "strict": 20,
+        "generous": 120
+      },
+      "defaultVariant": "default"
+    },
     "fitness.endurance.min_session_seconds": {
       "state": "ENABLED",
       "variants": {

--- a/services/game_coordinator/interventions.py
+++ b/services/game_coordinator/interventions.py
@@ -22,8 +22,11 @@ Design (from docs/research/722-intervention-surface.md §5/§6/§8/§9):
   agent also self-checks in #726):
     1. allowed-membership   — type must be in ``interventions_allowed`` (agent
        domain, default ``[]``)
-    2. weighted rate limit  — sliding 60s window, weighted cost per class,
-       budget from ``policy.max_interventions_per_minute``
+    2. weighted rate limit  — sliding 60s window, weighted cost per class. This
+       is the GENEROUS GLOBAL BACKSTOP (#919), budget from
+       ``policy.coordinator_backstop_per_minute``; the per-game budget is owned
+       authoritatively by the agent (see the defense-in-depth contract block
+       below).
     3. battery guard        — player-targeted interventions blocked when the
        target's battery pct < ``policy.battery_threshold``
     4. mode-capability matrix — declarative per-mode gating (§9)
@@ -56,6 +59,52 @@ WEIGHT_HARD = 2.0  # state-changing, player-visible as unfair if wrong
 
 # Sliding rate-limit window in seconds (§5: "max_interventions_per_minute").
 RATE_LIMIT_WINDOW_SECONDS = 60.0
+
+# ---------------------------------------------------------------------------- #
+# Defense-in-depth budget contract (#919)
+# ---------------------------------------------------------------------------- #
+# Intervention rate limiting is enforced in TWO layers, in two languages. They
+# have DISTINCT, non-overlapping roles — they are NOT two copies of the same
+# governor, and they intentionally read DIFFERENT flags so they cannot drift:
+#
+#   1. Go agent (AUTHORITATIVE, per-game). services/agent/decision/loopset.go
+#      gives every game_id its OWN decision Loop, each with its OWN weighted
+#      sliding-window budget read from ``policy.max_interventions_per_minute``
+#      (services/agent/decision/ratelimit.go). This is the real per-game
+#      governor: it decides how many interventions a single game may receive per
+#      minute, and one game exhausting its budget never starves another. The
+#      agent only emits an intervention (writes the flag) once its per-game
+#      limiter admits it.
+#
+#   2. Coordinator ``_RateLimiter`` (BACKSTOP, process-global). The limiter in
+#      this module is a single GLOBAL safety net shared across every concurrent
+#      game in this coordinator process. Its job is NOT to govern normal
+#      per-game pacing — that is the agent's. Its job is to cap a *runaway or
+#      buggy* agent that floods flag writes far beyond any sane per-game rate
+#      (e.g. a crash-loop rewriting nonces, or a misconfigured agent ignoring
+#      its own limiter). It is therefore deliberately set to a GENEROUS budget
+#      that normal multi-session traffic — several concurrent games each at
+#      their own authoritative per-game budget — will never reach. It reads its
+#      budget from a SEPARATE flag, ``policy.coordinator_backstop_per_minute``,
+#      so it can be tuned independently and so the two layers never share a
+#      value that could silently drift.
+#
+# The drift-prevention rule (closes bug classes #800/#848): the per-game pacing
+# decision lives in exactly ONE place — the agent. The coordinator does not
+# re-derive or mirror the per-game budget; it only owns the generous global cap.
+# To change how aggressively a single game may be nudged, change
+# ``policy.max_interventions_per_minute`` (agent). Touch the coordinator backstop
+# (``policy.coordinator_backstop_per_minute``) only to move the global flood
+# ceiling.
+
+# Generous default global-backstop budget (weighted interventions / minute)
+# applied across ALL concurrent games in this coordinator process. Picked so it
+# never fires for legitimate traffic: even a busy fleet of several concurrent
+# games each spending its full authoritative per-game budget (default 2/min,
+# aggressive 4/min) stays well under this; the backstop only trips on an agent
+# emitting flag writes at an order-of-magnitude-higher, clearly-runaway rate.
+# Overridable via the ``policy.coordinator_backstop_per_minute`` flag.
+DEFAULT_COORDINATOR_BACKSTOP_BUDGET = 60.0
 
 # Sentinel "no payload / no-op" values for edge-triggered flags.
 _EDGE_EMPTY_VALUES = {"", "none"}
@@ -287,7 +336,16 @@ class InterventionContext:
 
 
 class _RateLimiter:
-    """Weighted sliding-window rate limiter (§5).
+    """Weighted sliding-window rate limiter — the GLOBAL BACKSTOP (#919).
+
+    This is the process-global defense-in-depth backstop described in the
+    "Defense-in-depth budget contract" block at the top of this module. It is
+    NOT the per-game governor — the Go agent owns that
+    (``policy.max_interventions_per_minute``, per-game Loop). This limiter is one
+    generous global cap shared across all concurrent games, instantiated with
+    ``DEFAULT_COORDINATOR_BACKSTOP_BUDGET`` and tuned via the separate
+    ``policy.coordinator_backstop_per_minute`` flag. It only trips when a runaway
+    agent floods flag writes well beyond all sane per-game traffic combined.
 
     Tracks (timestamp, cost) of applied interventions over the last
     ``RATE_LIMIT_WINDOW_SECONDS``. ``check(cost)`` returns True (and reserves the
@@ -431,7 +489,10 @@ class InterventionManager:
         self._last_nonce: dict[str, dict[str, str]] = {}
         self._last_state_value: dict[str, dict[str, object]] = {}
 
-        self._rate_limiter = _RateLimiter(budget=2.0, time_fn=time_fn)
+        # Global BACKSTOP limiter (#919): generous, process-global, NOT the
+        # per-game governor (that is the agent's). See the defense-in-depth
+        # contract block at the top of this module.
+        self._rate_limiter = _RateLimiter(budget=DEFAULT_COORDINATOR_BACKSTOP_BUDGET, time_fn=time_fn)
 
         # Handler registry: flag_key -> Handler. Defaults to the no-op stub for
         # every spec. PRs C/D/E replace entries via register_handler().
@@ -980,8 +1041,11 @@ class InterventionManager:
             if pct is not None and pct < self._battery_threshold():
                 return BLOCK_LOW_BATTERY
 
-        # (b) weighted rate limit — reserves budget; do last so the reservation
-        # only happens for otherwise-allowed interventions.
+        # (b) weighted rate limit — the GENEROUS GLOBAL BACKSTOP (#919), NOT the
+        # per-game governor (that is the agent's). Reserves budget; do last so
+        # the reservation only happens for otherwise-allowed interventions. A
+        # block here means a process-wide flood across ALL games, not a single
+        # game pacing itself out.
         if not self._rate_limiter.check(spec.weight):
             return BLOCK_RATE_LIMITED
 
@@ -1155,14 +1219,27 @@ class InterventionManager:
             return 20.0
 
     def _refresh_budget(self) -> None:
-        budget = 2.0
+        """Refresh the GLOBAL BACKSTOP budget (#919).
+
+        Reads ``policy.coordinator_backstop_per_minute`` — NOT
+        ``policy.max_interventions_per_minute``. The latter is the agent's
+        authoritative per-game budget; the coordinator must not mirror it (that
+        is exactly the drift the contract forbids). This limiter owns only the
+        generous global flood ceiling, which falls back to
+        ``DEFAULT_COORDINATOR_BACKSTOP_BUDGET`` when the flag is unreachable.
+        """
+        budget = DEFAULT_COORDINATOR_BACKSTOP_BUDGET
         if self._agent_client is not None:
             try:
                 budget = float(
-                    self._agent_client.get_integer_value("policy.max_interventions_per_minute", 2, EvaluationContext())
+                    self._agent_client.get_integer_value(
+                        "policy.coordinator_backstop_per_minute",
+                        int(DEFAULT_COORDINATOR_BACKSTOP_BUDGET),
+                        EvaluationContext(),
+                    )
                 )
             except Exception:
-                budget = 2.0
+                budget = DEFAULT_COORDINATOR_BACKSTOP_BUDGET
         self._rate_limiter.set_budget(budget)
 
     def _dominant_objective(self) -> str:

--- a/services/game_coordinator/tests/test_interventions.py
+++ b/services/game_coordinator/tests/test_interventions.py
@@ -85,12 +85,21 @@ def make_manager(
     allowed=None,
     battery=None,
     game=None,
-    budget=2,
+    backstop=60,
     threshold=20,
     objectives=None,
     time_fn=None,
 ):
-    """Build a manager wired with fake clients, bypassing start()."""
+    """Build a manager wired with fake clients, bypassing start().
+
+    ``backstop`` is the coordinator's GLOBAL BACKSTOP budget (#919) — the
+    ``policy.coordinator_backstop_per_minute`` flag that ``_refresh_budget``
+    reads. It is deliberately generous by default (60) so normal multi-session
+    traffic never trips it; tests that exercise the backstop set it low. NOTE the
+    coordinator no longer reads ``policy.max_interventions_per_minute`` — that is
+    the agent's authoritative per-game budget and is set here only so the value
+    is present for any code/tests that still inspect it.
+    """
     events = []
 
     async def publisher(event_type, data):
@@ -98,7 +107,10 @@ def make_manager(
 
     agent_values = {
         "interventions_allowed": list(ALL_TYPES) if allowed is None else allowed,
-        "policy.max_interventions_per_minute": budget,
+        # Agent-owned per-game budget (NOT read by the coordinator backstop).
+        "policy.max_interventions_per_minute": 2,
+        # Coordinator-owned generous global backstop (what _refresh_budget reads).
+        "policy.coordinator_backstop_per_minute": backstop,
         "policy.battery_threshold": threshold,
     }
     if objectives is not None:
@@ -112,7 +124,7 @@ def make_manager(
     )
     mgr._interventions_client = FakeFlagClient(interventions or {})
     mgr._agent_client = FakeFlagClient(agent_values)
-    mgr._rate_limiter.set_budget(float(budget))
+    mgr._rate_limiter.set_budget(float(backstop))
     return mgr, events
 
 
@@ -305,20 +317,25 @@ async def test_empty_allowed_blocks_everything():
 
 
 # --------------------------------------------------------------------------- #
-# Enforcement: weighted rate limit
+# Enforcement: weighted rate limit — the GLOBAL BACKSTOP (#919)
+#
+# The coordinator limiter is the generous process-global backstop, not the
+# per-game governor (that is the agent's). These tests pin a LOW backstop to
+# prove the safety net still trips on a flood; the "normal traffic never trips"
+# and "per-game independence" properties are covered further below.
 # --------------------------------------------------------------------------- #
 @pytest.mark.asyncio
-async def test_rate_limit_blocks_after_budget_exhausted():
+async def test_backstop_blocks_after_global_budget_exhausted():
     clock = Clock()
     mgr, events = make_manager(
         interventions={"eliminate_player": "1:ctrl_a"},  # hard = 2.0
-        budget=2,
+        backstop=2,  # tiny backstop so the flood trips it immediately
         time_fn=clock,
     )
     with patch("services.game_coordinator.metrics.interventions_total"):
         await mgr.evaluate_all()  # consumes 2.0 (applied)
         mgr._interventions_client.set("eliminate_player", "2:ctrl_b")  # new trigger
-        await mgr.evaluate_all()  # budget exhausted -> blocked
+        await mgr.evaluate_all()  # backstop exhausted -> blocked
     elim = [d for et, d in events if et == GameEvent.AGENT_INTERVENTION and d["type"] == "eliminate_player"]
     assert elim[0]["blocked"] == "false"
     assert elim[1]["blocked"] == "true"
@@ -326,9 +343,9 @@ async def test_rate_limit_blocks_after_budget_exhausted():
 
 
 @pytest.mark.asyncio
-async def test_rate_limit_window_slide_allows_again():
+async def test_backstop_window_slide_allows_again():
     clock = Clock()
-    mgr, events = make_manager(interventions={"eliminate_player": "1:ctrl_a"}, budget=2, time_fn=clock)
+    mgr, events = make_manager(interventions={"eliminate_player": "1:ctrl_a"}, backstop=2, time_fn=clock)
     with patch("services.game_coordinator.metrics.interventions_total"):
         await mgr.evaluate_all()
         clock.advance(61.0)
@@ -339,13 +356,13 @@ async def test_rate_limit_window_slide_allows_again():
 
 
 @pytest.mark.asyncio
-async def test_blocked_intervention_does_not_consume_budget():
-    """A type blocked by membership must not eat rate-limit budget."""
+async def test_blocked_intervention_does_not_consume_backstop_budget():
+    """A type blocked by membership must not eat backstop budget."""
     clock = Clock()
     mgr, _ = make_manager(
         interventions={"eliminate_player": "1:ctrl_a"},
         allowed=["eliminate_player"],
-        budget=2,
+        backstop=2,
         time_fn=clock,
     )
     # block eliminate via membership by removing it AFTER constructing? Instead
@@ -354,6 +371,84 @@ async def test_blocked_intervention_does_not_consume_budget():
     with patch("services.game_coordinator.metrics.interventions_total"):
         await mgr.evaluate_all()  # blocked (not allowed) -> no reservation
     assert mgr._rate_limiter.current_weight() == pytest.approx(0.0)
+
+
+# --------------------------------------------------------------------------- #
+# Defense-in-depth budget contract (#919): the coordinator limiter is a GENEROUS
+# GLOBAL BACKSTOP, not the per-game governor. These tests pin the contract:
+#   - the default backstop is generous and is read from the dedicated
+#     coordinator flag (NOT the agent's per-game budget flag — drift guard);
+#   - normal multi-session traffic stays well under the backstop and is never
+#     throttled by the coordinator (per-game pacing is the agent's job).
+# --------------------------------------------------------------------------- #
+def test_default_backstop_is_generous():
+    """A freshly-constructed manager starts with the generous global backstop,
+    far above the agent's per-game budget — so it never governs normal pacing."""
+    from services.game_coordinator.interventions import (
+        DEFAULT_COORDINATOR_BACKSTOP_BUDGET,
+    )
+
+    mgr, _ = make_manager()
+    # Constructed budget is the generous default, not the agent per-game value.
+    assert mgr._rate_limiter._budget == pytest.approx(DEFAULT_COORDINATOR_BACKSTOP_BUDGET)
+    assert DEFAULT_COORDINATOR_BACKSTOP_BUDGET >= 60.0
+
+
+def test_refresh_budget_reads_coordinator_flag_not_per_game_flag():
+    """Drift guard (#919): _refresh_budget must read
+    policy.coordinator_backstop_per_minute and IGNORE the agent's
+    policy.max_interventions_per_minute, so the two layers can never silently
+    converge on one shared per-game value."""
+    mgr, _ = make_manager(backstop=42)
+    # Agent's per-game budget set to a small, different value.
+    mgr._agent_client.set("policy.max_interventions_per_minute", 1)
+    mgr._refresh_budget()
+    # Coordinator backstop tracks ONLY its own flag, never the per-game one.
+    assert mgr._rate_limiter._budget == pytest.approx(42.0)
+
+    mgr._agent_client.set("policy.coordinator_backstop_per_minute", 99)
+    mgr._refresh_budget()
+    assert mgr._rate_limiter._budget == pytest.approx(99.0)
+
+
+def test_refresh_budget_falls_back_to_generous_default_when_flag_absent():
+    """When the coordinator flag is unreachable, the backstop falls back to the
+    generous default — it must NOT collapse to the small per-game budget."""
+    from services.game_coordinator.interventions import (
+        DEFAULT_COORDINATOR_BACKSTOP_BUDGET,
+    )
+
+    mgr, _ = make_manager()
+    # Remove the coordinator flag entirely; leave a small per-game value present.
+    mgr._agent_client.values.pop("policy.coordinator_backstop_per_minute", None)
+    mgr._agent_client.set("policy.max_interventions_per_minute", 1)
+    mgr._refresh_budget()
+    assert mgr._rate_limiter._budget == pytest.approx(DEFAULT_COORDINATOR_BACKSTOP_BUDGET)
+
+
+@pytest.mark.asyncio
+async def test_normal_multi_session_traffic_does_not_trip_backstop():
+    """Normal traffic across several concurrent games — each well within its own
+    authoritative per-game budget — stays far under the generous global backstop,
+    so the coordinator never throttles it. Here we simulate many distinct
+    interventions (one per game's worth of activity) inside one window and assert
+    none are blocked.
+
+    Each game at the default agent budget (2.0/min) emitting a single hard (2.0)
+    intervention => 8 concurrent games = 16.0 weight, still < 60 default backstop.
+    """
+    clock = Clock()
+    # Default generous backstop (60). Fire 8 distinct hard interventions (16.0).
+    mgr, events = make_manager(time_fn=clock)  # backstop defaults to 60
+    with patch("services.game_coordinator.metrics.interventions_total"):
+        for i in range(8):
+            mgr._interventions_client.set("eliminate_player", f"{i}:ctrl_{i}")
+            await mgr.evaluate_all()
+    elim = [d for et, d in events if et == GameEvent.AGENT_INTERVENTION and d["type"] == "eliminate_player"]
+    assert len(elim) == 8
+    assert all(d["blocked"] == "false" for d in elim)
+    # 8 hard interventions = 16.0 weight, comfortably under the 60 backstop.
+    assert mgr._rate_limiter.current_weight() == pytest.approx(16.0)
 
 
 # --------------------------------------------------------------------------- #
@@ -522,7 +617,7 @@ async def test_multiple_flags_evaluated_in_one_pass():
         # shield_seconds is player-targeted: it resolves per active serial, so a
         # live game with at least one player is required for it to apply.
         game=FakeGame("Nonstop Joust", players={"p1": FakePlayer("p1")}),
-        budget=10,
+        backstop=10,
     )
     with patch("services.game_coordinator.metrics.interventions_total"):
         await mgr.evaluate_all()
@@ -550,7 +645,7 @@ async def test_player_targeted_state_dispatches_on_resolved_change():
     """A player-targeted state flag dispatches when its per-serial resolved value
     moves off neutral, even though the global defaultVariant never changes."""
     game = FakeGame("Nonstop Joust", players={"p1": FakePlayer("p1")})
-    mgr, events = make_manager(interventions={"player_sensitivity_factor": 1.0}, game=game, budget=10)
+    mgr, events = make_manager(interventions={"player_sensitivity_factor": 1.0}, game=game, backstop=10)
     with patch("services.game_coordinator.metrics.interventions_total"):
         await mgr.evaluate_all()  # neutral 1.0 -> no dispatch
     assert _applied(events, "adjust_player_sensitivity") == []
@@ -566,7 +661,7 @@ async def test_player_targeted_state_no_redispatch_when_unchanged():
     """Re-evaluating an unchanged resolved map does not re-fire (no spurious
     metric/event or rate-limit consumption)."""
     game = FakeGame("Nonstop Joust", players={"p1": FakePlayer("p1")})
-    mgr, events = make_manager(interventions={"player_sensitivity_factor": 1.5}, game=game, budget=10)
+    mgr, events = make_manager(interventions={"player_sensitivity_factor": 1.5}, game=game, backstop=10)
     with patch("services.game_coordinator.metrics.interventions_total"):
         await mgr.evaluate_all()
         await mgr.evaluate_all()  # same resolved map -> no second dispatch
@@ -576,7 +671,7 @@ async def test_player_targeted_state_no_redispatch_when_unchanged():
 @pytest.mark.asyncio
 async def test_player_targeted_state_no_game_is_noop():
     """No live game means no serials to target: no dispatch, no crash."""
-    mgr, events = make_manager(interventions={"shield_seconds": 5}, game=None, budget=10)
+    mgr, events = make_manager(interventions={"shield_seconds": 5}, game=None, backstop=10)
     with patch("services.game_coordinator.metrics.interventions_total"):
         await mgr.evaluate_all()
     assert _applied(events, "grant_shield") == []
@@ -587,7 +682,7 @@ async def test_player_targeted_state_revert_to_neutral_does_not_fire():
     """Reverting all serials back to neutral collapses the change key to empty
     and dispatches nothing (shields/factors simply expire/reset)."""
     game = FakeGame("Nonstop Joust", players={"p1": FakePlayer("p1")})
-    mgr, events = make_manager(interventions={"shield_seconds": 5}, game=game, budget=10)
+    mgr, events = make_manager(interventions={"shield_seconds": 5}, game=game, backstop=10)
     with patch("services.game_coordinator.metrics.interventions_total"):
         await mgr.evaluate_all()  # 5 -> applied
         mgr._interventions_client.set("shield_seconds", 0)

--- a/tests/integration/test_gameid_intervention_isolation.py
+++ b/tests/integration/test_gameid_intervention_isolation.py
@@ -131,10 +131,16 @@ def set_interventions_allowed(variant: str) -> None:
 
 
 def set_policy_budget(per_minute: int) -> None:
+    """Pin BOTH rate-limit budgets generously (#919): the agent's per-game
+    ``policy.max_interventions_per_minute`` and the coordinator's process-global
+    backstop ``policy.coordinator_backstop_per_minute``. This suite asserts
+    per-game-id isolation, so neither limiter must spuriously throttle the
+    gameId-scoped writes."""
     doc = _load(AGENT_PATH)
-    flag = doc["flags"]["policy.max_interventions_per_minute"]
-    flag["variants"]["active"] = int(per_minute)
-    flag["defaultVariant"] = "active"
+    for flag_key in ("policy.max_interventions_per_minute", "policy.coordinator_backstop_per_minute"):
+        flag = doc["flags"][flag_key]
+        flag["variants"]["active"] = int(per_minute)
+        flag["defaultVariant"] = "active"
     _dump_in_place(AGENT_PATH, doc)
 
 

--- a/tests/integration/test_intervention_flow.py
+++ b/tests/integration/test_intervention_flow.py
@@ -182,17 +182,24 @@ def set_interventions_allowed(variant: str) -> None:
 
 
 def set_policy_budget(per_minute: int) -> None:
-    """Raise the weighted rate-limit budget (policy.max_interventions_per_minute).
+    """Raise BOTH weighted rate-limit budgets for headroom (#919).
 
-    The shipped variants cap at ``aggressive`` (4); tests that drive several
-    interventions in a tight window need more headroom, so we inject a custom
-    ``active`` variant and flip defaultVariant to it. The manager reads this via
-    ``get_integer_value`` and feeds it to the weighted sliding-window limiter.
+    Rate limiting is enforced in two layers that read DIFFERENT flags (the
+    defense-in-depth contract): the agent's authoritative per-game budget
+    (``policy.max_interventions_per_minute``) and the coordinator's generous
+    process-global backstop (``policy.coordinator_backstop_per_minute``). Tests
+    that drive several interventions in a tight window need headroom in BOTH, so
+    we inject a custom ``active`` variant into each and flip its defaultVariant.
+    The shipped variants cap below this (agent ``aggressive`` = 4, coordinator
+    ``generous`` = 120), so the injected variant gives the suite the headroom it
+    needs. Each manager reads its own flag via ``get_integer_value`` and feeds it
+    to its weighted sliding-window limiter.
     """
     doc = _load(AGENT_PATH)
-    flag = doc["flags"]["policy.max_interventions_per_minute"]
-    flag["variants"]["active"] = int(per_minute)
-    flag["defaultVariant"] = "active"
+    for flag_key in ("policy.max_interventions_per_minute", "policy.coordinator_backstop_per_minute"):
+        flag = doc["flags"][flag_key]
+        flag["variants"]["active"] = int(per_minute)
+        flag["defaultVariant"] = "active"
     _dump_in_place(AGENT_PATH, doc)
 
 


### PR DESCRIPTION
Closes #919

## The ownership contract implemented

Intervention rate limiting runs in **two layers, in two languages**, with **distinct, non-overlapping roles** that read **different flags** so they cannot silently drift (closes bug classes #800/#848):

| Layer | Where | Scope | Reads flag | Role |
|-------|-------|-------|-----------|------|
| **Agent (authoritative)** | `services/agent/decision/` — per-game `Loop` (`loopset.go`), limiter (`ratelimit.go`) | **Per `game_id`** | `policy.max_interventions_per_minute` | The real per-game governor (already shipped by #845): each game gets its own weighted per-minute budget; one game exhausting it never starves another. |
| **Coordinator (backstop)** | `services/game_coordinator/interventions.py` — `_RateLimiter` | **Process-global** | `policy.coordinator_backstop_per_minute` | A *generous global safety net*. Caps a runaway/buggy agent that floods flag writes; tuned so normal multi-session traffic never reaches it. |

**Single-owner rule:** per-game pacing lives in exactly one place — the agent. The coordinator does not mirror or re-derive the per-game budget; it owns only the generous global flood ceiling.

## What changed in each layer

**Agent (Go) — no behavioral change needed.** The agent is *already* the authoritative per-game limiter: `decision.LoopSet` (#845) gives every `game_id` its own `Loop` with its own `rateLimiter` keyed off `policy.max_interventions_per_minute`. Confirmed this is the real enforcement point; added a contract note to `ratelimit.go` cross-referencing the coordinator backstop.

**Coordinator (Python) — reframed `_RateLimiter` as the global backstop:**
- `_RateLimiter` now constructs with `DEFAULT_COORDINATOR_BACKSTOP_BUDGET` (60) instead of `2.0`.
- `_refresh_budget()` now reads **`policy.coordinator_backstop_per_minute`**, NOT `policy.max_interventions_per_minute` — the decoupling that prevents drift.
- Added a module-level defense-in-depth contract comment block + class/chain docstrings marking it explicitly as the backstop.

**flagd:** new `policy.coordinator_backstop_per_minute` flag (`default` 60, `strict` 20, `generous` 120).

**Docs:** new "Rate-limit ownership" section in `docs/agent-act-runbook.md` (two-layer table + single-owner rule); `docs/feature-flags.md` documents the new flag and clarifies the per-game flag is the agent's authoritative cap.

## New backstop value + justification

**60 weighted interventions/minute, process-global.** A busy fleet of several concurrent games each spending its full authoritative per-game budget stays far under this (8 concurrent games each firing one *hard* (2.0) intervention = 16.0 weight). The backstop only trips at an order-of-magnitude-higher, clearly-runaway write rate. Configurable via the new flag; falls back to 60 when flagd is unreachable (it must NOT collapse to the small per-game value).

## Tests

- **Unit** (`test_interventions.py`): `budget` param renamed to `backstop` (defaults to generous 60). The three rate-limit dispatch tests reframed as backstop tests. New tests prove: default backstop is generous; `_refresh_budget` reads the coordinator flag and *ignores* `max_interventions_per_minute` (drift guard); fallback to the generous default when the flag is absent; **normal multi-session traffic (8 hard interventions = 16.0 weight) is never blocked by the backstop**. `cd services/game_coordinator && uv run --extra test pytest` → **937 passed**.
- **Integration**: `set_policy_budget` in `test_intervention_flow.py` and `test_gameid_intervention_isolation.py` now pins **both** flags (the coordinator limiter no longer reads `max_interventions_per_minute`), preserving the suites' rate-limit headroom.
- **Go**: `go build ./... && go vet ./... && go test ./...` in `services/agent` → all green.
- `ruff check .` clean; `agent.json` valid JSON and integration-mutation round-trips.

## Deferred / flagged

- **Per-game independence of the agent budget is verified by existing #845 tests** (`loopset_test.go`); the coordinator backstop is *intentionally* global (single shared budget) per the maintainer decision, so per-game-id scoping of the coordinator limiter was not added — the new unit test instead pins that the global backstop does not throttle normal multi-game traffic.
- The integration suites are not exercised by this PR's CI (they require docker compose / target `main`); local unit + Go suites are the primary gate here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
