### PR TITLE
feat(agent): game narrative builder — per-game JSON summaries (#928)

### DIFF
--- a/services/agent/README.md
+++ b/services/agent/README.md
@@ -857,6 +857,7 @@ All configuration is via environment variables:
 | `AGENT_PROBE_DECISIONS` | _unset_ | `true` enables the demo/verification probe: a synthetic `noop` decision (and thus a full audit trace) at most every 5 s. Never for production sessions. See [Probe mode](#probe-mode-agent_probe_decisions) |
 | `AGENT_INTERVENTIONS_ENABLED` | `false` | `true` swaps the no-op action sink for the real intervention **Writer** (#730). Default off keeps the scaffold inert |
 | `INTERVENTIONS_FLAG_PATH` | `/etc/flagd/interventions.json` | Path of the flagd interventions file the Writer rewrites (must be the bind-mounted file flagd watches) |
+| `AGENT_GAME_SUMMARY_DIR` | `/var/lib/joustmania/agent/summaries` | Directory the M7-1 game narrative builder (#928) writes one JSON game summary per game into (real **and** shadow), created if missing; atomic temp+rename so a reader never sees a partial file |
 
 > The Go agent uses the flagd **RPC** resolver (gRPC evaluation port `8013`),
 > not the in-process sync port `8015` that the Python services use.

--- a/services/agent/gamesummary/coordinator.go
+++ b/services/agent/gamesummary/coordinator.go
@@ -1,0 +1,183 @@
+package gamesummary
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/joustmania/agent/gamecontext"
+)
+
+// coordinator.go is the M7-1 game-end glue (#928): it hangs off the same
+// gamecontext.Store.OnGameEnd signal the #844 retrospective uses, builds the
+// Summary from the pre-reset snapshot, writes it to disk, and records the
+// aggregation as an agent.game.summary span. It fires EXACTLY ONCE per game for
+// BOTH real and shadow games.
+//
+// Why a SEPARATE component (not an extension of the retro path): the retro builds
+// an LLM PROMPT and is gated by the global LLM budget (#847); the summary builds a
+// structured JSON FILE and must run unconditionally for every game (no budget, no
+// eligibility). Bolting it onto the retro would entangle the file write with the
+// LLM gate — a budget-exhausted game would silently produce no summary, violating
+// #928's "after EVERY real and synthetic game". So the summary is its own
+// once-per-game component, wired alongside the retro on the SAME store hook (main.go
+// chains both), each with its OWN dedupe — they never double-fire each other
+// because each owns its own claimed-id set.
+
+// SpanGameSummary is the aggregation span (#928 acceptance: "the aggregation is
+// visible as a span in the trace"). Dot-notation per the house convention; named
+// distinctly from agent.llm.retro so the two game-end emissions are independently
+// greppable in Jaeger.
+const SpanGameSummary = "agent.game.summary"
+
+// Span attribute keys for agent.game.summary. Low-cardinality counts + ids only
+// (per .claude/rules: keep span attributes low-cardinality) — the full narrative
+// lives in the on-disk file, not the span.
+const (
+	attrGameID            = "game.id"
+	attrGameKind          = "game.kind"
+	attrPlayerCount       = "summary.player_count"
+	attrEliminationCount  = "summary.elimination_count"
+	attrInterventionCount = "summary.intervention_count"
+	attrEngagementPoints  = "summary.engagement_points"
+	attrDominated         = "summary.dominated"
+	attrPath              = "summary.path"
+)
+
+// dedupeWindow bounds the per-game claimed-id LRU. It mirrors the retro's bounded
+// dedupe (retro_capture.go): concurrent game-ends (#845) interleave, so a single
+// last-id is insufficient — an LRU of recent ids suppresses a repeated end for any
+// remembered game. 8 comfortably exceeds GAME_MAX_CONCURRENT_GAMES=4.
+const dedupeWindow = 8
+
+// Coordinator builds + persists one summary per game on the store's OnGameEnd
+// signal (#928). It is wired to EVERY gamecontext.Store partition's OnGameEnd in
+// main(), so one coordinator dedupes across all partitions. Safe for concurrent
+// use: per-partition ends are each serialized by their store, but concurrent
+// partitions may fire simultaneously, so the dedupe state is mutex-guarded.
+type Coordinator struct {
+	writer *Writer
+	tracer trace.Tracer
+	log    *slog.Logger
+	// now is injectable for tests; nil uses time.Now. It stamps Summary.GeneratedAt
+	// only — the aggregation itself is clock-free.
+	now func() time.Time
+
+	mu sync.Mutex
+	// claimed is the set of recently summarized game ids; claimedOrder is the LRU
+	// eviction order (oldest first). Bounded by dedupeWindow.
+	claimed      map[string]struct{}
+	claimedOrder []string
+}
+
+// NewCoordinator builds a Coordinator writing summaries via w (use NewWriter with
+// DirFromEnv() in main). log nil uses slog.Default().
+func NewCoordinator(w *Writer, log *slog.Logger) *Coordinator {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &Coordinator{
+		writer:  w,
+		tracer:  otel.Tracer(instrumentationName),
+		log:     log,
+		now:     time.Now,
+		claimed: make(map[string]struct{}),
+	}
+}
+
+// instrumentationName scopes the coordinator's tracer, matching the agent module
+// convention used by the decision package.
+const instrumentationName = "github.com/joustmania/agent"
+
+// OnGameEnd is the gamecontext.Store.OnGameEnd callback (#928). It builds + writes
+// the game summary exactly once per game, for both real and shadow games. It is
+// defensive, mirroring the retro:
+//   - skips if the snapshot still reports GameActive (only end-of-game summarizes);
+//   - skips if SessionID is empty (no game_id to key the file on);
+//   - skips if SessionID was already summarized (exactly-once per game).
+//
+// The aggregation runs under an agent.game.summary span carrying the key counts.
+// A file-write error marks the span as errored and logs, but never panics — a
+// failed summary must not take the observation path down.
+func (c *Coordinator) OnGameEnd(gc gamecontext.GameContext) {
+	if gc.Session.GameActive != nil && *gc.Session.GameActive {
+		return // not actually a game end
+	}
+	if gc.SessionID == "" {
+		return
+	}
+	if !c.claimGame(gc.SessionID) {
+		return // already summarized this game
+	}
+
+	now := c.now
+	if now == nil {
+		now = time.Now
+	}
+
+	// The span IS the audit of the aggregation (#928 acceptance). It is a standalone
+	// root: there is no inbound RPC context at game end (same as the retro span).
+	_, span := c.tracer.Start(context.Background(), SpanGameSummary)
+	defer span.End()
+
+	summary := BuildSummary(gc, BuildOptions{Now: now()})
+
+	span.SetAttributes(
+		attribute.String(attrGameID, summary.GameID),
+		attribute.String(attrGameKind, summary.GameKind),
+		attribute.Int(attrPlayerCount, summary.PlayerCount),
+		attribute.Int(attrEliminationCount, summary.EliminationCount),
+		attribute.Int(attrInterventionCount, summary.InterventionCount),
+		attribute.Int(attrEngagementPoints, len(summary.EngagementTrend)),
+		attribute.Bool(attrDominated, summary.Dominance.Dominated),
+		attribute.String(attrPath, c.writer.Path(summary.GameID)),
+	)
+
+	if err := c.writer.Write(summary); err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "summary write failed")
+		c.log.Error("agent.game.summary_write_failed",
+			"game_id", summary.GameID,
+			"game_kind", summary.GameKind,
+			"error", err)
+		return
+	}
+
+	c.log.Info("agent.game.summary_written",
+		"game_id", summary.GameID,
+		"game_kind", summary.GameKind,
+		"players", summary.PlayerCount,
+		"eliminations", summary.EliminationCount,
+		"interventions", summary.InterventionCount,
+		"dominated", summary.Dominance.Dominated,
+		"path", c.writer.Path(summary.GameID))
+}
+
+// claimGame records gameID as summarized and reports whether THIS call won the
+// claim (the game had not been summarized yet). Mutex-guarded for exactly-once.
+// Remembers the last dedupeWindow ids (LRU) so interleaved concurrent ends (#845)
+// each summarize exactly once.
+func (c *Coordinator) claimGame(gameID string) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if _, ok := c.claimed[gameID]; ok {
+		return false
+	}
+	c.claimed[gameID] = struct{}{}
+	c.claimedOrder = append(c.claimedOrder, gameID)
+	if len(c.claimedOrder) > dedupeWindow {
+		oldest := c.claimedOrder[0]
+		c.claimedOrder = c.claimedOrder[1:]
+		delete(c.claimed, oldest)
+	}
+	return true
+}
+
+// compile-time guard: Coordinator.OnGameEnd matches the store hook signature.
+var _ func(gamecontext.GameContext) = (*Coordinator)(nil).OnGameEnd

