### PR TITLE
feat(flags): thread game_kind into the eval context with fail-safe real default (#932)

### DIFF
--- a/lib/feature_flags.py
+++ b/lib/feature_flags.py
@@ -54,6 +54,15 @@ def _report_exception(flag_key: str, exc: Exception) -> None:
     record_flag_fallback(flag_key, type(exc).__name__, str(exc))
 
 
+# Shadow/real split for the agent's game-flag experiments (#931/#932). These
+# MUST stay byte-identical to services/agent/experiment/targeting.go's
+# GameKindReal ("real") — the experiment writer scopes targeting on
+# {"!=": [{"var":"game_kind"}, "real"]}, so anything that is NOT "real" resolves
+# the experimental variant. "real" is therefore the protected, fail-safe value.
+GAME_KIND_VAR = "game_kind"
+GAME_KIND_REAL = "real"
+GAME_KIND_SHADOW = "shadow"
+
 # Track initialized domains to avoid re-initialization
 _initialized_domains: set[str] = set()
 _hooks_registered: bool = False
@@ -92,6 +101,14 @@ def _init_global_context() -> None:
                 "language": "python",
                 "environment": environment,
                 "hostname": hostname,
+                # Fail-safe baseline for the shadow/real split (#932). The agent's
+                # experiment writer scopes on "game_kind != real" (targeting.go),
+                # so a context MISSING game_kind would resolve the experimental
+                # variant — a real game could silently run an experiment. Defaulting
+                # the always-available API-level context to "real" means any game
+                # that does not explicitly opt into shadow is protected by
+                # construction; only a shadow session overrides this per-session.
+                GAME_KIND_VAR: GAME_KIND_REAL,
             }
         )
     )
