### PR TITLE
feat(agent): M7-2 rolling game context window (#929)

### DIFF
--- a/services/agent/decision/async_apply.go
+++ b/services/agent/decision/async_apply.go
@@ -134,6 +134,10 @@ func (l *Loop) emitAsyncInferSpan(ctx context.Context, out asyncOutcome) ([]Deci
 		trace.WithAttributes(semconvGenAIChat(out.backend.Name())...),
 	)
 	span.SetAttributes(attribute.Int64(AttrLLMLatencyMs, out.latencyMs()))
+	// M7-2 (#929): record the cross-game context-window count actually injected into
+	// the prompt on the REAL inference span, mirroring the synchronous llmDecide path
+	// (AttrLLMContextGames). out.contextGames is what runInfer rendered (0 = un-wired).
+	span.SetAttributes(attribute.Int(AttrLLMContextGames, out.contextGames))
 	defer span.End(trace.WithTimestamp(out.end))
 
 	if out.timedOut {

--- a/services/agent/decision/async_infer.go
+++ b/services/agent/decision/async_infer.go
@@ -204,7 +204,20 @@ func (l *Loop) runInfer(root context.Context, snapshot flags.Snapshot, backend B
 	inferCtx, cancel := context.WithTimeout(root, budget)
 	defer cancel()
 
-	prompt := llm.Build(llm.BuildInput{Snapshot: snapshot, Context: c, Now: start})
+	// M7-2 cross-game context (#929): inject the SAME rolling-window block the sync
+	// llmDecide path would, so the PRODUCTION (async) path actually carries the last N
+	// game summaries — #917 moved prompt assembly here, so without this the feature
+	// would be bypassed in production. renderContextBlock is the shared #951 Loop
+	// helper (nil-window-safe -> "", 0), so an un-wired loop is unaffected. count is
+	// carried on the outcome and stamped on the agent.llm.infer span at apply time
+	// (emitAsyncInferSpan), mirroring how the sync path records AttrLLMContextGames.
+	contextBlock, contextCount := l.renderContextBlock(snapshot)
+	prompt := llm.Build(llm.BuildInput{
+		Snapshot:     snapshot,
+		Context:      c,
+		Now:          start,
+		ContextBlock: contextBlock,
+	})
 
 	// The raw inference call (#739). Spans are NOT created here — they are emitted by
 	// applyAsyncResult so the agent.llm.infer span hangs off the async apply root
@@ -213,12 +226,13 @@ func (l *Loop) runInfer(root context.Context, snapshot flags.Snapshot, backend B
 	end := now()
 
 	l.applyAsyncResult(root, snapshot, trig, asyncOutcome{
-		raw:      raw,
-		inferErr: inferErr,
-		timedOut: inferCtx.Err() == context.DeadlineExceeded,
-		start:    start,
-		end:      end,
-		backend:  backend,
+		raw:          raw,
+		inferErr:     inferErr,
+		timedOut:     inferCtx.Err() == context.DeadlineExceeded,
+		start:        start,
+		end:          end,
+		backend:      backend,
+		contextGames: contextCount,
 	})
 }
 
@@ -240,4 +254,10 @@ type asyncOutcome struct {
 	// backend is the tier that was called, for inference.used attribution and the
 	// gen_ai.request.model on the infer span.
 	backend Backend
+	// contextGames is the M7-2 rolling-context-window COUNT actually injected into
+	// this call's prompt (#929): the number of recent game summaries rendered into the
+	// cross-game narrative block. Carried from runInfer to the apply path so the
+	// agent.llm.infer span (emitted at apply time) records AttrLLMContextGames, exactly
+	// as the synchronous llmDecide path does. 0 when no window is wired (un-wired loops).
+	contextGames int
 }

--- a/services/agent/decision/context_window_test.go
+++ b/services/agent/decision/context_window_test.go
@@ -4,13 +4,16 @@ import (
 	"context"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 
 	"github.com/joustmania/agent/gamecontext"
 	"github.com/joustmania/agent/gamesummary"
 	"github.com/joustmania/agent/gamewindow"
+	"github.com/joustmania/agent/llm"
 )
 
 // context_window_test.go drives the M7-2 rolling-context-window injection (#929)
@@ -198,6 +201,140 @@ func TestContextWindow_CaptureSpanAlsoCarriesCount(t *testing.T) {
 	}
 	if v, ok := attrValue(caps[0], AttrLLMPromptSystem); !ok || !strings.Contains(v.AsString(), "PRIOR GAMES") {
 		t.Errorf("capture span System prompt missing the cross-game block")
+	}
+}
+
+// recordingBlockingBackend is the async-path fake for #929: like blockingBackend
+// (its Infer blocks on a release channel so the test can assert the loop returned
+// while inference is still running) but it also CAPTURES the System prompt it
+// received, so the test can prove the cross-game block reached the PRODUCTION
+// (async, #917) prompt — runInfer assembles the prompt, not the sync llmDecide path.
+type recordingBlockingBackend struct {
+	name             string
+	response         string
+	release          chan struct{}
+	started          chan struct{}
+	mu               sync.Mutex
+	lastPromptSystem string
+	calls            int
+}
+
+func newRecordingBlockingBackend(name, response string) *recordingBlockingBackend {
+	return &recordingBlockingBackend{
+		name:     name,
+		response: response,
+		release:  make(chan struct{}),
+		started:  make(chan struct{}),
+	}
+}
+
+func (b *recordingBlockingBackend) Name() string                   { return b.name }
+func (b *recordingBlockingBackend) Available(context.Context) bool { return true }
+
+func (b *recordingBlockingBackend) Infer(ctx context.Context, p llm.Prompt) (string, error) {
+	b.mu.Lock()
+	b.calls++
+	first := b.calls == 1
+	b.lastPromptSystem = p.System
+	b.mu.Unlock()
+	if first {
+		close(b.started)
+	}
+	select {
+	case <-b.release:
+		return b.response, nil
+	case <-ctx.Done():
+		return "", ctx.Err()
+	}
+}
+
+func (b *recordingBlockingBackend) systemPrompt() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.lastPromptSystem
+}
+
+// TestContextWindow_AsyncPathInjectsBlock is the #929 re-integration coverage onto
+// the #917 ASYNC inference path — the path PRODUCTION takes. A loop wired WITH a
+// context provider (async enabled) + a populated context window must, when it fires
+// an async Infer, carry the rendered "PRIOR GAMES" block in the System prompt the
+// backend receives AND stamp agent.llm.context_games = the injected count on the
+// agent.llm.infer span (emitted at apply time). Without runInfer's renderContextBlock
+// call this whole feature would be bypassed in production — this test proves it isn't.
+func TestContextWindow_AsyncPathInjectsBlock(t *testing.T) {
+	be := newRecordingBlockingBackend("phi4-mini", validShieldResponse)
+	snap := asyncSnapshot()
+	snap.ContextGames = 2
+
+	provider := newFakeContextProvider()
+	provider.set("g1", activeContext("g1", "AAAA"))
+	l, sr, _ := asyncLoop(t, snap, resolverWith(be), provider, "g1", nil)
+
+	store := gamewindow.NewStore()
+	recordDistinctGames(store, 2, 4, 6) // oldest players=2, newest players=6; N=2 -> 4 & 6
+	l.SetContextWindow(store)
+
+	// Fire the async inference (the loop returns promptly; Infer is blocked).
+	l.OnEvaluate(context.Background(), activeContext("g1", "AAAA"), testTrigger())
+	select {
+	case <-be.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("async Infer never started — the loop did not fire on the async path")
+	}
+	close(be.release) // let the call complete
+	l.AwaitInflight() // join the apply goroutine so the infer span is recorded
+
+	if be.calls != 1 {
+		t.Fatalf("backend Infer calls = %d, want 1", be.calls)
+	}
+
+	// 1) The PRODUCTION prompt carries the rendered cross-game block for the last 2.
+	got := be.systemPrompt()
+	want := gamewindow.Render(store.Recent(2))
+	if !strings.Contains(got, want) {
+		t.Errorf("async prompt System missing the cross-game block:\n--- want block ---\n%s\n--- got system ---\n%s", want, got)
+	}
+	// N=2: the 2 newest (players=4,6) appear; the oldest (players=2) does NOT.
+	if !strings.Contains(got, playersLine(4)) || !strings.Contains(got, playersLine(6)) {
+		t.Errorf("async prompt missing the 2 newest games:\n%s", got)
+	}
+	if strings.Contains(got, playersLine(2)) {
+		t.Errorf("async prompt includes the oldest game (players=2), but N=2 excludes it:\n%s", got)
+	}
+
+	// 2) The agent.llm.infer span (emitted at APPLY time) carries the injected count.
+	if c := lastInjectedCount(t, sr); c != 2 {
+		t.Errorf("async infer span %s = %d, want 2", AttrLLMContextGames, c)
+	}
+}
+
+// TestContextWindow_AsyncNilWindowNoBlock confirms an async loop WITHOUT a context
+// window injects no cross-game block and reports context_games = 0 — the async path
+// is purely additive, exactly like the sync path's nil-window case.
+func TestContextWindow_AsyncNilWindowNoBlock(t *testing.T) {
+	be := newRecordingBlockingBackend("phi4-mini", validShieldResponse)
+	snap := asyncSnapshot()
+	snap.ContextGames = 3 // flag set, but no window wired
+
+	provider := newFakeContextProvider()
+	provider.set("g1", activeContext("g1", "AAAA"))
+	l, sr, _ := asyncLoop(t, snap, resolverWith(be), provider, "g1", nil)
+	// NOTE: no l.SetContextWindow — window is nil.
+
+	l.OnEvaluate(context.Background(), activeContext("g1", "AAAA"), testTrigger())
+	select {
+	case <-be.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("async Infer never started")
+	}
+	close(be.release)
+	l.AwaitInflight()
+
+	if strings.Contains(be.systemPrompt(), "PRIOR GAMES") {
+		t.Errorf("nil window must inject no cross-game block on the async path:\n%s", be.systemPrompt())
+	}
+	if c := lastInjectedCount(t, sr); c != 0 {
+		t.Errorf("async nil-window injected count = %d, want 0", c)
 	}
 }
 

--- a/services/agent/decision/context_window_test.go
+++ b/services/agent/decision/context_window_test.go
@@ -1,0 +1,231 @@
+package decision
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"testing"
+
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"github.com/joustmania/agent/gamecontext"
+	"github.com/joustmania/agent/gamesummary"
+	"github.com/joustmania/agent/gamewindow"
+)
+
+// context_window_test.go drives the M7-2 rolling-context-window injection (#929)
+// end-to-end through the llm decision path: a wired gamewindow.Store + the #739
+// inferBackend fake (records lastPromptSystem) proves the rendered cross-game block
+// reaches the prompt, that N is read LIVE from the flag, and that the inference span
+// carries agent.llm.context_games = the injected count.
+
+// recordDistinctGames records summaries whose RENDERED header line is unique (the
+// player count varies), so a test can assert WHICH games landed in the prompt — the
+// rendered block uses an ordinal, not the GameID, so we distinguish on a visible
+// field. Recorded oldest-first; the last recorded is the newest.
+func recordDistinctGames(store *gamewindow.Store, playerCounts ...int) {
+	for _, pc := range playerCounts {
+		store.Record(gamesummary.Summary{
+			GameKind:         "real",
+			GameMode:         "joust",
+			PlayerCount:      pc,
+			EliminationCount: 3,
+		})
+	}
+}
+
+// playersLine is the rendered substring identifying a game with the given player
+// count in the cross-game block (each game renders "... players=<n> ...").
+func playersLine(pc int) string {
+	return "players=" + strconv.Itoa(pc) + " "
+}
+
+func TestContextWindow_BlockReachesPrompt(t *testing.T) {
+	be := &inferBackend{name: "phi4-mini", response: validShieldResponse}
+	snap := llmDecideSnapshot()
+	snap.ContextGames = 2
+
+	l, sr, _ := llmDecideLoop(t, snap, resolverWith(be), []Decision{{Intervention: "play_audio_cue", Reason: "rules"}})
+
+	store := gamewindow.NewStore()
+	recordDistinctGames(store, 2, 4, 6) // oldest players=2, newest players=6; N=2 -> 4 & 6
+	l.SetContextWindow(store)
+
+	l.OnEvaluate(context.Background(), gamecontext.GameContext{SessionID: "s1", GameKind: "real"}, testTrigger())
+
+	if be.calls != 1 {
+		t.Fatalf("backend Infer calls = %d, want 1", be.calls)
+	}
+	// The prompt must contain the EXACT rendered block for the last 2 summaries.
+	want := gamewindow.Render(store.Recent(2))
+	if !strings.Contains(be.lastPromptSystem, want) {
+		t.Errorf("prompt System missing the rendered cross-game block:\n--- want block ---\n%s\n--- got system ---\n%s", want, be.lastPromptSystem)
+	}
+	// It must reflect N=2: the 2 newest (players=4, players=6) appear, the oldest
+	// (players=2) does NOT.
+	if !strings.Contains(be.lastPromptSystem, playersLine(4)) || !strings.Contains(be.lastPromptSystem, playersLine(6)) {
+		t.Errorf("prompt missing the 2 newest games:\n%s", be.lastPromptSystem)
+	}
+	if strings.Contains(be.lastPromptSystem, playersLine(2)) {
+		t.Errorf("prompt includes the oldest game (players=2), but N=2 should exclude it:\n%s", be.lastPromptSystem)
+	}
+
+	// The inference span carries context_games = 2 (the injected COUNT).
+	if c := injectedCount(t, sr); c != 2 {
+		t.Errorf("%s = %d, want 2", AttrLLMContextGames, c)
+	}
+}
+
+func TestContextWindow_FlagIsLive(t *testing.T) {
+	be := &inferBackend{name: "phi4-mini", response: validShieldResponse}
+	fl := &settableFlags{snap: llmDecideSnapshot()}
+	fl.snap.ContextGames = 1
+
+	l, sr, _ := llmDecideLoop(t, fl.snap, resolverWith(be), []Decision{{Intervention: "play_audio_cue", Reason: "rules"}})
+	l.Flags = fl // swap in the mutable source so the flag can be flipped mid-test
+
+	store := gamewindow.NewStore()
+	recordDistinctGames(store, 2, 4, 6) // oldest players=2, newest players=6
+	l.SetContextWindow(store)
+
+	// First call: N=1 -> only the newest (players=6) injected, count 1.
+	l.OnEvaluate(context.Background(), gamecontext.GameContext{SessionID: "s1", GameKind: "real"}, testTrigger())
+	if c := lastInjectedCount(t, sr); c != 1 {
+		t.Fatalf("first call injected count = %d, want 1", c)
+	}
+	if !strings.Contains(be.lastPromptSystem, playersLine(6)) {
+		t.Errorf("N=1 should inject the newest game (players=6):\n%s", be.lastPromptSystem)
+	}
+	if strings.Contains(be.lastPromptSystem, playersLine(4)) {
+		t.Errorf("N=1 should inject ONLY the newest, but players=4 appeared:\n%s", be.lastPromptSystem)
+	}
+
+	// Flip the flag LIVE to N=3 — read on the very next call, no restart.
+	fl.snap.ContextGames = 3
+	l.OnEvaluate(context.Background(), gamecontext.GameContext{SessionID: "s1", GameKind: "real"}, testTrigger())
+	if c := lastInjectedCount(t, sr); c != 3 {
+		t.Fatalf("second call injected count = %d, want 3 (live flag)", c)
+	}
+	// All three games now appear, including the oldest (players=2).
+	for _, pc := range []int{2, 4, 6} {
+		if !strings.Contains(be.lastPromptSystem, playersLine(pc)) {
+			t.Errorf("N=3 should inject all three games, but players=%d missing:\n%s", pc, be.lastPromptSystem)
+		}
+	}
+}
+
+func TestContextWindow_NilWindowNoBlockZeroCount(t *testing.T) {
+	be := &inferBackend{name: "phi4-mini", response: validShieldResponse}
+	snap := llmDecideSnapshot()
+	snap.ContextGames = 3 // even with a flag set, no window means no block
+
+	// No SetContextWindow call: contextWindow stays nil.
+	l, sr, _ := llmDecideLoop(t, snap, resolverWith(be), nil)
+
+	l.OnEvaluate(context.Background(), gamecontext.GameContext{SessionID: "s1", GameKind: "real"}, testTrigger())
+
+	if strings.Contains(be.lastPromptSystem, "PRIOR GAMES") {
+		t.Errorf("nil window must inject no cross-game block, but PRIOR GAMES appeared:\n%s", be.lastPromptSystem)
+	}
+	if c := lastInjectedCount(t, sr); c != 0 {
+		t.Errorf("nil window injected count = %d, want 0", c)
+	}
+}
+
+func TestContextWindow_ClampsToRetentionCap(t *testing.T) {
+	be := &inferBackend{name: "phi4-mini", response: validShieldResponse}
+	snap := llmDecideSnapshot()
+	snap.ContextGames = gamewindow.RetentionCap + 50 // absurd over-config
+
+	l, sr, _ := llmDecideLoop(t, snap, resolverWith(be), nil)
+
+	store := gamewindow.NewStore()
+	// Record exactly 2 games; the injected count is bounded by what's held, not the flag.
+	recordDistinctGames(store, 2, 4)
+	l.SetContextWindow(store)
+
+	l.OnEvaluate(context.Background(), gamecontext.GameContext{SessionID: "s1", GameKind: "real"}, testTrigger())
+
+	if c := lastInjectedCount(t, sr); c != 2 {
+		t.Errorf("injected count = %d, want 2 (clamped to window length, flag was %d)", c, snap.ContextGames)
+	}
+}
+
+func TestContextWindow_EmptyWindowRendersMarker(t *testing.T) {
+	be := &inferBackend{name: "phi4-mini", response: validShieldResponse}
+	snap := llmDecideSnapshot()
+	snap.ContextGames = 3
+
+	// Window wired but EMPTY (no games ended yet): the block is still present with the
+	// explicit "(no prior games)" marker, and the count is 0.
+	l, sr, _ := llmDecideLoop(t, snap, resolverWith(be), nil)
+	l.SetContextWindow(gamewindow.NewStore())
+
+	l.OnEvaluate(context.Background(), gamecontext.GameContext{SessionID: "s1", GameKind: "real"}, testTrigger())
+
+	if !strings.Contains(be.lastPromptSystem, "PRIOR GAMES") {
+		t.Errorf("wired empty window should still render the PRIOR GAMES section:\n%s", be.lastPromptSystem)
+	}
+	if !strings.Contains(be.lastPromptSystem, "(no prior games)") {
+		t.Errorf("empty window should render the (no prior games) marker:\n%s", be.lastPromptSystem)
+	}
+	if c := lastInjectedCount(t, sr); c != 0 {
+		t.Errorf("empty window injected count = %d, want 0", c)
+	}
+}
+
+// TestContextWindow_CaptureSpanAlsoCarriesCount asserts the capture path
+// (agent.llm.prompt, emitted on the first throttled cycle) ALSO carries
+// context_games and injects the same block — the cheap-on-capture half of #929.
+func TestContextWindow_CaptureSpanAlsoCarriesCount(t *testing.T) {
+	be := &inferBackend{name: "phi4-mini", response: validShieldResponse}
+	snap := llmDecideSnapshot()
+	snap.ContextGames = 2
+
+	l, sr, _ := llmDecideLoop(t, snap, resolverWith(be), nil)
+	store := gamewindow.NewStore()
+	recordDistinctGames(store, 2, 4, 6)
+	l.SetContextWindow(store)
+
+	l.OnEvaluate(context.Background(), gamecontext.GameContext{SessionID: "s1", GameKind: "real"}, testTrigger())
+
+	caps := spansByName(sr.Ended(), SpanLLMPrompt)
+	if len(caps) != 1 {
+		t.Fatalf("agent.llm.prompt spans = %d, want 1", len(caps))
+	}
+	if v, ok := attrValue(caps[0], AttrLLMContextGames); !ok || v.AsInt64() != 2 {
+		t.Errorf("capture span %s = %d (present=%v), want 2", AttrLLMContextGames, v.AsInt64(), ok)
+	}
+	if v, ok := attrValue(caps[0], AttrLLMPromptSystem); !ok || !strings.Contains(v.AsString(), "PRIOR GAMES") {
+		t.Errorf("capture span System prompt missing the cross-game block")
+	}
+}
+
+// injectedCount reads the FIRST inference span's context_games attribute.
+func injectedCount(t *testing.T, sr *tracetest.SpanRecorder) int64 {
+	t.Helper()
+	infs := spansByName(sr.Ended(), SpanLLMInfer)
+	if len(infs) == 0 {
+		t.Fatalf("no agent.llm.infer span recorded")
+	}
+	v, ok := attrValue(infs[0], AttrLLMContextGames)
+	if !ok {
+		t.Fatalf("first agent.llm.infer span missing %s", AttrLLMContextGames)
+	}
+	return v.AsInt64()
+}
+
+// lastInjectedCount reads the MOST RECENT inference span's context_games attribute,
+// for tests that call OnEvaluate more than once (the live-flag test).
+func lastInjectedCount(t *testing.T, sr *tracetest.SpanRecorder) int64 {
+	t.Helper()
+	infs := spansByName(sr.Ended(), SpanLLMInfer)
+	if len(infs) == 0 {
+		t.Fatalf("no agent.llm.infer span recorded")
+	}
+	v, ok := attrValue(infs[len(infs)-1], AttrLLMContextGames)
+	if !ok {
+		t.Fatalf("last agent.llm.infer span missing %s", AttrLLMContextGames)
+	}
+	return v.AsInt64()
+}