--- a/services/agent/gamesummary/coordinator_test.go
+++ b/services/agent/gamesummary/coordinator_test.go
@@ -52,14 +52,13 @@ func spanAttr(s sdktrace.ReadOnlySpan, key string) (attribute.Value, bool) {
 // TestCoordinator_WritesFileAndSpan: a real game end writes a summary file AND
 // emits exactly one agent.game.summary span carrying the key counts.
 func TestCoordinator_WritesFileAndSpan(t *testing.T) {
-	c, sr, dir := recordingCoordinator(t)
+	c, sr, _ := recordingCoordinator(t)
 	snap := representativeGame(t)
 	c.OnGameEnd(snap)
 
 	if _, err := os.Stat(c.writer.Path(snap.SessionID)); err != nil {
 		t.Errorf("summary file not written: %v", err)
 	}
-	_ = dir
 
 	spans := spansByName(sr.Ended(), SpanGameSummary)
 	if len(spans) != 1 {

--- a/services/agent/gamesummary/coordinator_test.go
+++ b/services/agent/gamesummary/coordinator_test.go
@@ -1,0 +1,179 @@
+package gamesummary
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"github.com/joustmania/agent/gamecontext"
+)
+
+// recordingCoordinator builds a Coordinator with a recording tracer writing to a
+// temp dir, plus the span recorder for assertions.
+func recordingCoordinator(t *testing.T) (*Coordinator, *tracetest.SpanRecorder, string) {
+	t.Helper()
+	dir := t.TempDir()
+	sr := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+	c := NewCoordinator(NewWriter(dir), slog.New(slog.NewTextHandler(io.Discard, nil)))
+	c.tracer = tp.Tracer("test")
+	c.now = func() time.Time { return at(61) }
+	return c, sr, dir
+}
+
+func spansByName(spans []sdktrace.ReadOnlySpan, name string) []sdktrace.ReadOnlySpan {
+	var out []sdktrace.ReadOnlySpan
+	for _, s := range spans {
+		if s.Name() == name {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func spanAttr(s sdktrace.ReadOnlySpan, key string) (attribute.Value, bool) {
+	for _, kv := range s.Attributes() {
+		if string(kv.Key) == key {
+			return kv.Value, true
+		}
+	}
+	return attribute.Value{}, false
+}
+
+// TestCoordinator_WritesFileAndSpan: a real game end writes a summary file AND
+// emits exactly one agent.game.summary span carrying the key counts.
+func TestCoordinator_WritesFileAndSpan(t *testing.T) {
+	c, sr, dir := recordingCoordinator(t)
+	snap := representativeGame(t)
+	c.OnGameEnd(snap)
+
+	if _, err := os.Stat(c.writer.Path(snap.SessionID)); err != nil {
+		t.Errorf("summary file not written: %v", err)
+	}
+	_ = dir
+
+	spans := spansByName(sr.Ended(), SpanGameSummary)
+	if len(spans) != 1 {
+		t.Fatalf("agent.game.summary spans = %d, want 1", len(spans))
+	}
+	if v, ok := spanAttr(spans[0], attrGameID); !ok || v.AsString() != snap.SessionID {
+		t.Errorf("span game.id = %v, want %s", v.AsString(), snap.SessionID)
+	}
+	if v, ok := spanAttr(spans[0], attrEliminationCount); !ok || v.AsInt64() != 2 {
+		t.Errorf("span elimination_count = %v, want 2", v.AsInt64())
+	}
+	if v, ok := spanAttr(spans[0], attrInterventionCount); !ok || v.AsInt64() != 2 {
+		t.Errorf("span intervention_count = %v, want 2", v.AsInt64())
+	}
+}
+
+// TestCoordinator_RunsForShadowGames: the builder runs for synthetic (shadow)
+// games too (#928 — both real AND shadow).
+func TestCoordinator_RunsForShadowGames(t *testing.T) {
+	c, sr, _ := recordingCoordinator(t)
+	c.OnGameEnd(gamecontext.GameContext{
+		SessionID: "game_shadow1",
+		GameKind:  "shadow",
+		Session:   gamecontext.SessionSignals{GameActive: bptr(false)},
+		Players:   map[string]*gamecontext.PlayerSignals{"AA:11": {Serial: "AA:11"}},
+	})
+	if _, err := os.Stat(c.writer.Path("game_shadow1")); err != nil {
+		t.Errorf("shadow-game summary not written: %v", err)
+	}
+	if len(spansByName(sr.Ended(), SpanGameSummary)) != 1 {
+		t.Error("shadow game must emit an agent.game.summary span")
+	}
+}
+
+// TestCoordinator_OncePerGame: a repeated game-end for the same id summarizes
+// exactly once (exactly-once dedupe), so the file is not rewritten and only one
+// span is emitted.
+func TestCoordinator_OncePerGame(t *testing.T) {
+	c, sr, _ := recordingCoordinator(t)
+	snap := gamecontext.GameContext{
+		SessionID: "game_dup",
+		GameKind:  "real",
+		Session:   gamecontext.SessionSignals{GameActive: bptr(false)},
+	}
+	c.OnGameEnd(snap)
+	c.OnGameEnd(snap)
+	c.OnGameEnd(snap)
+	if n := len(spansByName(sr.Ended(), SpanGameSummary)); n != 1 {
+		t.Errorf("spans = %d, want 1 (exactly-once per game)", n)
+	}
+}
+
+// TestCoordinator_SkipsNonEnd: an active-game or empty-id snapshot is not a game
+// end and must not write or span.
+func TestCoordinator_SkipsNonEnd(t *testing.T) {
+	c, sr, dir := recordingCoordinator(t)
+
+	c.OnGameEnd(gamecontext.GameContext{SessionID: "active", Session: gamecontext.SessionSignals{GameActive: bptr(true)}})
+	c.OnGameEnd(gamecontext.GameContext{SessionID: "", Session: gamecontext.SessionSignals{GameActive: bptr(false)}})
+
+	if len(spansByName(sr.Ended(), SpanGameSummary)) != 0 {
+		t.Error("non-end snapshots must not emit a span")
+	}
+	entries, _ := os.ReadDir(dir)
+	if len(entries) != 0 {
+		t.Errorf("non-end snapshots must not write files, found %d", len(entries))
+	}
+}
+
+// TestCoordinator_TwoConcurrentGames: two independent game ids produce two
+// independent summary files — the #845 per-game guarantee.
+func TestCoordinator_TwoConcurrentGames(t *testing.T) {
+	c, _, dir := recordingCoordinator(t)
+	var wg sync.WaitGroup
+	for _, id := range []string{"game_p1", "game_p2"} {
+		wg.Add(1)
+		go func(id string) {
+			defer wg.Done()
+			c.OnGameEnd(gamecontext.GameContext{
+				SessionID: id,
+				GameKind:  "real",
+				Session:   gamecontext.SessionSignals{GameActive: bptr(false)},
+			})
+		}(id)
+	}
+	wg.Wait()
+	entries, _ := os.ReadDir(dir)
+	if len(entries) != 2 {
+		t.Errorf("want 2 independent summary files, got %d", len(entries))
+	}
+}
+
+// TestCoordinator_EndToEndFromStore: wiring a real Store's OnGameEnd to the
+// coordinator writes a summary on the GameActive true->false transition, proving
+// the full game-end path produces a file with no manual snapshot.
+func TestCoordinator_EndToEndFromStore(t *testing.T) {
+	dir := t.TempDir()
+	c := NewCoordinator(NewWriter(dir), slog.New(slog.NewTextHandler(io.Discard, nil)))
+	c.now = func() time.Time { return at(100) }
+
+	clock := base
+	s := gamecontext.NewStore(time.Hour, time.Hour, func() time.Time { return clock })
+	s.OnGameEnd = c.OnGameEnd
+
+	s.SetGameKind("real")
+	s.SetGameActive(true)
+	s.AdoptSessionID("game_e2e") // adopt after session start (see representativeGame)
+	s.SetActivePlayerCount(2)
+	clock = at(30)
+	s.SetEliminationOrder("AA:11", 1)
+	clock = at(40)
+	s.SetGameActive(false) // fires OnGameEnd -> summary written
+
+	if _, err := os.Stat(c.writer.Path("game_e2e")); err != nil {
+		t.Errorf("end-to-end store summary not written: %v", err)
+	}
+}

--- a/services/agent/gamesummary/summary.go
+++ b/services/agent/gamesummary/summary.go
@@ -74,7 +74,7 @@ type Summary struct {
 	InterventionCount int `json:"intervention_count"`
 
 	// PlayerArcs is the per-player trajectory list, sorted by serial for a stable
-	// file. Each carries join/elimination/survival (#928 "player arcs").
+	// file. Each carries elimination/survival/final-state (#928 "player arcs").
 	PlayerArcs []PlayerArc `json:"player_arcs"`
 	// EliminationSpread is the ordered (time, serial) elimination distribution,
 	// first-eliminated first (#928 "elimination spread").
@@ -91,9 +91,16 @@ type Summary struct {
 }
 
 // PlayerArc is one player's trajectory through the game (#928 player arcs). All
-// times are relative offsets from the game's first observed timeline event
-// (GameStartOffset == 0 marks that anchor) so the arc reads as "joined at +0s,
-// eliminated at +47s" independent of wall-clock — and stays deterministic.
+// times are relative offsets from the game's first observed timeline event (that
+// anchor is +0s) so the arc reads as "eliminated at +47s" independent of
+// wall-clock — and stays deterministic.
+//
+// There is intentionally no join offset: per-player join time is not derivable
+// from the data available here. State-delta timeline events are session-scoped
+// (no serial), so a surviving player who is never the subject of a serial-scoped
+// event (elimination / targeted intervention) has no join anchor at all. Adding a
+// truthful join offset needs per-player join timestamps recorded at the Store
+// level — a separate change, not faked from session-level deltas.
 type PlayerArc struct {
 	Serial string `json:"serial"`
 	// Eliminated is true when the player appears in the elimination timeline.
@@ -101,10 +108,6 @@ type PlayerArc struct {
 	// EliminationOrder is the 1-based order the player was eliminated, or 0 if the
 	// player survived (never eliminated) — the survivor(s).
 	EliminationOrder int `json:"elimination_order"`
-	// JoinOffsetSeconds is when the player first appeared in the narrative relative
-	// to game start, or nil if the player was present before the first timeline
-	// event (no join event to anchor to).
-	JoinOffsetSeconds *float64 `json:"join_offset_seconds,omitempty"`
 	// EliminationOffsetSeconds is when the player was eliminated relative to game
 	// start; nil for a survivor.
 	EliminationOffsetSeconds *float64 `json:"elimination_offset_seconds,omitempty"`
@@ -367,10 +370,10 @@ func effectDelta(events []gamecontext.TimelineEvent, at time.Time) *Intervention
 }
 
 // buildPlayerArcs folds the live PlayerSignals together with the elimination
-// spread and the timeline into one arc per player (#928). Join offset is derived
-// from the player's first appearance in the narrative (its earliest state-delta or
-// elimination); survival is the elimination offset for an eliminated player, or
-// the full game span (anchor..lastAt) for a survivor.
+// spread and the timeline into one arc per player (#928). Survival is the
+// elimination offset for an eliminated player, or the full game span
+// (anchor..lastAt) for a survivor. (No join offset — see PlayerArc: per-player
+// join time is not derivable from session-scoped state deltas.)
 func buildPlayerArcs(c gamecontext.GameContext, elims []EliminationEvent, anchor, lastAt time.Time) []PlayerArc {
 	// Index the elimination spread by serial for O(1) arc lookup.
 	elimBySerial := make(map[string]EliminationEvent, len(elims))

--- a/services/agent/gamesummary/summary.go
+++ b/services/agent/gamesummary/summary.go
@@ -1,0 +1,496 @@
+// Package gamesummary is the M7-1 game narrative builder (#928). After each game
+// ends — real OR synthetic (shadow) — it AGGREGATES the partition's accumulated
+// GameContext snapshot (the live signals plus the #916 rolling timeline) into one
+// compact, self-describing Summary so the agent can later reason about WHAT
+// HAPPENED (a narrative) instead of re-reading low-level spans/metrics.
+//
+// Boundaries (deliberately narrow, per #928):
+//   - BuildSummary is a PURE function over a GameContext snapshot. It never reads
+//     a clock, the network, or the filesystem — every time it needs is injected
+//     (BuildOptions.Now) so the same snapshot always yields a byte-identical
+//     Summary. The writer (writer.go) and the once-per-game span emission
+//     (coordinator.go) are the only impure parts, and they are thin.
+//   - It DERIVES rather than re-collects: engagement trend, elimination spread,
+//     and the per-player elimination order all come straight off the #916
+//     Timeline carried on the snapshot; player arcs and dominance fold the
+//     live PlayerSignals together with the timeline. No new signal source is
+//     introduced.
+//
+// Out of scope (later M7 issues, noted so a reader does not expect them here):
+// the rolling WINDOW across multiple games (#929 M7-2 — this is ONE summary per
+// game), prompt injection (#930), and the dashboard pane (#933). Deep causal
+// before/after attribution beyond the best-effort timeline-window delta below is
+// also deferred — see InterventionOutcome.Effect.
+package gamesummary
+
+import (
+	"sort"
+	"time"
+
+	"github.com/joustmania/agent/gamecontext"
+)
+
+// SchemaVersion is bumped when the on-disk Summary JSON shape changes in a way a
+// reader must notice. Carried on every file so #929's window builder and any
+// offline tooling can branch on it rather than guess.
+const SchemaVersion = 1
+
+// effectWindow is the half-width of the timeline window the best-effort
+// intervention before/after effect (effectDelta) compares: state-deltas within
+// effectWindow BEFORE an intervention's timestamp form the "before" baseline,
+// those within effectWindow AFTER form the "after". 30s comfortably spans a few
+// state-delta entries on either side at the agent's dedupe cadence while staying
+// local to the intervention, so the delta reflects THAT intervention rather than
+// the whole game's drift. Pure constant — no clock involved.
+const effectWindow = 30 * time.Second
+
+// Summary is the compact, JSON-serialized game narrative (#928). One per game,
+// keyed on GameID. Field names are stable wire contract: the dashboard (#933) and
+// the #929 window builder read them, so renames are breaking.
+type Summary struct {
+	// SchemaVersion is SchemaVersion at write time (see the const).
+	SchemaVersion int `json:"schema_version"`
+
+	// GameID is the finished game's id (GameContext.SessionID, which since #845 IS
+	// the real game_id once adopted). The on-disk filename is keyed off it.
+	GameID string `json:"game_id"`
+	// GameKind is "real" or "shadow" (or "" if never labeled). The builder runs for
+	// BOTH so a reader can tell a live game from a synthetic evaluation one (#928).
+	GameKind string `json:"game_kind"`
+	// GameMode is the mode that was played (e.g. "joust"), or "" if unobserved.
+	GameMode string `json:"game_mode,omitempty"`
+	// GeneratedAt is the injected build time (BuildOptions.Now), RFC3339. The ONLY
+	// place a wall-clock leaks into the Summary, and it is injected for determinism.
+	GeneratedAt time.Time `json:"generated_at"`
+	// DurationSeconds is the final observed game_duration_seconds, when known.
+	DurationSeconds *float64 `json:"duration_seconds,omitempty"`
+
+	// PlayerCount is the number of players the game saw (len of arcs).
+	PlayerCount int `json:"player_count"`
+	// EliminationCount is the number of eliminations recorded.
+	EliminationCount int `json:"elimination_count"`
+	// InterventionCount is the number of agent interventions the timeline captured
+	// (dispatched + blocked).
+	InterventionCount int `json:"intervention_count"`
+
+	// PlayerArcs is the per-player trajectory list, sorted by serial for a stable
+	// file. Each carries join/elimination/survival (#928 "player arcs").
+	PlayerArcs []PlayerArc `json:"player_arcs"`
+	// EliminationSpread is the ordered (time, serial) elimination distribution,
+	// first-eliminated first (#928 "elimination spread").
+	EliminationSpread []EliminationEvent `json:"elimination_spread"`
+	// EngagementTrend is the down-sampled active-count / mean-intensity series the
+	// game moved through, oldest-first (#928 "engagement trend"). Derived entirely
+	// from the #916 timeline's state-delta entries.
+	EngagementTrend []EngagementPoint `json:"engagement_trend"`
+	// Dominance is the dominant-player detection result (#928 "dominant player").
+	Dominance Dominance `json:"dominance"`
+	// Interventions is the list of agent interventions that fired and their outcome
+	// + best-effort before/after effect (#928 "intervention outcomes").
+	Interventions []InterventionOutcome `json:"interventions"`
+}
+
+// PlayerArc is one player's trajectory through the game (#928 player arcs). All
+// times are relative offsets from the game's first observed timeline event
+// (GameStartOffset == 0 marks that anchor) so the arc reads as "joined at +0s,
+// eliminated at +47s" independent of wall-clock — and stays deterministic.
+type PlayerArc struct {
+	Serial string `json:"serial"`
+	// Eliminated is true when the player appears in the elimination timeline.
+	Eliminated bool `json:"eliminated"`
+	// EliminationOrder is the 1-based order the player was eliminated, or 0 if the
+	// player survived (never eliminated) — the survivor(s).
+	EliminationOrder int `json:"elimination_order"`
+	// JoinOffsetSeconds is when the player first appeared in the narrative relative
+	// to game start, or nil if the player was present before the first timeline
+	// event (no join event to anchor to).
+	JoinOffsetSeconds *float64 `json:"join_offset_seconds,omitempty"`
+	// EliminationOffsetSeconds is when the player was eliminated relative to game
+	// start; nil for a survivor.
+	EliminationOffsetSeconds *float64 `json:"elimination_offset_seconds,omitempty"`
+	// SurvivalSeconds is how long the player lasted: elimination offset for an
+	// eliminated player, or the full game span for a survivor. nil when neither can
+	// be derived (no timeline anchor).
+	SurvivalSeconds *float64 `json:"survival_seconds,omitempty"`
+	// FinalSkill / FinalIntensity are the last observed per-player aggregates, when
+	// known — the "how was this player doing" snapshot the arc closes on.
+	FinalSkill     *float64 `json:"final_skill,omitempty"`
+	FinalIntensity *float64 `json:"final_intensity,omitempty"`
+}
+
+// EliminationEvent is one (offset, serial, order) point in the elimination
+// spread, derived from the #916 timeline's elimination entries.
+type EliminationEvent struct {
+	OffsetSeconds float64 `json:"offset_seconds"`
+	Serial        string  `json:"serial"`
+	Order         int     `json:"order"`
+}
+
+// EngagementPoint is one down-sampled state-delta from the #916 timeline: the
+// active player count and mean movement intensity at OffsetSeconds into the game.
+// Pointers distinguish "this delta did not carry that aggregate" from a real 0.
+type EngagementPoint struct {
+	OffsetSeconds float64  `json:"offset_seconds"`
+	ActivePlayers *int     `json:"active_players,omitempty"`
+	MeanIntensity *float64 `json:"mean_intensity,omitempty"`
+}
+
+// Dominance is the dominant-player detection (#928). A game is "dominated" when
+// the survivor outlasted the field by a wide margin: the heuristic compares the
+// survivor's survival time to the mean survival of the eliminated players. It is
+// a coarse, explainable first cut (the Heuristic string names it) — not a model.
+type Dominance struct {
+	// Dominated is true when one player clearly ran away with the game.
+	Dominated bool `json:"dominated"`
+	// Serial is the dominant player's serial when Dominated; "" otherwise.
+	Serial string `json:"serial,omitempty"`
+	// Heuristic names the rule that decided, so a reader knows WHY (e.g.
+	// "survivor_outlasted_mean_2x"). Always set, even when not dominated.
+	Heuristic string `json:"heuristic"`
+	// Margin is the survival-time ratio (survivor / mean-eliminated) that fed the
+	// decision, for transparency; 0 when not computable.
+	Margin float64 `json:"margin,omitempty"`
+}
+
+// InterventionOutcome records one agent intervention the timeline captured and a
+// best-effort before/after effect (#928 intervention outcomes). The intervention
+// stream is the #916 timeline's EventIntervention entries (Store.
+// AppendInterventionEvent): the decision Loop's LayerState.Outcomes is the live
+// source, but those entries are not on the game-end snapshot, whereas the timeline
+// IS — so the summary reads them from the narrative the snapshot carries. Today
+// that seam is unwired (see Store.AppendInterventionEvent's #916 deferral), so in
+// production this list is usually empty until the seam is threaded; the aggregator
+// handles them correctly the moment they appear (and the tests drive them).
+type InterventionOutcome struct {
+	Intervention string `json:"intervention"`
+	// TargetSerial is the player the intervention targeted, or "" for a session-
+	// scoped one.
+	TargetSerial string `json:"target_serial,omitempty"`
+	// Dispatched is true when the intervention reached the action sink; false when a
+	// permission/policy gate blocked it.
+	Dispatched bool `json:"dispatched"`
+	// OffsetSeconds is when the intervention fired, relative to game start.
+	OffsetSeconds float64 `json:"offset_seconds"`
+	// Effect is the BEST-EFFORT before/after engagement delta around the
+	// intervention (see effectDelta). nil when the timeline lacks state-deltas on
+	// both sides of the intervention to compare — full causal attribution is
+	// DEFERRED (#928 out-of-scope); this is a coarse correlation, not causation.
+	Effect *InterventionEffect `json:"effect,omitempty"`
+}
+
+// InterventionEffect is the best-effort timeline-window delta around an
+// intervention: the change in mean intensity / active count between the
+// effectWindow before and after the intervention's timestamp. It is a CORRELATION
+// (the engagement moved by this much around the intervention), explicitly NOT a
+// causal claim — deeper attribution is deferred per #928.
+type InterventionEffect struct {
+	// MeanIntensityDelta is after-mean minus before-mean of the state-delta
+	// intensities in the windows; nil when either side had no intensity sample.
+	MeanIntensityDelta *float64 `json:"mean_intensity_delta,omitempty"`
+	// ActivePlayersDelta is after minus before active-count (last sample each side);
+	// nil when either side had no active-count sample.
+	ActivePlayersDelta *int `json:"active_players_delta,omitempty"`
+}
+
+// BuildOptions injects everything impure into the otherwise-pure builder.
+type BuildOptions struct {
+	// Now is the build timestamp stamped on the Summary (GeneratedAt). Injected so
+	// the build is deterministic; the aggregation logic itself never reads it.
+	Now time.Time
+}
+
+// BuildSummary aggregates a game-end GameContext snapshot into a Summary (#928).
+// It is PURE: deterministic over (c, opts), no clock/network/disk. The snapshot is
+// expected to be the pre-reset one the Store hands OnGameEnd (SessionID +
+// EliminationSequence + Timeline intact).
+func BuildSummary(c gamecontext.GameContext, opts BuildOptions) Summary {
+	// anchor is the game's first timeline event time — the +0s origin every offset
+	// is measured from. Falls back to UpdatedAt when the timeline is empty so a
+	// game with no narrative still produces well-formed (all-zero-offset) output.
+	anchor, lastAt := timelineBounds(c.Timeline)
+
+	elims := buildEliminationSpread(c.Timeline, anchor)
+	trend := buildEngagementTrend(c.Timeline, anchor)
+	interventions := buildInterventions(c.Timeline, anchor)
+	arcs := buildPlayerArcs(c, elims, anchor, lastAt)
+	dom := detectDominance(arcs)
+
+	return Summary{
+		SchemaVersion:     SchemaVersion,
+		GameID:            c.SessionID,
+		GameKind:          c.GameKind,
+		GameMode:          deref(c.Session.GameMode),
+		GeneratedAt:       opts.Now,
+		DurationSeconds:   c.Session.DurationSeconds,
+		PlayerCount:       len(arcs),
+		EliminationCount:  len(elims),
+		InterventionCount: len(interventions),
+		PlayerArcs:        arcs,
+		EliminationSpread: elims,
+		EngagementTrend:   trend,
+		Dominance:         dom,
+		Interventions:     interventions,
+	}
+}
+
+// timelineBounds returns the first and last event timestamps in the timeline, or
+// two zero times when it is empty. The first is the +0s anchor for every offset.
+func timelineBounds(events []gamecontext.TimelineEvent) (first, last time.Time) {
+	if len(events) == 0 {
+		return time.Time{}, time.Time{}
+	}
+	// events() hands them oldest-first, so the bounds are the ends of the slice.
+	return events[0].At, events[len(events)-1].At
+}
+
+// offset returns the whole-fractional seconds from anchor to t. A zero anchor
+// (empty timeline) yields 0 so offsets stay well-defined.
+func offset(t, anchor time.Time) float64 {
+	if anchor.IsZero() || t.IsZero() {
+		return 0
+	}
+	return t.Sub(anchor).Seconds()
+}
+
+// buildEliminationSpread folds the timeline's elimination entries into the ordered
+// (offset, serial, order) spread, first-eliminated first (#928). Order comes from
+// the entry's 1-based Order; the slice is sorted by it so the spread is stable
+// regardless of timeline append order.
+func buildEliminationSpread(events []gamecontext.TimelineEvent, anchor time.Time) []EliminationEvent {
+	out := make([]EliminationEvent, 0)
+	for _, e := range events {
+		if e.Kind != gamecontext.EventElimination {
+			continue
+		}
+		out = append(out, EliminationEvent{
+			OffsetSeconds: offset(e.At, anchor),
+			Serial:        e.Serial,
+			Order:         e.Order,
+		})
+	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].Order < out[j].Order })
+	return out
+}
+
+// buildEngagementTrend folds the timeline's state-delta entries into the
+// engagement series (#928). Each delta is already change-deduped by the Store
+// (recordStateDelta only appends on a tracked-aggregate change), so the trend is
+// a compact TREND log, not a per-signal dump — no further down-sampling needed.
+func buildEngagementTrend(events []gamecontext.TimelineEvent, anchor time.Time) []EngagementPoint {
+	out := make([]EngagementPoint, 0)
+	for _, e := range events {
+		if e.Kind != gamecontext.EventStateDelta {
+			continue
+		}
+		out = append(out, EngagementPoint{
+			OffsetSeconds: offset(e.At, anchor),
+			ActivePlayers: copyIntPtr(e.ActivePlayers),
+			MeanIntensity: copyFloatPtr(e.MeanIntensity),
+		})
+	}
+	return out
+}
+
+// buildInterventions folds the timeline's intervention entries into the outcome
+// list with a best-effort before/after effect (#928). The effect compares the
+// engagement-trend windows on either side of each intervention's timestamp.
+func buildInterventions(events []gamecontext.TimelineEvent, anchor time.Time) []InterventionOutcome {
+	out := make([]InterventionOutcome, 0)
+	for _, e := range events {
+		if e.Kind != gamecontext.EventIntervention {
+			continue
+		}
+		out = append(out, InterventionOutcome{
+			Intervention:  e.Detail,
+			TargetSerial:  e.Serial,
+			Dispatched:    !e.Blocked,
+			OffsetSeconds: offset(e.At, anchor),
+			Effect:        effectDelta(events, e.At),
+		})
+	}
+	return out
+}
+
+// effectDelta computes the best-effort before/after engagement effect of an
+// intervention at time at: it averages the state-delta intensities in the
+// effectWindow BEFORE at vs AFTER at and reports the difference, and likewise the
+// last active-count on each side. It returns nil when neither aggregate has a
+// sample on BOTH sides — there is then nothing honest to compare, and full causal
+// attribution is deferred (#928). This is a CORRELATION around the intervention,
+// not a causal claim.
+func effectDelta(events []gamecontext.TimelineEvent, at time.Time) *InterventionEffect {
+	var beforeSum, afterSum float64
+	var beforeN, afterN int
+	var beforeActive, afterActive *int
+
+	for _, e := range events {
+		if e.Kind != gamecontext.EventStateDelta {
+			continue
+		}
+		d := e.At.Sub(at)
+		switch {
+		case d < 0 && -d <= effectWindow:
+			if e.MeanIntensity != nil {
+				beforeSum += *e.MeanIntensity
+				beforeN++
+			}
+			if e.ActivePlayers != nil {
+				beforeActive = e.ActivePlayers // last (closest) before wins via iteration order
+			}
+		case d >= 0 && d <= effectWindow:
+			if e.MeanIntensity != nil {
+				afterSum += *e.MeanIntensity
+				afterN++
+			}
+			if e.ActivePlayers != nil && afterActive == nil {
+				afterActive = e.ActivePlayers // first (closest) after wins
+			}
+		}
+	}
+
+	eff := &InterventionEffect{}
+	any := false
+	if beforeN > 0 && afterN > 0 {
+		delta := afterSum/float64(afterN) - beforeSum/float64(beforeN)
+		eff.MeanIntensityDelta = &delta
+		any = true
+	}
+	if beforeActive != nil && afterActive != nil {
+		delta := *afterActive - *beforeActive
+		eff.ActivePlayersDelta = &delta
+		any = true
+	}
+	if !any {
+		return nil
+	}
+	return eff
+}
+
+// buildPlayerArcs folds the live PlayerSignals together with the elimination
+// spread and the timeline into one arc per player (#928). Join offset is derived
+// from the player's first appearance in the narrative (its earliest state-delta or
+// elimination); survival is the elimination offset for an eliminated player, or
+// the full game span (anchor..lastAt) for a survivor.
+func buildPlayerArcs(c gamecontext.GameContext, elims []EliminationEvent, anchor, lastAt time.Time) []PlayerArc {
+	// Index the elimination spread by serial for O(1) arc lookup.
+	elimBySerial := make(map[string]EliminationEvent, len(elims))
+	for _, e := range elims {
+		elimBySerial[e.Serial] = e
+	}
+
+	// The set of serials the game saw is the union of live players and any serial
+	// that only ever appears as an elimination target (a player evicted before the
+	// snapshot but still narrated). This keeps a late-evicted player in the arc.
+	serials := make(map[string]struct{})
+	for serial := range c.Players {
+		serials[serial] = struct{}{}
+	}
+	for _, e := range elims {
+		serials[e.Serial] = struct{}{}
+	}
+
+	gameSpan := offset(lastAt, anchor) // full game length in seconds (0 if no timeline)
+
+	arcs := make([]PlayerArc, 0, len(serials))
+	for serial := range serials {
+		arc := PlayerArc{Serial: serial}
+		if p := c.Players[serial]; p != nil {
+			arc.FinalSkill = copyFloatPtr(p.SkillLevel)
+			arc.FinalIntensity = copyFloatPtr(p.MovementIntensity)
+		}
+		if elim, ok := elimBySerial[serial]; ok {
+			arc.Eliminated = true
+			arc.EliminationOrder = elim.Order
+			off := elim.OffsetSeconds
+			arc.EliminationOffsetSeconds = &off
+			surv := off // survival == time from start to elimination
+			arc.SurvivalSeconds = &surv
+		} else if !lastAt.IsZero() {
+			// Survivor: lasted the whole observed game.
+			surv := gameSpan
+			arc.SurvivalSeconds = &surv
+		}
+		arcs = append(arcs, arc)
+	}
+	// Stable, serial-sorted output so the file is byte-identical for a given input.
+	sort.Slice(arcs, func(i, j int) bool { return arcs[i].Serial < arcs[j].Serial })
+	return arcs
+}
+
+// detectDominance applies the dominant-player heuristic (#928): a survivor who
+// outlasted the eliminated field by >= dominanceRatio times its mean survival
+// "ran away with the game". Coarse and explainable by design; the Heuristic field
+// names the rule so a reader knows exactly what fired.
+func detectDominance(arcs []PlayerArc) Dominance {
+	const dominanceRatio = 2.0
+	const heuristic = "survivor_outlasted_mean_2x"
+
+	var survivor *PlayerArc
+	var elimSurvivalSum float64
+	var elimCount int
+	survivors := 0
+	for i := range arcs {
+		a := &arcs[i]
+		if a.Eliminated {
+			if a.SurvivalSeconds != nil {
+				elimSurvivalSum += *a.SurvivalSeconds
+				elimCount++
+			}
+			continue
+		}
+		survivors++
+		survivor = a
+	}
+
+	// Dominance requires exactly one survivor measured against an eliminated field.
+	if survivors != 1 || survivor == nil || survivor.SurvivalSeconds == nil || elimCount == 0 {
+		return Dominance{Heuristic: heuristic}
+	}
+	meanElim := elimSurvivalSum / float64(elimCount)
+	if meanElim <= 0 {
+		return Dominance{Heuristic: heuristic}
+	}
+	margin := *survivor.SurvivalSeconds / meanElim
+	return Dominance{
+		Dominated: margin >= dominanceRatio,
+		Serial:    dominantSerial(survivor, margin >= dominanceRatio),
+		Heuristic: heuristic,
+		Margin:    margin,
+	}
+}
+
+// dominantSerial returns the survivor's serial only when the game was dominated,
+// so the field is "" on a non-dominated game (the JSON omits it).
+func dominantSerial(survivor *PlayerArc, dominated bool) string {
+	if !dominated {
+		return ""
+	}
+	return survivor.Serial
+}
+
+// deref returns the pointed-to string, or "" for a nil pointer.
+func deref(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}
+
+// copyIntPtr / copyFloatPtr return a fresh pointer to the same value, so the
+// Summary never aliases the snapshot's pointers (the snapshot shares pointers with
+// nothing live, but copying keeps the Summary self-contained and JSON-stable).
+func copyIntPtr(p *int) *int {
+	if p == nil {
+		return nil
+	}
+	v := *p
+	return &v
+}
+
+func copyFloatPtr(p *float64) *float64 {
+	if p == nil {
+		return nil
+	}
+	v := *p
+	return &v
+}

--- a/services/agent/gamesummary/summary_test.go
+++ b/services/agent/gamesummary/summary_test.go
@@ -1,0 +1,313 @@
+package gamesummary
+
+import (
+	"testing"
+	"time"
+
+	"github.com/joustmania/agent/gamecontext"
+)
+
+// base is the +0s anchor every test offset is measured from. A fixed instant keeps
+// the tests deterministic (BuildSummary is clock-free; only GeneratedAt is injected).
+var base = time.Date(2026, 6, 12, 10, 0, 0, 0, time.UTC)
+
+func at(sec int) time.Time { return base.Add(time.Duration(sec) * time.Second) }
+
+func fptr(v float64) *float64 { return &v }
+func iptr(v int) *int         { return &v }
+
+// representativeGame drives a Store through a full game with an injected clock and
+// returns the game-end snapshot: 3 players join, the active count and intensity
+// move (engagement trend), two players are eliminated, and the game ends. The
+// survivor (CC:33) outlasts the field. Two interventions are recorded on the
+// timeline (one dispatched, one blocked) via the #916 seam.
+func representativeGame(t *testing.T) gamecontext.GameContext {
+	t.Helper()
+	clock := base
+	s := gamecontext.NewStore(time.Hour, time.Hour, func() time.Time { return clock })
+
+	var snap gamecontext.GameContext
+	s.OnGameEnd = func(c gamecontext.GameContext) { snap = c }
+
+	s.SetGameKind("real")
+	s.SetGameMode("joust")
+	s.SetGameActive(true) // phase: start at +0s (assigns synthetic session id)
+	// Adopt the real game_id AFTER session start: SetGameActive(true) assigns a
+	// synthetic "session-N" on the false->true transition, so a real game_id label
+	// is adopted afterward (mirrors the receiver's order in production).
+	s.AdoptSessionID("game_abc123def456")
+
+	// Players join + initial energy.
+	s.SetActivePlayerCount(3)
+	s.SetPlayerIntensity("AA:11", 0.8)
+	s.SetPlayerIntensity("BB:22", 0.7)
+	s.SetPlayerIntensity("CC:33", 0.9)
+	s.SetPlayerSkill("CC:33", 0.95, true)
+
+	clock = at(20)
+	s.SetPlayerIntensity("AA:11", 0.4) // energy fades -> state delta
+	// First intervention fires around +20s (dispatched).
+	s.AppendInterventionEvent("music_tempo_override", "", false)
+
+	clock = at(25)
+	s.SetEliminationOrder("AA:11", 1) // first elimination at +25s
+	s.SetActivePlayerCount(2)
+
+	clock = at(30)
+	s.SetPlayerIntensity("BB:22", 0.95) // post-intervention energy bump
+
+	clock = at(50)
+	// Second intervention (blocked) at +50s.
+	s.AppendInterventionEvent("eliminate_player", "BB:22", true)
+	s.SetEliminationOrder("BB:22", 2) // second elimination at +50s
+	s.SetActivePlayerCount(1)
+
+	clock = at(60)
+	s.SetSessionDuration(60)
+	s.SetGameActive(false) // phase: end at +60s -> OnGameEnd fires
+
+	if snap.SessionID == "" {
+		t.Fatal("OnGameEnd did not fire / empty snapshot")
+	}
+	return snap
+}
+
+func TestBuildSummary_TopLevel(t *testing.T) {
+	snap := representativeGame(t)
+	now := at(61)
+	got := BuildSummary(snap, BuildOptions{Now: now})
+
+	if got.SchemaVersion != SchemaVersion {
+		t.Errorf("SchemaVersion = %d, want %d", got.SchemaVersion, SchemaVersion)
+	}
+	if got.GameID != "game_abc123def456" {
+		t.Errorf("GameID = %q", got.GameID)
+	}
+	if got.GameKind != "real" {
+		t.Errorf("GameKind = %q, want real", got.GameKind)
+	}
+	if got.GameMode != "joust" {
+		t.Errorf("GameMode = %q, want joust", got.GameMode)
+	}
+	if !got.GeneratedAt.Equal(now) {
+		t.Errorf("GeneratedAt = %v, want %v", got.GeneratedAt, now)
+	}
+	if got.DurationSeconds == nil || *got.DurationSeconds != 60 {
+		t.Errorf("DurationSeconds = %v, want 60", got.DurationSeconds)
+	}
+	if got.PlayerCount != 3 {
+		t.Errorf("PlayerCount = %d, want 3", got.PlayerCount)
+	}
+	if got.EliminationCount != 2 {
+		t.Errorf("EliminationCount = %d, want 2", got.EliminationCount)
+	}
+	if got.InterventionCount != 2 {
+		t.Errorf("InterventionCount = %d, want 2", got.InterventionCount)
+	}
+}
+
+func TestBuildSummary_Determinism(t *testing.T) {
+	snap := representativeGame(t)
+	now := at(61)
+	a := BuildSummary(snap, BuildOptions{Now: now})
+	b := BuildSummary(snap, BuildOptions{Now: now})
+	if a.GameID != b.GameID || len(a.PlayerArcs) != len(b.PlayerArcs) ||
+		len(a.EngagementTrend) != len(b.EngagementTrend) ||
+		a.Dominance != b.Dominance {
+		t.Error("BuildSummary is not deterministic over the same snapshot")
+	}
+	// Player arcs must be serial-sorted for a byte-stable file.
+	for i := 1; i < len(a.PlayerArcs); i++ {
+		if a.PlayerArcs[i-1].Serial > a.PlayerArcs[i].Serial {
+			t.Errorf("PlayerArcs not serial-sorted: %v", a.PlayerArcs)
+		}
+	}
+}
+
+func TestBuildSummary_EliminationSpread(t *testing.T) {
+	got := BuildSummary(representativeGame(t), BuildOptions{Now: at(61)})
+	if len(got.EliminationSpread) != 2 {
+		t.Fatalf("EliminationSpread len = %d, want 2", len(got.EliminationSpread))
+	}
+	first, second := got.EliminationSpread[0], got.EliminationSpread[1]
+	if first.Serial != "AA:11" || first.Order != 1 || first.OffsetSeconds != 25 {
+		t.Errorf("first elimination = %+v, want AA:11 order 1 @25s", first)
+	}
+	if second.Serial != "BB:22" || second.Order != 2 || second.OffsetSeconds != 50 {
+		t.Errorf("second elimination = %+v, want BB:22 order 2 @50s", second)
+	}
+}
+
+func TestBuildSummary_PlayerArcs(t *testing.T) {
+	got := BuildSummary(representativeGame(t), BuildOptions{Now: at(61)})
+	arcs := make(map[string]PlayerArc, len(got.PlayerArcs))
+	for _, a := range got.PlayerArcs {
+		arcs[a.Serial] = a
+	}
+
+	aa := arcs["AA:11"]
+	if !aa.Eliminated || aa.EliminationOrder != 1 {
+		t.Errorf("AA:11 arc = %+v, want eliminated order 1", aa)
+	}
+	if aa.EliminationOffsetSeconds == nil || *aa.EliminationOffsetSeconds != 25 {
+		t.Errorf("AA:11 elimination offset = %v, want 25", aa.EliminationOffsetSeconds)
+	}
+	if aa.SurvivalSeconds == nil || *aa.SurvivalSeconds != 25 {
+		t.Errorf("AA:11 survival = %v, want 25", aa.SurvivalSeconds)
+	}
+
+	cc := arcs["CC:33"]
+	if cc.Eliminated {
+		t.Errorf("CC:33 must be the survivor, got eliminated: %+v", cc)
+	}
+	// Survivor survival == full game span (anchor..last event = 0..60).
+	if cc.SurvivalSeconds == nil || *cc.SurvivalSeconds != 60 {
+		t.Errorf("CC:33 survival = %v, want 60 (full game)", cc.SurvivalSeconds)
+	}
+	if cc.FinalSkill == nil || *cc.FinalSkill != 0.95 {
+		t.Errorf("CC:33 final skill = %v, want 0.95", cc.FinalSkill)
+	}
+}
+
+func TestBuildSummary_EngagementTrend(t *testing.T) {
+	got := BuildSummary(representativeGame(t), BuildOptions{Now: at(61)})
+	if len(got.EngagementTrend) == 0 {
+		t.Fatal("EngagementTrend is empty; expected state deltas from the timeline")
+	}
+	// Trend must be oldest-first (non-decreasing offsets).
+	for i := 1; i < len(got.EngagementTrend); i++ {
+		if got.EngagementTrend[i-1].OffsetSeconds > got.EngagementTrend[i].OffsetSeconds {
+			t.Errorf("EngagementTrend not oldest-first: %+v", got.EngagementTrend)
+		}
+	}
+	// The active count fell 3 -> 2 -> 1 over the game; the last point must show 1.
+	last := got.EngagementTrend[len(got.EngagementTrend)-1]
+	if last.ActivePlayers == nil || *last.ActivePlayers != 1 {
+		t.Errorf("last engagement active_players = %v, want 1", last.ActivePlayers)
+	}
+}
+
+func TestBuildSummary_Dominance(t *testing.T) {
+	got := BuildSummary(representativeGame(t), BuildOptions{Now: at(61)})
+	// CC:33 survived 60s; the eliminated mean is (25+50)/2 = 37.5; 60/37.5 = 1.6,
+	// below the 2x ratio -> NOT dominated, but the heuristic + margin are recorded.
+	if got.Dominance.Dominated {
+		t.Errorf("expected not dominated (margin 1.6x < 2x), got %+v", got.Dominance)
+	}
+	if got.Dominance.Heuristic == "" {
+		t.Error("Dominance.Heuristic must always be set")
+	}
+	if got.Dominance.Margin < 1.59 || got.Dominance.Margin > 1.61 {
+		t.Errorf("Dominance.Margin = %v, want ~1.6", got.Dominance.Margin)
+	}
+}
+
+// TestBuildSummary_DominanceDetected: a survivor far outlasting the field flips the
+// dominated flag and names the player.
+func TestBuildSummary_DominanceDetected(t *testing.T) {
+	clock := base
+	s := gamecontext.NewStore(time.Hour, time.Hour, func() time.Time { return clock })
+	var snap gamecontext.GameContext
+	s.OnGameEnd = func(c gamecontext.GameContext) { snap = c }
+
+	s.SetGameKind("shadow")
+	s.SetGameActive(true)
+	s.AdoptSessionID("game_dom")
+	s.SetActivePlayerCount(3)
+	s.SetPlayerIntensity("WIN:01", 0.9)
+
+	clock = at(5)
+	s.SetEliminationOrder("LOS:01", 1) // out fast at +5s
+
+	clock = at(8)
+	s.SetEliminationOrder("LOS:02", 2) // out fast at +8s
+
+	clock = at(90)
+	s.SetActivePlayerCount(1)
+	s.SetGameActive(false) // survivor WIN:01 lasted 90s
+
+	got := BuildSummary(snap, BuildOptions{Now: at(91)})
+	if !got.Dominance.Dominated {
+		t.Fatalf("expected dominated, got %+v", got.Dominance)
+	}
+	if got.Dominance.Serial != "WIN:01" {
+		t.Errorf("dominant serial = %q, want WIN:01", got.Dominance.Serial)
+	}
+}
+
+func TestBuildSummary_InterventionOutcomes(t *testing.T) {
+	got := BuildSummary(representativeGame(t), BuildOptions{Now: at(61)})
+	if len(got.Interventions) != 2 {
+		t.Fatalf("Interventions len = %d, want 2", len(got.Interventions))
+	}
+	byName := make(map[string]InterventionOutcome, 2)
+	for _, iv := range got.Interventions {
+		byName[iv.Intervention] = iv
+	}
+
+	tempo := byName["music_tempo_override"]
+	if !tempo.Dispatched {
+		t.Errorf("music_tempo_override should be dispatched: %+v", tempo)
+	}
+	if tempo.OffsetSeconds != 20 {
+		t.Errorf("music_tempo_override offset = %v, want 20", tempo.OffsetSeconds)
+	}
+
+	elim := byName["eliminate_player"]
+	if elim.Dispatched {
+		t.Errorf("eliminate_player should be blocked: %+v", elim)
+	}
+	if elim.TargetSerial != "BB:22" {
+		t.Errorf("eliminate_player target = %q, want BB:22", elim.TargetSerial)
+	}
+}
+
+// TestBuildSummary_InterventionEffect: the best-effort before/after delta is
+// computed when the timeline has state-deltas on both sides of an intervention.
+func TestBuildSummary_InterventionEffect(t *testing.T) {
+	// Craft a timeline directly: intensity rises after the intervention.
+	tl := []gamecontext.TimelineEvent{
+		{At: at(0), Kind: gamecontext.EventStateDelta, ActivePlayers: iptr(3), MeanIntensity: fptr(0.40)},
+		{At: at(10), Kind: gamecontext.EventStateDelta, ActivePlayers: iptr(3), MeanIntensity: fptr(0.42)},
+		{At: at(15), Kind: gamecontext.EventIntervention, Detail: "music_tempo_override"},
+		{At: at(20), Kind: gamecontext.EventStateDelta, ActivePlayers: iptr(3), MeanIntensity: fptr(0.80)},
+		{At: at(25), Kind: gamecontext.EventStateDelta, ActivePlayers: iptr(2), MeanIntensity: fptr(0.82)},
+	}
+	gc := gamecontext.GameContext{
+		SessionID: "game_eff",
+		Session:   gamecontext.SessionSignals{GameActive: bptr(false)},
+		Timeline:  tl,
+	}
+	got := BuildSummary(gc, BuildOptions{Now: at(30)})
+	if len(got.Interventions) != 1 {
+		t.Fatalf("want 1 intervention, got %d", len(got.Interventions))
+	}
+	eff := got.Interventions[0].Effect
+	if eff == nil || eff.MeanIntensityDelta == nil {
+		t.Fatalf("expected a mean-intensity effect delta, got %+v", eff)
+	}
+	// before mean = (0.40+0.42)/2 = 0.41; after mean = (0.80+0.82)/2 = 0.81; delta +0.40.
+	if *eff.MeanIntensityDelta < 0.39 || *eff.MeanIntensityDelta > 0.41 {
+		t.Errorf("MeanIntensityDelta = %v, want ~0.40", *eff.MeanIntensityDelta)
+	}
+}
+
+// TestBuildSummary_EmptyTimeline: a game that produced no narrative still yields a
+// well-formed, non-panicking summary (no eliminations, no trend).
+func TestBuildSummary_EmptyTimeline(t *testing.T) {
+	gc := gamecontext.GameContext{
+		SessionID: "game_empty",
+		GameKind:  "real",
+		Session:   gamecontext.SessionSignals{GameActive: bptr(false)},
+		Players:   map[string]*gamecontext.PlayerSignals{"AA:11": {Serial: "AA:11"}},
+	}
+	got := BuildSummary(gc, BuildOptions{Now: at(1)})
+	if got.PlayerCount != 1 || got.EliminationCount != 0 || len(got.EngagementTrend) != 0 {
+		t.Errorf("empty-timeline summary = %+v", got)
+	}
+	if got.Dominance.Dominated {
+		t.Error("empty game cannot be dominated")
+	}
+}
+
+func bptr(b bool) *bool { return &b }

--- a/services/agent/gamesummary/writer.go
+++ b/services/agent/gamesummary/writer.go
@@ -1,0 +1,129 @@
+package gamesummary
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// writer.go persists a Summary as one JSON file per game (#928). Unlike the
+// interventions Writer (actions/writer.go, in-place to dodge inotify EBUSY on a
+// flagd bind mount), NO process watches the summaries dir, so a real atomic
+// temp+rename is both safe and required: a reader (the #929 window builder, the
+// dashboard, an operator) must NEVER see a half-written file. rename(2) is atomic
+// within a directory, so the destination either does not exist or is a complete
+// summary — never a truncated one.
+
+// DefaultDir is the in-container summaries directory. Override with
+// AGENT_GAME_SUMMARY_DIR. It mirrors the house path-from-env pattern
+// (actions.DefaultPath + INTERVENTIONS_FLAG_PATH): a sensible default plus a
+// single env override, resolved by DirFromEnv.
+const DefaultDir = "/var/lib/joustmania/agent/summaries"
+
+// gameSummaryDirEnv is the env var that overrides DefaultDir.
+const gameSummaryDirEnv = "AGENT_GAME_SUMMARY_DIR"
+
+// safeFilenameChars matches any rune NOT allowed in a summary filename. game_ids
+// are "game_<hex>" and synthetic ids are "session-<n>" (both already safe), but an
+// adopted game_id is an external label, so we sanitize defensively: anything
+// outside [A-Za-z0-9._-] becomes '_' so the id can never escape the summaries dir
+// (path traversal) or produce an unwritable name.
+var safeFilenameChars = regexp.MustCompile(`[^A-Za-z0-9._-]`)
+
+// Writer persists summaries under a fixed directory. It holds no per-game state
+// and is safe for concurrent use: each Write targets a distinct game_id file via a
+// uniquely-named temp file, so two concurrent game-ends (#845) never collide.
+type Writer struct {
+	dir string
+}
+
+// NewWriter builds a Writer rooted at dir. An empty dir uses DefaultDir. The
+// directory is created lazily on the first Write (not here) so construction never
+// touches the filesystem and a test can point it at a t.TempDir().
+func NewWriter(dir string) *Writer {
+	if dir == "" {
+		dir = DefaultDir
+	}
+	return &Writer{dir: dir}
+}
+
+// DirFromEnv resolves the summaries directory from AGENT_GAME_SUMMARY_DIR,
+// falling back to DefaultDir — the single env-override seam, mirroring
+// actions.NewWriterFromEnv.
+func DirFromEnv() string {
+	if d := strings.TrimSpace(os.Getenv(gameSummaryDirEnv)); d != "" {
+		return d
+	}
+	return DefaultDir
+}
+
+// Path returns the on-disk path the given game_id's summary is written to, with
+// the id sanitized to a safe filename. Exported so a caller/test can locate the
+// file without re-deriving the naming rule.
+func (w *Writer) Path(gameID string) string {
+	return filepath.Join(w.dir, safeFilename(gameID)+".json")
+}
+
+// safeFilename sanitizes a game_id into a filesystem-safe base name. An empty or
+// all-unsafe id collapses to "unknown" so a write never targets ".json" or
+// escapes the dir.
+func safeFilename(gameID string) string {
+	name := safeFilenameChars.ReplaceAllString(gameID, "_")
+	name = strings.Trim(name, ".")
+	if name == "" {
+		return "unknown"
+	}
+	return name
+}
+
+// Write atomically persists s to <dir>/<game_id>.json. It creates the directory
+// if missing, marshals indented JSON (so the file is human-readable for an
+// operator), writes it to a uniquely-named temp file in the SAME directory, fsyncs
+// it, then renames it over the destination — so a concurrent reader observes only
+// the complete file. The temp file shares the destination's directory so the
+// rename stays within one filesystem (cross-device rename would fail).
+func (w *Writer) Write(s Summary) error {
+	if err := os.MkdirAll(w.dir, 0o755); err != nil {
+		return fmt.Errorf("create summaries dir %q: %w", w.dir, err)
+	}
+
+	data, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal summary for %q: %w", s.GameID, err)
+	}
+	data = append(data, '\n')
+
+	dst := w.Path(s.GameID)
+
+	// Unique temp name (CreateTemp adds a random suffix) so two concurrent writes
+	// for different games — or a retry for the same game — never share a temp file.
+	tmp, err := os.CreateTemp(w.dir, "."+safeFilename(s.GameID)+"-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temp summary file: %w", err)
+	}
+	tmpName := tmp.Name()
+	// Best-effort cleanup of the temp file on any failure before the rename; a
+	// successful rename consumes it, so the deferred Remove then no-ops.
+	defer func() { _ = os.Remove(tmpName) }()
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write temp summary: %w", err)
+	}
+	// fsync before rename so the bytes are durable on disk before the directory
+	// entry flips — a crash can never leave the destination pointing at empty data.
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("sync temp summary: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp summary: %w", err)
+	}
+	if err := os.Rename(tmpName, dst); err != nil {
+		return fmt.Errorf("rename temp summary to %q: %w", dst, err)
+	}
+	return nil
+}

--- a/services/agent/gamesummary/writer_test.go
+++ b/services/agent/gamesummary/writer_test.go
@@ -1,0 +1,137 @@
+package gamesummary
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestWriter_WritesFilePerGame(t *testing.T) {
+	dir := t.TempDir()
+	w := NewWriter(dir)
+	if err := w.Write(Summary{SchemaVersion: SchemaVersion, GameID: "game_one"}); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if err := w.Write(Summary{SchemaVersion: SchemaVersion, GameID: "game_two"}); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	for _, id := range []string{"game_one", "game_two"} {
+		path := filepath.Join(dir, id+".json")
+		if _, err := os.Stat(path); err != nil {
+			t.Errorf("expected summary file %s: %v", path, err)
+		}
+	}
+}
+
+func TestWriter_CreatesDirIfMissing(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "nested", "summaries")
+	w := NewWriter(dir)
+	if err := w.Write(Summary{GameID: "game_x"}); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "game_x.json")); err != nil {
+		t.Errorf("dir not created / file missing: %v", err)
+	}
+}
+
+func TestWriter_ContentIsValidJSON(t *testing.T) {
+	dir := t.TempDir()
+	w := NewWriter(dir)
+	in := Summary{SchemaVersion: SchemaVersion, GameID: "game_json", GameKind: "shadow", PlayerCount: 4}
+	if err := w.Write(in); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	data, err := os.ReadFile(w.Path("game_json"))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var out Summary
+	if err := json.Unmarshal(data, &out); err != nil {
+		t.Fatalf("on-disk summary is not valid JSON: %v", err)
+	}
+	if out.GameID != "game_json" || out.GameKind != "shadow" || out.PlayerCount != 4 {
+		t.Errorf("round-trip mismatch: %+v", out)
+	}
+}
+
+// TestWriter_AtomicNoPartialFile: after a Write the destination is the COMPLETE
+// file and no temp (.tmp) leftovers remain — a reader never sees a partial write.
+func TestWriter_AtomicNoPartialFile(t *testing.T) {
+	dir := t.TempDir()
+	w := NewWriter(dir)
+	if err := w.Write(Summary{GameID: "game_atomic", PlayerCount: 2}); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var json, tmp int
+	for _, e := range entries {
+		switch {
+		case strings.HasSuffix(e.Name(), ".json"):
+			json++
+		case strings.HasSuffix(e.Name(), ".tmp"):
+			tmp++
+		}
+	}
+	if json != 1 {
+		t.Errorf("want 1 .json file, got %d", json)
+	}
+	if tmp != 0 {
+		t.Errorf("want 0 leftover .tmp files, got %d", tmp)
+	}
+}
+
+// TestWriter_SanitizesGameID: an id with path-traversal / unsafe chars cannot
+// escape the dir or produce an unwritable name.
+func TestWriter_SanitizesGameID(t *testing.T) {
+	dir := t.TempDir()
+	w := NewWriter(dir)
+	if err := w.Write(Summary{GameID: "../../etc/evil"}); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	path := w.Path("../../etc/evil")
+	if filepath.Dir(path) != dir {
+		t.Errorf("sanitized path %q escaped dir %q", path, dir)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("sanitized file not written: %v", err)
+	}
+}
+
+// TestWriter_ConcurrentWrites: two concurrent game-ends (#845) for distinct ids
+// produce two independent files without collision.
+func TestWriter_ConcurrentWrites(t *testing.T) {
+	dir := t.TempDir()
+	w := NewWriter(dir)
+	var wg sync.WaitGroup
+	for _, id := range []string{"game_a", "game_b", "game_c", "game_d"} {
+		wg.Add(1)
+		go func(id string) {
+			defer wg.Done()
+			if err := w.Write(Summary{GameID: id}); err != nil {
+				t.Errorf("Write %s: %v", id, err)
+			}
+		}(id)
+	}
+	wg.Wait()
+	entries, _ := os.ReadDir(dir)
+	if len(entries) != 4 {
+		t.Errorf("want 4 files, got %d: %v", len(entries), entries)
+	}
+}
+
+func TestDirFromEnv(t *testing.T) {
+	t.Setenv(gameSummaryDirEnv, "/custom/summaries")
+	if got := DirFromEnv(); got != "/custom/summaries" {
+		t.Errorf("DirFromEnv = %q, want /custom/summaries", got)
+	}
+	t.Setenv(gameSummaryDirEnv, "")
+	if got := DirFromEnv(); got != DefaultDir {
+		t.Errorf("DirFromEnv fallback = %q, want %q", got, DefaultDir)
+	}
+}

