### PR TITLE
feat(agent): hot-reload lifecycle/decision calibration flags (#927)

### DIFF
--- a/services/agent/README.md
+++ b/services/agent/README.md
@@ -893,17 +893,27 @@ gates, reaches the real `Writer`, and completes the `agent.action` span — all
 without touching the game. Revert by flipping `interventions_allowed` back to
 `ambient` (or `none`).
 
-### Lifecycle flags — read at startup (#766 F5)
+### Lifecycle flags — hot-reloaded via OpenFeature config-change (#766 F5, #927)
 
 The agent's lifecycle and throttle calibration values live in the flagd `agent`
-domain ([`services/flagd/agent.json`](../flagd/agent.json)). Unlike the four
-decision-cycle flag layers above (evaluated **every cycle**, hot-reloadable),
-these are **read once at startup**: they configure the GameContext store TTLs,
-the eviction ticker, and the decision-loop log/span throttle, all of which are
-fixed at construction. **Changing one requires an agent restart** — it is *not*
-hot-reload by design (per #766 F5). If flagd is not yet reachable at startup each
-value falls back to its safe default, which reproduces the former hardcoded
-constant exactly (promotion is behavior-neutral).
+domain ([`services/flagd/agent.json`](../flagd/agent.json)). Like the four
+decision-cycle flag layers above they are **hot-reloadable** — but via a
+different mechanism. #766 F5 originally read them once at startup, so retuning
+the store TTLs / eviction cadence / throttle needed a restart. **#927 makes them
+live** by wiring the **OpenFeature provider's configuration-change event
+listener** (`openfeature.ProviderConfigChange`, the mechanism the maintainer
+requested): flagd emits a config-change when its source changes, the Go SDK
+surfaces the event, and a domain-scoped handler re-evaluates these four flags
+into a shared, concurrency-safe `flags.LifecycleHolder`
+([`flags/holder.go`](flags/holder.go)). The consumers read the holder on their
+hot path — the GameContext store reads the TTLs at eviction time, `main.go`'s
+eviction ticker re-reads (and `Reset`s to) the interval each loop, and the
+decision loop reads the throttle in `shouldLog()` — so **changing one takes
+effect with no restart**, and **without** polling the flag client per decision
+cycle (a holder read is a lock-free atomic load; only the rare config-change
+event re-reads flagd). The holder is **primed once at startup**, so values are
+correct before any event arrives; if flagd is not yet reachable each value falls
+back to its safe default, which reproduces the former hardcoded constant exactly.
 
 | Flag | Default | Configures |
 |------|---------|------------|
@@ -913,7 +923,8 @@ constant exactly (promotion is behavior-neutral).
 | `decision.throttle_seconds` | `1` | How often the `agent.evaluate` log line and the `agent.disabled` span are emitted |
 
 A non-positive value for any of these falls back to its default (a zero TTL or
-ticker interval would be unsafe).
+ticker interval would be unsafe), both at startup and on every hot-reload, so a
+transient bad flag read during a config-change can never collapse a TTL.
 
 ## Action sink (#730) — applying decisions as flag writes
 

--- a/services/agent/decision/decision.go
+++ b/services/agent/decision/decision.go
@@ -168,9 +168,18 @@ type Loop struct {
 	lastLog time.Time
 	now     func() time.Time
 	// throttle bounds how often the evaluate log line and agent.disabled span are
-	// emitted. Read once at startup from decision.throttle_seconds (#766 F5); a
-	// zero value means DefaultThrottleInterval.
+	// emitted. The STATIC fallback value, set via SetThrottle; a zero value means
+	// DefaultThrottleInterval. Used only when throttleSource is nil.
 	throttle time.Duration
+	// throttleSource, when non-nil, is the LIVE decision.throttle_seconds source
+	// (#927): shouldLog() reads it every cycle so a mid-session config-change to the
+	// throttle flag takes effect with no restart. It points at the shared
+	// flags.LifecycleHolder.DecisionThrottle (wired in main.go), which is itself
+	// refreshed only by the OpenFeature configuration-change event — so this is a
+	// lock-free atomic load on the hot path, NOT a per-cycle flagd evaluation. When
+	// nil (the construction default, and all existing tests) shouldLog falls back to
+	// the static throttle, preserving the #766 F5 read-at-startup behavior.
+	throttleSource func() time.Duration
 
 	// limiter is the unified weighted per-minute rate limiter spanning all
 	// dispatched interventions across cycles (#726 + #728, see ratelimit.go). It
@@ -260,6 +269,19 @@ func (l *Loop) SetThrottle(d time.Duration) {
 		return
 	}
 	l.throttle = d
+}
+
+// SetThrottleSource installs the LIVE decision.throttle_seconds source (#927):
+// shouldLog() reads it every cycle instead of the static SetThrottle value, so a
+// mid-session config-change to the throttle flag takes effect with no restart.
+// main.go passes the shared flags.LifecycleHolder.DecisionThrottle, which is a
+// lock-free atomic load refreshed only by the OpenFeature config-change event —
+// the hot path never evaluates flagd. A nil source (or a source returning a
+// non-positive duration) leaves the static throttle / default in place, so this
+// is purely additive over the #766 F5 behavior. Not safe to call concurrently
+// with OnEvaluate — set it during construction, before the loop serves.
+func (l *Loop) SetThrottleSource(src func() time.Duration) {
+	l.throttleSource = src
 }
 
 // OnEvaluate runs one evaluation pass and returns the cycle's LayerState (also
@@ -754,7 +776,16 @@ func (l *Loop) shouldLog() bool {
 	if now == nil {
 		now = time.Now
 	}
+	// Prefer the LIVE throttle source (#927) so a config-change to
+	// decision.throttle_seconds is honored on the very next cycle; fall back to the
+	// static read-at-startup value (and then the default) when no source is wired or
+	// it reports a non-positive duration.
 	throttle := l.throttle
+	if l.throttleSource != nil {
+		if d := l.throttleSource(); d > 0 {
+			throttle = d
+		}
+	}
 	if throttle <= 0 {
 		throttle = DefaultThrottleInterval
 	}

--- a/services/agent/decision/loop_test.go
+++ b/services/agent/decision/loop_test.go
@@ -396,6 +396,74 @@ func TestSetThrottle_HonorsConfiguredInterval(t *testing.T) {
 	}
 }
 
+// TestThrottleSource_HotReloadsMidSession is the #927 ACCEPTANCE test: a live
+// decision.throttle_seconds source (the shared LifecycleHolder.DecisionThrottle in
+// production) is read by shouldLog() EVERY cycle, so changing the source's value
+// mid-session changes the agent.disabled span cadence with NO restart. Driven
+// deterministically with the injected clock and a settable source — no live flagd,
+// no real time, no network: the throttle value is flipped between evaluations
+// exactly as the OpenFeature config-change handler would after a flag change.
+func TestThrottleSource_HotReloadsMidSession(t *testing.T) {
+	l, sr, fl := newTestLoop(t)
+	fl.snap.Enabled = false // disabled path goes through the throttled span
+
+	// The live source the holder would expose. Start at 10s.
+	throttle := 10 * time.Second
+	l.SetThrottleSource(func() time.Duration { return throttle })
+
+	clock := time.Now()
+	l.now = func() time.Time { return clock }
+	disabledSpans := func() int { return len(spansByName(sr.Ended(), SpanDisabled)) }
+
+	// First eval fires (throttle "fires" on first call).
+	l.OnEvaluate(context.Background(), gamecontext.GameContext{}, testTrigger())
+	if got := disabledSpans(); got != 1 {
+		t.Fatalf("first eval: disabled spans = %d, want 1", got)
+	}
+
+	// At +5s, under the 10s window, throttled — no new span.
+	clock = clock.Add(5 * time.Second)
+	l.OnEvaluate(context.Background(), gamecontext.GameContext{}, testTrigger())
+	if got := disabledSpans(); got != 1 {
+		t.Fatalf("within 10s window: disabled spans = %d, want 1", got)
+	}
+
+	// Config-change: shorten the throttle to 2s mid-session (the source now returns
+	// the new value, exactly as a config-change Reload would). The SAME +5s elapsed
+	// since the last emit now EXCEEDS the live 2s window, so the next eval fires —
+	// proving the new value took effect with no restart.
+	throttle = 2 * time.Second
+	l.OnEvaluate(context.Background(), gamecontext.GameContext{}, testTrigger())
+	if got := disabledSpans(); got != 2 {
+		t.Fatalf("after throttle shortened to 2s: disabled spans = %d, want 2 (mid-session change took effect)", got)
+	}
+}
+
+// TestThrottleSource_NonPositiveFallsBackToStatic verifies a source returning a
+// non-positive duration is ignored in favor of the static SetThrottle value, so a
+// transient bad read can never collapse the throttle (#927).
+func TestThrottleSource_NonPositiveFallsBackToStatic(t *testing.T) {
+	l, sr, fl := newTestLoop(t)
+	fl.snap.Enabled = false
+	l.SetThrottle(10 * time.Second)
+	l.SetThrottleSource(func() time.Duration { return 0 }) // bad/unset read
+
+	clock := time.Now()
+	l.now = func() time.Time { return clock }
+	disabledSpans := func() int { return len(spansByName(sr.Ended(), SpanDisabled)) }
+
+	l.OnEvaluate(context.Background(), gamecontext.GameContext{}, testTrigger())
+	if got := disabledSpans(); got != 1 {
+		t.Fatalf("first eval: disabled spans = %d, want 1", got)
+	}
+	// +9s: under the 10s STATIC fallback (source returned 0, so it is ignored).
+	clock = clock.Add(9 * time.Second)
+	l.OnEvaluate(context.Background(), gamecontext.GameContext{}, testTrigger())
+	if got := disabledSpans(); got != 1 {
+		t.Fatalf("within static window: disabled spans = %d, want 1 (non-positive source ignored)", got)
+	}
+}
+
 // TestSetThrottle_NonPositiveKeepsDefault verifies a non-positive throttle leaves
 // the default in place (does not disable throttling).
 func TestSetThrottle_NonPositiveKeepsDefault(t *testing.T) {

--- a/services/agent/flags/flags.go
+++ b/services/agent/flags/flags.go
@@ -56,10 +56,12 @@ const (
 	keyBluetoothMaxDroppedEventsPct = "fitness.bluetooth.max_dropped_events_pct"
 	keyBluetoothMinMovementUpdateHz = "fitness.bluetooth.min_movement_update_hz"
 
-	// Lifecycle + throttle calibration flags (#766 F5). Unlike the layers above
-	// these are READ ONCE AT STARTUP (main.go), not per cycle: they configure the
-	// gamecontext store TTLs / eviction ticker and the decision loop's throttle,
-	// which are fixed at construction. Changing them requires an agent restart.
+	// Lifecycle + throttle calibration flags (#766 F5, hot-reloaded since #927).
+	// Unlike the per-cycle layers above, these are NOT re-read on the decision hot
+	// path; they are primed once at startup and then refreshed by the OpenFeature
+	// configuration-change LISTENER into a shared LifecycleHolder (holder.go), which
+	// the gamecontext store TTLs / eviction ticker / decision-loop throttle read
+	// live. Changing a flag takes effect with no restart and no per-cycle polling.
 	keyPlayerTTLSeconds     = "lifecycle.player_ttl_seconds"
 	keySessionGraceSeconds  = "lifecycle.session_grace_seconds"
 	keyEvictIntervalSeconds = "lifecycle.evict_interval_seconds"
@@ -279,13 +281,20 @@ type BluetoothFitness struct {
 	MinMovementUpdateHz float64
 }
 
-// Lifecycle holds the agent's lifecycle + throttle calibration values (#766 F5).
+// Lifecycle holds the agent's lifecycle + throttle calibration values (#766 F5),
+// HOT-RELOADED live since #927.
 //
-// These are READ ONCE AT STARTUP, not per decision cycle: they configure the
-// gamecontext store TTLs, the eviction ticker, and the decision loop's log/span
-// throttle, all of which are fixed at construction. A flag change here requires
-// an agent restart to take effect (deliberately NOT hot-reload — the issue's
-// read-at-startup decision for the store TTLs). All values are durations.
+// These configure the gamecontext store TTLs, the eviction ticker, and the
+// decision loop's log/span throttle. #766 F5 read them ONCE at startup and baked
+// them into those consumers, so retuning the agent's perception/cadence needed a
+// restart. #927 makes them live without a restart VIA the OpenFeature provider's
+// configuration-change event listener (the mechanism the maintainer requested):
+// flagd emits a config-change when its source changes, the Go SDK surfaces it as
+// openfeature.ProviderConfigChange, and the handler re-evaluates these four flags
+// into a shared LifecycleHolder (holder.go) that the consumers read on their hot
+// path. So a flag change here takes effect on the next eviction tick / decision
+// cycle with NO restart and NO per-cycle polling of the flag client. All values
+// are durations.
 type Lifecycle struct {
 	// PlayerTTL bounds how long a silent player is retained before eviction
 	// (lifecycle.player_ttl_seconds, default 5s).

--- a/services/agent/flags/holder.go
+++ b/services/agent/flags/holder.go
@@ -81,6 +81,11 @@ func (h *LifecycleHolder) Load() Lifecycle {
 // its schema default rather than to zero. The ctx is the evaluation context for
 // the four flag reads.
 func (h *LifecycleHolder) Reload(ctx context.Context) {
+	// The OpenFeature SDK dispatches each handler invocation on its OWN goroutine,
+	// so rapid config-changes can run Reload concurrently. That is safe: the publish
+	// is a single atomic.Pointer.Store (correct for any number of writers), and the
+	// prev/next delta-log below is best-effort — under a concurrent reload the worst
+	// case is a duplicated/elided log line, never a torn value.
 	next := h.flags.Lifecycle(ctx)
 	prev := *h.val.Load()
 	h.val.Store(&next)
@@ -132,11 +137,18 @@ func (h *LifecycleHolder) DecisionThrottle() time.Duration { return h.Load().Dec
 // eventClient is the narrow interface the agent client satisfies (*openfeature.Client);
 // taking the interface keeps this unit-testable with a fake that records the
 // callback and lets a test invoke it with a synthetic EventDetails.
-func (h *LifecycleHolder) RegisterConfigChangeHandler(ctx context.Context, eventClient EventClient) openfeature.EventCallback {
+func (h *LifecycleHolder) RegisterConfigChangeHandler(eventClient EventClient) openfeature.EventCallback {
 	cb := func(_ openfeature.EventDetails) {
 		// Re-evaluate on the event goroutine. Cheap (four flag reads, all with
 		// safe-default guards) so it never wedges the SDK's event dispatch.
-		h.Reload(ctx)
+		//
+		// context.Background(), NOT the startup ctx: that ctx is the SIGTERM
+		// signal.NotifyContext, so a config-change arriving DURING shutdown would
+		// reload with a cancelled context, fail every flag eval, and briefly revert
+		// the live values to defaults. The reload eval is local + instant, so it
+		// needs no cancellation; after openfeature.Shutdown() clears handlers this
+		// callback no longer fires at all.
+		h.Reload(context.Background())
 	}
 	// EventCallback is *func(EventDetails); take the address of the local so the
 	// SDK stores a stable pointer (RemoveHandler matches on pointer identity).

--- a/services/agent/flags/holder.go
+++ b/services/agent/flags/holder.go
@@ -1,0 +1,153 @@
+package flags
+
+import (
+	"context"
+	"log/slog"
+	"sync/atomic"
+	"time"
+
+	"github.com/open-feature/go-sdk/openfeature"
+)
+
+// LifecycleHolder is the concurrency-safe, hot-reloadable home of the four
+// calibration values (#927): lifecycle.player_ttl_seconds,
+// lifecycle.session_grace_seconds, lifecycle.evict_interval_seconds, and
+// decision.throttle_seconds.
+//
+// History: #766 F5 read these four ONCE at startup and baked them into the store
+// TTLs, the eviction ticker, and the decision-loop throttle, so retuning the
+// agent's perception/cadence required a restart (#927). #927 makes them LIVE via
+// the OpenFeature provider's configuration-change event — the mechanism the
+// maintainer asked for ("we can utilize the openfeature listener for
+// configuration changed for this"): flagd emits a config-change when its flag
+// source changes, the Go SDK surfaces it as openfeature.ProviderConfigChange, and
+// the handler re-evaluates the four flags and Stores them here. The consumers
+// (the decision Loop's throttle, main.go's eviction ticker, and the gamecontext
+// Store's eviction TTLs) read the CURRENT value from this holder on their own
+// hot path instead of a construction-time constant — so a flag change takes
+// effect with no restart and WITHOUT polling the flag client per decision cycle
+// (the config-change event is the only thing that re-reads flagd; reads here are
+// a lock-free atomic load).
+//
+// Concurrency: the handler Reload()s from the SDK's event goroutine while the
+// Loop / ticker / Store read from their own goroutines, so the value is held in
+// an atomic.Pointer — a lock-free load on the read (hot) path and a single
+// atomic store on the (rare) config-change path. The four other agent flag
+// layers (enabled/mode/objectives/policy/fitness/llm) are unaffected: they were
+// already re-evaluated per cycle (#727) and must NOT route through this holder.
+type LifecycleHolder struct {
+	// flags is the source the config-change handler re-evaluates the four flags
+	// from. It is the same *Flags the per-cycle layers use (one flagd client).
+	flags *Flags
+	log   *slog.Logger
+	// val holds the most recently evaluated Lifecycle. atomic.Pointer gives the
+	// hot-path readers a lock-free load and the config-change handler a single
+	// atomic store; it is never nil after NewLifecycleHolder primes it.
+	val atomic.Pointer[Lifecycle]
+}
+
+// NewLifecycleHolder builds a holder and PRIMES it once with the initial
+// Lifecycle read, so every consumer sees correct values before any
+// configuration-change event arrives (and even if one never does — e.g. flagd
+// already at its final config at startup). The initial read keeps the existing
+// safe-default / non-positive guards: a down control plane primes the holder
+// with the flagd-schema defaults (the former hardcoded constants), exactly as
+// the read-at-startup path did. log may be nil (slog.Default() is used).
+func NewLifecycleHolder(ctx context.Context, f *Flags, log *slog.Logger) *LifecycleHolder {
+	if log == nil {
+		log = slog.Default()
+	}
+	h := &LifecycleHolder{flags: f, log: log}
+	initial := f.Lifecycle(ctx)
+	h.val.Store(&initial)
+	return h
+}
+
+// Load returns the current Lifecycle values (lock-free atomic load). Safe to call
+// from any goroutine concurrently with Reload.
+func (h *LifecycleHolder) Load() Lifecycle {
+	return *h.val.Load()
+}
+
+// Reload re-evaluates the four calibration flags and atomically replaces the held
+// values. It is the function the OpenFeature configuration-change handler calls
+// (see provider.go), and it is exported so tests can drive the update path
+// deterministically WITHOUT a live flagd — exactly as #927's acceptance test does
+// (a settable fake flag source + a direct Reload stands in for the event).
+//
+// A re-eval of four flags is cheap and must not block the SDK's event goroutine;
+// each flag still falls back to its safe default on any error (Flags.Lifecycle's
+// guards), so a transient flagd hiccup during a config-change reverts a value to
+// its schema default rather than to zero. The ctx is the evaluation context for
+// the four flag reads.
+func (h *LifecycleHolder) Reload(ctx context.Context) {
+	next := h.flags.Lifecycle(ctx)
+	prev := *h.val.Load()
+	h.val.Store(&next)
+	// Log only the deltas so a config-change for an unrelated agent flag (the
+	// event fires for ANY flag in the domain) is near-silent, while an actual
+	// calibration retune is visible in the agent log for the demo (#743).
+	if next != prev {
+		h.log.Info("agent lifecycle flags hot-reloaded via OpenFeature config-change (#927)",
+			"player_ttl", next.PlayerTTL,
+			"session_grace", next.SessionGrace,
+			"evict_interval", next.EvictInterval,
+			"decision_throttle", next.DecisionThrottle,
+		)
+	}
+}
+
+// PlayerTTL / SessionGrace / EvictInterval / DecisionThrottle are the live source
+// funcs the consumers hold instead of a fixed duration. Each is a closure-free
+// method value (h.PlayerTTL) the consumer reads on its hot path: the gamecontext
+// Store reads PlayerTTL/SessionGrace at eviction time, main.go's ticker reads
+// EvictInterval each loop, and the decision Loop reads DecisionThrottle in
+// shouldLog(). They never block and never touch flagd — just an atomic load.
+
+// PlayerTTL returns the current lifecycle.player_ttl_seconds as a duration.
+func (h *LifecycleHolder) PlayerTTL() time.Duration { return h.Load().PlayerTTL }
+
+// SessionGrace returns the current lifecycle.session_grace_seconds as a duration.
+func (h *LifecycleHolder) SessionGrace() time.Duration { return h.Load().SessionGrace }
+
+// EvictInterval returns the current lifecycle.evict_interval_seconds as a duration.
+func (h *LifecycleHolder) EvictInterval() time.Duration { return h.Load().EvictInterval }
+
+// DecisionThrottle returns the current decision.throttle_seconds as a duration.
+func (h *LifecycleHolder) DecisionThrottle() time.Duration { return h.Load().DecisionThrottle }
+
+// RegisterConfigChangeHandler wires the OpenFeature configuration-change event to
+// this holder's Reload (#927, the maintainer's requested mechanism). It returns
+// the registered openfeature.EventCallback so the caller can RemoveHandler at
+// shutdown if it wishes (openfeature.Shutdown also clears all handlers).
+//
+// We register a DOMAIN-scoped handler on the agent client (client.AddHandler)
+// rather than the API-global openfeature.AddHandler, so the agent only reacts to
+// its OWN flagd domain's config-changes — not another provider's, were one ever
+// registered. The flagd RPC resolver (provider.go) connects to flagd's evaluation
+// port and the provider surfaces flagd's change notifications as
+// ProviderConfigChange events on this domain. The event fires for ANY flag in the
+// domain (config-changes are rare), and Reload simply re-reads the four it owns.
+//
+// eventClient is the narrow interface the agent client satisfies (*openfeature.Client);
+// taking the interface keeps this unit-testable with a fake that records the
+// callback and lets a test invoke it with a synthetic EventDetails.
+func (h *LifecycleHolder) RegisterConfigChangeHandler(ctx context.Context, eventClient EventClient) openfeature.EventCallback {
+	cb := func(_ openfeature.EventDetails) {
+		// Re-evaluate on the event goroutine. Cheap (four flag reads, all with
+		// safe-default guards) so it never wedges the SDK's event dispatch.
+		h.Reload(ctx)
+	}
+	// EventCallback is *func(EventDetails); take the address of the local so the
+	// SDK stores a stable pointer (RemoveHandler matches on pointer identity).
+	callback := openfeature.EventCallback(&cb)
+	eventClient.AddHandler(openfeature.ProviderConfigChange, callback)
+	return callback
+}
+
+// EventClient is the subset of *openfeature.Client the holder needs to register a
+// domain-scoped configuration-change handler. The real OpenFeature client
+// satisfies it; tests supply a fake that captures the callback.
+type EventClient interface {
+	AddHandler(eventType openfeature.EventType, callback openfeature.EventCallback)
+}

--- a/services/agent/flags/holder_test.go
+++ b/services/agent/flags/holder_test.go
@@ -1,0 +1,216 @@
+package flags
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/open-feature/go-sdk/openfeature"
+)
+
+// settableEvaluator is a mutable stubEvaluator: tests mutate its float values
+// between Reload calls to simulate a flagd config-change WITHOUT a live flagd.
+// It satisfies Evaluator like the hand-rolled stub in flags_test.go but lets a
+// test change a flag mid-flight under a mutex (Reload runs from the "event"
+// goroutine in the race test).
+type settableEvaluator struct {
+	mu     sync.Mutex
+	floats map[string]float64
+}
+
+func newSettableEvaluator() *settableEvaluator {
+	return &settableEvaluator{floats: map[string]float64{}}
+}
+
+func (s *settableEvaluator) set(key string, v float64) {
+	s.mu.Lock()
+	s.floats[key] = v
+	s.mu.Unlock()
+}
+
+func (s *settableEvaluator) FloatValue(_ context.Context, flag string, def float64, _ openfeature.EvaluationContext, _ ...openfeature.Option) (float64, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if v, ok := s.floats[flag]; ok {
+		return v, nil
+	}
+	return def, nil
+}
+
+// The remaining Evaluator methods are unused by Lifecycle (it reads only floats)
+// but are required to satisfy the interface.
+func (s *settableEvaluator) BooleanValue(_ context.Context, _ string, def bool, _ openfeature.EvaluationContext, _ ...openfeature.Option) (bool, error) {
+	return def, nil
+}
+func (s *settableEvaluator) StringValue(_ context.Context, _ string, def string, _ openfeature.EvaluationContext, _ ...openfeature.Option) (string, error) {
+	return def, nil
+}
+func (s *settableEvaluator) IntValue(_ context.Context, _ string, def int64, _ openfeature.EvaluationContext, _ ...openfeature.Option) (int64, error) {
+	return def, nil
+}
+func (s *settableEvaluator) ObjectValue(_ context.Context, _ string, def any, _ openfeature.EvaluationContext, _ ...openfeature.Option) (any, error) {
+	return def, nil
+}
+
+// TestLifecycleHolder_PrimedWithInitialValues verifies the holder primes once at
+// construction (before any config-change event) with the current flag values, so
+// consumers read correct values from the first cycle (#927).
+func TestLifecycleHolder_PrimedWithInitialValues(t *testing.T) {
+	ev := newSettableEvaluator()
+	ev.set(keyDecisionThrottleSecs, 3)
+	ev.set(keyPlayerTTLSeconds, 7)
+	ev.set(keyEvictIntervalSeconds, 2)
+	ev.set(keySessionGraceSeconds, 20)
+
+	h := NewLifecycleHolder(context.Background(), New(ev, nil), nil)
+
+	got := h.Load()
+	if got.DecisionThrottle != 3*time.Second {
+		t.Errorf("primed DecisionThrottle = %v, want 3s", got.DecisionThrottle)
+	}
+	if got.PlayerTTL != 7*time.Second {
+		t.Errorf("primed PlayerTTL = %v, want 7s", got.PlayerTTL)
+	}
+	if got.EvictInterval != 2*time.Second {
+		t.Errorf("primed EvictInterval = %v, want 2s", got.EvictInterval)
+	}
+	if got.SessionGrace != 20*time.Second {
+		t.Errorf("primed SessionGrace = %v, want 20s", got.SessionGrace)
+	}
+}
+
+// TestLifecycleHolder_DefaultsWhenUnset verifies an empty flag source primes the
+// holder with the flagd-schema safe defaults — the down-control-plane behavior
+// the read-at-startup path had, preserved by #927.
+func TestLifecycleHolder_DefaultsWhenUnset(t *testing.T) {
+	h := NewLifecycleHolder(context.Background(), New(newSettableEvaluator(), nil), nil)
+	got := h.Load()
+	if got.DecisionThrottle != time.Duration(DefaultDecisionThrottleSeconds*float64(time.Second)) {
+		t.Errorf("default DecisionThrottle = %v, want %vs", got.DecisionThrottle, DefaultDecisionThrottleSeconds)
+	}
+	if got.PlayerTTL != time.Duration(DefaultPlayerTTLSeconds*float64(time.Second)) {
+		t.Errorf("default PlayerTTL = %v, want %vs", got.PlayerTTL, DefaultPlayerTTLSeconds)
+	}
+}
+
+// TestLifecycleHolder_ReloadAppliesNewValues is the #927 ACCEPTANCE test driver
+// at the holder level: changing decision.throttle_seconds and re-running the
+// holder's update path (the function the config-change handler calls) makes the
+// new value visible with NO restart — the live source funcs the consumers hold
+// reflect it on the very next read.
+func TestLifecycleHolder_ReloadAppliesNewValues(t *testing.T) {
+	ev := newSettableEvaluator()
+	ev.set(keyDecisionThrottleSecs, 1)
+	h := NewLifecycleHolder(context.Background(), New(ev, nil), nil)
+
+	if got := h.DecisionThrottle(); got != 1*time.Second {
+		t.Fatalf("initial DecisionThrottle source = %v, want 1s", got)
+	}
+
+	// Simulate a flagd config-change: the flag's value moves, then the event
+	// handler's Reload runs. No live flagd, no sleep, no network.
+	ev.set(keyDecisionThrottleSecs, 5)
+	h.Reload(context.Background())
+
+	if got := h.DecisionThrottle(); got != 5*time.Second {
+		t.Fatalf("after Reload DecisionThrottle source = %v, want 5s (mid-session change, no restart)", got)
+	}
+	// The other live sources also reflect the reload (they share the same Load()).
+	if got := h.PlayerTTL(); got != time.Duration(DefaultPlayerTTLSeconds*float64(time.Second)) {
+		t.Errorf("PlayerTTL source = %v, want default (unchanged flag)", got)
+	}
+}
+
+// fakeEventClient captures the registered config-change handler so a test can
+// invoke it with a synthetic event — standing in for flagd emitting a
+// ProviderConfigChange.
+type fakeEventClient struct {
+	eventType openfeature.EventType
+	callback  openfeature.EventCallback
+}
+
+func (f *fakeEventClient) AddHandler(eventType openfeature.EventType, callback openfeature.EventCallback) {
+	f.eventType = eventType
+	f.callback = callback
+}
+
+// TestLifecycleHolder_ConfigChangeEventReloads verifies the wired OpenFeature
+// configuration-change handler (the maintainer's requested mechanism) re-reads
+// the flags when the SDK fires the event: we register against a fake client,
+// then invoke the captured callback with a synthetic EventDetails and assert the
+// holder picked up the new throttle value (#927).
+func TestLifecycleHolder_ConfigChangeEventReloads(t *testing.T) {
+	ev := newSettableEvaluator()
+	ev.set(keyDecisionThrottleSecs, 1)
+	h := NewLifecycleHolder(context.Background(), New(ev, nil), nil)
+
+	fc := &fakeEventClient{}
+	h.RegisterConfigChangeHandler(context.Background(), fc)
+
+	if fc.eventType != openfeature.ProviderConfigChange {
+		t.Fatalf("registered for %q, want ProviderConfigChange", fc.eventType)
+	}
+	if fc.callback == nil {
+		t.Fatal("no config-change callback was registered")
+	}
+
+	// flagd's config changes, then the SDK fires the event -> invoke the callback.
+	ev.set(keyDecisionThrottleSecs, 8)
+	(*fc.callback)(openfeature.EventDetails{ProviderName: "flagd"})
+
+	if got := h.DecisionThrottle(); got != 8*time.Second {
+		t.Fatalf("after config-change event DecisionThrottle = %v, want 8s", got)
+	}
+}
+
+// TestLifecycleHolder_ConcurrentReloadAndRead runs Reload (the event goroutine)
+// concurrently with the consumer read paths under -race, guarding the holder's
+// atomic value (#927 concurrency requirement: the handler writes from the SDK's
+// event goroutine while the Loop/ticker/Store read from their own).
+func TestLifecycleHolder_ConcurrentReloadAndRead(t *testing.T) {
+	ev := newSettableEvaluator()
+	ev.set(keyDecisionThrottleSecs, 1)
+	h := NewLifecycleHolder(context.Background(), New(ev, nil), nil)
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	// Writer: simulates the event goroutine reloading on rapid config-changes.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; ; i++ {
+			select {
+			case <-stop:
+				return
+			default:
+				ev.set(keyDecisionThrottleSecs, float64(i%5)+1)
+				h.Reload(context.Background())
+			}
+		}
+	}()
+
+	// Readers: the three consumer hot-path source funcs.
+	for r := 0; r < 3; r++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					_ = h.DecisionThrottle()
+					_ = h.PlayerTTL()
+					_ = h.SessionGrace()
+					_ = h.EvictInterval()
+				}
+			}
+		}()
+	}
+
+	time.Sleep(20 * time.Millisecond)
+	close(stop)
+	wg.Wait()
+}

--- a/services/agent/flags/holder_test.go
+++ b/services/agent/flags/holder_test.go
@@ -146,7 +146,7 @@ func TestLifecycleHolder_ConfigChangeEventReloads(t *testing.T) {
 	h := NewLifecycleHolder(context.Background(), New(ev, nil), nil)
 
 	fc := &fakeEventClient{}
-	h.RegisterConfigChangeHandler(context.Background(), fc)
+	h.RegisterConfigChangeHandler(fc)
 
 	if fc.eventType != openfeature.ProviderConfigChange {
 		t.Fatalf("registered for %q, want ProviderConfigChange", fc.eventType)

--- a/services/agent/flags/provider.go
+++ b/services/agent/flags/provider.go
@@ -1,6 +1,7 @@
 package flags
 
 import (
+	"context"
 	"log/slog"
 
 	flagd "github.com/open-feature/go-sdk-contrib/providers/flagd/pkg"
@@ -19,14 +20,23 @@ type ProviderConfig struct {
 }
 
 // SetupFlagd registers a flagd-backed OpenFeature provider for the agent domain
-// and returns a Flags wrapper plus a shutdown func. The RPC resolver (flagd's
-// default) is used against the gRPC evaluation port (8013) so flag changes are
-// observed live on every evaluation.
+// and returns a Flags wrapper, a hot-reloadable LifecycleHolder (#927), and a
+// shutdown func. The RPC resolver (flagd's default) is used against the gRPC
+// evaluation port (8013) so flag changes are observed live on every evaluation.
 //
 // Provider setup never blocks startup: if flagd is unreachable the provider
 // still registers and every evaluation falls back to its safe default, so the
 // agent comes up disabled (enabled=false) rather than failing to start.
-func SetupFlagd(cfg ProviderConfig, log *slog.Logger) (*Flags, func(), error) {
+//
+// The LifecycleHolder is primed ONCE here with the four calibration flags
+// (lifecycle.player_ttl/session_grace/evict_interval + decision.throttle) and is
+// kept live by a DOMAIN-scoped OpenFeature configuration-change handler (#927):
+// flagd emits a config-change when its source changes, the Go SDK surfaces it as
+// openfeature.ProviderConfigChange, and the handler re-evaluates the four flags
+// into the holder. The consumers (store TTLs, eviction ticker, decision throttle)
+// read the holder on their hot path, so retuning them needs no agent restart. ctx
+// scopes the holder's flag evaluations.
+func SetupFlagd(ctx context.Context, cfg ProviderConfig, log *slog.Logger) (*Flags, *LifecycleHolder, func(), error) {
 	if log == nil {
 		log = slog.Default()
 	}
@@ -37,17 +47,25 @@ func SetupFlagd(cfg ProviderConfig, log *slog.Logger) (*Flags, func(), error) {
 		flagd.WithPort(cfg.Port),
 	)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	// SetNamedProvider (non-blocking) so an unreachable flagd never wedges
 	// startup; the provider connects in the background and evaluations fall
 	// back to defaults until it is READY.
 	if err := openfeature.SetNamedProvider(Domain, provider); err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	client := openfeature.GetApiInstance().GetNamedClient(Domain)
+	f := New(client, log)
+
+	// Hot-reload the four calibration flags via the OpenFeature config-change
+	// listener (#927). Prime the holder before wiring the handler so consumers see
+	// correct values from the first cycle even if no event ever fires.
+	holder := NewLifecycleHolder(ctx, f, log)
+	holder.RegisterConfigChangeHandler(ctx, client)
+
 	shutdown := func() { openfeature.Shutdown() }
-	return New(client, log), shutdown, nil
+	return f, holder, shutdown, nil
 }

--- a/services/agent/flags/provider.go
+++ b/services/agent/flags/provider.go
@@ -64,7 +64,7 @@ func SetupFlagd(ctx context.Context, cfg ProviderConfig, log *slog.Logger) (*Fla
 	// listener (#927). Prime the holder before wiring the handler so consumers see
 	// correct values from the first cycle even if no event ever fires.
 	holder := NewLifecycleHolder(ctx, f, log)
-	holder.RegisterConfigChangeHandler(ctx, client)
+	holder.RegisterConfigChangeHandler(client)
 
 	shutdown := func() { openfeature.Shutdown() }
 	return f, holder, shutdown, nil

--- a/services/agent/gamecontext/store.go
+++ b/services/agent/gamecontext/store.go
@@ -40,7 +40,19 @@ type Store struct {
 
 	playerTTL    time.Duration
 	sessionGrace time.Duration
-	now          func() time.Time
+	// playerTTLSource / sessionGraceSource, when non-nil, are the LIVE eviction-TTL
+	// sources (#927): EvictStale reads them AT EVICTION TIME instead of the fixed
+	// playerTTL/sessionGrace baked at construction, so a config-change to
+	// lifecycle.player_ttl_seconds / lifecycle.session_grace_seconds takes effect on
+	// the next eviction tick with no restart. They point at the shared
+	// flags.LifecycleHolder (wired in main.go via SetTTLSources), so each read is a
+	// lock-free atomic load — NOT a per-tick flagd evaluation. Nil (the construction
+	// default, and all existing tests) keeps the fixed durations, preserving the
+	// #766 F5 read-at-startup behavior. Eviction SEMANTICS are unchanged; only the
+	// SOURCE of the two durations moves.
+	playerTTLSource    func() time.Duration
+	sessionGraceSource func() time.Duration
+	now                func() time.Time
 
 	// ownService is this agent's own OTEL service name. Telemetry from this
 	// service is skipped by the extractors: the collector fans the agent's own
@@ -66,6 +78,43 @@ type Store struct {
 // receiving Apply* calls.
 func (s *Store) SetOwnService(name string) {
 	s.ownService = name
+}
+
+// SetTTLSources installs the LIVE eviction-TTL sources (#927): EvictStale reads
+// playerTTL from playerSrc and sessionGrace from graceSrc at eviction time instead
+// of the durations baked at construction, so a config-change to
+// lifecycle.player_ttl_seconds / lifecycle.session_grace_seconds takes effect on
+// the next eviction tick with no restart. main.go passes the shared
+// flags.LifecycleHolder's PlayerTTL / SessionGrace (lock-free atomic loads), so the
+// eviction path never evaluates flagd. A nil source falls back to that field's
+// fixed construction value, so this is purely additive over the #766 F5 behavior.
+// Set before serving; not safe to call concurrently with EvictStale.
+func (s *Store) SetTTLSources(playerSrc, graceSrc func() time.Duration) {
+	s.playerTTLSource = playerSrc
+	s.sessionGraceSource = graceSrc
+}
+
+// effectivePlayerTTL / effectiveSessionGrace return the LIVE TTL when a source is
+// wired and reports a positive duration, else the construction-time fixed value.
+// A non-positive live value is ignored (treated as "unset") so a transient bad
+// flag read can never collapse the TTL to zero and evict everything. Caller holds
+// s.mu (EvictStale does).
+func (s *Store) effectivePlayerTTL() time.Duration {
+	if s.playerTTLSource != nil {
+		if d := s.playerTTLSource(); d > 0 {
+			return d
+		}
+	}
+	return s.playerTTL
+}
+
+func (s *Store) effectiveSessionGrace() time.Duration {
+	if s.sessionGraceSource != nil {
+		if d := s.sessionGraceSource(); d > 0 {
+			return d
+		}
+	}
+	return s.sessionGrace
 }
 
 // NewStore constructs a Store. playerTTL bounds how long a silent player is
@@ -562,15 +611,21 @@ func (s *Store) EvictStale() {
 	defer s.mu.Unlock()
 	now := s.now()
 
+	// Read the TTLs LIVE (#927): a config-change to lifecycle.player_ttl_seconds /
+	// lifecycle.session_grace_seconds is honored on this very tick. Read once per
+	// EvictStale so all players this tick are judged against one consistent TTL.
+	playerTTL := s.effectivePlayerTTL()
+	sessionGrace := s.effectiveSessionGrace()
+
 	for serial, p := range s.ctx.Players {
-		if s.disconnected[serial] || now.Sub(p.LastUpdate) > s.playerTTL {
+		if s.disconnected[serial] || now.Sub(p.LastUpdate) > playerTTL {
 			delete(s.ctx.Players, serial)
 			delete(s.disconnected, serial)
 			delete(s.deathCounts, serial)
 		}
 	}
 
-	if !s.endedAt.IsZero() && now.Sub(s.endedAt) > s.sessionGrace {
+	if !s.endedAt.IsZero() && now.Sub(s.endedAt) > sessionGrace {
 		s.ctx.Session = SessionSignals{GameActive: ptr(false)}
 		s.ctx.SessionID = ""
 		s.ctx.GameKind = ""

--- a/services/agent/gamecontext/store_test.go
+++ b/services/agent/gamecontext/store_test.go
@@ -89,6 +89,93 @@ func TestStore_SessionGraceClearsSessionKeepsPlayers(t *testing.T) {
 	}
 }
 
+// TestStore_LiveTTLSourceHotReloads verifies the live player-TTL source (#927):
+// EvictStale reads lifecycle.player_ttl_seconds from the source AT EVICTION TIME,
+// so shortening it mid-session evicts a player that the construction-time TTL
+// would have retained — no restart. Driven with the fake clock and a settable
+// source (the shared LifecycleHolder.PlayerTTL in production), no flagd.
+func TestStore_LiveTTLSourceHotReloads(t *testing.T) {
+	clk := &clock{t: time.Unix(0, 0)}
+	// Construct with a LONG static TTL (1h) so only the live source can evict.
+	s := NewStore(time.Hour, time.Hour, clk.now)
+	playerTTL := time.Hour
+	s.SetTTLSources(func() time.Duration { return playerTTL }, nil)
+
+	s.SetPlayerIntensity("A", 1.0)
+	clk.advance(10 * time.Second)
+
+	// Under the live 1h TTL the player is retained (matches the static value).
+	s.EvictStale()
+	if _, ok := s.Snapshot().Players["A"]; !ok {
+		t.Fatal("player evicted under 1h live TTL; should be retained")
+	}
+
+	// Config-change: shorten the live TTL to 5s. The same 10s-silent player now
+	// exceeds it, so the NEXT EvictStale removes it — proving the new value took
+	// effect with no restart and the static 1h field was overridden.
+	playerTTL = 5 * time.Second
+	s.EvictStale()
+	if _, ok := s.Snapshot().Players["A"]; ok {
+		t.Fatal("player should be evicted after live TTL shortened to 5s (#927)")
+	}
+}
+
+// TestStore_LiveSessionGraceSourceHotReloads verifies the live session-grace
+// source (#927): EvictStale reads lifecycle.session_grace_seconds live, so
+// shortening it mid-session resets the session sooner than the construction value.
+func TestStore_LiveSessionGraceSourceHotReloads(t *testing.T) {
+	clk := &clock{t: time.Unix(0, 0)}
+	s := NewStore(time.Hour, time.Hour, clk.now) // long static grace
+	grace := time.Hour
+	s.SetTTLSources(nil, func() time.Duration { return grace })
+
+	s.SetGameActive(true)
+	s.SetGameActive(false) // opens grace window
+	clk.advance(20 * time.Second)
+
+	// Under the 1h live grace, the session is still inside its window.
+	s.EvictStale()
+	if s.Snapshot().SessionID == "" {
+		t.Fatal("session reset under 1h live grace; should still be in grace window")
+	}
+
+	// Shorten live grace to 5s: the 20s-ended session now exceeds it and resets.
+	grace = 5 * time.Second
+	s.EvictStale()
+	if id := s.Snapshot().SessionID; id != "" {
+		t.Fatalf("SessionID = %q, want empty after live grace shortened to 5s (#927)", id)
+	}
+}
+
+// TestStore_NilTTLSourceUsesStaticValue verifies that with no live source wired
+// (all existing call sites / tests) EvictStale falls back to the construction-time
+// TTL exactly as before #927 — the change is purely additive.
+func TestStore_NilTTLSourceUsesStaticValue(t *testing.T) {
+	clk := &clock{t: time.Unix(0, 0)}
+	s := NewStore(5*time.Second, time.Hour, clk.now) // no SetTTLSources call
+	s.SetPlayerIntensity("A", 1.0)
+	clk.advance(6 * time.Second)
+	s.EvictStale()
+	if _, ok := s.Snapshot().Players["A"]; ok {
+		t.Fatal("player should be evicted past the static 5s TTL with no live source")
+	}
+}
+
+// TestStore_NonPositiveTTLSourceFallsBackToStatic verifies a source returning a
+// non-positive duration is ignored in favor of the static TTL, so a transient bad
+// flag read can never collapse the TTL to zero and evict everyone (#927).
+func TestStore_NonPositiveTTLSourceFallsBackToStatic(t *testing.T) {
+	clk := &clock{t: time.Unix(0, 0)}
+	s := NewStore(time.Hour, time.Hour, clk.now) // long static TTL
+	s.SetTTLSources(func() time.Duration { return 0 }, nil)
+	s.SetPlayerIntensity("A", 1.0)
+	clk.advance(10 * time.Second)
+	s.EvictStale()
+	if _, ok := s.Snapshot().Players["A"]; !ok {
+		t.Fatal("non-positive live TTL must fall back to the static 1h TTL; player wrongly evicted")
+	}
+}
+
 func TestStore_SnapshotIsolation(t *testing.T) {
 	clk := &clock{t: time.Unix(0, 0)}
 	s := NewStore(time.Hour, time.Hour, clk.now)

--- a/services/agent/main.go
+++ b/services/agent/main.go
@@ -212,7 +212,7 @@ func main() {
 		Host: getEnv("FLAGD_HOST", "flagd"),
 		Port: parsePort(getEnv("FLAGD_PORT", "8013"), 8013),
 	}
-	agentFlags, shutdownFlags, err := flags.SetupFlagd(flagCfg, logger)
+	agentFlags, lifecycleHolder, shutdownFlags, err := flags.SetupFlagd(ctx, flagCfg, logger)
 	if err != nil {
 		slog.Error("Failed to set up flagd provider", "error", err)
 		os.Exit(1)
@@ -220,14 +220,17 @@ func main() {
 	defer shutdownFlags()
 	slog.Info("OpenFeature flagd provider registered", "host", flagCfg.Host, "port", flagCfg.Port)
 
-	// Lifecycle + throttle calibration flags (#766 F5) are READ ONCE here, after
-	// the provider is registered. They configure the store TTLs, eviction ticker,
-	// and decision-loop throttle, all fixed at construction — so changing them
-	// requires an agent restart (deliberately NOT hot-reload). If flagd is not yet
-	// ready every value falls back to its safe default (the former hardcoded
-	// constants), so the agent still starts behavior-neutrally.
-	lifecycle := agentFlags.Lifecycle(ctx)
-	slog.Info("Agent lifecycle flags evaluated (read-at-startup; restart to change)",
+	// Lifecycle + throttle calibration flags (#766 F5) are HOT-RELOADED live since
+	// #927: SetupFlagd primed the holder with the four flags and wired the
+	// OpenFeature configuration-change listener (the maintainer's requested
+	// mechanism), so the store TTLs, eviction ticker, and decision-loop throttle
+	// read the CURRENT values from the holder on their hot path and a flag change
+	// takes effect with no restart. The initial snapshot below is only for the
+	// startup log; the consumers wired further down read the holder's live source
+	// funcs, never this captured value. If flagd is not yet ready every value falls
+	// back to its safe default (the former hardcoded constants).
+	lifecycle := lifecycleHolder.Load()
+	slog.Info("Agent lifecycle flags primed (hot-reloaded live via OpenFeature config-change, #927)",
 		"player_ttl", lifecycle.PlayerTTL,
 		"session_grace", lifecycle.SessionGrace,
 		"evict_interval", lifecycle.EvictInterval,
@@ -297,9 +300,12 @@ func main() {
 		// flags are evaluated every cycle, the kill switch / objectives / permission
 		// gate are applied, and decisions flow through the #724 audit spans.
 		loop := decision.NewLoop(agentFlags, logger)
-		// Throttle for the evaluate log line / agent.disabled span is read-at-startup
-		// from decision.throttle_seconds (#766 F5).
-		loop.SetThrottle(lifecycle.DecisionThrottle)
+		// Throttle for the evaluate log line / agent.disabled span reads
+		// decision.throttle_seconds LIVE from the shared LifecycleHolder (#927): a
+		// config-change to the throttle flag is honored on the next cycle with no
+		// restart (the holder is a lock-free atomic load, so the hot path never
+		// evaluates flagd). Every per-game loop shares the one holder source.
+		loop.SetThrottleSource(lifecycleHolder.DecisionThrottle)
 		// Inject the SHARED global LLM request budget (#847) so every per-game loop
 		// references the same instance: the gate's eligibility + cadence layers are
 		// per-loop, but the budget layer is one global cap across all games.
@@ -385,14 +391,24 @@ func main() {
 	// self-ingestion loop), and wires OnGameEnd per partition so the retrospective
 	// fires per game on the right partition's state.
 	mux := gamecontext.NewMultiplexer(func(gameID string) *gamecontext.Store {
+		// Prime with the holder's current values as the static fallback, then wire the
+		// LIVE TTL sources (#927): EvictStale reads lifecycle.player_ttl_seconds /
+		// lifecycle.session_grace_seconds from the shared holder at eviction time, so a
+		// config-change is honored on the next tick with no restart. Every partition
+		// created later shares the same holder source funcs.
 		s := gamecontext.NewStore(lifecycle.PlayerTTL, lifecycle.SessionGrace, nil)
+		s.SetTTLSources(lifecycleHolder.PlayerTTL, lifecycleHolder.SessionGrace)
 		s.SetOwnService(ownService)
 		s.OnGameEnd = retro.OnGameEnd
 		return s
 	})
 	mux.SetOwnService(ownService)
 
-	pipe := newPipeline(mux, loops, lifecycle.PlayerTTL).withInfra(infraStore, infraLoop)
+	pipe := newPipeline(mux, loops, lifecycle.PlayerTTL).
+		// Hot-reload the evaluate gate's freshness window in lockstep with the store
+		// eviction TTL (#927): both read lifecycle.player_ttl_seconds from the holder.
+		withPlayerTTLSource(lifecycleHolder.PlayerTTL).
+		withInfra(infraStore, infraLoop)
 
 	grpcServer := grpc.NewServer()
 	ptraceotlp.RegisterGRPCServer(grpcServer, &traceReceiver{pipe: pipe})
@@ -422,10 +438,15 @@ func main() {
 		}
 	}()
 
-	// Eviction ticker.
-	ticker := time.NewTicker(lifecycle.EvictInterval)
-	defer ticker.Stop()
+	// Eviction ticker. The interval is HOT-RELOADED from the holder (#927): after
+	// each fire we re-read lifecycle.evict_interval_seconds and, if it changed,
+	// Reset the ticker so a config-change to the eviction cadence takes effect with
+	// no restart. The holder read is a lock-free atomic load, so this costs nothing
+	// on the steady-state path; we only call Reset when the value actually moved.
 	go func() {
+		interval := lifecycleHolder.EvictInterval()
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
 		for {
 			select {
 			case <-ctx.Done():
@@ -439,6 +460,11 @@ func main() {
 				// not retained; it is recreated lazily (fresh budget) if it resumes.
 				loops.Retain(partitionSet(mux.Partitions()))
 				infraStore.EvictStale()
+				// Re-arm at the current configured interval if it changed (#927).
+				if next := lifecycleHolder.EvictInterval(); next > 0 && next != interval {
+					interval = next
+					ticker.Reset(interval)
+				}
 			}
 		}
 	}()

--- a/services/agent/receiver.go
+++ b/services/agent/receiver.go
@@ -39,9 +39,17 @@ const (
 // single-game mode every signal lands on the fallback partition's single loop, so
 // behavior collapses to exactly the single-store agent's.
 type pipeline struct {
-	mux       *gamecontext.Multiplexer
-	loops     *decision.LoopSet
+	mux   *gamecontext.Multiplexer
+	loops *decision.LoopSet
+	// playerTTL is the static fallback freshness window for the evaluate gate; used
+	// only when playerTTLSource is nil (tests).
 	playerTTL time.Duration
+	// playerTTLSource, when non-nil, is the LIVE lifecycle.player_ttl_seconds source
+	// (#927): signalUpdated reads it each gate check so the freshness window tracks
+	// the same hot-reloaded TTL the store eviction uses. main.go passes the shared
+	// flags.LifecycleHolder.PlayerTTL (a lock-free atomic load). Nil keeps the static
+	// playerTTL, preserving the read-at-startup behavior in tests.
+	playerTTLSource func() time.Duration
 
 	infraStore *infracontext.Store
 	infraLoop  decision.InfraEvaluator
@@ -56,6 +64,25 @@ func newPipeline(mux *gamecontext.Multiplexer, loops *decision.LoopSet, playerTT
 		playerTTL: playerTTL,
 		now:       time.Now,
 	}
+}
+
+// withPlayerTTLSource installs the LIVE player-TTL source for the evaluate gate
+// (#927) so the freshness window hot-reloads in lockstep with the store eviction
+// TTL. Returns the pipeline for chaining at construction.
+func (p *pipeline) withPlayerTTLSource(src func() time.Duration) *pipeline {
+	p.playerTTLSource = src
+	return p
+}
+
+// effectivePlayerTTL returns the live player-TTL when a source is wired and
+// reports a positive duration, else the static construction value.
+func (p *pipeline) effectivePlayerTTL() time.Duration {
+	if p.playerTTLSource != nil {
+		if d := p.playerTTLSource(); d > 0 {
+			return d
+		}
+	}
+	return p.playerTTL
 }
 
 // withInfra attaches the infrastructure observe path. Returns the pipeline for
@@ -95,7 +122,7 @@ func (p *pipeline) signalUpdated(ctx context.Context, gameIDs []string, trig dec
 		if !ok {
 			continue
 		}
-		if gate.ShouldEvaluate(snap, t, p.playerTTL) {
+		if gate.ShouldEvaluate(snap, t, p.effectivePlayerTTL()) {
 			// loops.For lazily creates this game's Loop on first touch, so its budget
 			// and throttle state are isolated from every other game's.
 			p.loops.For(gameID).OnEvaluate(ctx, snap, trig)


### PR DESCRIPTION
## What

Part of #927. The four calibration flags were read **once at startup** (#766 F5) and baked into the store TTLs, the eviction ticker, and the decision-loop throttle, so retuning the agent's perception/cadence required a restart:

- `lifecycle.player_ttl_seconds`
- `lifecycle.session_grace_seconds`
- `lifecycle.evict_interval_seconds`
- `decision.throttle_seconds`

This PR makes them update **live with no restart**.

## How — the maintainer's requested mechanism

I implemented exactly the approach @aepfli asked for in the issue comment:

> we can utilize the openfeature listener for configuration changed for this

A domain-scoped **OpenFeature configuration-change event listener** (`openfeature.ProviderConfigChange`, registered via the agent client's `AddHandler`) drives the reload. flagd emits a config-change when its flag source changes, the Go SDK surfaces it as `ProviderConfigChange`, and the handler re-evaluates the four flags into a new concurrency-safe **`flags.LifecycleHolder`** (`atomic.Pointer`, lock-free reads / single atomic store).

- The holder is **primed once at startup** so values are correct before any event arrives (and if one never fires).
- Consumers read the holder's live source funcs on their hot path — **no per-cycle flagd polling** (a holder read is a lock-free atomic load; only the rare config-change event re-reads flagd):
  - **Decision throttle** → `Loop.shouldLog()` reads a `throttleSource func() time.Duration` (acceptance-test target).
  - **Evict interval** → `main.go`'s eviction ticker re-reads the interval each loop and `ticker.Reset`s when it changes.
  - **Player TTL / session grace** → the gamecontext `Store` reads them **at eviction time** via live source funcs; the evaluate gate's freshness window hot-reloads in lockstep.
- Existing **safe-default / non-positive guards** are preserved on every reload (a down control plane / transient bad read keeps the flagd-schema defaults), so a config-change can never collapse a TTL to zero.

The live sources are **purely additive** (nil falls back to the static construction value), so all existing eviction / throttle / gate tests are unchanged. The other decision flags (enabled/mode/objectives/policy/fitness/llm) already update per-cycle and are untouched.

## Tests (all `-race` green)

- **Acceptance (#927):** `TestThrottleSource_HotReloadsMidSession` — flips the live throttle from 10s → 2s **mid-session** (injected clock, settable source, **no live flagd / no sleeps / no network**) and asserts the `agent.disabled` span cadence reflects the new value on the next cycle.
- `TestLifecycleHolder_*` — priming, defaults-when-unset, `Reload` applies new values, a **synthetic config-change event** invokes the captured handler, and a **concurrent reload-while-reading** `-race` test (handler goroutine vs consumer reads).
- `TestStore_LiveTTLSourceHotReloads` / `TestStore_LiveSessionGraceSourceHotReloads` + nil/non-positive fallbacks — eviction reflects the live TTLs after the holder updates.
- No regression: existing gamecontext eviction, decision throttle, and #847 gate tests still pass.

## Out of scope

Anything beyond these four flags. The decision flags already update per-cycle and are not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)