### PR TITLE
feat(agent): reject type-mismatched experiment proposals (#932)

### DIFF
--- a/services/agent/experiment/experiment_test.go
+++ b/services/agent/experiment/experiment_test.go
@@ -347,6 +347,103 @@ func TestCheckRealResolution_DetectsChange(t *testing.T) {
 	}
 }
 
+// ---- Type-compatibility guard (#953 N3) ------------------------------------
+
+// A string on a numeric flag must be REJECTED with type_mismatch before any
+// write — a shadow game's reader of invincibility_seconds expects a float and
+// would crash/misbehave on a string. File unchanged, blocked span emitted.
+func TestReview_BlocksStringOnNumericFlag(t *testing.T) {
+	g, path, rec := gateWithRecorder(t)
+	before := mustRead(t, path)
+
+	err := g.Review(context.Background(), Proposal{
+		FlagKey:           "invincibility_seconds",
+		ExperimentalValue: "six",
+		Rationale:         "mistyped value an LLM might emit",
+	})
+	assertBlocked(t, err, ReasonTypeMismatch)
+	assertUnchanged(t, path, before)
+	assertSpan(t, rec, SpanProposed, true, ReasonTypeMismatch)
+}
+
+// A numeric value on a numeric flag is accepted — and crucially an INTEGER on a
+// float-variant flag (6 vs the 4.0 variants) is NOT a false reject: JSON has one
+// number kind.
+func TestReview_AcceptsIntOnFloatFlag(t *testing.T) {
+	g, _, _ := gateWithRecorder(t)
+	if err := g.Review(context.Background(), Proposal{
+		FlagKey:           "invincibility_seconds",
+		ExperimentalValue: 6, // int literal vs the flag's 4.0/6.0 float variants
+	}); err != nil {
+		t.Fatalf("int on float-variant flag rejected: %v", err)
+	}
+}
+
+// A float value on a flag whose variants are integers (num_teams: 2..6) is also
+// accepted — same number kind, no int-vs-float reject in the other direction.
+func TestReview_AcceptsFloatOnIntFlag(t *testing.T) {
+	g, _, _ := gateWithRecorder(t)
+	if err := g.Review(context.Background(), Proposal{
+		FlagKey:           "num_teams",
+		ExperimentalValue: 4.0,
+	}); err != nil {
+		t.Fatalf("float on int-variant flag rejected: %v", err)
+	}
+}
+
+// A bool on a bool flag (random_assignment: true/false) is accepted.
+func TestReview_AcceptsBoolOnBoolFlag(t *testing.T) {
+	g, _, _ := gateWithRecorder(t)
+	if err := g.Review(context.Background(), Proposal{
+		FlagKey:           "random_assignment",
+		ExperimentalValue: false,
+	}); err != nil {
+		t.Fatalf("bool on bool flag rejected: %v", err)
+	}
+}
+
+// A number on a bool flag is rejected with type_mismatch, file unchanged.
+func TestReview_BlocksNumberOnBoolFlag(t *testing.T) {
+	g, path, rec := gateWithRecorder(t)
+	before := mustRead(t, path)
+
+	err := g.Review(context.Background(), Proposal{
+		FlagKey:           "random_assignment",
+		ExperimentalValue: 1,
+	})
+	assertBlocked(t, err, ReasonTypeMismatch)
+	assertUnchanged(t, path, before)
+	assertSpan(t, rec, SpanProposed, true, ReasonTypeMismatch)
+}
+
+// Unit-level: checkTypeCompatible's kind matching, including the int-vs-float
+// nuance and the experimental-variant skip (an existing agent_experiment of a
+// different kind must NOT constrain the new value).
+func TestCheckTypeCompatible_KindMatching(t *testing.T) {
+	numFlag := mustFlag(t, `{"variants":{"a":1.0,"b":2.0},"defaultVariant":"a"}`)
+	if rej := checkTypeCompatible(numFlag, 5); rej != nil {
+		t.Fatalf("int on numeric flag rejected: %v", rej)
+	}
+	if rej := checkTypeCompatible(numFlag, "x"); rej == nil || rej.Reason != ReasonTypeMismatch {
+		t.Fatalf("string on numeric flag: got %v, want type_mismatch", rej)
+	}
+
+	boolFlag := mustFlag(t, `{"variants":{"on":true,"off":false},"defaultVariant":"on"}`)
+	if rej := checkTypeCompatible(boolFlag, true); rej != nil {
+		t.Fatalf("bool on bool flag rejected: %v", rej)
+	}
+	if rej := checkTypeCompatible(boolFlag, 3); rej == nil || rej.Reason != ReasonTypeMismatch {
+		t.Fatalf("number on bool flag: got %v, want type_mismatch", rej)
+	}
+
+	// The reserved experimental variant is skipped as a type witness: a stale
+	// agent_experiment string must not block a numeric re-experiment.
+	staleExp := mustFlag(t, `{"variants":{"a":1.0,"agent_experiment":"oops"},"defaultVariant":"a"}`)
+	if rej := checkTypeCompatible(staleExp, 9.0); rej != nil {
+		t.Fatalf("numeric value blocked by stale experimental variant: %v", rej)
+	}
+}
+
 // ---- Idempotent re-experimentation -----------------------------------------
 
 func TestReview_ReExperimentIsIdempotent(t *testing.T) {

--- a/services/agent/experiment/gate.go
+++ b/services/agent/experiment/gate.go
@@ -48,6 +48,13 @@ const (
 	// while validating (file unreadable, malformed flag). Fail closed.
 	ReasonReadError            Reason = "read_error"
 	ReasonWriteSimulationError Reason = "write_simulation_error"
+	// ReasonTypeMismatch — ExperimentalValue's JSON kind (number/string/bool/
+	// array/object) does not match the flag's EXISTING variant values. The
+	// invariant is structurally safe regardless (shadow-only), but a game-side
+	// reader of the flag expects a stable type, so a string on a numeric flag would
+	// crash/misbehave the reader in a SHADOW game once an LLM emits a mistyped
+	// value. Reject before the write so only well-typed experiments reach shadow.
+	ReasonTypeMismatch Reason = "type_mismatch"
 )
 
 // gameFlagFileName is the only basename the Gate will validate a write against.
@@ -177,6 +184,17 @@ func (g *Gate) validate(p Proposal) *RejectError {
 	if err != nil {
 		return &RejectError{Reason: ReasonReadError, Detail: err.Error()}
 	}
+
+	// Type-compatibility: the experimental value must be the same JSON kind as the
+	// flag's existing variants. The invariant is upheld either way (the experiment
+	// is shadow-scoped), but a mistyped value would surface to a SHADOW game's
+	// reader that expects a consistent type — reject before the write so only
+	// well-typed experiments reach shadow. Runs before the structural simulation:
+	// it's a property of the proposal vs the current variants, not of the write.
+	if rej := checkTypeCompatible(beforeFlag, p.ExperimentalValue); rej != nil {
+		return rej
+	}
+
 	after, err := parseDoc(raw)
 	if err != nil {
 		return &RejectError{Reason: ReasonReadError, Detail: err.Error()}
@@ -243,6 +261,75 @@ func checkVariantsAndDefault(before, after *flagObj) *RejectError {
 		}
 		if name != ExperimentVariant {
 			return &RejectError{Reason: ReasonTargetingNotShadowScoped, Detail: "unexpected new variant " + name}
+		}
+	}
+	return nil
+}
+
+// jsonKind classifies a raw JSON value into one of the five JSON kinds the type
+// guard distinguishes: "number", "string", "bool", "array", "object". JSON null
+// and unrecognised bytes return "" (no kind). Crucially ALL numerics share the
+// "number" kind — JSON has one number type, so int-vs-float (6 vs 4.0) are
+// compatible and never rejected; flagd/Go decode both to float64 anyway.
+func jsonKind(raw json.RawMessage) string {
+	var v any
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return ""
+	}
+	switch v.(type) {
+	case float64:
+		return "number"
+	case string:
+		return "string"
+	case bool:
+		return "bool"
+	case []any:
+		return "array"
+	case map[string]any:
+		return "object"
+	default: // nil (JSON null) — kindless; nothing to match against.
+		return ""
+	}
+}
+
+// checkTypeCompatible rejects an ExperimentalValue whose JSON kind differs from
+// the flag's EXISTING (non-experimental) variant values. The reader of a game
+// flag expects one stable type, so a string on a numeric flag would
+// crash/misbehave in a shadow game once an LLM emits a mistyped value. We compare
+// against the existing variants (not defaultVariant alone) so a flag whose
+// variants are uniformly numbers requires a number, etc. The reserved
+// experimental variant is skipped — it is the value we are (re)writing, not a
+// game-authored type witness. Empty/kindless existing variants (e.g. all-null)
+// impose no constraint; a kindless experimental value matches anything.
+func checkTypeCompatible(flag *flagObj, experimental any) *RejectError {
+	expRaw, err := json.Marshal(experimental)
+	if err != nil {
+		return &RejectError{Reason: ReasonTypeMismatch, Detail: "experimental value is not JSON-encodable"}
+	}
+	expKind := jsonKind(expRaw)
+	if expKind == "" {
+		// A null/kindless experimental value can sit alongside any-typed variants;
+		// the structural checks still guard the invariant.
+		return nil
+	}
+
+	var variants map[string]json.RawMessage
+	if _, err := flag.get("variants", &variants); err != nil {
+		return &RejectError{Reason: ReasonReadError, Detail: err.Error()}
+	}
+	for name, vRaw := range variants {
+		if name == ExperimentVariant {
+			continue
+		}
+		k := jsonKind(vRaw)
+		if k == "" {
+			continue // kindless existing variant imposes no type constraint.
+		}
+		if k != expKind {
+			return &RejectError{
+				Reason: ReasonTypeMismatch,
+				Detail: fmt.Sprintf("experimental value is %s but variant %q is %s", expKind, name, k),
+			}
 		}
 	}
 	return nil

--- a/services/agent/experiment/proposal.go
+++ b/services/agent/experiment/proposal.go
@@ -45,8 +45,11 @@ type Proposal struct {
 	FlagKey string
 
 	// ExperimentalValue is the value shadow games should resolve for FlagKey. It
-	// is added as a new variant; its JSON type should match the flag's existing
-	// variants (the game-side reader expects a consistent type).
+	// is added as a new variant; its JSON kind MUST match the flag's existing
+	// variants (the game-side reader expects a consistent type). The Gate enforces
+	// this (ReasonTypeMismatch) — e.g. a string on a numeric flag is rejected
+	// before the write. JSON has one number type, so int-vs-float (6 vs 4.0) is
+	// fine.
 	ExperimentalValue any
 
 	// Rationale is the agent's hypothesis ("why this value might improve the


### PR DESCRIPTION
## What

Addresses nit **N3** from the #953 (PR) adversarial review of the experiment writer gate.

The experiment `Gate` accepted a `Proposal.ExperimentalValue any` whose JSON type might not match the flag's existing variants — e.g. a string on a numeric game flag like `invincibility_seconds`. The real-resolution invariant is unaffected (the experiment is shadow-scoped, real games are untouched), but a game-side reader expecting a float could crash or misbehave in a **SHADOW** game once the (later, LLM-generated) proposal is mistyped.

## Change

- New typed reason `ReasonTypeMismatch` (mirrors the existing closed reason set in `gate.go`).
- `checkTypeCompatible` runs in the `Review`/`validate` path alongside the structural checks: the experimental value's JSON **kind** (number/string/bool/array/object) must match the flag's EXISTING non-`agent_experiment` variant values. On a mismatch the proposal is REJECTED before any write — no file change, `code_improvement.blocked=true` + reason on the span.
- **int-vs-float is NOT a mismatch**: JSON has one number kind, so `6` on the `4.0`-variant `invincibility_seconds` flag (and the reverse, a float on integer `num_teams`) is accepted. Null/kindless witnesses impose no constraint; the reserved experimental variant is skipped as a type witness.
- Scope kept to `gate.go` + `proposal.go` + tests only (disjoint from the parallel M7-7 PR).

## Tests

- string on numeric flag → blocked `type_mismatch`, file unchanged, blocked span
- int on float-variant flag, float on int-variant flag → accepted (no false reject)
- bool on bool flag → accepted; number on bool flag → blocked, file unchanged
- unit coverage of `checkTypeCompatible` kind matching + stale-experimental-variant skip

`gofmt -l .` clean, `go vet ./...`, `go build ./...`, `go test -race ./...` all green from `services/agent/`.

Part of #932.

🤖 Generated with [Claude Code](https://claude.com/claude-code)