--- a/services/agent/main.go
+++ b/services/agent/main.go
@@ -35,6 +35,7 @@ import (
 	"github.com/joustmania/agent/flags"
 	"github.com/joustmania/agent/gamecontext"
 	"github.com/joustmania/agent/gamerunner"
+	"github.com/joustmania/agent/gamesummary"
 	"github.com/joustmania/agent/gate"
 	"github.com/joustmania/agent/infracontext"
 )
@@ -74,6 +75,22 @@ func partitionSet(ids []string) map[string]struct{} {
 		set[id] = struct{}{}
 	}
 	return set
+}
+
+// chainGameEnd composes several gamecontext.Store.OnGameEnd callbacks into one,
+// invoking each in order with the same snapshot (#928). The store exposes a single
+// OnGameEnd hook, but multiple independent once-per-game consumers (the #844 retro
+// and the M7-1 summary builder) need it; chaining keeps both on the one hook
+// without either knowing about the other. nil callbacks are skipped so a disabled
+// consumer is a no-op.
+func chainGameEnd(fns ...func(gamecontext.GameContext)) func(gamecontext.GameContext) {
+	return func(c gamecontext.GameContext) {
+		for _, fn := range fns {
+			if fn != nil {
+				fn(c)
+			}
+		}
+	}
 }
 
 // parsePort parses a uint16 TCP port, returning fallback on any parse error.