@@ -404,10 +421,31 @@ def read_int_flag(domain: str, flag_key: str, default: int, game_id: str | None 
         return default
 
 
+def set_game_session_kind_context(game_kind: str = GAME_KIND_REAL) -> None:
+    """Set ONLY the game_kind on the current async context's transaction context.
+
+    The shadow/real split (#932) must be in place BEFORE a game mode's __init__
+    runs its init-frozen calibration reads (thresholds, grace period, per-mode
+    config) — those reads evaluate in this same contextvars context, so if
+    game_kind weren't set yet they would fall back to the API-level "real"
+    default and a shadow session would miss its experiments. This minimal setter
+    establishes the split at the session boundary; :func:`set_game_transaction_context`
+    later overwrites the transaction context with the full game session attributes
+    (carrying the same game_kind).
+
+    Args:
+        game_kind: ``"shadow"`` for a shadow session, ``"real"`` (default) for a
+            protected real/primary game. MUST match targeting.go's GameKindReal.
+    """
+    api.set_transaction_context(EvaluationContext(attributes={GAME_KIND_VAR: game_kind}))
+    logger.debug(f"Session-kind transaction context set: game_kind={game_kind}")
+
+
 def set_game_transaction_context(
     game_mode: str,
     controller_count: int,
     sensitivity: int | None = None,
+    game_kind: str = GAME_KIND_REAL,
 ) -> None:
     """
     Set transaction-level evaluation context for the current game session.
@@ -420,10 +458,18 @@ def set_game_transaction_context(
         game_mode: Game mode name (e.g., "FFA", "Werewolf")
         controller_count: Number of controllers/players in the session
         sensitivity: Optional sensitivity level (0-4)
+        game_kind: Shadow/real marker for the agent experiment split (#932).
+            Defaults to ``"real"`` (the protected baseline) so an unlabeled game
+            never resolves an experiment; ONLY a shadow session passes
+            ``"shadow"``. The transaction context overrides the API-level default
+            for this async context alone, so a shadow session's experiments stay
+            scoped to that session. The value MUST match targeting.go's
+            GameKindReal/"shadow" (see GAME_KIND_* constants).
     """
     attributes: dict = {
         "game_mode": game_mode,
         "controller_count": controller_count,
+        GAME_KIND_VAR: game_kind,
     }
     if sensitivity is not None:
         attributes["sensitivity"] = sensitivity
@@ -436,5 +482,6 @@ def set_game_transaction_context(
     )
     logger.debug(
         f"Transaction context set: game_mode={game_mode}, "
-        f"controller_count={controller_count}, sensitivity={sensitivity}"
+        f"controller_count={controller_count}, sensitivity={sensitivity}, "
+        f"game_kind={game_kind}"
     )

--- a/lib/tests/test_feature_flags.py
+++ b/lib/tests/test_feature_flags.py
@@ -319,6 +319,119 @@ def test_set_game_transaction_context_without_sensitivity(mock_api):
 
 
 # --------------------------------------------------------------------------- #
+# game_kind shadow/real split (#932) — fail-safe-real-default safety property.
+# The agent's experiment writer (services/agent/experiment/targeting.go) scopes
+# targeting on {"!=": [{"var":"game_kind"}, "real"]}: anything NOT "real"
+# resolves the experimental variant. So "real" MUST be the default everywhere,
+# and only an explicit shadow session may override it. These tests prove that.
+# --------------------------------------------------------------------------- #
+
+
+def test_game_kind_constants_match_targeting_contract():
+    """The Python constants MUST equal targeting.go's GameKindVar/GameKindReal.
+
+    If these drift, real games stop being protected (or shadow experiments stop
+    resolving). The Go side is the single source of truth; this pins the values.
+    """
+    from lib.feature_flags import GAME_KIND_REAL, GAME_KIND_SHADOW, GAME_KIND_VAR
+
+    assert GAME_KIND_VAR == "game_kind"
+    assert GAME_KIND_REAL == "real"
+    assert GAME_KIND_SHADOW == "shadow"
+
+
+@patch("lib.feature_flags.FlagdProvider")
+@patch("lib.feature_flags.api")
+def test_api_level_context_defaults_game_kind_to_real(mock_api, _mock_provider):
+    """The always-available API-level context carries game_kind="real".
+
+    An evaluation with NO per-game context still sees game_kind="real", so an
+    unlabeled game is protected from experiments by construction (fail-safe).
+    """
+    ff_module._initialized_domains.discard("test_gk")
+    ff_module._hooks_registered = False
+    ff_module._propagator_registered = False
+
+    init_flag_domain("test_gk")
+
+    ctx = mock_api.set_evaluation_context.call_args[0][0]
+    assert ctx.attributes["game_kind"] == "real"
+
+    ff_module._initialized_domains.discard("test_gk")
+    ff_module._hooks_registered = False
+    ff_module._propagator_registered = False
+
+
+@patch("lib.feature_flags.api")
+def test_set_game_transaction_context_defaults_game_kind_to_real(mock_api):
+    """A default (real-game) call puts game_kind="real" in the transaction."""
+    from lib.feature_flags import set_game_transaction_context
+
+    set_game_transaction_context(game_mode="FFA", controller_count=4)
+
+    ctx = mock_api.set_transaction_context.call_args[0][0]
+    assert ctx.attributes["game_kind"] == "real"
+
+
+@patch("lib.feature_flags.api")
+def test_set_game_transaction_context_shadow_override(mock_api):
+    """A shadow session passing game_kind="shadow" overrides the real default."""
+    from lib.feature_flags import set_game_transaction_context
+
+    set_game_transaction_context(game_mode="FFA", controller_count=4, game_kind="shadow")
+
+    ctx = mock_api.set_transaction_context.call_args[0][0]
+    assert ctx.attributes["game_kind"] == "shadow"
+
+
+@patch("lib.feature_flags.api")
+def test_set_game_session_kind_context_defaults_real(mock_api):
+    """The session-boundary setter defaults to game_kind="real" (protected)."""
+    from lib.feature_flags import set_game_session_kind_context
+
+    set_game_session_kind_context()
+
+    ctx = mock_api.set_transaction_context.call_args[0][0]
+    assert ctx.attributes["game_kind"] == "real"
+
+
+@patch("lib.feature_flags.api")
+def test_set_game_session_kind_context_shadow(mock_api):
+    """A shadow session sets game_kind="shadow" before its init-time reads."""
+    from lib.feature_flags import set_game_session_kind_context
+
+    set_game_session_kind_context("shadow")
+
+    ctx = mock_api.set_transaction_context.call_args[0][0]
+    assert ctx.attributes["game_kind"] == "shadow"
+
+
+def test_experiment_targeting_protects_real_resolves_shadow():
+    """End-to-end intent: the agent's "!= real" targeting resolves the baseline
+    for a real/unlabeled context and the experimental value for a shadow context.
+
+    Mirrors flagd JSONLogic {"if":[{"!=":[{"var":"game_kind"},"real"]}, "X", <else>]}
+    so we prove the wiring's effect without the docker stack: it is the merged
+    eval-context attributes that decide the branch.
+    """
+    from lib.feature_flags import GAME_KIND_REAL, GAME_KIND_SHADOW, GAME_KIND_VAR
+
+    def resolve(attrs: dict) -> str:
+        # The fake provider models flagd's "!= real" branch on game_kind.
+        return "X" if attrs.get(GAME_KIND_VAR) != GAME_KIND_REAL else "baseline"
+
+    # Real (explicit) and unlabeled-but-default-real → protected baseline.
+    assert resolve({GAME_KIND_VAR: GAME_KIND_REAL}) == "baseline"
+    assert resolve({GAME_KIND_VAR: GAME_KIND_REAL, "game_mode": "FFA"}) == "baseline"
+    # Shadow → experimental value.
+    assert resolve({GAME_KIND_VAR: GAME_KIND_SHADOW}) == "X"
+    # SAFETY: a context that somehow MISSES game_kind would resolve the
+    # experiment — which is exactly why "real" is the fail-safe default the
+    # wiring guarantees is always present.
+    assert resolve({}) == "X"
+
+
+# --------------------------------------------------------------------------- #
 # gameId calibration context (#838)
 # --------------------------------------------------------------------------- #
 from lib.feature_flags import _calibration_context, read_object_flag  # noqa: E402

--- a/services/game_coordinator/game_session.py
+++ b/services/game_coordinator/game_session.py
@@ -27,6 +27,15 @@ import logging
 import threading
 import time
 
+from lib.feature_flags import (
+    GAME_KIND_REAL as EVAL_GAME_KIND_REAL,
+)
+from lib.feature_flags import (
+    GAME_KIND_SHADOW as EVAL_GAME_KIND_SHADOW,
+)
+from lib.feature_flags import (
+    set_game_session_kind_context,
+)
 from lib.telemetry import get_tracer
 from lib.types import get_game_display_name
 from proto import game_coordinator_pb2
@@ -138,10 +147,32 @@ class GameSession:
             finally:
                 loop.close()
 
+    def _eval_game_kind(self) -> str:
+        """Map this session's kind to the eval-context game_kind (#932).
+
+        The session kind is "primary"/"shadow" (metric-label semantics, #775); the
+        agent's experiment writer scopes targeting on "game_kind != real"
+        (targeting.go). Only a SHADOW session resolves experiments; a primary
+        (menu-driven, player-facing) game is the protected "real" baseline.
+        """
+        return EVAL_GAME_KIND_SHADOW if self.game_kind == GAME_KIND_SHADOW else EVAL_GAME_KIND_REAL
+
     async def _run_game_loop_async(self) -> None:
         """Run the async game loop for this session."""
         # Initialize async gRPC clients in this event loop
         await self.clients.connect()
+
+        # Establish the shadow/real eval-context split for THIS session's async
+        # context BEFORE the game is constructed (#932). GameFactory.create_game()
+        # below runs the game mode's __init__, which reads init-frozen calibration
+        # flags (thresholds, grace period, per-mode config). Those reads happen in
+        # this contextvars context, so the game_kind must already be set here —
+        # otherwise a shadow session's init-time reads would fall back to the
+        # API-level "real" default and miss its experiments. (BaseGameMode._run
+        # later re-sets the full transaction context with game_mode/sensitivity,
+        # carrying the same game_kind.) This is contextvars-scoped, so it never
+        # leaks across sessions.
+        set_game_session_kind_context(self._eval_game_kind())
 
         # Get the display name for the game span
         game_span_name = get_game_display_name(self.game_name)

--- a/services/game_coordinator/games/base.py
+++ b/services/game_coordinator/games/base.py
@@ -29,7 +29,13 @@ from opentelemetry import context as otel_context
 from opentelemetry import trace
 
 from lib.controller_constants import battery_to_pct
-from lib.feature_flags import read_float_flag, read_object_flag, set_game_transaction_context
+from lib.feature_flags import (
+    GAME_KIND_REAL,
+    GAME_KIND_SHADOW,
+    read_float_flag,
+    read_object_flag,
+    set_game_transaction_context,
+)
 from lib.telemetry import inject_trace_context
 from lib.types import GameEvent, Sensitivity, Sound
 from services.game_coordinator import metrics
@@ -1855,11 +1861,19 @@ class BaseGameMode(ABC):
 
                 init_span.set_attribute("player_count", len(self.players))
 
-                # Set transaction context for flag evaluations during this game
+                # Set transaction context for flag evaluations during this game.
+                # Map the session kind ("primary"/"shadow", #775) to the eval-context
+                # game_kind the agent's experiment writer scopes on ("real"/"shadow",
+                # targeting.go #932): only a SHADOW session resolves experiments;
+                # every primary (menu-driven, player-facing) game is protected as
+                # "real". This runs inside the per-session game loop, so the override
+                # is scoped to this session's async context (contextvars).
+                eval_game_kind = GAME_KIND_SHADOW if self.game_kind == GAME_KIND_SHADOW else GAME_KIND_REAL
                 set_game_transaction_context(
                     game_mode=self.get_game_name(),
                     controller_count=len(self.players),
                     sensitivity=self.sensitivity.value,
+                    game_kind=eval_game_kind,
                 )
 
                 # Additional phases (e.g., color_assignment, team_formation)

--- a/services/game_coordinator/tests/test_game_session.py
+++ b/services/game_coordinator/tests/test_game_session.py
@@ -195,6 +195,61 @@ class TestGameSessionLoop:
         # players_alive (still a single global gauge) reset only by primary.
         mock_metrics.players_alive.set.assert_any_call(0)
 
+    def test_eval_game_kind_maps_session_kind_to_real_or_shadow(self):
+        """Session kind (primary/shadow, #775) maps to eval game_kind (real/shadow,
+        #932): only shadow resolves experiments, primary is the protected "real"."""
+        assert _make_session(game_kind=GAME_KIND_PRIMARY)._eval_game_kind() == "real"
+        assert _make_session(game_kind=GAME_KIND_SHADOW)._eval_game_kind() == "shadow"
+
+    @pytest.mark.asyncio
+    @patch("services.game_coordinator.game_session.metrics")
+    @patch("services.game_coordinator.game_session.set_game_session_kind_context")
+    @patch("services.game_coordinator.game_session.GameFactory")
+    @patch("services.game_coordinator.game_session.tracer")
+    async def test_loop_sets_shadow_eval_context_before_create_game(
+        self, mock_tracer_mod, mock_factory, mock_set_kind, mock_metrics
+    ):
+        """A shadow session establishes game_kind="shadow" in its async context
+        BEFORE GameFactory.create_game() runs __init__-time calibration reads, so
+        those reads see the shadow split (#932). Order is asserted via a sentinel."""
+        order = []
+        mock_set_kind.side_effect = lambda kind: order.append(("set_kind", kind))
+        session = _make_session(game_kind=GAME_KIND_SHADOW)
+        mock_tracer_mod.start_as_current_span = _tracer_mock().start_as_current_span
+        mock_game = MagicMock()
+        mock_game.run = AsyncMock()
+
+        def _record_create(*_a, **_k):
+            order.append(("create_game", None))
+            return mock_game
+
+        mock_factory.create_game.side_effect = _record_create
+
+        await session._run_game_loop_async()
+
+        assert order[0] == ("set_kind", "shadow")
+        assert ("create_game", None) in order
+        assert order.index(("set_kind", "shadow")) < order.index(("create_game", None))
+
+    @pytest.mark.asyncio
+    @patch("services.game_coordinator.game_session.metrics")
+    @patch("services.game_coordinator.game_session.set_game_session_kind_context")
+    @patch("services.game_coordinator.game_session.GameFactory")
+    @patch("services.game_coordinator.game_session.tracer")
+    async def test_loop_sets_real_eval_context_for_primary(
+        self, mock_tracer_mod, mock_factory, mock_set_kind, mock_metrics
+    ):
+        """A primary (menu) session establishes the protected game_kind="real"."""
+        session = _make_session(game_kind=GAME_KIND_PRIMARY)
+        mock_tracer_mod.start_as_current_span = _tracer_mock().start_as_current_span
+        mock_game = MagicMock()
+        mock_game.run = AsyncMock()
+        mock_factory.create_game.return_value = mock_game
+
+        await session._run_game_loop_async()
+
+        mock_set_kind.assert_called_once_with("real")
+
     @pytest.mark.asyncio
     @patch("services.game_coordinator.game_session.metrics")
     @patch("services.game_coordinator.game_session.GameFactory")

--- a/services/menu/servicer.py
+++ b/services/menu/servicer.py
@@ -11,7 +11,12 @@ from opentelemetry import context as otel_context
 from opentelemetry import trace
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 
-from lib.feature_flags import get_flag_client, init_flag_domain, set_game_transaction_context
+from lib.feature_flags import (
+    GAME_KIND_REAL,
+    get_flag_client,
+    init_flag_domain,
+    set_game_transaction_context,
+)
 from lib.flag_config_writer import FlagConfigWriter
 from lib.telemetry import get_tracer
 from lib.types import Games
@@ -789,10 +794,15 @@ class MenuServicer(menu_pb2_grpc.MenuServiceServicer):
         """
         from proto import game_coordinator_pb2
 
-        # Set transaction context so all flag evaluations include game session info
+        # Set transaction context so all flag evaluations include game session info.
+        # The menu drives the REAL, player-facing game (#837), so mark it "real"
+        # explicitly — this protects it from the agent's shadow-scoped experiments
+        # (targeting.go scopes on game_kind != "real", #932). Explicit at the
+        # real-game call site for clarity even though "real" is also the default.
         set_game_transaction_context(
             game_mode=game_mode.name,
             controller_count=len(players),
+            game_kind=GAME_KIND_REAL,
         )
 
         # Read game settings from flagd (game domain)


### PR DESCRIPTION
## What

Threads the `game_kind` attribute into the OpenFeature evaluation context so the agent's shadow-scoped game-flag experiments (#931/#932) actually take effect at runtime. This is the **runtime prerequisite** the experiment writer's docstring (`services/agent/experiment/targeting.go`) calls out — until now real games always resolved `defaultVariant` because `game_kind` was never in the context.

## The safety property: fail-safe-real-default

The experiment writer scopes targeting on `{"!=": [{"var":"game_kind"}, "real"]}` — **everything that is NOT `game_kind="real"` resolves the EXPERIMENTAL value; only an explicit `"real"` is protected.** That means a context *missing* `game_kind` would resolve the experiment, so a real game could silently run one. The fix makes `"real"` the default everywhere, so any game that doesn't explicitly opt into shadow is protected **by construction**:

- **API-level default** (`lib/feature_flags._init_global_context`): the always-available context now carries `game_kind="real"`. An evaluation with no per-game context still sees `"real"`.
- **Per-game override** (`set_game_transaction_context(..., game_kind="real")`): new param defaults to `"real"`; only a shadow session passes `"shadow"`. Contextvars-scoped, so a shadow session's experiments stay scoped to that session.
- **Session wiring** (`GameSession`): maps its session kind (`primary`/`shadow`, #775) to the eval value (`real`/`shadow`) and sets it via a new `set_game_session_kind_context` **before** `GameFactory.create_game` — so a game mode's `__init__`-time calibration reads (thresholds, grace period, per-mode config) also see the correct split. `BaseGameMode._run` later re-sets the full transaction context carrying the same `game_kind`.
- **Menu** (the real, player-facing game, #837) passes `game_kind="real"` explicitly for clarity.

Shared `GAME_KIND_VAR`/`GAME_KIND_REAL`/`GAME_KIND_SHADOW` constants in `lib/feature_flags.py` pin the values to `targeting.go`'s `GameKindReal = "real"`; a test asserts they match the Go contract so they can't drift.

## Gap investigated (and closed)

`__init__`-time calibration reads happen in `GameFactory.create_game` **before** `_run` set the transaction context. Without the session-boundary `set_game_session_kind_context`, a shadow session's init reads would fall back to the API-level `"real"` default and miss its experiments. This was **fail-safe** (a real game is never put at risk — the worst case was a shadow game not getting its experiment on init-frozen flags), but I closed it anyway by setting `game_kind` at the session boundary before `create_game`. No fail-OPEN path was found: `set_game_transaction_context` is the single transaction-context entry point, every game flows through `GameSession`, and the agent service (Go) does not evaluate the Python game flags directly.

## Tests

- `lib`: API-level default is `"real"`; transaction default `"real"` / shadow override `"shadow"`; constants match the Go contract; a fake-provider test models the `"!= real"` targeting and proves real/unlabeled → baseline, shadow → experimental, and that a context missing `game_kind` would resolve the experiment (why `"real"` must be the default).
- `game_coordinator`: `_eval_game_kind` mapping; the session sets `"shadow"`/`"real"` **before** `create_game` (order asserted).
- Full suites green: `lib` 37, `game_coordinator` 943, `menu` 358. `make lint` clean.

## Out of scope (follow-ups)

- The agent-side experiment writer/gate (#931/#932) — already built in `services/agent/experiment/`.
- Full integration test of a *written* experiment reaching a shadow game (needs the docker stack) — follow-up.
- Promotion (#936).

Part of #932.

🤖 Generated with [Claude Code](https://claude.com/claude-code)