### PR TITLE
feat(agent): LLM decision path with objective-aware prompting (#739)

### DIFF
--- a/services/agent/decision/decision.go
+++ b/services/agent/decision/decision.go
@@ -338,6 +338,13 @@ func (l *Loop) OnEvaluate(ctx context.Context, c gamecontext.GameContext, trig E
 	// after decide so it reflects this cycle's thresholds and live context. This
 	// happens even on an empty-decision cycle so a future cycle-scoped consumer
 	// still sees the evaluation, but it only reaches a span when a decision emits.
+	//
+	// TODO(#739/real-backend): LastFitness is written only inside the rules engine's
+	// Evaluate. On an llm cycle that the backend decided (decide ran llmDecide, not
+	// rules), this reads the PRIOR rules cycle's stale evaluation. Harmless today
+	// (pure-llm sessions never populate it, and there is no real backend), but once a
+	// tier actually decides, a mixed llm/rules sequence would attach stale fitness to
+	// the llm decision span — guard it on "rules ran this cycle" when wiring #917.
 	if rd, ok := l.Rules.(fitnessReader); ok {
 		if vals := rd.LastFitness().Evaluated(); len(vals) > 0 {
 			state.FitnessEvaluated = vals
@@ -396,23 +403,28 @@ func (l *Loop) setLastLayer(state LayerState) {
 	l.mu.Unlock()
 }
 
-// decide selects the decision path from snapshot.Mode and runs it. The "llm"
-// path (M4 prompt-capture spike, #739) builds the prompt the agent WOULD send,
-// records it on a dedicated, throttled agent.llm.prompt span (so it is visible
-// in Jaeger even on idle cycles, where the lazy agent.decision spans never
-// emit), then falls back to the deterministic rules engine — no backend exists
-// yet (#741). The "rules" path and any unrecognized mode go straight to rules.
-// emit is this cycle's shared throttle decision (from OnEvaluate); the capture
-// span/log only fire when it is true.
+// decide selects the decision path from snapshot.Mode and runs it. The "rules"
+// path (and any unrecognized mode) goes straight to the deterministic engine. The
+// "llm" path is gated, resolved, and — when a tier is reachable — actually CALLED
+// (#847 + #741 + #739):
 //
-// The LLM call gate (#847) sits in FRONT of the prompt build/capture: an llm-mode
-// cycle first passes the three-layer gate (eligibility -> cadence -> budget). When
-// the gate DENIES, the cycle records the specific gate fallback_reason on the
-// LayerState, increments agent_llm_gated_total, and does NOT build or capture the
-// prompt (no token burn, even the prompt serialization is skipped). When the gate
-// ALLOWS, current behavior is unchanged: the prompt is captured and the cycle
-// falls back to rules with no_backend_available. Either way the rules engine still
-// runs (the gate only guards the LLM ATTEMPT, never the deterministic fallback).
+//  1. The LLM call gate (#847) runs FIRST: the cycle must pass the three-layer gate
+//     (eligibility -> cadence -> budget). On DENY it records the gate fallback_reason
+//     on the LayerState, increments agent_llm_gated_total, and does NOT build/capture
+//     a prompt or resolve a tier (no token burn) — inference.used stays "rules".
+//  2. On ADMIT, resolve_backend (#741) picks WHICH tier would serve and sets
+//     inference.used / fallback_reason (the configured tier, a degraded lower tier
+//     with endpoint_unreachable, or rules with no_backend_available when the whole
+//     chain is down). The prompt is captured on the throttled agent.llm.prompt span
+//     (emit gates it).
+//  3. When resolve_backend returns a REACHABLE non-rules tier, the cycle CALLS it via
+//     llmDecide (#739) and returns the model's decision — run through the SAME
+//     permission/rate-limit chain as a rules decision. Unparseable/invalid output, an
+//     Infer error, or an unreachable chain all fall back to the rules engine, which
+//     therefore ALWAYS provides a safe deterministic answer.
+//
+// emit is this cycle's shared throttle decision (from OnEvaluate); the prompt
+// capture span/log only fire when it is true.
 func (l *Loop) decide(ctx context.Context, snapshot flags.Snapshot, c gamecontext.GameContext, emit bool, state *LayerState) []Decision {
 	if snapshot.Mode == "llm" {
 		// Resolve the gate BEFORE any prompt work so a gated cycle never serializes

--- a/services/agent/decision/decision.go
+++ b/services/agent/decision/decision.go
@@ -447,6 +447,27 @@ func (l *Loop) decide(ctx context.Context, snapshot flags.Snapshot, c gamecontex
 			if emit {
 				l.captureLLMPrompt(ctx, snapshot, c)
 			}
+			// #739: a non-nil Backend means resolve_backend found a REACHABLE non-rules
+			// tier — so actually CALL it instead of falling back to rules (the #741
+			// behavior was "resolve but always run rules"; this is the milestone payoff).
+			// A nil Backend (whole chain unreachable, the dev default) keeps the #741
+			// fallback: drop through to the rules engine below with used="rules" /
+			// no_backend_available already set above.
+			if res.Backend != nil {
+				decisions, fallback := l.llmDecide(ctx, res.Backend, snapshot, c)
+				if fallback == "" {
+					// The model answered usably (a valid decision, or a contract-following
+					// noop that yields zero decisions). inference.used stays the called
+					// tier; return the LLM's decisions, which flow through the SAME
+					// runDecision/evaluatePermission chain as rules decisions (so the
+					// allow-list, battery, and rate-limit gates apply identically).
+					return decisions
+				}
+				// Unparseable/invalid/errored: NEVER dispatch untrusted output. Record the
+				// reason (inference.used stays the called tier — it answered, just unusably)
+				// and fall through to the deterministic rules engine below.
+				state.LLMFallbackReason = fallback
+			}
 		}
 	}
 	return l.Rules.Evaluate(ctx, c)

--- a/services/agent/decision/llm_decide.go
+++ b/services/agent/decision/llm_decide.go
@@ -1,0 +1,154 @@
+package decision
+
+import (
+	"context"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	semconv "go.opentelemetry.io/otel/semconv/v1.34.0"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/joustmania/agent/flags"
+	"github.com/joustmania/agent/gamecontext"
+	"github.com/joustmania/agent/llm"
+)
+
+// semconvGenAIChat is the GenAI request attribution for the inference span: the
+// operation (chat) and the request model. It mirrors the capture span's gen_ai.*
+// attributes (llmPromptAttributes) so a real call and a captured prompt are
+// queryable the same way in Jaeger; the JSON output type is implied by the
+// RESPONSE CONTRACT and asserted by the decoder, so it is not re-emitted here.
+func semconvGenAIChat(model string) []attribute.KeyValue {
+	return []attribute.KeyValue{
+		semconv.GenAIOperationNameChat,
+		semconv.GenAIRequestModel(model),
+		genAIOutputTypeJSON,
+	}
+}
+
+// llm_decide.go is the actual LLM decision path (#739): the agent.mode=="llm"
+// branch that, when the #847 gate ADMITS and resolve_backend (#741) resolves a
+// REACHABLE non-rules tier, asks that tier's model for a decision instead of
+// running the deterministic rules engine. It is the M4 milestone's payoff — the
+// agent finally USES the inference tier the resolver has been honestly attributing
+// since #741, rather than always falling back to rules.
+//
+// It is deliberately thin and SAFE, reusing the existing machinery so the LLM path
+// is indistinguishable from the rules path everywhere it matters:
+//
+//   - PROMPT: llm.Build (already objective-aware via the snapshot — it renders the
+//     objective weights and the allow-list into the System prompt) is reused
+//     verbatim, the SAME builder the prompt-capture span uses. Objectives shape
+//     what the model is asked to optimize (endurance/balanced/accelerate/chaos).
+//   - PARSE: llm.Decode (decode.go) parses the response DEFENSIVELY. Unparseable,
+//     invalid, or out-of-vocabulary output NEVER dispatches an arbitrary action —
+//     it returns no decision and decide() falls back to the rules engine with
+//     FallbackUnparseable recorded on the span.
+//   - GATE + LIMIT: the parsed Decision is returned to decide() and flows through
+//     the EXACT SAME runDecision -> evaluatePermission chain as a rules decision,
+//     so the interventions.allowed allow-list, the battery threshold, and the
+//     weighted rate limit all apply IDENTICALLY. An LLM-chosen action not in
+//     interventions.allowed is blocked with decision.blocked=true — there is no
+//     LLM-specific dispatch path to bypass any gate.
+//
+// The call is SYNCHRONOUS against the resolved backend for now (#739). #917 will
+// wrap it for async inference; the call site in decide() is structured so that
+// wrapping is a local change (one method call), not a re-architecture.
+
+// llmDecide runs one inference against the resolved backend and returns the parsed
+// decisions plus the fallback_reason to record. The contract decide() relies on:
+//
+//   - (decisions, "")            : the model produced a valid, in-vocab decision
+//     (possibly a noop, which yields ZERO decisions but is NOT a fallback — the
+//     model legitimately chose to do nothing). inference.used stays the called
+//     tier; no fallback_reason.
+//   - (nil, FallbackUnparseable) : Infer errored, or the response was empty /
+//     not JSON / missing a required field / named an unknown objective. The caller
+//     MUST fall back to the rules engine; inference.used stays the called tier
+//     (the tier answered, just unusably) and FallbackUnparseable rides the span.
+//
+// llmDecide NEVER returns a decision built from untrusted output: a parse failure
+// yields nil, so decide() runs rules instead. It does NOT itself enforce the
+// allow-list — that is runDecision/evaluatePermission's job, applied uniformly to
+// whatever decision is ultimately dispatched, so an out-of-allow-list LLM choice
+// is blocked exactly like an out-of-allow-list rules choice (decision.blocked).
+func (l *Loop) llmDecide(ctx context.Context, backend Backend, snapshot flags.Snapshot, c gamecontext.GameContext) ([]Decision, string) {
+	now := l.now
+	if now == nil {
+		now = time.Now
+	}
+
+	// Reuse the objective-aware prompt builder (the same one the capture span uses).
+	// The System prompt already encodes the objective weights and the allow-list, so
+	// the model is asked to optimize for THIS session's objectives.
+	prompt := llm.Build(llm.BuildInput{
+		Snapshot: snapshot,
+		Context:  c,
+		Now:      now(),
+	})
+
+	// Record the inference as a gen_ai.* child span so the audit trace shows the
+	// actual call (#739): the request model and, on success, the reasoning the model
+	// returned. The span is the SAME shape the capture path uses for attribution, but
+	// it represents a REAL call (Infer ran), not a captured-but-unsent prompt.
+	infCtx, span := l.Tracer.Start(ctx, SpanLLMInfer, trace.WithAttributes(
+		semconvGenAIChat(prompt.Model)...,
+	))
+	defer span.End()
+
+	raw, err := backend.Infer(infCtx, prompt)
+	if err != nil {
+		// A reachable tier that cannot actually answer (the unwired production
+		// endpointBackend, a transport error, a timeout) degrades to rules SAFELY —
+		// no untrusted output, no dispatch. Recorded, never silent.
+		span.SetAttributes(attribute.String(AttrLLMInferError, err.Error()))
+		l.Log.Warn("agent.llm.infer_failed",
+			"session_id", c.SessionID,
+			"tier", backend.Name(),
+			"error", err)
+		return nil, FallbackUnparseable
+	}
+
+	resp, err := llm.Decode(raw)
+	if err != nil {
+		// Unparseable / invalid / out-of-vocab: the cardinal safety case. The model
+		// answered, but the answer cannot be trusted to dispatch — fall back to rules.
+		span.SetAttributes(attribute.String(AttrLLMInferError, err.Error()))
+		l.Log.Warn("agent.llm.unparseable",
+			"session_id", c.SessionID,
+			"tier", backend.Name(),
+			"error", err)
+		return nil, FallbackUnparseable
+	}
+
+	// Record the model's reasoning + chosen objective on the inference span (the
+	// "reasoning behind the action", #739 acceptance). decision.* attribution then
+	// rides the agent.decision span via runDecision exactly as for a rules decision.
+	span.SetAttributes(
+		attribute.String(AttrDecisionReason, resp.Reason),
+		attribute.String(AttrDecisionObjective, resp.ObjectiveServed),
+		attribute.String(AttrDecisionAction, resp.Intervention),
+	)
+
+	// A noop is a valid, contract-following choice that dispatches nothing: the
+	// model decided, and decided to do nothing. Return ZERO decisions (no rules
+	// fallback — the model was heard) with no fallback_reason.
+	if resp.IsNoop() {
+		return nil, ""
+	}
+
+	// Map the validated response onto a Decision. The allow-list is NOT checked
+	// here — runDecision/evaluatePermission applies it (and the battery + rate-limit
+	// gates) uniformly, so an out-of-allow-list LLM intervention is blocked with
+	// decision.blocked=true exactly like a rules one. Objectives carries the cycle's
+	// weights so the decision span's agent.objectives is consistent with the rules
+	// path; Fitness is left nil (the model does not emit fitness inputs).
+	return []Decision{{
+		Intervention:    resp.Intervention,
+		TargetSerial:    resp.TargetSerial,
+		Value:           resp.Value,
+		Reason:          resp.Reason,
+		ObjectiveServed: resp.ObjectiveServed,
+		Objectives:      snapshot.Objectives,
+	}}, ""
+}

--- a/services/agent/decision/llm_decide.go
+++ b/services/agent/decision/llm_decide.go
@@ -91,11 +91,21 @@ func (l *Loop) llmDecide(ctx context.Context, backend Backend, snapshot flags.Sn
 	// actual call (#739): the request model and, on success, the reasoning the model
 	// returned. The span is the SAME shape the capture path uses for attribution, but
 	// it represents a REAL call (Infer ran), not a captured-but-unsent prompt.
+	//
+	// gen_ai.request.model is the tier ACTUALLY called (backend.Name()), NOT the
+	// configured agent.model: on a degraded chain (configured "claude" unreachable ->
+	// served by "phi4-mini") the request really went to the lower tier, and the span
+	// must say so to match the sibling decision span's inference.used. The capture
+	// span legitimately keeps the configured model; this is a real request.
 	infCtx, span := l.Tracer.Start(ctx, SpanLLMInfer, trace.WithAttributes(
-		semconvGenAIChat(prompt.Model)...,
+		semconvGenAIChat(backend.Name())...,
 	))
 	defer span.End()
 
+	// TODO(#738/#742): bound this call with a per-call context.WithTimeout once a real
+	// transport lands — today the production endpointBackend.Infer returns immediately
+	// (sentinel error) and the fakes are instant, but a slow network Infer would block
+	// this Export-handler goroutine (async application is #917).
 	raw, err := backend.Infer(infCtx, prompt)
 	if err != nil {
 		// A reachable tier that cannot actually answer (the unwired production

--- a/services/agent/decision/llm_decide_test.go
+++ b/services/agent/decision/llm_decide_test.go
@@ -1,0 +1,358 @@
+package decision
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel/sdk/metric"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"github.com/joustmania/agent/flags"
+	"github.com/joustmania/agent/gamecontext"
+	"github.com/joustmania/agent/llm"
+)
+
+// llm_decide_test.go drives the #739 LLM decision path end-to-end through the loop
+// with a FAKE backend, asserting every acceptance criterion: the llm path is taken
+// (not rules) on a valid response; objectives reach the prompt; an unparseable /
+// invalid / out-of-vocab / errored response dispatches NO arbitrary action and
+// falls back with the recorded reason; the SAME permission gate + rate limit apply
+// to llm decisions; and the inference span carries used=<tier> + the reasoning.
+
+// inferBackend is the #739 inference fake: always available, returns a canned raw
+// response (or a canned error) for every Infer call, and records the last prompt
+// so a test can assert objective-aware prompting. Distinct from fakeBackend (the
+// #741 resolver fake) so the two concerns stay separate.
+type inferBackend struct {
+	name             string
+	response         string // raw text returned from Infer (the model's reply)
+	inferErr         error  // when non-nil, Infer returns this instead of response
+	lastPromptSystem string
+	lastPromptUser   string
+	calls            int
+}
+
+func (b *inferBackend) Name() string                   { return b.name }
+func (b *inferBackend) Available(context.Context) bool { return true }
+func (b *inferBackend) Infer(_ context.Context, p llm.Prompt) (string, error) {
+	b.calls++
+	b.lastPromptSystem = p.System
+	b.lastPromptUser = p.User
+	if b.inferErr != nil {
+		return "", b.inferErr
+	}
+	return b.response, nil
+}
+
+// resolverWith builds a resolver whose single-tier chain is the given backend, so
+// resolve(model) resolves to it (model "phi4-mini" selects the phi tier name). The
+// cache is primed (Available()=true). It is the seam that injects a #739 inference
+// fake into the live loop.
+func resolverWith(b Backend) *Resolver {
+	r := NewResolver([]Backend{b}, 0)
+	r.Refresh(context.Background())
+	return r
+}
+
+// llmDecideLoop wires a loop for the #739 path: recording tracer, an always-admit
+// llm gate, the given resolver (single fake tier), and a rules engine whose output
+// is the RULES fallback (so a test can tell an llm decision from a rules one by the
+// decision.reason). Returns the loop, span recorder, and the action sink.
+func llmDecideLoop(t *testing.T, snap flags.Snapshot, resolver *Resolver, rulesOut []Decision) (*Loop, *tracetest.SpanRecorder, *fakeSink) {
+	t.Helper()
+	sr := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+
+	reader := metric.NewManualReader()
+	mp := metric.NewMeterProvider(metric.WithReader(reader))
+
+	sink := &fakeSink{}
+	l := NewLoop(&settableFlags{snap: snap}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	l.Tracer = tp.Tracer("test")
+	l.Rules = fakeRules{out: rulesOut}
+	l.Actions = sink
+	l.llmGated = newLLMGatedCounter(mp)
+	l.SetLLMBudget(NewLLMBudget())
+	l.SetResolver(resolver)
+	return l, sr, sink
+}
+
+// llmDecideSnapshot is an llm-mode snapshot whose #847 gate always admits and whose
+// model (phi4-mini) selects the single-tier fake. The allow-list contains the
+// interventions the valid-response tests choose, but NOT the out-of-allow-list one.
+func llmDecideSnapshot() flags.Snapshot {
+	return flags.Snapshot{
+		Enabled:              true,
+		Mode:                 "llm",
+		Objectives:           map[string]float64{"endurance": 0.7, "chaos": 0.3},
+		Capability:           flags.Capability{Model: "phi4-mini", PromptVariant: "balanced"},
+		InterventionsAllowed: []string{"noop", "grant_shield", "play_audio_cue"},
+		Policy:               flags.Policy{MaxInterventionsPerMinute: 100},
+		LLMGate: flags.LLMGate{
+			EligibleGameKinds:    []string{"real"},
+			MinDecisionInterval:  0,
+			MaxRequestsPerMinute: 100,
+		},
+	}
+}
+
+const validShieldResponse = `{"intervention":"grant_shield","target_serial":"","value":"","reason":"llm chose this","objective_served":"endurance"}`
+
+// --- Acceptance: the llm path is TAKEN (not rules) on a valid response ---
+
+func TestLLMDecide_ValidResponseTakesLLMPath(t *testing.T) {
+	be := &inferBackend{name: "phi4-mini", response: validShieldResponse}
+	// The rules engine would return a DISTINCT decision; if the llm path is taken,
+	// the dispatched decision must be the LLM's, not the rules engine's.
+	l, sr, sink := llmDecideLoop(t, llmDecideSnapshot(), resolverWith(be), []Decision{{Intervention: "play_audio_cue", Reason: "from rules"}})
+
+	l.OnEvaluate(context.Background(), gamecontext.GameContext{SessionID: "s1", GameKind: "real"}, testTrigger())
+
+	if be.calls != 1 {
+		t.Fatalf("backend Infer calls = %d, want 1 (llm path taken)", be.calls)
+	}
+	decs := spansByName(sr.Ended(), SpanDecision)
+	if len(decs) != 1 {
+		t.Fatalf("agent.decision spans = %d, want 1", len(decs))
+	}
+	if v, ok := attrValue(decs[0], AttrDecisionReason); !ok || v.AsString() != "llm chose this" {
+		t.Errorf("decision.reason = %q, want the LLM's reason (not the rules fallback)", v.AsString())
+	}
+	if v, ok := attrValue(decs[0], AttrDecisionAction); !ok || v.AsString() != "grant_shield" {
+		t.Errorf("decision.action = %q, want grant_shield (the LLM choice)", v.AsString())
+	}
+	if v, ok := attrValue(decs[0], AttrInferenceUsed); !ok || v.AsString() != "phi4-mini" {
+		t.Errorf("inference.used = %q, want phi4-mini (the tier that decided)", v.AsString())
+	}
+	if v, ok := attrValue(decs[0], AttrInferenceFallback); !ok || v.AsString() != "" {
+		t.Errorf("inference.fallback_reason = %q, want empty (llm decided cleanly)", v.AsString())
+	}
+	if sink.calls.Load() != 1 {
+		t.Errorf("action sink calls = %d, want 1 (llm decision dispatched)", sink.calls.Load())
+	}
+	// The inference span exists and carries the model's reasoning.
+	inf := spansByName(sr.Ended(), SpanLLMInfer)
+	if len(inf) != 1 {
+		t.Fatalf("agent.llm.infer spans = %d, want 1", len(inf))
+	}
+	if v, ok := attrValue(inf[0], AttrDecisionReason); !ok || v.AsString() != "llm chose this" {
+		t.Errorf("infer span decision.reason = %q, want the model reasoning", v.AsString())
+	}
+	if v, ok := attrValue(inf[0], "gen_ai.request.model"); !ok || v.AsString() != "phi4-mini" {
+		t.Errorf("infer span gen_ai.request.model = %q, want phi4-mini", v.AsString())
+	}
+}
+
+// --- Acceptance: objectives reach the prompt ---
+
+func TestLLMDecide_ObjectivesShapePrompt(t *testing.T) {
+	be := &inferBackend{name: "phi4-mini", response: validShieldResponse}
+	snap := llmDecideSnapshot()
+	snap.Objectives = map[string]float64{"endurance": 0.8, "accelerate": 0.2}
+	l, _, _ := llmDecideLoop(t, snap, resolverWith(be), nil)
+
+	l.OnEvaluate(context.Background(), gamecontext.GameContext{SessionID: "s1", GameKind: "real"}, testTrigger())
+
+	if be.calls != 1 {
+		t.Fatalf("backend Infer calls = %d, want 1", be.calls)
+	}
+	// The System prompt must encode the objective weights (objective-aware prompting).
+	for _, want := range []string{"endurance=0.8", "accelerate=0.2"} {
+		if !strings.Contains(be.lastPromptSystem, want) {
+			t.Errorf("prompt System missing %q; the objectives must shape the prompt\n--- system ---\n%s", want, be.lastPromptSystem)
+		}
+	}
+	// And the allow-list, also objective context for the model.
+	if !strings.Contains(be.lastPromptSystem, "grant_shield") {
+		t.Error("prompt System must list the allowed interventions")
+	}
+}
+
+// --- Acceptance: a noop response dispatches nothing but is NOT a rules fallback ---
+
+func TestLLMDecide_NoopDispatchesNothing(t *testing.T) {
+	be := &inferBackend{name: "phi4-mini",
+		response: `{"intervention":"noop","reason":"nothing actionable","objective_served":"endurance"}`}
+	// Rules WOULD return a decision; a clean noop must NOT trigger the rules fallback.
+	l, sr, sink := llmDecideLoop(t, llmDecideSnapshot(), resolverWith(be), []Decision{{Intervention: "grant_shield", Reason: "from rules"}})
+
+	l.OnEvaluate(context.Background(), gamecontext.GameContext{SessionID: "s1", GameKind: "real"}, testTrigger())
+
+	if be.calls != 1 {
+		t.Fatalf("backend Infer calls = %d, want 1", be.calls)
+	}
+	if n := len(spansByName(sr.Ended(), SpanDecision)); n != 0 {
+		t.Errorf("agent.decision spans = %d, want 0 (noop dispatches nothing, and rules did NOT run)", n)
+	}
+	if sink.calls.Load() != 0 {
+		t.Errorf("action sink calls = %d, want 0 (noop)", sink.calls.Load())
+	}
+	// The inference span still records the model's reasoning.
+	if n := len(spansByName(sr.Ended(), SpanLLMInfer)); n != 1 {
+		t.Errorf("agent.llm.infer spans = %d, want 1", n)
+	}
+}
+
+// --- Acceptance: unparseable / invalid / errored response falls back to rules,
+//     dispatching NO arbitrary action, with FallbackUnparseable recorded ---
+
+func TestLLMDecide_BadResponseFallsBackToRules(t *testing.T) {
+	cases := []struct {
+		name     string
+		response string
+		inferErr error
+	}{
+		{"empty", "", nil},
+		{"not json", "I will not comply.", nil},
+		{"malformed json", `{"intervention":}`, nil},
+		{"missing reason", `{"intervention":"grant_shield","objective_served":"endurance"}`, nil},
+		{"out-of-vocab objective", `{"intervention":"grant_shield","reason":"r","objective_served":"win"}`, nil},
+		{"infer error", "", errors.New("backend exploded")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			be := &inferBackend{name: "phi4-mini", response: tc.response, inferErr: tc.inferErr}
+			// The RULES engine returns a recognizable decision; the cycle must dispatch
+			// IT (the safe deterministic fallback), never anything from the bad response.
+			l, sr, sink := llmDecideLoop(t, llmDecideSnapshot(), resolverWith(be), []Decision{{Intervention: "grant_shield", Reason: "rules fallback"}})
+
+			l.OnEvaluate(context.Background(), gamecontext.GameContext{SessionID: "s1", GameKind: "real"}, testTrigger())
+
+			if be.calls != 1 {
+				t.Fatalf("backend Infer calls = %d, want 1", be.calls)
+			}
+			decs := spansByName(sr.Ended(), SpanDecision)
+			if len(decs) != 1 {
+				t.Fatalf("agent.decision spans = %d, want 1 (the rules fallback)", len(decs))
+			}
+			// The dispatched decision is the RULES one — no arbitrary action from the
+			// untrusted response leaked through.
+			if v, ok := attrValue(decs[0], AttrDecisionReason); !ok || v.AsString() != "rules fallback" {
+				t.Errorf("decision.reason = %q, want the rules fallback (untrusted output must NOT dispatch)", v.AsString())
+			}
+			// inference.used stays the called tier (it answered, just unusably) and the
+			// fallback reason is recorded on the span.
+			if v, ok := attrValue(decs[0], AttrInferenceUsed); !ok || v.AsString() != "phi4-mini" {
+				t.Errorf("inference.used = %q, want phi4-mini (the tier that was called)", v.AsString())
+			}
+			if v, ok := attrValue(decs[0], AttrInferenceFallback); !ok || v.AsString() != FallbackUnparseable {
+				t.Errorf("inference.fallback_reason = %q, want %q", v.AsString(), FallbackUnparseable)
+			}
+			if sink.calls.Load() != 1 {
+				t.Errorf("action sink calls = %d, want 1 (the rules fallback dispatched)", sink.calls.Load())
+			}
+		})
+	}
+}
+
+// --- Acceptance: the permission gate applies IDENTICALLY to an llm decision ---
+
+func TestLLMDecide_OutOfAllowListBlocked(t *testing.T) {
+	// The model chooses an intervention NOT in interventions.allowed; the SAME
+	// allow-list gate the rules path uses must block it (decision.blocked=true) and
+	// it must NOT reach the action sink. No llm-specific bypass.
+	be := &inferBackend{name: "phi4-mini",
+		response: `{"intervention":"eliminate_player","target_serial":"AAAA","reason":"chaos","objective_served":"chaos"}`}
+	l, sr, sink := llmDecideLoop(t, llmDecideSnapshot(), resolverWith(be), nil)
+
+	l.OnEvaluate(context.Background(), gamecontext.GameContext{SessionID: "s1", GameKind: "real"}, testTrigger())
+
+	decs := spansByName(sr.Ended(), SpanDecision)
+	if len(decs) != 1 {
+		t.Fatalf("agent.decision spans = %d, want 1 (a blocked decision is still audited)", len(decs))
+	}
+	if v, ok := attrValue(decs[0], AttrDecisionBlocked); !ok || !v.AsBool() {
+		t.Error("decision.blocked must be true for an out-of-allow-list LLM action")
+	}
+	if v, ok := attrValue(decs[0], AttrDecisionBlockReason); !ok || v.AsString() != string(ReasonNotAllowed) {
+		t.Errorf("block reason = %q, want %q", v.AsString(), ReasonNotAllowed)
+	}
+	if sink.calls.Load() != 0 {
+		t.Errorf("action sink calls = %d, want 0 (blocked action never dispatched)", sink.calls.Load())
+	}
+}
+
+// --- Acceptance: the weighted rate limit applies IDENTICALLY to llm decisions ---
+
+func TestLLMDecide_RateLimitApplies(t *testing.T) {
+	be := &inferBackend{name: "phi4-mini", response: validShieldResponse}
+	snap := llmDecideSnapshot()
+	snap.Policy.MaxInterventionsPerMinute = 1 // one weighted slot per minute
+	clock := time.Unix(2000, 0)
+	l, sr, sink := llmDecideLoop(t, snap, resolverWith(be), nil)
+	l.now = func() time.Time { return clock }
+	ctx := gamecontext.GameContext{SessionID: "s1", GameKind: "real"}
+
+	l.OnEvaluate(context.Background(), ctx, testTrigger()) // dispatches (slot 1)
+	clock = clock.Add(time.Second)
+	l.OnEvaluate(context.Background(), ctx, testTrigger()) // rate-limited
+
+	decs := spansByName(sr.Ended(), SpanDecision)
+	if len(decs) != 2 {
+		t.Fatalf("agent.decision spans = %d, want 2", len(decs))
+	}
+	// The second llm decision is blocked by the SAME weighted rate limiter the rules
+	// path uses — not silently dropped, recorded with the rate_limit reason.
+	if v, ok := attrValue(decs[1], AttrDecisionBlocked); !ok || !v.AsBool() {
+		t.Error("second llm decision must be rate-limited (blocked)")
+	}
+	if v, ok := attrValue(decs[1], AttrDecisionBlockReason); !ok || v.AsString() != string(ReasonRateLimit) {
+		t.Errorf("second block reason = %q, want %q", v.AsString(), ReasonRateLimit)
+	}
+	if sink.calls.Load() != 1 {
+		t.Errorf("action sink calls = %d, want 1 (only the first llm decision dispatched)", sink.calls.Load())
+	}
+}
+
+// --- Acceptance: a gate-DENIED llm cycle never calls the backend (gate first) ---
+
+func TestLLMDecide_GateDeniedNeverInfers(t *testing.T) {
+	be := &inferBackend{name: "phi4-mini", response: validShieldResponse}
+	snap := llmDecideSnapshot()
+	snap.LLMGate.EligibleGameKinds = []string{"real"} // a shadow game is gated
+	l, sr, _ := llmDecideLoop(t, snap, resolverWith(be), []Decision{{Intervention: "grant_shield", Reason: "rules"}})
+
+	l.OnEvaluate(context.Background(), gamecontext.GameContext{SessionID: "s1", GameKind: "shadow"}, testTrigger())
+
+	if be.calls != 0 {
+		t.Errorf("backend Infer calls = %d, want 0 (gate denied -> no inference)", be.calls)
+	}
+	_, used, fallback := inferenceTriple(t, sr)
+	if used != InferenceRules {
+		t.Errorf("inference.used = %q, want rules (gate denied)", used)
+	}
+	if fallback != FallbackNotEligible {
+		t.Errorf("inference.fallback_reason = %q, want %q (the gate reason)", fallback, FallbackNotEligible)
+	}
+}
+
+// --- The dev default: no resolver / unreachable chain keeps the rules behavior ---
+
+func TestLLMDecide_UnreachableChainKeepsRules(t *testing.T) {
+	be := &inferBackend{name: "phi4-mini", response: validShieldResponse}
+	r := NewResolver([]Backend{be}, 0) // NOT refreshed -> cache empty -> tier unreachable
+	l, sr, sink := llmDecideLoop(t, llmDecideSnapshot(), r, []Decision{{Intervention: "grant_shield", Reason: "rules"}})
+
+	l.OnEvaluate(context.Background(), gamecontext.GameContext{SessionID: "s1", GameKind: "real"}, testTrigger())
+
+	if be.calls != 0 {
+		t.Errorf("backend Infer calls = %d, want 0 (chain unreachable -> rules, no call)", be.calls)
+	}
+	_, used, fallback := inferenceTriple(t, sr)
+	if used != InferenceRules {
+		t.Errorf("inference.used = %q, want rules", used)
+	}
+	if fallback != FallbackNoBackend {
+		t.Errorf("inference.fallback_reason = %q, want %q", fallback, FallbackNoBackend)
+	}
+	if sink.calls.Load() != 1 {
+		t.Errorf("action sink calls = %d, want 1 (rules decision dispatched)", sink.calls.Load())
+	}
+}

--- a/services/agent/decision/llm_decide_test.go
+++ b/services/agent/decision/llm_decide_test.go
@@ -150,6 +150,60 @@ func TestLLMDecide_ValidResponseTakesLLMPath(t *testing.T) {
 	}
 }
 
+// unavailableBackend is a chain tier whose probe never reports reachable, used to
+// force resolve() to degrade past it to a lower tier. Its Infer is never called
+// (Available()=false keeps it out of the resolution), so the body is irrelevant.
+type unavailableBackend struct{ name string }
+
+func (b unavailableBackend) Name() string                   { return b.name }
+func (b unavailableBackend) Available(context.Context) bool { return false }
+func (b unavailableBackend) Infer(context.Context, llm.Prompt) (string, error) {
+	return "", errUnavailableBackend
+}
+
+var errUnavailableBackend = errors.New("unavailable backend should never be called")
+
+// TestLLMDecide_InferSpanReportsCalledTierNotConfiguredModel locks the fix from the
+// #946 review: on a DEGRADED chain (configured "claude" unreachable, served by the
+// lower "phi4-mini" tier) the agent.llm.infer span's gen_ai.request.model must name
+// the tier ACTUALLY called (phi4-mini), not the configured model (claude) — otherwise
+// the request span misattributes the call versus the sibling decision span's
+// inference.used.
+func TestLLMDecide_InferSpanReportsCalledTierNotConfiguredModel(t *testing.T) {
+	cloud := unavailableBackend{name: TierCloud}                           // configured tier, unreachable
+	phi := &inferBackend{name: "phi4-mini", response: validShieldResponse} // reachable lower tier
+	r := NewResolver([]Backend{cloud, phi}, 0)
+	r.Refresh(context.Background())
+
+	snap := llmDecideSnapshot()
+	snap.Capability.Model = "claude" // cloud model -> top of the walk, which is down
+
+	l, sr, _ := llmDecideLoop(t, snap, r, []Decision{{Intervention: "play_audio_cue", Reason: "from rules"}})
+	l.OnEvaluate(context.Background(), gamecontext.GameContext{SessionID: "s1", GameKind: "real"}, testTrigger())
+
+	if phi.calls != 1 {
+		t.Fatalf("phi4-mini Infer calls = %d, want 1 (chain degraded to the reachable lower tier)", phi.calls)
+	}
+	inf := spansByName(sr.Ended(), SpanLLMInfer)
+	if len(inf) != 1 {
+		t.Fatalf("agent.llm.infer spans = %d, want 1", len(inf))
+	}
+	if v, ok := attrValue(inf[0], "gen_ai.request.model"); !ok || v.AsString() != "phi4-mini" {
+		t.Errorf("infer span gen_ai.request.model = %q, want phi4-mini (the tier called, not configured claude)", v.AsString())
+	}
+	// The sibling decision span records the degrade honestly.
+	dec := spansByName(sr.Ended(), SpanDecision)
+	if len(dec) != 1 {
+		t.Fatalf("agent.decision spans = %d, want 1", len(dec))
+	}
+	if v, ok := attrValue(dec[0], AttrInferenceUsed); !ok || v.AsString() != "phi4-mini" {
+		t.Errorf("inference.used = %q, want phi4-mini", v.AsString())
+	}
+	if v, ok := attrValue(dec[0], AttrInferenceFallback); !ok || v.AsString() != FallbackEndpointUnreachable {
+		t.Errorf("inference.fallback_reason = %q, want %q", v.AsString(), FallbackEndpointUnreachable)
+	}
+}
+
 // --- Acceptance: objectives reach the prompt ---
 
 func TestLLMDecide_ObjectivesShapePrompt(t *testing.T) {

--- a/services/agent/decision/probe_backend.go
+++ b/services/agent/decision/probe_backend.go
@@ -2,8 +2,11 @@ package decision
 
 import (
 	"context"
+	"errors"
 	"net"
 	"time"
+
+	"github.com/joustmania/agent/llm"
 )
 
 // probe_backend.go is the PRODUCTION inference probe (#741): a Backend whose
@@ -89,4 +92,30 @@ func (e *endpointBackend) Available(ctx context.Context) bool {
 	}
 	_ = conn.Close()
 	return true
+}
+
+// errInferNotImplemented is returned by endpointBackend.Infer until a real
+// backend client exists. llm_decide treats ANY Infer error as "this tier could
+// not produce a usable answer" and falls back to the rules engine with a
+// recorded reason — so a production agent that resolves a reachable endpoint
+// (its TCP port is open) but has no inference client yet degrades SAFELY to
+// rules rather than dispatching anything. It is a sentinel so callers/tests can
+// errors.Is it.
+var errInferNotImplemented = errors.New("decision: endpoint inference not implemented (blocked on #738 Jetson / #742 cloud)")
+
+// Infer is the PRODUCTION inference call seam (#739) — and is deliberately
+// NOT-YET-IMPLEMENTED. The real model call (Ollama /api/chat for the Jetson
+// gemma3:4b and localhost phi4-mini tiers, the cloud chat API for claude/copilot)
+// is OUT OF SCOPE here: the Jetson backend is hardware-blocked (#738) and the
+// cloud backend is credential-blocked (#742). Returning an error keeps the system
+// HONEST and SAFE: a tier whose endpoint TCP-dials open (so Available reports it
+// reachable, and inference.used names it) but has no client yet cannot fabricate
+// a Decision — llm_decide catches this error and falls back to rules with
+// FallbackUnparseable-class attribution. #738/#742 replace this body with: build
+// the provider request from `prompt` (System+User), POST to e.addr with a bounded
+// ctx, and return the model's raw response string for decode.go to parse. The
+// signature and the parse pipeline are already in place, so those issues only fill
+// in the transport.
+func (e *endpointBackend) Infer(_ context.Context, _ llm.Prompt) (string, error) {
+	return "", errInferNotImplemented
 }

--- a/services/agent/decision/resolver.go
+++ b/services/agent/decision/resolver.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"sync"
 	"time"
+
+	"github.com/joustmania/agent/llm"
 )
 
 // resolver.go is the inference availability checker and fallback chain (#741).
@@ -100,6 +102,18 @@ type Backend interface {
 	// (a short-timeout dial), but even a slow one cannot stall a decision because
 	// decisions read the cache.
 	Available(ctx context.Context) bool
+	// Infer is the actual inference call (#739): it sends the objective-aware
+	// prompt (llm.Build, already objective-weighted via the snapshot) to this tier
+	// and returns the model's RAW response text, which llm_decide parses
+	// DEFENSIVELY into a Decision (unparseable/out-of-vocab output never dispatches
+	// — see decode.go). It is called ONLY for a resolved, REACHABLE non-rules tier
+	// (the rules engine is the implicit terminal rung and is NOT a Backend), and
+	// ONLY after the #847 gate admits, so a tier that returns an error here simply
+	// falls back to rules with a recorded reason. Cohesive with Available: a tier
+	// reported reachable should be able to Infer; production endpointBackend.Infer
+	// is the seam #738 (Jetson) / #742 (cloud) fill in — until then it errors and
+	// the chain safely degrades to rules. ctx bounds the call (timeout/cancel).
+	Infer(ctx context.Context, prompt llm.Prompt) (string, error)
 }
 
 // Resolver holds the ordered inference chain and a periodically-refreshed
@@ -190,6 +204,13 @@ type Resolution struct {
 	// chain when one at/below the configured model is reachable, else InferenceRules
 	// when the whole chain is unreachable and it bottoms out at the rules engine.
 	Used string
+	// Backend is the resolved tier's Backend — the one llm_decide (#739) calls
+	// Infer on — or NIL when the chain bottomed out at the rules engine (Used ==
+	// InferenceRules). decide() branches on this: a non-nil Backend means a real
+	// llm tier is reachable, so the LLM path runs; nil means rules decide (the
+	// #741 fallback). Carrying the instance (not just the name) avoids a second
+	// chain walk to recover it. The rules engine is NOT a Backend, hence nil.
+	Backend Backend
 	// FallbackReason is inference.fallback_reason: "" when the configured tier
 	// itself is reachable (no degradation), FallbackEndpointUnreachable when a LOWER
 	// tier serves (a higher one was unreachable), or FallbackNoBackend when the whole
@@ -220,7 +241,9 @@ func (r *Resolver) resolve(configuredModel string) Resolution {
 			if i > start {
 				reason = FallbackEndpointUnreachable
 			}
-			return Resolution{Used: r.chain[i].Name(), FallbackReason: reason}
+			// Carry the resolved Backend so decide() can call Infer without a second
+			// chain walk; a non-nil Backend is the signal that a real llm tier serves.
+			return Resolution{Used: r.chain[i].Name(), Backend: r.chain[i], FallbackReason: reason}
 		}
 	}
 	// Whole chain unreachable: the rules engine is the always-available terminal

--- a/services/agent/decision/resolver_test.go
+++ b/services/agent/decision/resolver_test.go
@@ -5,6 +5,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+
+	"github.com/joustmania/agent/llm"
 )
 
 // fakeBackend is the test Backend (#741): a named tier whose availability is a
@@ -28,6 +30,24 @@ func (b *fakeBackend) Name() string { return b.name }
 func (b *fakeBackend) Available(context.Context) bool {
 	b.probes.Add(1)
 	return b.up.Load()
+}
+
+// fakeBackendResponse is the canned valid response fakeBackend.Infer returns. The
+// #741 resolver/attribution tests assert WHICH tier resolves (inference.used +
+// fallback_reason); since #739 a resolved tier is now actually CALLED, so Infer
+// must return a contract-valid response for those tests to keep seeing a clean
+// llm decision (used=<tier>, fallback="") rather than an unparseable fallback. The
+// intervention (grant_shield) matches the allow-list the resolverLoop snapshot and
+// rules engine use, so the decision dispatches just like the rules one did.
+const fakeBackendResponse = `{"intervention":"grant_shield","target_serial":"","value":"","reason":"x","objective_served":"endurance"}`
+
+// Infer satisfies the #739 Backend interface. For the resolver/attribution tests
+// (which exercise availability RESOLUTION, not parse paths) it returns the canned
+// valid response above so a resolved tier produces a clean llm decision. The
+// dedicated parse-path coverage (valid/invalid/out-of-vocab/empty/error) lives in
+// llm_decide_test.go with a purpose-built inferBackend.
+func (b *fakeBackend) Infer(context.Context, llm.Prompt) (string, error) {
+	return fakeBackendResponse, nil
 }
 
 func (b *fakeBackend) set(up bool)       { b.up.Store(up) }

--- a/services/agent/decision/telemetry.go
+++ b/services/agent/decision/telemetry.go
@@ -45,6 +45,22 @@ const SpanDisabled = "agent.disabled"
 // one per throttleInterval (shared with the evaluate log / agent.disabled span).
 const SpanLLMPrompt = "agent.llm.prompt"
 
+// SpanLLMInfer is the actual-inference span (#739): emitted when the llm path
+// calls a resolved backend's Infer (NOT the capture path, which only renders the
+// prompt). It is a child of agent.span_received and a SIBLING of the resulting
+// agent.decision span, carrying the GenAI request attribution and — on a parsed
+// response — the model's reasoning + chosen objective + action. On an Infer error
+// or an unparseable response it carries AttrLLMInferError and the cycle falls back
+// to rules; the gen_ai.* shape lets Jaeger treat it as a model call.
+const SpanLLMInfer = "agent.llm.infer"
+
+// AttrLLMInferError records why an llm.infer span did not yield a usable Decision
+// (#739): the Infer transport error, or the llm.Decode rejection reason
+// (empty / not-JSON / missing-field / out-of-vocab-objective). Present only on the
+// failure path; its presence on the span is the marker that the cycle fell back to
+// rules with FallbackUnparseable.
+const AttrLLMInferError = "llm.infer.error"
+
 // Custom attribute keys of the agent.llm.prompt span (#739). The gen_ai.*
 // attributes use semconv constants where they exist; these three carry the
 // captured prompt text and size, which have no semantic convention.
@@ -171,6 +187,19 @@ const (
 	// FallbackNoBackend means the WHOLE chain was unreachable and rules decided.
 	// Recorded together with inference.used=<the lower tier> on the decision span.
 	FallbackEndpointUnreachable = "endpoint_unreachable"
+	// FallbackUnparseable is the inference.fallback_reason when the #847 gate ADMITTED
+	// an llm attempt AND resolve_backend (#741) resolved a REACHABLE tier whose Infer
+	// was actually called (#739), but the model's response could NOT be turned into a
+	// valid Decision — the call errored, the body was not the contracted JSON, a
+	// required field was missing, or the chosen intervention was out-of-vocabulary
+	// (not in the agent's known intervention set). The cycle falls back to the rules
+	// engine, and inference.used is recorded as the TIER THAT WAS CALLED (not "rules")
+	// so the span honestly shows "this tier answered, but unusably". This is the
+	// safety floor of the LLM path: an unparseable/invalid/out-of-vocab response NEVER
+	// dispatches an arbitrary action — it always degrades to the deterministic engine
+	// with this reason. Distinct from FallbackNoBackend (no tier was reachable at all,
+	// Infer was never called).
+	FallbackUnparseable = "llm_unparseable"
 	// DefaultObjectives until the objectives flag schema exists (#725).
 	DefaultObjectives = "unset"
 	// UnrestrictedAllowed is the interventions.allowed summary while the

--- a/services/agent/llm/decode.go
+++ b/services/agent/llm/decode.go
@@ -1,0 +1,167 @@
+package llm
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// decode.go is the DEFENSIVE response parser for the #739 llm decision path. The
+// model is asked (by the RESPONSE CONTRACT in buildSystem) to reply with EXACTLY
+// ONE JSON object shaped like Response below. A real model does not always
+// comply: it may wrap the JSON in prose or ```json fences, omit required fields,
+// emit malformed JSON, or name an intervention that is not in the allow-list.
+//
+// The cardinal safety rule of the llm path (#739 acceptance): an unparseable,
+// invalid, or out-of-vocabulary response must NEVER dispatch an arbitrary action.
+// So Decode is strict and total — it returns a usable Response ONLY when the
+// reply is well-formed AND complete; on anything else it returns a typed error
+// and the caller (decision.llmDecide) falls back to the rules engine with a
+// recorded reason. Decode does NOT know the per-session allow-list (that lives in
+// the flags snapshot in the decision package); it validates STRUCTURE and the
+// fixed objective vocabulary here, and the decision package validates the chosen
+// intervention against interventions.allowed via the SAME permission gate the
+// rules engine uses (so an out-of-vocab/disallowed intervention is blocked
+// identically — decision.blocked=true — rather than special-cased here).
+//
+// This file is pure and has no decision-package dependency (avoids an import
+// cycle: decision imports llm, never the reverse), so it is exhaustively
+// table-tested in decode_test.go independent of the loop.
+
+// Response is the strict schema the model must return — one JSON object mirroring
+// the dispatchable fields of decision.Decision (intervention/target_serial/value/
+// reason/objective_served). decision.llmDecide maps a decoded Response onto a
+// decision.Decision; it deliberately does NOT mirror Decision's internal Fitness/
+// Objectives maps (those are scoring inputs the agent owns, not model output).
+type Response struct {
+	// Intervention is the chosen action id. It must be present and non-empty; the
+	// decision package validates it against interventions.allowed (out-of-vocab =>
+	// blocked, never dispatched). "noop" is the contracted "do nothing" sentinel.
+	Intervention string `json:"intervention"`
+	// TargetSerial scopes a player-targeted intervention; "" = session-scoped.
+	// Optional (a session-scoped action legitimately omits it).
+	TargetSerial string `json:"target_serial"`
+	// Value is the optional per-intervention payload string (see decision.Decision).
+	Value string `json:"value"`
+	// Reason is the model's one-sentence justification, recorded as decision.reason.
+	// Required: a dispatched action with no recorded reason is not auditable.
+	Reason string `json:"reason"`
+	// ObjectiveServed names which session objective the choice serves. Required and
+	// validated against the fixed objective vocabulary (endurance/balanced/
+	// accelerate/chaos) — a value outside it rejects the whole response, since a
+	// model that invents an objective is not following the contract.
+	ObjectiveServed string `json:"objective_served"`
+}
+
+// IsNoop reports whether the model chose to do nothing this cycle. A noop is a
+// VALID, contract-following response (the System prompt explicitly offers it), but
+// it dispatches no action — the caller treats it as "the llm decided, and decided
+// to intervene with nothing", distinct from a parse failure.
+func (r Response) IsNoop() bool { return r.Intervention == noopIntervention }
+
+// noopIntervention is the contracted "do nothing" intervention id (see the
+// RESPONSE CONTRACT in buildSystem). It is always a valid model choice and never
+// dispatches an action.
+const noopIntervention = "noop"
+
+// objectiveVocabulary is the fixed set of session objectives the model may claim
+// to serve, matching the objectives flag schema (#725) the prompt is weighted by.
+// A response naming anything outside it is rejected (ErrInvalidObjective): an
+// out-of-vocab objective signals the model is not following the contract, so the
+// whole response is untrusted and the cycle falls back to rules. This is a CLOSED
+// set on purpose — it is the same vocabulary buildSystem tells the model to use.
+var objectiveVocabulary = map[string]struct{}{
+	"endurance":  {},
+	"balanced":   {},
+	"accelerate": {},
+	"chaos":      {},
+}
+
+// Decode-time rejection reasons. All are wrapped in the returned error so the
+// caller can log the precise cause, but they collapse to a single fallback class
+// (FallbackUnparseable) on the span — the model failed the contract, full stop.
+var (
+	// ErrEmptyResponse: the model returned nothing usable (empty/whitespace-only).
+	ErrEmptyResponse = errors.New("llm: empty response")
+	// ErrNotJSON: no JSON object could be extracted/parsed from the response.
+	ErrNotJSON = errors.New("llm: response is not a single JSON object")
+	// ErrMissingField: a required field (intervention, reason, objective_served)
+	// was absent or empty.
+	ErrMissingField = errors.New("llm: response missing required field")
+	// ErrInvalidObjective: objective_served is not in the fixed vocabulary.
+	ErrInvalidObjective = errors.New("llm: objective_served outside vocabulary")
+)
+
+// Decode parses a raw model response into a validated Response, or returns a
+// typed error. It is intentionally strict: the result is safe to act on (subject
+// to the allow-list check the decision package still applies) ONLY when err is
+// nil. Validation, in order:
+//
+//  1. non-empty                         -> ErrEmptyResponse
+//  2. extractable + parseable JSON obj  -> ErrNotJSON
+//  3. intervention present              -> ErrMissingField
+//  4. reason present                    -> ErrMissingField
+//  5. objective_served present & in set -> ErrMissingField / ErrInvalidObjective
+//
+// A "noop" intervention passes (it is the contracted do-nothing choice) but still
+// requires a reason and a valid objective — even doing nothing must be auditable.
+func Decode(raw string) (Response, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return Response{}, ErrEmptyResponse
+	}
+
+	obj, err := extractJSONObject(trimmed)
+	if err != nil {
+		return Response{}, err
+	}
+
+	var r Response
+	// DisallowUnknownFields is intentionally NOT used: a compliant model may add
+	// commentary keys, and we only consume the contracted ones. Extra fields are
+	// harmless; MISSING required fields are the failure mode we guard below.
+	if err := json.Unmarshal(obj, &r); err != nil {
+		return Response{}, fmt.Errorf("%w: %v", ErrNotJSON, err)
+	}
+
+	// Required fields. An action with no intervention id is meaningless; a
+	// dispatched action with no reason is not auditable; the objective must be one
+	// the agent recognizes.
+	if strings.TrimSpace(r.Intervention) == "" {
+		return Response{}, fmt.Errorf("%w: intervention", ErrMissingField)
+	}
+	if strings.TrimSpace(r.Reason) == "" {
+		return Response{}, fmt.Errorf("%w: reason", ErrMissingField)
+	}
+	if strings.TrimSpace(r.ObjectiveServed) == "" {
+		return Response{}, fmt.Errorf("%w: objective_served", ErrMissingField)
+	}
+	if _, ok := objectiveVocabulary[r.ObjectiveServed]; !ok {
+		return Response{}, fmt.Errorf("%w: %q", ErrInvalidObjective, r.ObjectiveServed)
+	}
+
+	return r, nil
+}
+
+// extractJSONObject pulls the single JSON object out of a model reply. Models
+// frequently wrap the object in prose or in a ```json fence despite the "no
+// prose" instruction, so rather than demand a byte-perfect object we locate the
+// first '{' and the matching last '}' and parse the span between them. This is
+// deliberately forgiving about SURROUNDING text but strict about the object
+// itself: the extracted span must parse as a JSON object (json.Valid + leading
+// '{'), otherwise ErrNotJSON. It does not attempt to find a SECOND object — the
+// contract is exactly one — so trailing junk after the object is ignored, which
+// is the common, benign case (a fence close or a stray newline).
+func extractJSONObject(s string) ([]byte, error) {
+	start := strings.IndexByte(s, '{')
+	end := strings.LastIndexByte(s, '}')
+	if start < 0 || end < start {
+		return nil, ErrNotJSON
+	}
+	candidate := s[start : end+1]
+	if !json.Valid([]byte(candidate)) {
+		return nil, ErrNotJSON
+	}
+	return []byte(candidate), nil
+}

--- a/services/agent/llm/decode_test.go
+++ b/services/agent/llm/decode_test.go
@@ -1,0 +1,114 @@
+package llm
+
+import (
+	"errors"
+	"testing"
+)
+
+// decode_test.go exhaustively table-tests the defensive response parser (#739).
+// The safety property under test: Decode returns a usable Response ONLY for a
+// well-formed, complete, in-vocab reply; EVERY other input yields a typed error so
+// the decision loop falls back to rules and never dispatches untrusted output.
+
+func TestDecode_Valid(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want Response
+	}{
+		{
+			name: "minimal session-scoped",
+			raw:  `{"intervention":"grant_shield","target_serial":"","value":"","reason":"even the field","objective_served":"balanced"}`,
+			want: Response{Intervention: "grant_shield", Reason: "even the field", ObjectiveServed: "balanced"},
+		},
+		{
+			name: "player-targeted with value",
+			raw:  `{"intervention":"send_controller_effect","target_serial":"AAAA1111","value":"rumble","reason":"hype","objective_served":"chaos"}`,
+			want: Response{Intervention: "send_controller_effect", TargetSerial: "AAAA1111", Value: "rumble", Reason: "hype", ObjectiveServed: "chaos"},
+		},
+		{
+			name: "noop is valid",
+			raw:  `{"intervention":"noop","target_serial":"","value":"","reason":"nothing actionable","objective_served":"endurance"}`,
+			want: Response{Intervention: "noop", Reason: "nothing actionable", ObjectiveServed: "endurance"},
+		},
+		{
+			name: "wrapped in prose and a json fence",
+			raw:  "Sure! Here is my decision:\n```json\n{\"intervention\":\"adjust_music_tempo\",\"value\":\"1.2\",\"reason\":\"raise energy\",\"objective_served\":\"accelerate\"}\n```\nHope that helps.",
+			want: Response{Intervention: "adjust_music_tempo", Value: "1.2", Reason: "raise energy", ObjectiveServed: "accelerate"},
+		},
+		{
+			name: "extra unknown fields are ignored",
+			raw:  `{"intervention":"grant_shield","reason":"r","objective_served":"balanced","confidence":0.9,"notes":"extra"}`,
+			want: Response{Intervention: "grant_shield", Reason: "r", ObjectiveServed: "balanced"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := Decode(tc.raw)
+			if err != nil {
+				t.Fatalf("Decode error = %v, want nil", err)
+			}
+			if got != tc.want {
+				t.Errorf("Decode = %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDecode_Rejects(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		wantErr error
+	}{
+		{"empty", "", ErrEmptyResponse},
+		{"whitespace only", "   \n\t ", ErrEmptyResponse},
+		{"no json at all", "I refuse to answer.", ErrNotJSON},
+		{"malformed json", `{"intervention":"grant_shield", "reason":}`, ErrNotJSON},
+		{"bare json array no object", `["grant_shield","play_audio_cue"]`, ErrNotJSON},
+		{"missing intervention", `{"reason":"r","objective_served":"balanced"}`, ErrMissingField},
+		{"empty intervention", `{"intervention":"  ","reason":"r","objective_served":"balanced"}`, ErrMissingField},
+		{"missing reason", `{"intervention":"grant_shield","objective_served":"balanced"}`, ErrMissingField},
+		{"empty reason", `{"intervention":"grant_shield","reason":"","objective_served":"balanced"}`, ErrMissingField},
+		{"missing objective", `{"intervention":"grant_shield","reason":"r"}`, ErrMissingField},
+		{"out-of-vocab objective", `{"intervention":"grant_shield","reason":"r","objective_served":"maximize_fun"}`, ErrInvalidObjective},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := Decode(tc.raw)
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("Decode error = %v, want %v", err, tc.wantErr)
+			}
+			// The cardinal safety property: a rejected response yields the zero
+			// Response, so no field can leak into a dispatched action.
+			if got != (Response{}) {
+				t.Errorf("rejected Decode returned non-zero Response %+v", got)
+			}
+		})
+	}
+}
+
+// TestDecode_OutOfVocabInterventionIsStructurallyValid documents the boundary
+// between the two validation layers: an UNKNOWN intervention id is STRUCTURALLY
+// valid here (Decode does not know the per-session allow-list), so Decode accepts
+// it — the decision package's permission gate is what blocks it (decision.blocked).
+// This keeps the allow-list check in ONE place (evaluatePermission), applied
+// identically to rules and llm choices.
+func TestDecode_OutOfVocabInterventionIsStructurallyValid(t *testing.T) {
+	got, err := Decode(`{"intervention":"launch_nukes","reason":"chaos reigns","objective_served":"chaos"}`)
+	if err != nil {
+		t.Fatalf("Decode error = %v, want nil (allow-list is enforced downstream, not here)", err)
+	}
+	if got.Intervention != "launch_nukes" {
+		t.Errorf("intervention = %q, want launch_nukes (decode is allow-list-agnostic)", got.Intervention)
+	}
+}
+
+func TestResponse_IsNoop(t *testing.T) {
+	if !(Response{Intervention: "noop"}).IsNoop() {
+		t.Error("noop intervention must report IsNoop")
+	}
+	if (Response{Intervention: "grant_shield"}).IsNoop() {
+		t.Error("non-noop intervention must not report IsNoop")
+	}
+}


### PR DESCRIPTION
Part of #739. Implements `llm_decide` — the `agent.mode == "llm"` branch of the decision loop with **objective-aware prompting**. After #847 (call gate, merged) + #741 (inference resolver, PR #942), a gate-ADMITTED cycle resolved a reachable inference tier but *always ran rules*. This PR makes the agent actually USE that tier: it calls the resolved backend's inference, turns the response into the SAME `Decision` the rules engine produces, and returns it through the existing audit/permission/rate-limit chain.

> **Stacking note:** authored as a stacked diff on top of **#741 / PR #942** (`feat/741-inference-fallback-chain`), which is itself stacked on the merged #847. The base of this PR is `feat/741-inference-fallback-chain`, so the diff shows ONLY the #739 changes on top of #741. If #942 squash-merges to main and its branch is deleted before this merges, rebase onto main (`git rebase --onto origin/main <741-squash-commit> feat/739-llm-decide` — the #741 content is identical and applies cleanly) and retarget at `main`; the diff stays #739-only.

## What's in it

- **Backend gets an inference method.** #741's `Backend` interface (`Name()` + `Available()`) is extended with `Infer(ctx, llm.Prompt) (string, error)`. `Resolution` now carries the resolved `Backend` (nil = rules terminal), so `decide()` branches on a real reachable tier without a second chain walk. `Available()` and `Infer()` stay cohesive: a tier reported reachable is the one we call.
- **`decide()` now calls the tier.** On a gate-ADMITTED cycle where `resolve_backend` returns a reachable non-rules tier (`Backend != nil`), the loop runs `llmDecide` instead of rules. A nil backend (whole chain unreachable — the dev default, no real backend exists) keeps the #741 fallback to rules verbatim.
- **Objective-aware prompt, reused.** `llmDecide` reuses `llm.Build` (the existing builder the capture span uses) — already objective-weighted via the snapshot, so the System prompt encodes the `agent.objectives` weights and the allow-list. The model is asked to optimize for *this* session's objectives (endurance/balanced/accelerate/chaos).
- **Defensive parsing (`llm/decode.go`, new).** A strict response contract `{intervention, target_serial, value, reason, objective_served}`. `Decode` returns a usable `Response` ONLY for well-formed, complete, in-vocab JSON (tolerates surrounding prose / ` ```json ` fences); empty / not-JSON / missing-required-field / out-of-vocab-objective all return typed errors. **Unparseable/invalid/out-of-vocab output NEVER dispatches an arbitrary action** — the cycle falls back to rules with the new `FallbackUnparseable` (`llm_unparseable`) reason, and `inference.used` stays the tier that was called (it answered, just unusably). Exhaustively table-tested.
- **Same gates, identically applied.** The parsed `Decision` flows through the EXACT `runDecision` -> `evaluatePermission` chain as a rules decision. An LLM-chosen action not in `interventions.allowed` is blocked with `decision.blocked=true`; the battery threshold and the weighted rate limit apply unchanged. No LLM-specific dispatch path. A `noop` response is a valid, contract-following choice that dispatches nothing (and is NOT a rules fallback).
- **Spans.** New `agent.llm.infer` span carries the `gen_ai.*` request attribution plus the model's reasoning / objective / action (or `llm.infer.error` on the fallback path). `inference.configured` / `inference.used` (the deciding tier) ride the decision span as before.
- **Production stub.** `endpointBackend.Infer` is a clearly-marked NOT-YET-IMPLEMENTED that returns an error, so a production agent that resolves a reachable endpoint but has no client yet degrades SAFELY to rules. The real Ollama/cloud transport is filled in by #738 (Jetson, hardware-blocked) / #742 (cloud, credential-blocked) — the signature + parse pipeline are already in place.

## Acceptance criteria

- [x] `agent.mode == "llm"` routes through the LLM path when the gate admits AND a backend resolves reachable (`TestLLMDecide_ValidResponseTakesLLMPath`)
- [x] Prompts incorporate the objective weights + game context (`TestLLMDecide_ObjectivesShapePrompt`)
- [x] Unparseable / invalid / out-of-vocab / errored output does NOT dispatch — falls back safely with a recorded reason (`TestLLMDecide_BadResponseFallsBackToRules`, `llm.TestDecode_Rejects`)
- [x] Permission gating + weighted rate limit apply identically (`TestLLMDecide_OutOfAllowListBlocked`, `TestLLMDecide_RateLimitApplies`)
- [x] Decision/infer spans carry `inference.configured`/`inference.used` + the reasoning (`TestLLMDecide_ValidResponseTakesLLMPath`)
- [x] Gate-first ordering preserved: a denied cycle never infers (`TestLLMDecide_GateDeniedNeverInfers`); dev default (unreachable chain) keeps rules (`TestLLMDecide_UnreachableChainKeepsRules`)

## Out of scope (per #739)
Real Jetson/cloud backend clients (#738/#742). Prompt variants per flag (#740 — stacks on this). Async inference (#917 — stacks on this; the call site is structured so it can be wrapped).

## Verification
`gofmt -l .` clean, `go vet ./...`, `go build ./...`, `go test -race ./...` all green from `services/agent/` (9 packages). #847/#741 tests (resolver attribution, gate ordering, disabled+llm) still pass — the #741 `fakeBackend.Infer` now returns a canned valid response so resolver-attribution tests still observe a clean resolved tier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)