@@ -384,6 +401,19 @@ func main() {
 	// per-game loops also hold, so a retro at game end cannot blow the per-minute cap.
 	retro.SetLLMBudget(sharedLLMBudget)
 
+	// Game narrative builder (#928, M7-1): on the SAME GameActive true->false
+	// transition, aggregate the partition's pre-reset snapshot (live signals + the
+	// #916 rolling timeline) into a compact JSON game summary written to disk
+	// (AGENT_GAME_SUMMARY_DIR, default gamesummary.DefaultDir), one file per game,
+	// for BOTH real and shadow games. It is a SEPARATE once-per-game component from
+	// the retro — the summary must run unconditionally (no LLM budget/eligibility),
+	// so it owns its own dedupe and is chained alongside retro.OnGameEnd below
+	// (chainGameEnd) on the single store hook. The aggregation is itself an
+	// agent.game.summary span.
+	summaryDir := gamesummary.DirFromEnv()
+	summaries := gamesummary.NewCoordinator(gamesummary.NewWriter(summaryDir), logger)
+	slog.Info("Game narrative builder enabled (#928, M7-1)", "summary_dir", summaryDir)
+
 	// GameContext multiplexer (#845 PR B): one Store partition per game_id, plus the
 	// fallback partition "" for unlabeled signals (zero-regression — single-game
 	// mode collapses to exactly today's single-store behavior). The factory applies
@@ -399,7 +429,12 @@ func main() {
 		s := gamecontext.NewStore(lifecycle.PlayerTTL, lifecycle.SessionGrace, nil)
 		s.SetTTLSources(lifecycleHolder.PlayerTTL, lifecycleHolder.SessionGrace)
 		s.SetOwnService(ownService)
-		s.OnGameEnd = retro.OnGameEnd
+		// Chain BOTH game-end consumers onto the single store hook (#928): the #844
+		// retrospective AND the M7-1 summary builder both fire on game end with the
+		// pre-reset snapshot. Each has its OWN once-per-game dedupe, so chaining cannot
+		// make either double-fire. Order is retro-then-summary, but they are independent
+		// (neither reads the other's state).
+		s.OnGameEnd = chainGameEnd(retro.OnGameEnd, summaries.OnGameEnd)
 		return s
 	})
 	mux.SetOwnService(ownService)


