### PR TITLE
feat(agent): prompt variants per flag value (#740)

### DIFF
--- a/services/agent/decision/layerstate.go
+++ b/services/agent/decision/layerstate.go
@@ -1,6 +1,9 @@
 package decision
 
-import "github.com/joustmania/agent/flags"
+import (
+	"github.com/joustmania/agent/flags"
+	"github.com/joustmania/agent/llm"
+)
 
 // BlockReason identifies which layer/policy blocked a decision. It is the
 // structured attribution issue #729 lifts onto the decision span.
@@ -109,11 +112,17 @@ type LayerState struct {
 // are filled in as decisions are processed.
 func newLayerState(s flags.Snapshot) LayerState {
 	return LayerState{
-		Enabled:       s.Enabled,
-		Mode:          s.Mode,
-		Objectives:    s.Objectives,
-		Model:         s.Capability.Model,
-		PromptVariant: s.Capability.PromptVariant,
+		Enabled:    s.Enabled,
+		Mode:       s.Mode,
+		Objectives: s.Objectives,
+		Model:      s.Capability.Model,
+		// Record the EFFECTIVE prompt variant (#740), not the raw flag value: the
+		// llm path resolves an unknown/garbage prompt_variant to "conservative"
+		// before building the prompt, so the decision span's agent.prompt_variant
+		// must report the variant that ACTUALLY ran — otherwise a misconfiguration
+		// would be invisible in the audit trail. ResolveVariant is the SINGLE
+		// fallback point shared with llm.Build, so span and prompt never disagree.
+		PromptVariant: llm.ResolveVariant(s.Capability.PromptVariant),
 		// inference.used defaults to rules (#741): a cycle that never resolves a
 		// backend (rules mode, or a gate-denied llm cycle) honestly reports rules. The
 		// loop overwrites this only on a gate-admitted llm cycle with the resolved tier.

--- a/services/agent/decision/llm_decide_test.go
+++ b/services/agent/decision/llm_decide_test.go
@@ -410,3 +410,102 @@ func TestLLMDecide_UnreachableChainKeepsRules(t *testing.T) {
 		t.Errorf("action sink calls = %d, want 1 (rules decision dispatched)", sink.calls.Load())
 	}
 }
+
+// --- #740: prompt variant selection on the LLM decision path ---
+
+// variantSnapshot is an llm-mode snapshot identical to llmDecideSnapshot but with
+// the prompt_variant flag set to raw, so a test can flip ONLY the variant and
+// observe the prompt the backend receives change on the next decision.
+func variantSnapshot(raw string) flags.Snapshot {
+	snap := llmDecideSnapshot()
+	snap.Capability.PromptVariant = raw
+	return snap
+}
+
+// TestLLMDecide_VariantReachesInferencePrompt is the #740 decision-level proof
+// that the capability-layer prompt_variant flag actually shapes the prompt the
+// resolved backend is asked to infer over: building the loop with variant A vs B
+// and reading the fake backend's lastPromptSystem shows DIFFERENT System prompts,
+// each carrying its own risk-posture instruction. Because flags are read
+// per-cycle (the snapshot is rebuilt every OnEvaluate), flipping the flag on
+// stage changes behavior on the NEXT decision with no restart.
+func TestLLMDecide_VariantReachesInferencePrompt(t *testing.T) {
+	systemFor := func(raw string) string {
+		be := &inferBackend{name: "phi4-mini", response: validShieldResponse}
+		l, _, _ := llmDecideLoop(t, variantSnapshot(raw), resolverWith(be), []Decision{{Intervention: "play_audio_cue", Reason: "from rules"}})
+		l.OnEvaluate(context.Background(), gamecontext.GameContext{SessionID: "s1", GameKind: "real"}, testTrigger())
+		if be.calls != 1 {
+			t.Fatalf("backend Infer calls = %d, want 1 (llm path taken for variant %q)", be.calls, raw)
+		}
+		return be.lastPromptSystem
+	}
+
+	cons := systemFor("conservative")
+	aggr := systemFor("aggressive")
+	bal := systemFor("balanced")
+
+	// The flag selected three materially different prompts at the REAL inference call
+	// site (not just on the capture span): all pairwise distinct.
+	if cons == aggr || cons == bal || aggr == bal {
+		t.Fatalf("flipping prompt_variant did not change the inference prompt (cons==aggr=%v cons==bal=%v aggr==bal=%v)",
+			cons == aggr, cons == bal, aggr == bal)
+	}
+	if !strings.Contains(cons, "the bar to act is HIGH") {
+		t.Errorf("conservative inference prompt missing its instruction:\n%s", cons)
+	}
+	if !strings.Contains(aggr, "the bar to act is LOW") {
+		t.Errorf("aggressive inference prompt missing its instruction:\n%s", aggr)
+	}
+	if !strings.Contains(bal, "MODERATELY actionable") {
+		t.Errorf("balanced inference prompt missing its instruction:\n%s", bal)
+	}
+}
+
+// TestLLMDecide_UnknownVariantFallsBackSafely is the #740 fail-safe at the
+// decision level: a garbage prompt_variant value must NOT produce an empty or
+// undefined prompt — the inference call receives the conservative prompt — AND
+// the decision span's agent.prompt_variant records the EFFECTIVE variant
+// (conservative), so the misconfiguration is safe and visible in the audit trail.
+func TestLLMDecide_UnknownVariantFallsBackSafely(t *testing.T) {
+	be := &inferBackend{name: "phi4-mini", response: validShieldResponse}
+	l, sr, _ := llmDecideLoop(t, variantSnapshot("totally-bogus"), resolverWith(be), []Decision{{Intervention: "play_audio_cue", Reason: "from rules"}})
+	l.OnEvaluate(context.Background(), gamecontext.GameContext{SessionID: "s1", GameKind: "real"}, testTrigger())
+
+	if be.calls != 1 {
+		t.Fatalf("backend Infer calls = %d, want 1 (a bogus variant must still infer, never an undefined prompt)", be.calls)
+	}
+	// The dispatched inference prompt is the conservative one (the safe default),
+	// never empty.
+	if be.lastPromptSystem == "" {
+		t.Fatal("inference prompt is empty for an unknown variant — must fall back to a defined prompt")
+	}
+	if !strings.Contains(be.lastPromptSystem, "the bar to act is HIGH") {
+		t.Errorf("unknown variant did not fall back to the conservative prompt:\n%s", be.lastPromptSystem)
+	}
+
+	// The decision span records the EFFECTIVE variant, not the raw garbage.
+	decs := spansByName(sr.Ended(), SpanDecision)
+	if len(decs) != 1 {
+		t.Fatalf("agent.decision spans = %d, want 1", len(decs))
+	}
+	if v, ok := attrValue(decs[0], AttrPromptVariant); !ok || v.AsString() != "conservative" {
+		t.Errorf("decision span agent.prompt_variant = %q, want conservative (the effective variant)", v.AsString())
+	}
+}
+
+// TestLLMDecide_KnownVariantRecordedOnSpan: a recognized prompt_variant rides the
+// decision span verbatim (the effective variant equals the configured one when it
+// is valid), completing the #740 audit-trail requirement.
+func TestLLMDecide_KnownVariantRecordedOnSpan(t *testing.T) {
+	be := &inferBackend{name: "phi4-mini", response: validShieldResponse}
+	l, sr, _ := llmDecideLoop(t, variantSnapshot("aggressive"), resolverWith(be), []Decision{{Intervention: "play_audio_cue", Reason: "from rules"}})
+	l.OnEvaluate(context.Background(), gamecontext.GameContext{SessionID: "s1", GameKind: "real"}, testTrigger())
+
+	decs := spansByName(sr.Ended(), SpanDecision)
+	if len(decs) != 1 {
+		t.Fatalf("agent.decision spans = %d, want 1", len(decs))
+	}
+	if v, ok := attrValue(decs[0], AttrPromptVariant); !ok || v.AsString() != "aggressive" {
+		t.Errorf("decision span agent.prompt_variant = %q, want aggressive", v.AsString())
+	}
+}

--- a/services/agent/llm/prompt.go
+++ b/services/agent/llm/prompt.go
@@ -48,25 +48,59 @@ type BuildInput struct {
 // unknown is the literal rendered for any never-observed (nil) signal.
 const unknown = "unknown"
 
-// variantGuidance maps a resolved prompt_variant to its System-prompt guidance
-// line. This is the single producer of variant text so #740 can expand it in
-// one place. conservativeVariant is the default and the fallback for any
-// unrecognized variant value.
+// The three capability-layer prompt_variant values (#740). The flag selects HOW
+// the model is prompted on the #739 llm decision path: each variant lays a
+// distinct RISK POSTURE on top of the (already objective-aware) System prompt —
+// it shifts the action threshold and the bias between ambient cues and
+// state-changing interventions, WITHOUT replacing objective-awareness.
+// conservativeVariant is the default and the fail-safe fallback for any
+// unrecognized value (#740: a misconfiguration must be safe + visible, never an
+// empty/undefined prompt).
 const (
 	conservativeVariant = "conservative"
 	aggressiveVariant   = "aggressive"
 	balancedVariant     = "balanced"
 )
 
+// variantGuidance maps a resolved prompt_variant to its full System-prompt
+// guidance BLOCK (#740). The blocks differ MATERIALLY — not just a label — so
+// the model is asked to do something different per variant: conservative biases
+// toward soft/no intervention with a high bar to act; aggressive is readier to
+// intervene with stronger, state-changing actions; balanced sits between. The
+// wording is fixed and reviewed (golden-tested) so the prompt stays
+// deterministic — no time/random input. This map is the SINGLE producer of
+// variant text; ResolveVariant is the single place the unknown->conservative
+// fallback lives, so the effective variant is consistent everywhere it is read
+// (the prompt, the capture span, and the decision span's agent.prompt_variant).
 var variantGuidance = map[string]string{
-	conservativeVariant: `Intervene only when a signal is clearly actionable; when in doubt, choose "noop". Favor ambient cues over state changes.`,
-	aggressiveVariant:   "Intervene proactively to maximize excitement; prefer state-changing interventions when the objective calls for it.",
-	balancedVariant:     "Intervene when a signal is moderately actionable; balance ambient cues and state changes.",
+	conservativeVariant: `Adopt a CONSERVATIVE risk posture: the bar to act is HIGH. Intervene ONLY
+when a signal is clearly and strongly actionable; whenever you are in any
+doubt, choose "noop". Strongly prefer the least disruptive option — favor
+ambient cues (audio cues, music tempo) over player-targeted, state-changing
+interventions, and avoid changing a player's state unless nothing softer
+will serve the objective. When two options serve the objective equally,
+pick the gentler one or do nothing.`,
+	aggressiveVariant: `Adopt an AGGRESSIVE risk posture: the bar to act is LOW. Intervene readily
+and proactively to drive excitement toward the objective — you should act on
+even moderately actionable signals rather than wait. Prefer STRONGER,
+state-changing interventions (grant_shield, set_music_tempo) over passive
+ambient cues when the objective calls for it. Reserve "noop" for cycles where
+no allowed intervention would plausibly serve the objective at all.`,
+	balancedVariant: `Adopt a BALANCED risk posture: act on MODERATELY actionable signals. Weigh
+the disruption of each option against the benefit to the objective, choosing
+ambient cues and state-changing interventions on their merits rather than
+biasing toward either. Choose "noop" when no option clearly serves the
+objective, but do not hold back when one plainly does.`,
 }
 
-// resolveVariant maps a raw prompt_variant flag value to a known variant,
-// falling back to conservative for anything unrecognized.
-func resolveVariant(raw string) string {
+// ResolveVariant maps a raw prompt_variant flag value to its EFFECTIVE variant,
+// falling back to conservative for anything unrecognized (#740). It is exported
+// because the decision layer records the EFFECTIVE variant on the decision span
+// (agent.prompt_variant): a garbage flag value must report "conservative" — the
+// variant actually in force — not the misconfigured raw string. Keeping this the
+// ONE resolution point means the span, the capture log, and the prompt can never
+// disagree about which variant ran.
+func ResolveVariant(raw string) string {
 	if _, ok := variantGuidance[raw]; ok {
 		return raw
 	}
@@ -76,7 +110,7 @@ func resolveVariant(raw string) string {
 // Build renders the deterministic prompt for one decision cycle. The same
 // BuildInput (with a fixed Now) always yields a byte-identical Prompt.
 func Build(in BuildInput) Prompt {
-	variant := resolveVariant(in.Snapshot.Capability.PromptVariant)
+	variant := ResolveVariant(in.Snapshot.Capability.PromptVariant)
 	return Prompt{
 		System:  buildSystem(in.Snapshot, variant),
 		User:    buildUser(in.Context, in.Now),
@@ -112,9 +146,11 @@ POLICY CONSTRAINTS:
 	b.WriteString(` weighted interventions per minute across the session.
   - Prefer the least disruptive intervention that serves the objective.
 
-VARIANT: `)
+VARIANT (`)
 	b.WriteString(variant)
-	b.WriteString(". ")
+	// variant is already the EFFECTIVE variant (Build resolved it), so this lookup
+	// is always present — an unknown flag value rendered the conservative block.
+	b.WriteString("):\n")
 	b.WriteString(variantGuidance[variant])
 	b.WriteString(`
 

--- a/services/agent/llm/prompt_test.go
+++ b/services/agent/llm/prompt_test.go
@@ -337,21 +337,100 @@ func TestDeterminism(t *testing.T) {
 }
 
 // TestUnknownVariant: an unrecognized prompt_variant falls back to conservative
-// text and the resolved Variant is "conservative".
+// text and the resolved Variant is "conservative" (#740 fail-safe — a garbage
+// flag must never produce an empty/undefined prompt, and the EFFECTIVE variant
+// is what is recorded). Also covers the empty-string flag value.
 func TestUnknownVariant(t *testing.T) {
-	p := Build(BuildInput{
-		Snapshot: baseSnapshot("totally-made-up"),
-		Context:  threePlayerContext(),
-		Now:      fixedNow,
-	})
-	if p.Variant != conservativeVariant {
-		t.Errorf("variant = %q, want conservative", p.Variant)
+	for _, raw := range []string{"totally-made-up", "", "CONSERVATIVE", "Aggressive"} {
+		raw := raw
+		t.Run("raw="+raw, func(t *testing.T) {
+			p := Build(BuildInput{
+				Snapshot: baseSnapshot(raw),
+				Context:  threePlayerContext(),
+				Now:      fixedNow,
+			})
+			if p.Variant != conservativeVariant {
+				t.Errorf("variant = %q, want conservative", p.Variant)
+			}
+			if !strings.Contains(p.System, variantGuidance[conservativeVariant]) {
+				t.Errorf("system missing conservative guidance:\n%s", p.System)
+			}
+			if !strings.Contains(p.System, "VARIANT (conservative):") {
+				t.Errorf("system missing 'VARIANT (conservative):' header:\n%s", p.System)
+			}
+		})
 	}
-	if !strings.Contains(p.System, variantGuidance[conservativeVariant]) {
-		t.Errorf("system missing conservative guidance:\n%s", p.System)
+}
+
+// TestResolveVariant covers the exported single-fallback-point directly: the
+// three known variants resolve to themselves; everything else (#740 fail-safe)
+// resolves to conservative. This is the function both llm.Build AND the decision
+// span (layerstate.go) call, so it is the contract that the prompt and the
+// audit-trail agent.prompt_variant can never disagree.
+func TestResolveVariant(t *testing.T) {
+	cases := map[string]string{
+		conservativeVariant: conservativeVariant,
+		aggressiveVariant:   aggressiveVariant,
+		balancedVariant:     balancedVariant,
+		"":                  conservativeVariant,
+		"garbage":           conservativeVariant,
+		"Balanced":          conservativeVariant, // case-sensitive: not a known value
 	}
-	if !strings.Contains(p.System, "VARIANT: conservative.") {
-		t.Errorf("system missing 'VARIANT: conservative.' line:\n%s", p.System)
+	for raw, want := range cases {
+		if got := ResolveVariant(raw); got != want {
+			t.Errorf("ResolveVariant(%q) = %q, want %q", raw, got, want)
+		}
+	}
+}
+
+// TestVariantsAreMateriallyDifferent: #740's core acceptance — each variant
+// produces a DIFFERENT System prompt that meaningfully shapes what the model is
+// asked to do, and the difference is in the prompt TEXT (assertable), not merely
+// a recorded label. Conservative biases toward not acting (HIGH bar), aggressive
+// toward acting (LOW bar), balanced toward the middle (MODERATELY actionable).
+func TestVariantsAreMateriallyDifferent(t *testing.T) {
+	build := func(v string) string {
+		return Build(BuildInput{Snapshot: baseSnapshot(v), Context: threePlayerContext(), Now: fixedNow}).System
+	}
+	cons := build(conservativeVariant)
+	aggr := build(aggressiveVariant)
+	bal := build(balancedVariant)
+
+	// All three System prompts must differ pairwise.
+	if cons == aggr || cons == bal || aggr == bal {
+		t.Fatalf("variant System prompts are not all distinct:\ncons==aggr=%v cons==bal=%v aggr==bal=%v",
+			cons == aggr, cons == bal, aggr == bal)
+	}
+
+	// Each variant carries its distinguishing instruction (the risk-posture text a
+	// reviewer would key on), and NOT another variant's.
+	checks := []struct {
+		name    string
+		system  string
+		must    string
+		mustNot []string
+	}{
+		{"conservative", cons, "the bar to act is HIGH", []string{"the bar to act is LOW", "MODERATELY actionable"}},
+		{"aggressive", aggr, "the bar to act is LOW", []string{"the bar to act is HIGH", "MODERATELY actionable"}},
+		{"balanced", bal, "MODERATELY actionable", []string{"the bar to act is HIGH", "the bar to act is LOW"}},
+	}
+	for _, ch := range checks {
+		if !strings.Contains(ch.system, ch.must) {
+			t.Errorf("%s System missing distinguishing instruction %q:\n%s", ch.name, ch.must, ch.system)
+		}
+		for _, bad := range ch.mustNot {
+			if strings.Contains(ch.system, bad) {
+				t.Errorf("%s System leaked another variant's instruction %q", ch.name, bad)
+			}
+		}
+	}
+
+	// Variants layer risk posture ON TOP of objective-awareness (#739/#740): the
+	// objective weights and allow-list survive in EVERY variant.
+	for _, sys := range []string{cons, aggr, bal} {
+		if !strings.Contains(sys, "balanced=0.7") || !strings.Contains(sys, "grant_shield") {
+			t.Errorf("variant dropped objective/allow-list awareness:\n%s", sys)
+		}
 	}
 }
 

--- a/services/agent/llm/testdata/aggressive_3players.golden
+++ b/services/agent/llm/testdata/aggressive_3players.golden
@@ -18,7 +18,13 @@ POLICY CONSTRAINTS:
   - At most 2 weighted interventions per minute across the session.
   - Prefer the least disruptive intervention that serves the objective.
 
-VARIANT: aggressive. Intervene proactively to maximize excitement; prefer state-changing interventions when the objective calls for it.
+VARIANT (aggressive):
+Adopt an AGGRESSIVE risk posture: the bar to act is LOW. Intervene readily
+and proactively to drive excitement toward the objective — you should act on
+even moderately actionable signals rather than wait. Prefer STRONGER,
+state-changing interventions (grant_shield, set_music_tempo) over passive
+ambient cues when the objective calls for it. Reserve "noop" for cycles where
+no allowed intervention would plausibly serve the objective at all.
 
 RESPONSE CONTRACT — reply with EXACTLY ONE JSON object, no prose, matching:
 {

--- a/services/agent/llm/testdata/all_unknown.golden
+++ b/services/agent/llm/testdata/all_unknown.golden
@@ -18,7 +18,14 @@ POLICY CONSTRAINTS:
   - At most 2 weighted interventions per minute across the session.
   - Prefer the least disruptive intervention that serves the objective.
 
-VARIANT: conservative. Intervene only when a signal is clearly actionable; when in doubt, choose "noop". Favor ambient cues over state changes.
+VARIANT (conservative):
+Adopt a CONSERVATIVE risk posture: the bar to act is HIGH. Intervene ONLY
+when a signal is clearly and strongly actionable; whenever you are in any
+doubt, choose "noop". Strongly prefer the least disruptive option — favor
+ambient cues (audio cues, music tempo) over player-targeted, state-changing
+interventions, and avoid changing a player's state unless nothing softer
+will serve the objective. When two options serve the objective equally,
+pick the gentler one or do nothing.
 
 RESPONSE CONTRACT — reply with EXACTLY ONE JSON object, no prose, matching:
 {

--- a/services/agent/llm/testdata/balanced_3players.golden
+++ b/services/agent/llm/testdata/balanced_3players.golden
@@ -18,7 +18,12 @@ POLICY CONSTRAINTS:
   - At most 2 weighted interventions per minute across the session.
   - Prefer the least disruptive intervention that serves the objective.
 
-VARIANT: balanced. Intervene when a signal is moderately actionable; balance ambient cues and state changes.
+VARIANT (balanced):
+Adopt a BALANCED risk posture: act on MODERATELY actionable signals. Weigh
+the disruption of each option against the benefit to the objective, choosing
+ambient cues and state-changing interventions on their merits rather than
+biasing toward either. Choose "noop" when no option clearly serves the
+objective, but do not hold back when one plainly does.
 
 RESPONSE CONTRACT — reply with EXACTLY ONE JSON object, no prose, matching:
 {

--- a/services/agent/llm/testdata/conservative_3players.golden
+++ b/services/agent/llm/testdata/conservative_3players.golden
@@ -18,7 +18,14 @@ POLICY CONSTRAINTS:
   - At most 2 weighted interventions per minute across the session.
   - Prefer the least disruptive intervention that serves the objective.
 
-VARIANT: conservative. Intervene only when a signal is clearly actionable; when in doubt, choose "noop". Favor ambient cues over state changes.
+VARIANT (conservative):
+Adopt a CONSERVATIVE risk posture: the bar to act is HIGH. Intervene ONLY
+when a signal is clearly and strongly actionable; whenever you are in any
+doubt, choose "noop". Strongly prefer the least disruptive option — favor
+ambient cues (audio cues, music tempo) over player-targeted, state-changing
+interventions, and avoid changing a player's state unless nothing softer
+will serve the objective. When two options serve the objective equally,
+pick the gentler one or do nothing.
 
 RESPONSE CONTRACT — reply with EXACTLY ONE JSON object, no prose, matching:
 {

--- a/services/agent/llm/testdata/empty_players.golden
+++ b/services/agent/llm/testdata/empty_players.golden
@@ -18,7 +18,14 @@ POLICY CONSTRAINTS:
   - At most 2 weighted interventions per minute across the session.
   - Prefer the least disruptive intervention that serves the objective.
 
-VARIANT: conservative. Intervene only when a signal is clearly actionable; when in doubt, choose "noop". Favor ambient cues over state changes.
+VARIANT (conservative):
+Adopt a CONSERVATIVE risk posture: the bar to act is HIGH. Intervene ONLY
+when a signal is clearly and strongly actionable; whenever you are in any
+doubt, choose "noop". Strongly prefer the least disruptive option — favor
+ambient cues (audio cues, music tempo) over player-targeted, state-changing
+interventions, and avoid changing a player's state unless nothing softer
+will serve the objective. When two options serve the objective equally,
+pick the gentler one or do nothing.
 
 RESPONSE CONTRACT — reply with EXACTLY ONE JSON object, no prose, matching:
 {

--- a/services/agent/llm/testdata/timeline_3players.golden
+++ b/services/agent/llm/testdata/timeline_3players.golden
@@ -18,7 +18,12 @@ POLICY CONSTRAINTS:
   - At most 2 weighted interventions per minute across the session.
   - Prefer the least disruptive intervention that serves the objective.
 
-VARIANT: balanced. Intervene when a signal is moderately actionable; balance ambient cues and state changes.
+VARIANT (balanced):
+Adopt a BALANCED risk posture: act on MODERATELY actionable signals. Weigh
+the disruption of each option against the benefit to the objective, choosing
+ambient cues and state-changing interventions on their merits rather than
+biasing toward either. Choose "noop" when no option clearly serves the
+objective, but do not hold back when one plainly does.
 
 RESPONSE CONTRACT — reply with EXACTLY ONE JSON object, no prose, matching:
 {


### PR DESCRIPTION
Part of #740. Selects HOW the LLM is prompted on the #739 decision path from the capability-layer `agent.prompt_variant` flag:

```
agent.prompt_variant = "conservative" | "aggressive" | "balanced"
```

> **Stacking note:** authored as a stacked diff on top of **#739 / PR #946** (`feat/739-llm-decide`), which itself stacks on the merged #847 + #741. The base of this PR is `feat/739-llm-decide`, so the diff shows ONLY the #740 changes. If #946 squash-merges to `main` and its branch is deleted before this merges, rebase onto main (`git rebase --onto origin/main feat/739-llm-decide feat/740-prompt-variants`) and the PR auto-retargets to `main`; the diff stays #740-only.

## What's in it

- **Three materially-different variants.** The #739 prompt builder already had a `prompt_variant` seam, but the three values were placeholder one-liners that differed only by a recorded label. This makes each variant a distinct multi-line System-prompt block that shifts the agent's RISK POSTURE on top of the existing objective-awareness (objectives + allow-list survive in every variant):
  - `conservative` — HIGH bar to act; bias toward soft/no intervention, ambient cues over state changes.
  - `aggressive` — LOW bar to act; readier to dispatch stronger, state-changing interventions.
  - `balanced` — act on moderately-actionable signals; weigh disruption vs. benefit, no bias either way.
  The differences are in the System prompt TEXT, assertable in tests and reviewed in the goldens.
- **Per-cycle, live.** `llm.Build` resolves the variant on every `OnEvaluate`, so flipping `agent.prompt_variant` on stage changes behavior on the NEXT decision with no restart. Nothing caches the variant. A decision-level test (`TestLLMDecide_VariantReachesInferencePrompt`) flips the flag and asserts the System prompt the real inference call receives changes accordingly.
- **One fail-safe fallback point.** `ResolveVariant` is exported as the SINGLE place the unknown→`conservative` fallback lives, shared by `llm.Build` AND the decision span (`layerstate.go`). A garbage/empty `prompt_variant`:
  - still produces a DEFINED prompt — the inference call is never empty/undefined (`TestLLMDecide_UnknownVariantFallsBackSafely`), and
  - records the EFFECTIVE variant (`conservative`) on the decision span's `agent.prompt_variant`, so a misconfiguration is safe AND visible in the audit trail. Previously the span recorded the raw flag value, which would have hidden the fallback.

## Acceptance criteria

- [x] All three variants implemented for the LLM path, each a different prompt that shapes what the model is asked to do (`TestVariantsAreMateriallyDifferent`, goldens)
- [x] Variant selection read from the flag on EACH decision, not cached (`TestLLMDecide_VariantReachesInferencePrompt`)
- [x] Flipping the flag observably changes the prompt/decision behavior on the next decision (same test — build A vs B, System prompts differ)
- [x] Active variant recorded on the decision span as the EFFECTIVE variant; unknown → conservative fallback never dispatches an undefined prompt (`TestLLMDecide_UnknownVariantFallsBackSafely`, `TestLLMDecide_KnownVariantRecordedOnSpan`, `TestResolveVariant`)

## Out of scope (per #740)
Backend transport (#738 Jetson / #742 cloud). Async inference (#917 — stacks on this next). Anything beyond the three named variants.

## Tests
`gofmt -l .` clean, `go vet ./...`, `go build ./...`, `go test -race ./...` all green; `make lint` (ruff, no Python changes) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)