--- a/services/agent/decision/decision.go
+++ b/services/agent/decision/decision.go
@@ -50,6 +50,7 @@ import (
 
 	"github.com/joustmania/agent/flags"
 	"github.com/joustmania/agent/gamecontext"
+	"github.com/joustmania/agent/gamesummary"
 	"github.com/joustmania/agent/llm"
 )
 
@@ -105,6 +106,19 @@ type ActionSink interface {
 // *flags.Flags satisfies it; tests supply a fake.
 type FlagSource interface {
 	Evaluate(ctx context.Context) flags.Snapshot
+}
+
+// ContextWindow is the M7-2 rolling cross-game context source (#929): on the llm
+// decision path the loop pulls the last N recent game summaries from it and renders
+// them into the prompt's narrative context block. *gamewindow.Store satisfies it
+// (one shared instance across all loops — the window is GLOBAL cross-session
+// memory, like the LLM budget/resolver). It returns the last n summaries
+// oldest-first (Store.Recent's contract); the loop clamps n to the window's
+// retention cap. Nil (the construction default, rules-only deployments, and most
+// tests) means no cross-game block is injected and context_games is 0 — purely
+// additive over the #739 path.
+type ContextWindow interface {
+	Recent(n int) []gamesummary.Summary
 }
 
 // objectivePublisher is the optional seam the loop uses to push the per-cycle
@@ -227,6 +241,15 @@ type Loop struct {
 	// place (see async_infer.go). A nil ctxProvider keeps decide() on the synchronous
 	// #739 path, so a Loop not wired for async is behavior-unchanged.
 	asyncInferState
+
+	// contextWindow is the SHARED M7-2 rolling cross-game context source (#929),
+	// injected via SetContextWindow from the one gamewindow.Store main.go constructs
+	// (global cross-session memory, like budget/resolver). On a gate-admitted llm
+	// cycle llmDecide pulls Recent(N) from it, renders the narrative context block,
+	// and records context_games on the inference span. Nil = no cross-game block
+	// (rules-only / unwired / tests): the prompt carries no PRIOR GAMES section and
+	// context_games is 0.
+	contextWindow ContextWindow
 }
 
 // NewLoop builds a Loop with the no-op rules/actions stubs, the global tracer,

--- a/services/agent/decision/decision.go
+++ b/services/agent/decision/decision.go
@@ -290,6 +290,16 @@ func (l *Loop) SetLLMBudget(b *llmBudget) { l.budget = b }
 // the loop serves.
 func (l *Loop) SetResolver(r *Resolver) { l.resolver = r }
 
+// SetContextWindow injects the SHARED M7-2 rolling cross-game context source
+// (#929). main.go constructs ONE gamewindow.Store (global cross-session memory, one
+// window shared across every per-game loop — like the budget/resolver) and calls
+// this on every Loop the factory builds, so each loop's llm path renders the SAME
+// recent-games window. A nil window (the construction default, rules-only
+// deployments, and most tests) means no cross-game block is injected and
+// context_games is 0 — purely additive over the #739 path. Not safe to call
+// concurrently with OnEvaluate — set it during construction, before the loop serves.
+func (l *Loop) SetContextWindow(w ContextWindow) { l.contextWindow = w }
+
 // SetThrottle overrides the log/span throttle interval. It is read once at
 // startup from decision.throttle_seconds (#766 F5); a non-positive value leaves
 // the default in place. Not safe to call concurrently with OnEvaluate — set it
@@ -665,19 +675,26 @@ func (l *Loop) captureLLMPrompt(ctx context.Context, snapshot flags.Snapshot, c 
 	if now == nil {
 		now = time.Now
 	}
+	// M7-2 (#929): inject the SAME cross-game context block the real inference path
+	// (llmDecide) would, so a captured prompt matches what the agent would actually
+	// send, and record the injected count on this capture span too (cheap — the block
+	// was already rendered for the prompt). Nil window -> empty block, count 0.
+	contextBlock, contextCount := l.renderContextBlock(snapshot)
 	prompt := llm.Build(llm.BuildInput{
-		Snapshot: snapshot,
-		Context:  c,
-		Now:      now(),
+		Snapshot:     snapshot,
+		Context:      c,
+		Now:          now(),
+		ContextBlock: contextBlock,
 	})
-	_, span := l.Tracer.Start(ctx, SpanLLMPrompt,
-		trace.WithAttributes(llmPromptAttributes(llmPromptAttrs{
-			prompt:     prompt,
-			objectives: snapshot.Objectives,
-			allowed:    snapshot.InterventionsAllowed,
-			gameKind:   c.GameKind,
-			gameID:     c.SessionID,
-		})...))
+	attrs := llmPromptAttributes(llmPromptAttrs{
+		prompt:     prompt,
+		objectives: snapshot.Objectives,
+		allowed:    snapshot.InterventionsAllowed,
+		gameKind:   c.GameKind,
+		gameID:     c.SessionID,
+	})
+	attrs = append(attrs, attribute.Int(AttrLLMContextGames, contextCount))
+	_, span := l.Tracer.Start(ctx, SpanLLMPrompt, trace.WithAttributes(attrs...))
 	span.End()
 
 	l.Log.Info("agent.llm.prompt_captured",

--- a/services/agent/decision/llm_decide.go
+++ b/services/agent/decision/llm_decide.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/joustmania/agent/flags"
 	"github.com/joustmania/agent/gamecontext"
+	"github.com/joustmania/agent/gamewindow"
 	"github.com/joustmania/agent/llm"
 )
 
@@ -81,13 +82,23 @@ func (l *Loop) llmDecide(ctx context.Context, backend Backend, snapshot flags.Sn
 		now = time.Now
 	}
 
+	// M7-2 cross-game context (#929): pull the last N recent game summaries from the
+	// shared rolling window and render them into the prompt's narrative context block,
+	// so the model reasons across games/sessions — not just this game's live snapshot.
+	// N is the LIVE flag (snapshot.ContextGames), clamped to the window's retention
+	// cap; contextCount is how many summaries were ACTUALLY injected (bounded by how
+	// many games have ended), recorded on the spans below. A nil window (rules-only /
+	// unwired / tests) yields an empty block and a 0 count — purely additive.
+	contextBlock, contextCount := l.renderContextBlock(snapshot)
+
 	// Reuse the objective-aware prompt builder (the same one the capture span uses).
 	// The System prompt already encodes the objective weights and the allow-list, so
 	// the model is asked to optimize for THIS session's objectives.
 	prompt := llm.Build(llm.BuildInput{
-		Snapshot: snapshot,
-		Context:  c,
-		Now:      now(),
+		Snapshot:     snapshot,
+		Context:      c,
+		Now:          now(),
+		ContextBlock: contextBlock,
 	})
 
 	// Record the inference as a gen_ai.* child span so the audit trace shows the
@@ -100,8 +111,12 @@ func (l *Loop) llmDecide(ctx context.Context, backend Backend, snapshot flags.Sn
 	// served by "phi4-mini") the request really went to the lower tier, and the span
 	// must say so to match the sibling decision span's inference.used. The capture
 	// span legitimately keeps the configured model; this is a real request.
+	//
+	// agent.llm.context_games (#929) is recorded here on the REAL inference span with
+	// the COUNT actually injected — what the model truly saw, not the raw flag.
 	infCtx, span := l.Tracer.Start(ctx, SpanLLMInfer, trace.WithAttributes(
-		semconvGenAIChat(backend.Name())...,
+		append(semconvGenAIChat(backend.Name()),
+			attribute.Int(AttrLLMContextGames, contextCount))...,
 	))
 	defer span.End()
 
@@ -164,4 +179,35 @@ func (l *Loop) llmDecide(ctx context.Context, backend Backend, snapshot flags.Sn
 		ObjectiveServed: resp.ObjectiveServed,
 		Objectives:      snapshot.Objectives,
 	}}, ""
+}
+
+// renderContextBlock pulls the last N recent game summaries from the shared M7-2
+// rolling window and renders the cross-game NARRATIVE CONTEXT BLOCK (#929),
+// returning the block plus the COUNT actually injected. N is the LIVE flag
+// (snapshot.ContextGames), clamped to [0, gamewindow.RetentionCap] so a
+// mis-/over-configured flag can never ask for more than the window can ever hold;
+// the window itself further bounds the result by how many games have actually
+// ended (Store.Recent(N) returns all it holds when N exceeds its length). The
+// returned count is len(Recent), i.e. what the prompt + the span attribute report —
+// what the model truly saw, never the raw flag.
+//
+// A nil window (no SetContextWindow — rules-only deployments and most tests) renders
+// no block and reports 0, so the prompt carries no PRIOR GAMES section: M7-2 is
+// purely additive over the #739 path. When a window IS wired, gamewindow.Render
+// always returns a non-empty block (it renders "(no prior games)" for an empty
+// window), so the section is present on every llm call (acceptance: "each LLM call
+// includes the last N game summaries as a narrative context block").
+func (l *Loop) renderContextBlock(snapshot flags.Snapshot) (block string, count int) {
+	if l.contextWindow == nil {
+		return "", 0
+	}
+	n := snapshot.ContextGames
+	if n < 0 {
+		n = 0
+	}
+	if n > gamewindow.RetentionCap {
+		n = gamewindow.RetentionCap
+	}
+	recent := l.contextWindow.Recent(n)
+	return gamewindow.Render(recent), len(recent)
 }

--- a/services/agent/decision/telemetry.go
+++ b/services/agent/decision/telemetry.go
@@ -115,6 +115,18 @@ const (
 	DiscardTimeout = "timeout"
 )
 
+// AttrLLMContextGames is the M7-2 rolling-context-window size recorded on the
+// inference span (#929): the COUNT of recent game summaries actually injected into
+// this call's prompt as the cross-game narrative context block. It is the live N
+// (flags.Snapshot.ContextGames, clamped to [0, gamewindow.RetentionCap] and bounded
+// by how many games have ended), NOT the configured flag value — so the span shows
+// what the model really saw. Recorded on agent.llm.infer (the REAL inference span,
+// SpanLLMInfer — the issue's "agent.inference") and, cheaply, on agent.llm.prompt
+// (the capture span) so the count is queryable on both. Naming note: the issue
+// prose says agent.inference, but the codebase's real inference span is
+// agent.llm.infer (#739); the attribute lands there, not on an invented span.
+const AttrLLMContextGames = "agent.llm.context_games"
+
 // AttrLLMInferError records why an llm.infer span did not yield a usable Decision
 // (#739): the Infer transport error, or the llm.Decode rejection reason
 // (empty / not-JSON / missing-field / out-of-vocab-objective). Present only on the

--- a/services/agent/flags/flags.go
+++ b/services/agent/flags/flags.go
@@ -47,6 +47,14 @@ const (
 	// cycle like the other gate flags so the budget can be tuned live on stage.
 	keyLLMLatencyBudget = "llm.latency_budget_seconds"
 
+	// M7-2 rolling game context window (#929). How many recent game summaries the
+	// agent injects into EVERY llm prompt as the cross-game narrative context block.
+	// Read EVERY cycle (never cached) on the decision hot path — exactly like the
+	// #847 gate flags above — so retuning N on stage takes effect on the very next
+	// llm call with no restart. The decision path clamps the value to
+	// [0, gamewindow.RetentionCap].
+	keyLLMContextGames = "llm.context_games"
+
 	// Fitness thresholds (#731). The game-objective fitness flags.
 	keyEnduranceMinSessionSeconds  = "fitness.endurance.min_session_seconds"
 	keyBalancedMaxSkillGap         = "fitness.balanced.max_skill_gap"
@@ -111,6 +119,11 @@ const (
 	// healthy backend to answer, short enough that a hung tier degrades to rules
 	// within one decision interval.
 	DefaultLLMLatencyBudgetSeconds = 8.0
+	// DefaultLLMContextGames is the M7-2 cross-game context window size (#929): how
+	// many recent game summaries to inject into every llm prompt when flagd is
+	// unreachable or the flag is undefined. 3 mirrors the agent.json defaultVariant
+	// — a few games of memory, well under gamewindow.RetentionCap.
+	DefaultLLMContextGames = 3
 
 	// Fitness threshold defaults (#731), mirroring the services/flagd/agent.json
 	// defaultVariants. Applied when flagd is unreachable or a flag is undefined.
@@ -373,6 +386,13 @@ type Snapshot struct {
 	// LLMGate holds the three-layer LLM call gate (#847): eligibility, per-game
 	// cadence, and the global per-minute request budget.
 	LLMGate LLMGate
+	// ContextGames is the M7-2 rolling context-window size (#929, llm.context_games):
+	// how many recent game summaries to inject into this cycle's llm prompt as the
+	// cross-game narrative context block. Read every cycle so retuning N is live; the
+	// decision path clamps it to [0, gamewindow.RetentionCap] before assembling the
+	// block. A non-positive value injects no prior games (the block renders the
+	// explicit "(no prior games)" marker).
+	ContextGames int
 	// Fitness holds the per-objective fitness thresholds (#731).
 	Fitness Fitness
 	// BluetoothFitness holds the infrastructure fitness thresholds (#735).
@@ -423,6 +443,11 @@ func (f *Flags) Evaluate(ctx context.Context) Snapshot {
 			MaxInterventionsPerMinute: f.intFlag(ctx, keyMaxInterventionsPerMinute, DefaultMaxInterventionsPerMinute),
 		},
 		LLMGate: f.llmGate(ctx),
+		// M7-2 (#929): the cross-game context-window size, read every cycle so a
+		// runtime change to llm.context_games is honored on the next llm call. Uses the
+		// typed intFlag getter (the flagd numeric-flag gotcha: a numeric flag read via
+		// ObjectValue resolves as a silent TYPE_MISMATCH default — see llmGate).
+		ContextGames: f.intFlag(ctx, keyLLMContextGames, DefaultLLMContextGames),
 		Fitness: Fitness{
 			EnduranceMinSessionSeconds:     f.intFlag(ctx, keyEnduranceMinSessionSeconds, DefaultEnduranceMinSessionSeconds),
 			BalancedMaxSkillGap:            f.floatFlag(ctx, keyBalancedMaxSkillGap, DefaultBalancedMaxSkillGap),

--- a/services/agent/gamesummary/coordinator.go
+++ b/services/agent/gamesummary/coordinator.go
@@ -56,6 +56,19 @@ const (
 // remembered game. 8 comfortably exceeds GAME_MAX_CONCURRENT_GAMES=4.
 const dedupeWindow = 8
 
+// Observer is notified of each game Summary the moment it is built, BEFORE it is
+// written to disk — the M7-2 rolling-window seam (#929). The window store
+// (gamewindow.Store) satisfies it: chaining it here means the cross-game context
+// window advances on the SAME game-end path that writes the JSON file, with no
+// disk re-read and no staleness. It is OPTIONAL (nil = M7-1 behavior unchanged):
+// the summary file is still written whether or not an observer is wired. Called
+// once per game (inside the dedupe), for BOTH real and shadow games.
+type Observer interface {
+	// Record ingests one freshly-built game Summary. It must not block (the window
+	// store's Record is a mutex-guarded append) — it runs on the game-end path.
+	Record(Summary)
+}
+
 // Coordinator builds + persists one summary per game on the store's OnGameEnd
 // signal (#928). It is wired to EVERY gamecontext.Store partition's OnGameEnd in
 // main(), so one coordinator dedupes across all partitions. Safe for concurrent
@@ -65,6 +78,11 @@ type Coordinator struct {
 	writer *Writer
 	tracer trace.Tracer
 	log    *slog.Logger
+	// observer, when non-nil, is notified of each built Summary (#929 M7-2): the
+	// rolling context-window store hangs off here so the window advances on every
+	// game end. Set once at construction via SetObserver, before the coordinator
+	// serves, so no lock is needed around the read.
+	observer Observer
 	// now is injectable for tests; nil uses time.Now. It stamps Summary.GeneratedAt
 	// only — the aggregation itself is clock-free.
 	now func() time.Time
@@ -90,6 +108,14 @@ func NewCoordinator(w *Writer, log *slog.Logger) *Coordinator {
 		claimed: make(map[string]struct{}),
 	}
 }
+
+// SetObserver wires the M7-2 rolling-window observer (#929): main.go constructs
+// ONE gamewindow.Store (the global cross-game memory, shared across all per-game
+// loops like the LLM budget/resolver) and registers it here, so the window
+// advances on every game end. Optional and additive — a coordinator with no
+// observer is exactly the M7-1 behavior. Set during construction, before the
+// store fires OnGameEnd, so the field read in OnGameEnd needs no lock.
+func (c *Coordinator) SetObserver(o Observer) { c.observer = o }
 
 // instrumentationName scopes the coordinator's tracer, matching the agent module
 // convention used by the decision package.
@@ -127,6 +153,14 @@ func (c *Coordinator) OnGameEnd(gc gamecontext.GameContext) {
 	defer span.End()
 
 	summary := BuildSummary(gc, BuildOptions{Now: now()})
+
+	// Advance the M7-2 rolling context window (#929) FIRST — before the disk write —
+	// so the cross-game memory updates on every game end even if persistence fails:
+	// the window is the live LLM-path input, independent of the on-disk file. Skips
+	// cleanly when no observer is wired (M7-1 behavior).
+	if c.observer != nil {
+		c.observer.Record(summary)
+	}
 
 	span.SetAttributes(
 		attribute.String(attrGameID, summary.GameID),

--- a/services/agent/gamewindow/render.go
+++ b/services/agent/gamewindow/render.go
@@ -1,0 +1,167 @@
+package gamewindow
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/joustmania/agent/gamesummary"
+)
+
+// blockHeader labels the cross-game context section in the prompt. It is a fixed,
+// greppable marker (#929 acceptance: "each LLM call includes the last N game
+// summaries as a narrative context block") so the block is findable in a captured
+// prompt and in a Jaeger llm.prompt.system attribute by name, independent of how
+// many games it holds.
+const blockHeader = "PRIOR GAMES (most recent last; cross-game memory):"
+
+// emptyMarker is rendered when the window is empty (no games have ended yet, or N
+// resolved to 0). The section is ALWAYS present and ALWAYS greppable — an empty
+// window renders an explicit marker rather than omitting the section — so the
+// prompt shape is deterministic and a reader can tell "no prior games" from "the
+// block was dropped". Mirrors the prompt builder's "(none)" timeline convention.
+const emptyMarker = "  (no prior games)"
+
+// Render assembles the compact, deterministic NARRATIVE CONTEXT BLOCK from the
+// given summaries — the last N the decision path pulled via Store.Recent(N) (#929
+// M7-2). It is the cross-game memory injected into every llm prompt. The block is:
+//
+//   - COMPACT, not the full JSON: each game renders to ONE summary line plus at
+//     most a couple of detail lines (dominance, notable interventions), so N games
+//     stay a few lines each — the model gets the narrative, not a telemetry dump
+//     (the full Summary lives in the on-disk file / the agent.game.summary span).
+//   - DETERMINISTic: pure over its input (no clock/random/map-iteration order —
+//     the Summary's own slices are already serial-/order-sorted by the M7-1
+//     builder), so the same window always renders byte-identically. The golden
+//     prompt tests rely on this.
+//   - ALWAYS PRESENT: an empty slice renders the header + the explicit
+//     "(no prior games)" marker, so the section never vanishes.
+//
+// summaries are oldest-first (Store.Recent's contract); they render in that order
+// under "most recent last" so the model reads them chronologically toward the
+// present game.
+func Render(summaries []gamesummary.Summary) string {
+	var b strings.Builder
+	b.WriteString(blockHeader)
+	b.WriteString("\n")
+	if len(summaries) == 0 {
+		b.WriteString(emptyMarker)
+		return b.String()
+	}
+	for i, s := range summaries {
+		renderSummary(&b, i+1, s)
+	}
+	// Trim the trailing newline so the block has no dangling blank line — a stable,
+	// minimal shape for the golden tests and the prompt concatenation.
+	return strings.TrimRight(b.String(), "\n")
+}
+
+// renderSummary writes one game's compact lines: a header line with the at-a-glance
+// counts, then optional dominance and intervention-outcome lines only when they
+// carry signal. idx is the 1-based position in the rendered window (for a stable,
+// human-readable ordinal — NOT the game id, which is high-cardinality and not
+// useful to the model's cross-game reasoning).
+func renderSummary(b *strings.Builder, idx int, s gamesummary.Summary) {
+	// Header: kind, mode, duration, players, eliminations, interventions. These are
+	// the narrative skeleton — "a 92s real joust game with 4 players, 3 eliminated,
+	// 2 agent interventions" — enough for the model to place the game without the
+	// per-player arcs (which would blow the budget for N games).
+	fmt.Fprintf(b, "  %d. %s/%s duration=%s players=%d eliminations=%d interventions=%d\n",
+		idx,
+		kindOrUnknown(s.GameKind),
+		modeOrUnknown(s.GameMode),
+		durationOrUnknown(s.DurationSeconds),
+		s.PlayerCount,
+		s.EliminationCount,
+		s.InterventionCount,
+	)
+
+	// Dominance, only when a player clearly ran away with the game — the single most
+	// narrative-worthy outcome (#928 dominant-player). Named heuristic + margin so the
+	// model sees WHY, mirroring the on-disk field's transparency.
+	if s.Dominance.Dominated && s.Dominance.Serial != "" {
+		fmt.Fprintf(b, "     dominated_by=%s (%s, margin=%s)\n",
+			s.Dominance.Serial,
+			s.Dominance.Heuristic,
+			strconv.FormatFloat(s.Dominance.Margin, 'f', 1, 64),
+		)
+	}
+
+	// Intervention outcomes, only when any fired — the agent's OWN history in that
+	// game (what it did and whether it landed), the most relevant cross-game signal
+	// for a director learning from its past actions. Rendered compactly: the action,
+	// dispatched-or-blocked, and the best-effort engagement effect when known.
+	for _, iv := range s.Interventions {
+		fmt.Fprintf(b, "     intervention=%s%s %s%s\n",
+			iv.Intervention,
+			targetSuffix(iv.TargetSerial),
+			dispatchWord(iv.Dispatched),
+			effectSuffix(iv.Effect),
+		)
+	}
+}
+
+// targetSuffix renders "->serial" for a player-targeted intervention, or "" for a
+// session-scoped one, so a session-scoped action reads cleanly.
+func targetSuffix(serial string) string {
+	if serial == "" {
+		return ""
+	}
+	return "->" + serial
+}
+
+// dispatchWord renders the intervention's gate outcome as a single word the model
+// can reason over: it reached the action sink, or a permission/policy gate blocked
+// it.
+func dispatchWord(dispatched bool) string {
+	if dispatched {
+		return "dispatched"
+	}
+	return "blocked"
+}
+
+// effectSuffix renders the best-effort before/after engagement effect (#928's
+// coarse correlation) when the timeline had comparable samples on both sides, or
+// "" when it did not — the model sees "this action moved intensity by +0.12" only
+// when there is an honest number to show.
+func effectSuffix(eff *gamesummary.InterventionEffect) string {
+	if eff == nil {
+		return ""
+	}
+	parts := make([]string, 0, 2)
+	if eff.MeanIntensityDelta != nil {
+		parts = append(parts, "intensity_delta="+strconv.FormatFloat(*eff.MeanIntensityDelta, 'f', 2, 64))
+	}
+	if eff.ActivePlayersDelta != nil {
+		parts = append(parts, "active_delta="+strconv.Itoa(*eff.ActivePlayersDelta))
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return " [" + strings.Join(parts, " ") + "]"
+}
+
+// kindOrUnknown / modeOrUnknown / durationOrUnknown mirror the prompt builder's
+// "unknown" sentinel convention (llm/prompt.go) so the cross-game block reads in
+// the same vocabulary as the rest of the prompt — an unobserved field is the
+// literal "unknown", never an empty gap.
+func kindOrUnknown(kind string) string {
+	if kind == "" {
+		return "unknown"
+	}
+	return kind
+}
+
+func modeOrUnknown(mode string) string {
+	if mode == "" {
+		return "unknown"
+	}
+	return mode
+}
+
+func durationOrUnknown(d *float64) string {
+	if d == nil {
+		return "unknown"
+	}
+	return strconv.FormatFloat(*d, 'f', 1, 64) + "s"
+}

--- a/services/agent/gamewindow/render_test.go
+++ b/services/agent/gamewindow/render_test.go
@@ -1,0 +1,110 @@
+package gamewindow
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/joustmania/agent/gamesummary"
+)
+
+func f64(v float64) *float64 { return &v }
+func intp(v int) *int        { return &v }
+
+func TestRenderEmptyWindow(t *testing.T) {
+	got := Render(nil)
+	if !strings.Contains(got, blockHeader) {
+		t.Errorf("empty render missing header %q:\n%s", blockHeader, got)
+	}
+	if !strings.Contains(got, "(no prior games)") {
+		t.Errorf("empty render missing empty marker:\n%s", got)
+	}
+	// nil and empty slice render identically.
+	if Render([]gamesummary.Summary{}) != got {
+		t.Errorf("nil and empty-slice renders differ")
+	}
+}
+
+func TestRenderDeterministic(t *testing.T) {
+	in := []gamesummary.Summary{
+		{
+			GameKind:          "real",
+			GameMode:          "joust",
+			DurationSeconds:   f64(92),
+			PlayerCount:       4,
+			EliminationCount:  3,
+			InterventionCount: 2,
+			Dominance:         gamesummary.Dominance{Dominated: true, Serial: "AA11", Heuristic: "survivor_outlasted_mean_2x", Margin: 2.5},
+			Interventions: []gamesummary.InterventionOutcome{
+				{Intervention: "grant_shield", TargetSerial: "BB22", Dispatched: true,
+					Effect: &gamesummary.InterventionEffect{MeanIntensityDelta: f64(0.12), ActivePlayersDelta: intp(1)}},
+			},
+		},
+	}
+	first := Render(in)
+	for i := 0; i < 5; i++ {
+		if got := Render(in); got != first {
+			t.Fatalf("Render not deterministic on call %d:\n--- first ---\n%s\n--- got ---\n%s", i, first, got)
+		}
+	}
+}
+
+func TestRenderPopulatedBlock(t *testing.T) {
+	in := []gamesummary.Summary{
+		{ // oldest
+			GameKind: "shadow", GameMode: "ffa", DurationSeconds: f64(40),
+			PlayerCount: 6, EliminationCount: 5, InterventionCount: 0,
+		},
+		{ // newest
+			GameKind: "real", GameMode: "joust", DurationSeconds: f64(92),
+			PlayerCount: 4, EliminationCount: 3, InterventionCount: 2,
+			Dominance: gamesummary.Dominance{Dominated: true, Serial: "AA11", Heuristic: "survivor_outlasted_mean_2x", Margin: 2.5},
+			Interventions: []gamesummary.InterventionOutcome{
+				{Intervention: "grant_shield", TargetSerial: "BB22", Dispatched: true,
+					Effect: &gamesummary.InterventionEffect{MeanIntensityDelta: f64(0.12)}},
+				{Intervention: "end_game", Dispatched: false},
+			},
+		},
+	}
+	got := Render(in)
+
+	if !strings.Contains(got, blockHeader) {
+		t.Errorf("missing header:\n%s", got)
+	}
+	// Header counts of both games.
+	if !strings.Contains(got, "shadow/ffa duration=40.0s players=6 eliminations=5 interventions=0") {
+		t.Errorf("missing oldest game header line:\n%s", got)
+	}
+	if !strings.Contains(got, "real/joust duration=92.0s players=4 eliminations=3 interventions=2") {
+		t.Errorf("missing newest game header line:\n%s", got)
+	}
+	// Dominance line (only the dominated game).
+	if !strings.Contains(got, "dominated_by=AA11 (survivor_outlasted_mean_2x, margin=2.5)") {
+		t.Errorf("missing dominance line:\n%s", got)
+	}
+	// Interventions: dispatched with effect, and blocked.
+	if !strings.Contains(got, "intervention=grant_shield->BB22 dispatched [intensity_delta=0.12]") {
+		t.Errorf("missing dispatched intervention line:\n%s", got)
+	}
+	if !strings.Contains(got, "intervention=end_game blocked") {
+		t.Errorf("missing blocked session-scoped intervention line:\n%s", got)
+	}
+
+	// Order: oldest (ffa) appears BEFORE newest (joust).
+	oldestIdx := strings.Index(got, "shadow/ffa")
+	newestIdx := strings.Index(got, "real/joust")
+	if oldestIdx < 0 || newestIdx < 0 || oldestIdx > newestIdx {
+		t.Errorf("order wrong: oldest must render before newest (oldest=%d newest=%d):\n%s", oldestIdx, newestIdx, got)
+	}
+	// Ordinals are 1-based in window position.
+	if !strings.Contains(got, "1. shadow/ffa") || !strings.Contains(got, "2. real/joust") {
+		t.Errorf("ordinals wrong (want 1. oldest, 2. newest):\n%s", got)
+	}
+}
+
+func TestRenderUnknownFields(t *testing.T) {
+	// A summary with unobserved kind/mode/duration renders the "unknown" sentinels.
+	got := Render([]gamesummary.Summary{{PlayerCount: 2}})
+	if !strings.Contains(got, "unknown/unknown duration=unknown players=2") {
+		t.Errorf("unknown sentinels not rendered:\n%s", got)
+	}
+}

--- a/services/agent/gamewindow/window.go
+++ b/services/agent/gamewindow/window.go
@@ -1,0 +1,117 @@
+// Package gamewindow is the M7-2 rolling game context window (#929). It maintains
+// a bounded, in-memory ring of the most recent game gamesummary.Summary values —
+// the per-game narratives the M7-1 builder (#928) produces on game end — and
+// renders the last N of them into one compact NARRATIVE CONTEXT BLOCK that the
+// #739 llm decision path injects into EVERY inference prompt. That block is the
+// agent's CROSS-GAME memory: without it each llm cycle sees only the current
+// game's live snapshot (+ the #916 in-game timeline); with it the model also sees
+// "what happened in the last few games", so it can reason across games/sessions.
+//
+// Boundaries (deliberately narrow, per #929 M7-2):
+//   - The window is GLOBAL across games (shared cross-session memory), NOT
+//     per-game: two concurrent games (#845) both see the SAME recent-games window.
+//     That is intentional — distinct from #916's per-game timeline, which is
+//     per-partition. So the store is mutex-guarded: game-end writes (Record) race
+//     concurrent llm-path reads (Recent).
+//   - It does NOT re-read the on-disk JSON files the M7-1 writer produced — it
+//     hooks the SAME game-end production path (the gamesummary coordinator calls
+//     Record with the freshly-built Summary), so the window advances the instant a
+//     game ends, with no disk round-trip and no staleness window.
+//   - HOW MANY summaries to inject (N) is NOT this package's concern: it retains a
+//     fixed cap (RetentionCap) and hands back the last N on demand (Recent(n)).
+//     N is read live from an OpenFeature flag on the decision path (see
+//     flags.Snapshot.ContextGames + decision/llm_decide.go), so retuning N takes
+//     effect on the next llm call with no redeploy. Render renders whatever slice
+//     it is given.
+//
+// Out of scope (later M7 issues): WHICH context is injected via flags (#930 M7-3
+// toggles the window/timeline/etc. on and off — M7-2 just builds + injects this
+// one window); the dashboard pane (#933); deeper per-summary improvement (#931+).
+package gamewindow
+
+import (
+	"sync"
+
+	"github.com/joustmania/agent/gamesummary"
+)
+
+// RetentionCap bounds the ring: the MOST summaries the window ever holds, and thus
+// the most N (flags.Snapshot.ContextGames) can ever inject. It is a safety ceiling,
+// not the injected count — the decision path clamps N to [0, RetentionCap] and asks
+// for Recent(N). 20 comfortably exceeds any sane N (the flag default is 3) while
+// keeping the in-memory footprint and the rendered block bounded; a game-end that
+// would push past 20 evicts the OLDEST, so the window always reflects the most
+// recent games. Pure constant — no clock, no config.
+const RetentionCap = 20
+
+// Store is the global rolling window of recent game summaries (#929). It is a
+// fixed-capacity ring retaining the last RetentionCap summaries in arrival
+// (game-end) order, oldest-first. Safe for concurrent use: Record (game-end
+// writes, possibly two concurrent games) and Recent/Len (llm-path reads) are all
+// mutex-guarded, because the window is GLOBAL — one Store shared across every
+// per-game decision loop, exactly like the shared LLM budget/resolver (#847/#741).
+type Store struct {
+	mu sync.Mutex
+	// summaries holds the retained window, oldest-first, len <= RetentionCap. A plain
+	// slice (not a head/tail ring buffer) keeps Recent a trivial tail-slice and the
+	// code obvious; RetentionCap is tiny, so the O(cap) shift on eviction is
+	// negligible and runs only on game end (not on the hot read path).
+	summaries []gamesummary.Summary
+}
+
+// NewStore builds an empty rolling window. main.go constructs ONE and shares it
+// across all per-game loops (the window is global cross-session memory), wiring
+// Record into the gamesummary coordinator's game-end path and the Store itself
+// into every Loop as the context-window source.
+func NewStore() *Store {
+	return &Store{summaries: make([]gamesummary.Summary, 0, RetentionCap)}
+}
+
+// Record appends one freshly-built game Summary to the window, evicting the oldest
+// when the ring is full so the window always holds the most recent RetentionCap
+// games (#929). It is THE seam that advances the window: the gamesummary
+// coordinator calls it once per game on game end, for BOTH real and shadow games,
+// from the SAME pre-reset-snapshot path that writes the JSON file — so the window
+// updates after EVERY completed game with no disk re-read. Concurrency-safe:
+// concurrent game-ends (#845) serialize on mu.
+func (s *Store) Record(summary gamesummary.Summary) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.summaries = append(s.summaries, summary)
+	if len(s.summaries) > RetentionCap {
+		// Drop the oldest. Copy-shift into a fresh backing array rather than reslicing
+		// s.summaries[1:], so the evicted Summary is not pinned alive by the slice's
+		// retained backing array (the Summaries carry slices of their own).
+		trimmed := make([]gamesummary.Summary, RetentionCap)
+		copy(trimmed, s.summaries[len(s.summaries)-RetentionCap:])
+		s.summaries = trimmed
+	}
+}
+
+// Recent returns a COPY of the last n retained summaries, newest-LAST (oldest of
+// the returned window first), for the llm path to render. n is clamped to
+// [0, len]: a non-positive n returns an empty (non-nil) slice (the caller renders
+// the explicit "(no prior games)" marker), and an n past the retained count
+// returns everything held. The returned slice is a fresh copy, so a caller can
+// never mutate the window or observe a later Record mid-read. Concurrency-safe.
+func (s *Store) Recent(n int) []gamesummary.Summary {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if n <= 0 {
+		return []gamesummary.Summary{}
+	}
+	if n > len(s.summaries) {
+		n = len(s.summaries)
+	}
+	out := make([]gamesummary.Summary, n)
+	copy(out, s.summaries[len(s.summaries)-n:])
+	return out
+}
+
+// Len reports how many summaries the window currently holds (0..RetentionCap),
+// for tests and at-a-glance sizing. Concurrency-safe.
+func (s *Store) Len() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.summaries)
+}

--- a/services/agent/gamewindow/window_test.go
+++ b/services/agent/gamewindow/window_test.go
@@ -1,0 +1,185 @@
+package gamewindow
+
+import (
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/joustmania/agent/gamesummary"
+)
+
+// sum builds a small distinguishable Summary for ordering assertions: GameID is
+// the only field the tests need to tell summaries apart.
+func sum(id string) gamesummary.Summary {
+	return gamesummary.Summary{GameID: id}
+}
+
+// ids extracts the GameIDs of a summary slice so order/content is asserted
+// compactly.
+func ids(ss []gamesummary.Summary) []string {
+	out := make([]string, len(ss))
+	for i, s := range ss {
+		out[i] = s.GameID
+	}
+	return out
+}
+
+func equalIDs(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestRecordAppendsOldestFirst(t *testing.T) {
+	s := NewStore()
+	if s.Len() != 0 {
+		t.Fatalf("fresh store Len = %d, want 0", s.Len())
+	}
+	for _, id := range []string{"g1", "g2", "g3"} {
+		s.Record(sum(id))
+	}
+	if s.Len() != 3 {
+		t.Fatalf("Len = %d, want 3", s.Len())
+	}
+	// Recent(all) returns oldest-first (arrival order), newest last.
+	got := ids(s.Recent(3))
+	if want := []string{"g1", "g2", "g3"}; !equalIDs(got, want) {
+		t.Errorf("Recent(3) = %v, want %v (oldest-first)", got, want)
+	}
+}
+
+func TestRecentReturnsLastNNewestLast(t *testing.T) {
+	s := NewStore()
+	for _, id := range []string{"g1", "g2", "g3", "g4"} {
+		s.Record(sum(id))
+	}
+	got := ids(s.Recent(2))
+	if want := []string{"g3", "g4"}; !equalIDs(got, want) {
+		t.Errorf("Recent(2) = %v, want %v (the 2 newest, newest last)", got, want)
+	}
+}
+
+func TestRecentReturnsFreshCopy(t *testing.T) {
+	s := NewStore()
+	s.Record(sum("g1"))
+	s.Record(sum("g2"))
+
+	out := s.Recent(2)
+	// Mutating the returned slice must NOT affect the store.
+	out[0].GameID = "MUTATED"
+	out[1] = sum("ALSO_MUTATED")
+
+	again := ids(s.Recent(2))
+	if want := []string{"g1", "g2"}; !equalIDs(again, want) {
+		t.Errorf("store leaked its backing array: Recent(2) = %v, want %v", again, want)
+	}
+}
+
+func TestEvictionPastRetentionCap(t *testing.T) {
+	s := NewStore()
+	// Record one past the cap: the oldest must be evicted and the length capped.
+	for i := 0; i < RetentionCap+1; i++ {
+		s.Record(sum("g" + strconv.Itoa(i)))
+	}
+	if s.Len() != RetentionCap {
+		t.Fatalf("Len after %d records = %d, want %d (capped)", RetentionCap+1, s.Len(), RetentionCap)
+	}
+	all := ids(s.Recent(RetentionCap))
+	// Oldest ("g0") evicted; window holds g1..gRetentionCap, oldest-first.
+	if all[0] != "g1" {
+		t.Errorf("oldest retained = %q, want g1 (g0 evicted)", all[0])
+	}
+	if last := all[len(all)-1]; last != "g"+strconv.Itoa(RetentionCap) {
+		t.Errorf("newest retained = %q, want g%d", last, RetentionCap)
+	}
+}
+
+func TestEvictionKeepsEvictingAsMoreArrive(t *testing.T) {
+	s := NewStore()
+	for i := 0; i < RetentionCap*2; i++ {
+		s.Record(sum("g" + strconv.Itoa(i)))
+	}
+	if s.Len() != RetentionCap {
+		t.Fatalf("Len = %d, want %d", s.Len(), RetentionCap)
+	}
+	all := ids(s.Recent(RetentionCap))
+	// Window holds the last RetentionCap: g(RetentionCap)..g(2*RetentionCap-1).
+	if all[0] != "g"+strconv.Itoa(RetentionCap) {
+		t.Errorf("oldest retained = %q, want g%d", all[0], RetentionCap)
+	}
+}
+
+func TestRecentZeroAndNegativeEmptyNonNil(t *testing.T) {
+	s := NewStore()
+	s.Record(sum("g1"))
+	for _, n := range []int{0, -1, -100} {
+		got := s.Recent(n)
+		if got == nil {
+			t.Errorf("Recent(%d) returned nil, want empty non-nil slice", n)
+		}
+		if len(got) != 0 {
+			t.Errorf("Recent(%d) len = %d, want 0", n, len(got))
+		}
+	}
+}
+
+func TestRecentMoreThanLenReturnsAll(t *testing.T) {
+	s := NewStore()
+	s.Record(sum("g1"))
+	s.Record(sum("g2"))
+	got := ids(s.Recent(50))
+	if want := []string{"g1", "g2"}; !equalIDs(got, want) {
+		t.Errorf("Recent(50) = %v, want all held %v", got, want)
+	}
+}
+
+func TestRecentOnEmptyStore(t *testing.T) {
+	s := NewStore()
+	got := s.Recent(3)
+	if got == nil {
+		t.Fatalf("Recent on empty store returned nil, want empty non-nil")
+	}
+	if len(got) != 0 {
+		t.Errorf("Recent on empty store len = %d, want 0", len(got))
+	}
+}
+
+// TestConcurrentRecordAndRecent exercises the mutex under -race: many goroutines
+// Record while others read Recent/Len. The window is GLOBAL (one Store shared
+// across concurrent games), so this is the production access pattern.
+func TestConcurrentRecordAndRecent(t *testing.T) {
+	s := NewStore()
+	var wg sync.WaitGroup
+	const writers, readers, iters = 4, 4, 200
+
+	for w := 0; w < writers; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			for i := 0; i < iters; i++ {
+				s.Record(sum("w" + strconv.Itoa(w) + "_" + strconv.Itoa(i)))
+			}
+		}(w)
+	}
+	for r := 0; r < readers; r++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iters; i++ {
+				_ = s.Recent(5)
+				_ = s.Len()
+			}
+		}()
+	}
+	wg.Wait()
+
+	if s.Len() != RetentionCap {
+		t.Fatalf("after %d records Len = %d, want %d (capped)", writers*iters, s.Len(), RetentionCap)
+	}
+}

--- a/services/agent/llm/prompt.go
+++ b/services/agent/llm/prompt.go
@@ -43,6 +43,17 @@ type BuildInput struct {
 	Snapshot flags.Snapshot
 	Context  gamecontext.GameContext
 	Now      time.Time // injected for determinism — Build must never read the wall clock
+	// ContextBlock is the M7-2 cross-game NARRATIVE CONTEXT BLOCK (#929): the last N
+	// recent game summaries rendered compactly (gamewindow.Render), giving the model
+	// memory across games/sessions. Passed in pre-assembled so Build stays PURE and
+	// the window store does not leak into the llm package — the decision path reads
+	// the live N (flags.Snapshot.ContextGames), pulls Store.Recent(N), renders, and
+	// passes the result here. Empty string = no cross-game section (e.g. the
+	// capture path before the window is wired, or rules mode); a non-empty block is
+	// injected verbatim as a System section. gamewindow.Render always returns a
+	// non-empty block (it renders "(no prior games)" for an empty window), so in the
+	// llm path this is populated on every call.
+	ContextBlock string
 }
 
 // unknown is the literal rendered for any never-observed (nil) signal.
@@ -112,7 +123,7 @@ func ResolveVariant(raw string) string {
 func Build(in BuildInput) Prompt {
 	variant := ResolveVariant(in.Snapshot.Capability.PromptVariant)
 	return Prompt{
-		System:  buildSystem(in.Snapshot, variant),
+		System:  buildSystem(in.Snapshot, variant, in.ContextBlock),
 		User:    buildUser(in.Context, in.Now),
 		Variant: variant,
 		Model:   in.Snapshot.Capability.Model,
@@ -120,8 +131,9 @@ func Build(in BuildInput) Prompt {
 }
 
 // buildSystem renders the System prompt: role, objectives, allow-list, policy
-// constraints, the resolved variant guidance, and the JSON response contract.
-func buildSystem(s flags.Snapshot, variant string) string {
+// constraints, the resolved variant guidance, the M7-2 cross-game context block
+// (#929), and the JSON response contract.
+func buildSystem(s flags.Snapshot, variant, contextBlock string) string {
 	var b strings.Builder
 	b.WriteString(`You are the JoustMania game director, an autonomous agent that tunes a live
 physical movement game to make it more fun. Each decision cycle you receive a
@@ -152,6 +164,19 @@ VARIANT (`)
 	// is always present — an unknown flag value rendered the conservative block.
 	b.WriteString("):\n")
 	b.WriteString(variantGuidance[variant])
+
+	// M7-2 cross-game context block (#929): the last N recent game summaries, injected
+	// as its own System section so the model has memory across games/sessions. The
+	// block is pre-assembled by the decision path (gamewindow.Render) and passed
+	// through verbatim; empty means no cross-game section (rules mode / capture before
+	// the window is wired). In the llm path Render always yields a non-empty block, so
+	// this section is present on every llm call (acceptance: "each LLM call includes
+	// the last N game summaries as a narrative context block").
+	if contextBlock != "" {
+		b.WriteString("\n\n")
+		b.WriteString(contextBlock)
+	}
+
 	b.WriteString(`
 
 RESPONSE CONTRACT — reply with EXACTLY ONE JSON object, no prose, matching:

--- a/services/agent/llm/prompt_test.go
+++ b/services/agent/llm/prompt_test.go
@@ -458,3 +458,35 @@ func TestEmptyInterventionsMarker(t *testing.T) {
 		t.Errorf("allow-list join = %q, want 'a, b'", got)
 	}
 }
+
+// TestContextBlockInjection guards the M7-2 seam (#929): the System prompt carries
+// the cross-game ContextBlock verbatim only when it is non-empty; an empty
+// ContextBlock (rules mode / capture before the window is wired, and every existing
+// golden case) leaves the System prompt byte-identical, so the goldens are unchanged.
+func TestContextBlockInjection(t *testing.T) {
+	base := BuildInput{
+		Snapshot: baseSnapshot(balancedVariant),
+		Context:  threePlayerContext(),
+		Now:      fixedNow,
+	}
+
+	empty := Build(base).System
+
+	withBlock := base
+	block := "PRIOR GAMES (most recent last; cross-game memory):\n  1. real/joust duration=92.0s players=4 eliminations=3 interventions=2"
+	withBlock.ContextBlock = block
+	withSystem := Build(withBlock).System
+
+	// The block is present verbatim only in the with-block prompt.
+	if strings.Contains(empty, "PRIOR GAMES") {
+		t.Errorf("empty ContextBlock must add no cross-game section:\n%s", empty)
+	}
+	if !strings.Contains(withSystem, block) {
+		t.Errorf("non-empty ContextBlock must be injected verbatim:\n%s", withSystem)
+	}
+	// Adding the block must not disturb the rest of the prompt: removing the injected
+	// section recovers the empty-block prompt exactly (the block is a clean insert).
+	if recovered := strings.Replace(withSystem, "\n\n"+block, "", 1); recovered != empty {
+		t.Errorf("ContextBlock injection changed the surrounding prompt:\n--- recovered ---\n%s\n--- empty ---\n%s", recovered, empty)
+	}
+}

--- a/services/agent/main.go
+++ b/services/agent/main.go
@@ -36,6 +36,7 @@ import (
 	"github.com/joustmania/agent/gamecontext"
 	"github.com/joustmania/agent/gamerunner"
 	"github.com/joustmania/agent/gamesummary"
+	"github.com/joustmania/agent/gamewindow"
 	"github.com/joustmania/agent/gate"
 	"github.com/joustmania/agent/infracontext"
 )
@@ -307,6 +308,13 @@ func main() {
 		Localhost: getEnv("AGENT_LOCALHOST_ENDPOINT", "localhost:11434"), // #739 Ollama locally; unreachable unless running
 	}), decision.DefaultProbeInterval)
 	sharedResolver.Start(ctx)
+	// Shared rolling cross-game context window (#929, M7-2). Constructed ONCE here as
+	// GLOBAL cross-session memory — one bounded ring of recent game summaries shared
+	// across every per-game loop, exactly like the budget/resolver above. The
+	// gamesummary coordinator (below) records each freshly-built Summary into it on
+	// game end, and every per-game Loop reads Recent(N) from it on the llm path to
+	// render the prompt's narrative context block (N = llm.context_games, live).
+	sharedContextWindow := gamewindow.NewStore()
 	probeDecisions := strings.EqualFold(getEnv("AGENT_PROBE_DECISIONS", ""), "true")
 	if probeDecisions {
 		slog.Warn("Probe decisions enabled (demo/verification mode)",
@@ -346,6 +354,12 @@ func main() {
 		loop.SetGameID(gameID)
 		loop.SetContextProvider(decision.MuxContextProvider{Mux: mux})
 		loop.SetRootContext(ctx)
+		// Inject the SHARED rolling cross-game context window (#929, M7-2): every
+		// per-game loop reads the SAME recent-games window, so the llm path renders the
+		// last N game summaries into the prompt's narrative context block — the agent's
+		// global cross-session memory, mirroring the shared budget/resolver. The async
+		// path (above) reads it in runInfer; the sync path (un-wired loops) in llmDecide.
+		loop.SetContextWindow(sharedContextWindow)
 		// The objective-weighted rules engine (#726) is the active default, built
 		// FRESH per loop (see the factory doc above). Its objective weights are driven
 		// live from the `objectives` flag each cycle; policy/fitness run on
@@ -427,7 +441,13 @@ func main() {
 	// agent.game.summary span.
 	summaryDir := gamesummary.DirFromEnv()
 	summaries := gamesummary.NewCoordinator(gamesummary.NewWriter(summaryDir), logger)
+	// Advance the M7-2 rolling window on every game end (#929): the coordinator
+	// Records each freshly-built Summary into the shared window BEFORE the disk write,
+	// so the cross-game context the llm path injects reflects a game the instant it
+	// ends, with no disk re-read. One observer, the same global window every loop reads.
+	summaries.SetObserver(sharedContextWindow)
 	slog.Info("Game narrative builder enabled (#928, M7-1)", "summary_dir", summaryDir)
+	slog.Info("Rolling game context window enabled (#929, M7-2)", "retention_cap", gamewindow.RetentionCap)
 
 	// GameContext multiplexer (#845 PR B): one Store partition per game_id, plus the
 	// fallback partition "" for unlabeled signals (zero-regression — single-game

--- a/services/flagd/agent.json
+++ b/services/flagd/agent.json
@@ -176,6 +176,16 @@
       },
       "defaultVariant": "default"
     },
+    "llm.context_games": {
+      "state": "ENABLED",
+      "variants": {
+        "off": 0,
+        "default": 3,
+        "wide": 5,
+        "max": 10
+      },
+      "defaultVariant": "default"
+    },
     "policy.coordinator_backstop_per_minute": {
       "state": "ENABLED",
       "variants": {


### PR DESCRIPTION
## What

M7-2: a **rolling cross-game context window** (#929) for the Go agent. The agent now carries memory across games: every LLM decision prompt includes the last N recent game summaries as a compact narrative context block, so the model can reason about *what happened in the last few games* — not just the current game's live snapshot + the #916 in-game timeline.

This PR was **finished from a cut-off first pass**: the foundational pieces were already committed as a WIP commit (the `gamewindow` package, the `llm.context_games` flag, the `AttrLLMContextGames` span const, the gamesummary `Observer` seam, and `BuildInput.ContextBlock`). This change **wires them together and adds the full test suite**. The two commits squash on merge.

## Feature pieces

- **Window** (`gamewindow/`): `Store` is a bounded, mutex-guarded ring (`RetentionCap=20`) of recent `gamesummary.Summary` values; `Record` appends + evicts oldest, `Recent(n)` hands back a fresh copy of the last n (oldest-first). `Render` produces a deterministic, compact `PRIOR GAMES` block (header counts + dominance + intervention outcomes), `(no prior games)` when empty.
- **Flag** (`flags.go` + `services/flagd/agent.json`): `llm.context_games` read **live** each cycle (`Snapshot.ContextGames`, default 3, tight/patient variants), so N is retunable with no redeploy.
- **Window advance** (`gamesummary/coordinator.go` → `main.go`): one global `gamewindow.Store` is registered as the coordinator's `Observer`, so it `Record`s each freshly-built summary on game end (before the disk write), for both real and shadow games.
- **Injection** (`decision/llm_decide.go`): on the LLM path the loop reads `ContextGames`, clamps to `[0, RetentionCap]`, pulls `Recent(N)`, renders, and passes the block as `BuildInput.ContextBlock`. The same block is injected on the capture path (`agent.llm.prompt`).
- **Span** (`telemetry.go`): `agent.llm.context_games` records the **count actually injected** (`len(Recent)`, bounded by games-ended) — not the raw flag — on both the `agent.llm.infer` and `agent.llm.prompt` spans.
- One global `Store` shared across all per-game loops (`SetContextWindow`), exactly like the shared LLM budget/resolver. **Nil-safe**: a loop with no window injected renders no cross-game block and reports count 0 — purely additive over the #739 path.

## Where the block + span land in the LLM path

`decision/llm_decide.go::llmDecide` calls `renderContextBlock(snapshot)` → `gamewindow.Render(window.Recent(clamp(ContextGames)))`, passes the result as `llm.BuildInput{ContextBlock: ...}` into `llm.Build`, and records `attribute.Int(AttrLLMContextGames, count)` on the `agent.llm.infer` span. `decision/decision.go::captureLLMPrompt` mirrors both for the capture span.

## Tests

- `gamewindow/window_test.go`: append/Recent ordering + fresh-copy isolation, eviction past cap, `Recent(0)`/negative/`>len`, concurrent record+read under `-race`.
- `gamewindow/render_test.go`: determinism, empty marker, populated multi-summary block, oldest-first order, unknown sentinels.
- `decision/context_window_test.go`: block reaches the backend prompt, **live flag** (flipping `ContextGames` changes the injected count on the next call), span carries the count, nil/empty window paths, clamp-to-cap, capture span also carries the count.
- `llm/prompt_test.go`: `ContextBlock` injected verbatim only when non-empty; an empty block leaves the System prompt byte-identical, so **existing goldens are unchanged**.

`gofmt -l` clean, `go vet ./...` clean, `go build ./...` + `go test -race ./...` all green.

## Note on #917 / PR #949 (async inference)

This branch predates #917 async inference (PR #949, still open), so `llmDecide` builds the prompt **synchronously** and the injection wires into that sync path. If #949 merges first, a rebase moves the injection into the async fire path; the `llm.Build` `ContextBlock` seam is stable either way (the injection is a one-line `BuildInput` field + a span attribute).

Part of #929 (M7-2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)