### PR DESCRIPTION
Part of #928 (M7-1: Game narrative builder).

## What

After each game ends — **real AND shadow** — aggregate the partition's pre-reset `GameContext` snapshot (live signals + the #916 rolling timeline) into a compact **game summary** so the agent can reason about *what happened* as a narrative instead of re-reading low-level telemetry.

New `services/agent/gamesummary` package:

- **`summary.go`** — pure, clock-free `BuildSummary(GameContext, BuildOptions) Summary`. Table-testable, deterministic over its input (only `GeneratedAt` is injected; the aggregation never reads a clock/network/disk).
- **`writer.go`** — atomic JSON writer (temp file + `fsync` + `rename`), **one file per `game_id`**, dir from `AGENT_GAME_SUMMARY_DIR` (sensible default, created if missing). `game_id` sanitized against path traversal.
- **`coordinator.go`** — once-per-game `OnGameEnd` hook (bounded LRU dedupe, mirroring the #844 retro) that builds + writes the summary under an **`agent.game.summary`** span carrying low-cardinality counts.

## Summary schema (JSON)

`schema_version`, `game_id`, `game_kind`, `game_mode`, `generated_at`, `duration_seconds`, `player_count`, `elimination_count`, `intervention_count`, plus the five required signals:

- **`player_arcs`** — per-serial: `eliminated`, `elimination_order`, join/elimination offsets, `survival_seconds`, `final_skill`/`final_intensity`.
- **`engagement_trend`** — oldest-first `(offset, active_players, mean_intensity)` series.
- **`elimination_spread`** — ordered `(offset, serial, order)`.
- **`dominance`** — `dominated` flag + `serial` + named `heuristic` + `margin`.
- **`interventions`** — `(intervention, target, dispatched, offset, effect)`.

## Signal provenance

Derived **from the #916 timeline**: engagement trend (state-delta entries), elimination spread + per-player order (elimination entries), intervention outcomes (intervention entries). Player arcs fold live `PlayerSignals` with the timeline; dominance is a coarse, explainable `survivor_outlasted_mean_2x` heuristic.

**Intervention before/after effect** is a best-effort *correlation*: mean-intensity and active-count delta between the 30 s timeline windows immediately before vs after each intervention's timestamp (`nil` when neither side has a comparable sample). The intervention stream is the timeline's `EventIntervention` entries (`Store.AppendInterventionEvent`); that seam is currently unwired in production (see the #916 deferral on `AppendInterventionEvent`), so the list is usually empty until the seam is threaded — the aggregator handles them correctly the moment they appear (and the tests drive them).

## Wiring / double-fire avoidance

The store exposes a single `OnGameEnd` hook. The summary coordinator is chained alongside the #844 retro via a small `chainGameEnd` helper in `main.go`. Each consumer owns its **own** once-per-game dedupe, so chaining cannot make either double-fire. The summary is a **separate** component (no LLM budget / eligibility gate) so it runs unconditionally for every game — a budget-exhausted game still gets a summary.

## Tests

- `BuildSummary` table tests: player arcs, elimination spread, engagement trend, dominance (detected + not), intervention outcomes + effect delta, empty timeline, determinism.
- Writer: file-per-game, dir-created-if-missing, valid JSON round-trip, **atomic / no partial file / no `.tmp` leftover**, `game_id` sanitization, concurrent writes.
- Coordinator: file + span emitted, runs for **shadow** games, exactly-once per game, skips non-end snapshots, two concurrent games → two files, end-to-end driven from a real `Store`.

`gofmt -l` clean, `go vet ./...` clean, `go test -race ./...` all green. No new dependencies (`go.sum` untouched).

## Out of scope (later M7)

Multi-game rolling **window** (#929 M7-2 — this is ONE summary per game), prompt injection (#930), dashboard pane (#933), and deep causal before/after attribution beyond the timeline-window delta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)