### PR TITLE
feat(agent): synthetic validation gate for flag experiments (#935)

### DIFF
--- a/services/agent/experiment/validate.go
+++ b/services/agent/experiment/validate.go
@@ -1,0 +1,401 @@
+package experiment
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// validate.go implements M7-7 (#935): the SYNTHETIC VALIDATION GATE for the
+// agent's flag experiments.
+//
+// Where this sits in the #931/#932 self-improvement track:
+//
+//	M7-4/M7-5 (gate.go/writer.go): the agent forms a structured {flag, value}
+//	Proposal and the Writer/Gate apply it to game.json SHADOW-scoped — real games
+//	are untouched by construction (see THE INVARIANT in proposal.go).
+//	    ↓
+//	M7-7 (THIS file): before that experiment is ever promoted to real players,
+//	prove it actually helps. Establish a fitness BASELINE from recent real games
+//	(#731 fitness eval), run the experiment through the M6 synthetic/shadow suite
+//	(#774–#893), measure fitness with the experiment active, and DECIDE on the
+//	delta: PROMOTE if it clears the threshold, DISCARD otherwise, REVERT if it
+//	degraded and revert_on_degradation is set.
+//	    ↓
+//	M7-8 (#936): the SEPARATE gated action that actually moves the value to real
+//	players (PR/human, or autonomous behind the kill-switch). M7-7 returns a
+//	PROMOTE *decision*; it does NOT change the real defaultVariant itself.
+//
+// RESCOPE NOTE (#931/#932 "Refined design 2026-06-12"): the original #935 body
+// says "apply the proposed diff to a staging copy of the service" and "patch the
+// code". That is superseded — there is NO source-code diff. "Apply the
+// experiment" = the shadow-scoped game-flag write the Writer already performs;
+// "the patched build" = the same services running with the experiment's flag
+// value active for shadow (game_kind != "real") games. So validation = run shadow
+// games with the experiment active, compare fitness to the real-game baseline.
+//
+// INJECTABLE SEAMS (the whole point of building this in isolation, mirrors the
+// Gate/Writer split): the Validator owns only the DECISION LOGIC. The two effects
+// it cannot perform deterministically in a unit test — running shadow games and
+// reading fitness from telemetry — are interfaces (SyntheticRunner,
+// FitnessMeasurer, Baseline). Tests supply fakes; the real wiring (trigger shadow
+// games via the coordinator, read fitness from the #731 evaluator / OTel) is a
+// documented FOLLOW-UP, not built here. See the interface docs below for the
+// exact production implementation each seam expects.
+
+// Outcome is the Validator's verdict on an experiment after synthetic validation.
+// The set is closed so the audit trail / dashboards can enumerate every result.
+type Outcome string
+
+const (
+	// OutcomePromote — fitness_after exceeded fitness_before by MORE than the
+	// improvement threshold. The experiment earned promotion. M7-7 stops here and
+	// returns this verdict; the real-default change is M7-8's (#936) gated job.
+	OutcomePromote Outcome = "promote"
+	// OutcomeDiscard — the improvement did not clear the threshold (it may even be
+	// slightly positive, just not enough). The experiment is dropped; nothing is
+	// promoted. The shadow experiment write may stay in place for the next
+	// proposal to overwrite (idempotent ExperimentVariant) — discarding is a
+	// DECISION, not a rollback.
+	OutcomeDiscard Outcome = "discard"
+	// OutcomeRevert — fitness_after was strictly WORSE than baseline (degradation)
+	// AND revert_on_degradation was true, so the active experiment was rolled back
+	// via Reverter. Distinct from Discard so a degradation-driven rollback is
+	// attributable separately from a merely-insufficient improvement.
+	OutcomeRevert Outcome = "revert"
+)
+
+// Decision is the full result of one Validate cycle: the verdict plus the
+// fitness numbers it rested on. Returned to the caller (the decision loop / M7-8)
+// so the promote path can act on Outcome without re-reading the span.
+type Decision struct {
+	// Outcome is the verdict (promote/discard/revert).
+	Outcome Outcome
+	// FitnessBefore is the baseline fitness from recent real games.
+	FitnessBefore float64
+	// FitnessAfter is the fitness measured over the synthetic suite with the
+	// experiment active. Zero/meaningless when Err is non-nil (failed closed).
+	FitnessAfter float64
+	// Games is the number of synthetic games actually run (the resolved
+	// validation_games flag value).
+	Games int
+	// Reverted is true only on OutcomeRevert (degradation + revert flag).
+	Reverted bool
+	// Err, when non-nil, means the cycle could NOT complete (baseline unavailable,
+	// synthetic run failed, measurement failed). The Validator FAILS CLOSED: on an
+	// error Outcome is OutcomeDiscard and nothing is ever promoted on a broken
+	// fitness signal. The caller can inspect Err for telemetry / retry; it has
+	// already been recorded on the span.
+	Err error
+}
+
+// Config is the live, per-cycle flag configuration the Validator reads (#935
+// flags, resolved fresh each Validate so a stage retune takes effect on the next
+// cycle — same never-cached contract as the #847 llm.* gate flags). The caller
+// resolves these via flags.Validation(ctx) (see flags/flags.go) and passes the
+// value in, so the experiment package stays free of an OpenFeature dependency
+// (the Gate/Writer already follow this "package owns logic, caller owns flagd"
+// split).
+type Config struct {
+	// ValidationGames is how many synthetic games to run for the experiment
+	// (code_improvement.validation_games, default 5). Clamped to >= 1 by Validate:
+	// a zero/negative game count cannot measure anything, so a misconfigured flag
+	// runs at least one game rather than promoting on no evidence.
+	ValidationGames int
+	// ImprovementThreshold is the minimum fitness improvement (after - before) the
+	// experiment must EXCEED to be promoted
+	// (code_improvement.fitness_improvement_threshold). Promotion requires
+	// delta > threshold (strict): an experiment exactly at the bar is NOT promoted,
+	// matching "improvement exceeds the threshold" in the #935 AC.
+	ImprovementThreshold float64
+	// RevertOnDegradation, when true, rolls back the active experiment via the
+	// Reverter if fitness_after is strictly worse than baseline
+	// (code_improvement.revert_on_degradation). When false a degradation is a plain
+	// DISCARD (no rollback) — the shadow scoping means a degrading experiment never
+	// touched real players anyway, so reverting is hygiene, not safety.
+	RevertOnDegradation bool
+}
+
+// Baseline supplies the fitness BASELINE the experiment is measured against:
+// the aggregate fitness of the last N REAL games (#935 "a baseline established
+// from the last N real games"; #731 fitness eval). It is injected so the
+// Validator's decision logic is unit-testable with a fixed baseline.
+//
+// PRODUCTION FOLLOW-UP (not built here): the real implementation reads recent
+// real-game fitness from the #731 fitness evaluator / the gamesummary window
+// (services/agent/gamesummary, gamewindow) — i.e. the same recent-real-game
+// fitness the agent already aggregates — and returns its mean. An error (no real
+// games yet, telemetry unreachable) makes Validate FAIL CLOSED.
+type Baseline interface {
+	// Fitness returns the baseline fitness for the experiment's objective(s).
+	// ctx carries the validation span; an error fails the cycle closed.
+	Fitness(ctx context.Context, p Proposal) (float64, error)
+}
+
+// SyntheticRunner runs the experiment through the M6 synthetic/shadow game suite
+// (#774–#893) and returns a handle the FitnessMeasurer reads fitness from. It is
+// injected so the Validator never blocks a unit test on a real game run.
+//
+// PRODUCTION FOLLOW-UP (not built here): the real implementation triggers `games`
+// headless shadow games via the game coordinator (the M6 shadow-game harness,
+// e.g. tests/integration/test_parallel_lifecycle.py's gameId-scoped batches but
+// driven from the agent), with the experiment's flag ALREADY written shadow-scoped
+// (the Writer did that). Because the experiment targets game_kind != "real", those
+// synthetic games resolve the experimental variant while any concurrent real game
+// is untouched — that is exactly the isolation #932 guarantees. The returned Run
+// identifies the batch so the FitnessMeasurer can read its fitness.
+type SyntheticRunner interface {
+	// Run executes `games` synthetic games with the proposal's experiment active
+	// and returns a Run handle, or an error (coordinator unreachable, games failed
+	// to start) that fails the cycle closed.
+	Run(ctx context.Context, p Proposal, games int) (Run, error)
+}
+
+// Run is an opaque handle to a completed synthetic-game batch, threaded from the
+// SyntheticRunner to the FitnessMeasurer. Kept minimal (just a batch identity)
+// so the two seams can be implemented independently; the real handle will likely
+// carry the shadow game_ids / a fitness-query key.
+type Run struct {
+	// ID identifies the synthetic batch (e.g. a run UUID or comma-joined shadow
+	// game_ids). Opaque to the Validator; meaningful to the FitnessMeasurer.
+	ID string
+	// Games is the number of games the runner actually completed, echoed back so
+	// the measurer and the span agree on the realized sample size.
+	Games int
+}
+
+// FitnessMeasurer reads the aggregate fitness of a completed synthetic Run. It is
+// injected so the Validator's promote/discard logic is exercised against exact
+// fitness numbers in tests.
+//
+// PRODUCTION FOLLOW-UP (not built here): the real implementation reads the
+// shadow games' fitness from the #731 fitness evaluator (the same
+// EvaluateFitness / FitnessEvaluation the decision loop produces, aggregated over
+// the batch) via telemetry / the coordinator's per-game fitness, keyed by the
+// Run's shadow game_ids. An error fails the cycle closed.
+type FitnessMeasurer interface {
+	// Measure returns the aggregate fitness of the synthetic Run. An error fails
+	// the cycle closed (no promotion on an unmeasurable run).
+	Measure(ctx context.Context, run Run) (float64, error)
+}
+
+// Reverter rolls back an active experiment (used only on OutcomeRevert). It is
+// injected and OPTIONAL: a nil Reverter means "no rollback mechanism wired yet",
+// in which case a degradation with the revert flag set still records
+// OutcomeRevert on the span but performs no rollback (and notes the missing
+// reverter). Separating the verdict from the rollback keeps the decision logic
+// testable without a real Writer round-trip.
+//
+// PRODUCTION FOLLOW-UP (not built here): the real implementation removes the
+// experimental variant + shadow targeting from game.json — the inverse of the
+// Writer's Apply, run through the Gate so the real-resolution invariant still
+// holds (removing the shadow branch only ever AFFECTS shadow games, so it is
+// trivially invariant-safe, but routing it through the Writer keeps one write
+// path).
+type Reverter interface {
+	// Revert rolls back the proposal's active experiment from the game flagset.
+	// An error is recorded but does NOT change the outcome (the experiment was
+	// shadow-scoped, so a failed rollback never reaches real players); the span
+	// carries the error for follow-up.
+	Revert(ctx context.Context, p Proposal) error
+}
+
+// Validator runs the synthetic validation cycle for an experiment Proposal and
+// returns a promote/discard/revert Decision. It owns ONLY the decision logic; the
+// game run, the fitness reads, and the rollback are the injected seams above, so
+// the whole cycle is unit-testable with fakes and the live wiring is a documented
+// follow-up.
+//
+// The Validator does NOT run the Gate/Writer itself: by the time Validate is
+// called the experiment has ALREADY been written shadow-scoped (the Gate accepted
+// it). Validate's job is to decide whether that already-shadow-active experiment
+// deserves promotion to real — purely from fitness. This ordering keeps the two
+// gates orthogonal: the Gate proves "this write cannot harm real players"
+// (structural invariant); the Validator proves "this experiment helps shadow
+// games" (fitness), and only then does M7-8 promote it to real.
+type Validator struct {
+	baseline Baseline
+	runner   SyntheticRunner
+	measurer FitnessMeasurer
+	reverter Reverter // optional; nil means no rollback wired (see Reverter)
+	tracer   trace.Tracer
+	log      *slog.Logger
+}
+
+// NewValidator builds a Validator over the injected seams. reverter may be nil
+// (no rollback mechanism wired — a revert verdict is still recorded). tracer nil
+// uses the global tracer (same instrumentation scope as the rest of the agent);
+// log nil uses slog.Default().
+func NewValidator(baseline Baseline, runner SyntheticRunner, measurer FitnessMeasurer, reverter Reverter, tracer trace.Tracer, log *slog.Logger) *Validator {
+	if tracer == nil {
+		tracer = otel.Tracer(instrumentationName)
+	}
+	if log == nil {
+		log = slog.Default()
+	}
+	return &Validator{
+		baseline: baseline,
+		runner:   runner,
+		measurer: measurer,
+		reverter: reverter,
+		tracer:   tracer,
+		log:      log,
+	}
+}
+
+// Validate runs one synthetic validation cycle for p under the live cfg and
+// returns the Decision. It emits code_improvement.synthetic_validation as the
+// parent span (so the cycle is the issue's single trace tree: the caller's
+// evaluation → invocation spans parent THIS, which parents the apply|discard
+// leaf) carrying fitness_before/after/delta + the resolved flags + the outcome.
+//
+// Sequence:
+//  1. resolve the baseline from recent real games,
+//  2. run `validation_games` synthetic games with the experiment active,
+//  3. measure fitness over that run,
+//  4. decide: PROMOTE if (after-before) > threshold; else DISCARD; REVERT instead
+//     of DISCARD when after < before AND revert_on_degradation.
+//
+// FAIL CLOSED: any seam error short-circuits to OutcomeDiscard with Decision.Err
+// set and code_improvement.validation_error on the span — the agent NEVER
+// promotes an experiment on a baseline/run/measurement it could not obtain.
+func (v *Validator) Validate(ctx context.Context, p Proposal, cfg Config) Decision {
+	games := cfg.ValidationGames
+	if games < 1 {
+		// A zero/negative game count cannot produce evidence; clamp to one game
+		// rather than "validate" against an empty run (which would risk promoting
+		// on no data). Logged so a misconfigured flag is visible.
+		v.log.Warn("validation_games non-positive, clamping to 1", "configured", cfg.ValidationGames)
+		games = 1
+	}
+
+	ctx, span := v.tracer.Start(ctx, SpanSyntheticValidation, trace.WithAttributes(
+		attribute.String(AttrFlagKey, p.FlagKey),
+		attribute.String(AttrRationale, p.Rationale),
+		attribute.Int(AttrValidationGames, games),
+		attribute.Float64(AttrImprovementThreshold, cfg.ImprovementThreshold),
+	))
+	defer span.End()
+
+	// (1) Baseline from recent real games (#731 fitness). Fail closed on error:
+	// without a baseline there is nothing to compare against, so the experiment
+	// cannot be shown to improve anything.
+	before, err := v.baseline.Fitness(ctx, p)
+	if err != nil {
+		return v.fail(span, games, fmt.Errorf("baseline fitness: %w", err))
+	}
+	span.SetAttributes(attribute.Float64(AttrFitnessBefore, before))
+
+	// (2) Run the experiment through the synthetic suite. The experiment is
+	// already written shadow-scoped (Gate-accepted), so these games resolve the
+	// experimental variant while real games stay untouched (#932 isolation).
+	run, err := v.runner.Run(ctx, p, games)
+	if err != nil {
+		return v.fail(span, games, fmt.Errorf("synthetic run: %w", err))
+	}
+	// Trust the runner's realized game count for the span/decision: it may have
+	// completed fewer than requested (still a valid, if smaller, sample).
+	if run.Games > 0 {
+		games = run.Games
+		span.SetAttributes(attribute.Int(AttrValidationGames, games))
+	}
+
+	// (3) Measure fitness over the synthetic run.
+	after, err := v.measurer.Measure(ctx, run)
+	if err != nil {
+		return v.fail(span, games, fmt.Errorf("measure fitness: %w", err))
+	}
+
+	// (4) Decide on the delta.
+	delta := after - before
+	span.SetAttributes(
+		attribute.Float64(AttrFitnessAfter, after),
+		attribute.Float64(AttrFitnessDelta, delta),
+	)
+
+	dec := Decision{FitnessBefore: before, FitnessAfter: after, Games: games}
+	switch {
+	case delta > cfg.ImprovementThreshold:
+		// Cleared the bar: this experiment earned promotion. M7-7 returns the
+		// verdict; M7-8 (#936) performs the actual real-default change.
+		dec.Outcome = OutcomePromote
+	case after < before && cfg.RevertOnDegradation:
+		// Strict degradation AND the revert flag is set: roll the experiment back.
+		dec.Outcome = OutcomeRevert
+		dec.Reverted = true
+		v.revert(ctx, span, p)
+	default:
+		// Insufficient improvement (or a degradation without the revert flag):
+		// discard. Nothing is promoted; the shadow experiment simply does not
+		// graduate.
+		dec.Outcome = OutcomeDiscard
+	}
+
+	v.recordOutcome(ctx, span, dec)
+	return dec
+}
+
+// fail records a failed-closed cycle on the span and returns a discard Decision
+// carrying the error. No promotion ever happens on a seam error.
+func (v *Validator) fail(span trace.Span, games int, err error) Decision {
+	span.SetAttributes(
+		attribute.String(AttrOutcome, string(OutcomeDiscard)),
+		attribute.String(AttrValidationError, err.Error()),
+	)
+	span.SetStatus(codes.Error, err.Error())
+	v.log.Warn("code_improvement.validation failed closed",
+		"outcome", string(OutcomeDiscard), "error", err)
+	return Decision{Outcome: OutcomeDiscard, Games: games, Err: err}
+}
+
+// revert invokes the optional Reverter for a degradation rollback. A nil Reverter
+// (no rollback wired yet) or a Revert error is recorded but never changes the
+// outcome — a shadow experiment never reached real players, so a failed rollback
+// is not a safety issue, only a hygiene one for the next proposal.
+func (v *Validator) revert(ctx context.Context, span trace.Span, p Proposal) {
+	if v.reverter == nil {
+		span.SetAttributes(attribute.String(AttrValidationError, "revert requested but no reverter wired"))
+		v.log.Warn("code_improvement.revert requested but no reverter wired", "flag_key", p.FlagKey)
+		return
+	}
+	if err := v.reverter.Revert(ctx, p); err != nil {
+		span.SetAttributes(attribute.String(AttrValidationError, "revert failed: "+err.Error()))
+		v.log.Warn("code_improvement.revert failed", "flag_key", p.FlagKey, "error", err)
+	}
+}
+
+// recordOutcome emits the apply|discard LEAF span (the issue's
+// apply | discard node) under the validation span and stamps the outcome on the
+// validation span itself, so a trace shows both the decision and its branch.
+func (v *Validator) recordOutcome(ctx context.Context, span trace.Span, dec Decision) {
+	span.SetAttributes(
+		attribute.String(AttrOutcome, string(dec.Outcome)),
+		attribute.Bool(AttrReverted, dec.Reverted),
+	)
+
+	// The promote branch resolves to apply (#936 performs the real change later);
+	// discard and revert both resolve to the discard leaf (nothing promoted).
+	leaf := SpanDiscard
+	if dec.Outcome == OutcomePromote {
+		leaf = SpanApply
+	}
+	_, leafSpan := v.tracer.Start(ctx, leaf, trace.WithAttributes(
+		attribute.String(AttrOutcome, string(dec.Outcome)),
+		attribute.Float64(AttrFitnessBefore, dec.FitnessBefore),
+		attribute.Float64(AttrFitnessAfter, dec.FitnessAfter),
+		attribute.Bool(AttrReverted, dec.Reverted),
+	))
+	leafSpan.End()
+
+	v.log.Info("code_improvement.validated",
+		"outcome", string(dec.Outcome),
+		"fitness_before", dec.FitnessBefore,
+		"fitness_after", dec.FitnessAfter,
+		"games", dec.Games,
+		"reverted", dec.Reverted)
+}

--- a/services/agent/experiment/validate_telemetry.go
+++ b/services/agent/experiment/validate_telemetry.go
@@ -1,0 +1,79 @@
+package experiment
+
+// Span names + attribute keys for the M7-7 synthetic VALIDATION cycle (#935).
+//
+// M7-7 sits BETWEEN the agent forming a Proposal and that proposal becoming the
+// real default (#936). Its job: run the proposed flag experiment through the M6
+// synthetic/shadow game suite (#774–#893), measure fitness against a baseline
+// drawn from recent real games (#731 fitness eval), and DECIDE — promote,
+// discard, or revert — purely on the fitness delta.
+//
+// The full self-improvement cycle is ONE trace tree (the #935 AC, "single trace
+// tree"): the caller's evaluation → invocation spans parent a
+// code_improvement.synthetic_validation span (this package), which in turn
+// parents either code_improvement.apply (PROMOTE) or code_improvement.discard
+// (DISCARD/REVERT). Dot notation matches the repo span convention
+// (decision/telemetry.go). These consts live in a SEPARATE file from telemetry.go
+// (which a parallel PR owns) so the additions never collide; the experiment.Attr*
+// keys there (flag_key/blocked/reason/rationale) describe the WRITE gate, the
+// keys here describe the VALIDATE gate — distinct phases of the same #931/#932
+// flag-experiment track.
+const (
+	// SpanSyntheticValidation wraps one Validator.Validate of a Proposal: run the
+	// synthetic suite with the experiment active, measure before/after fitness,
+	// decide. It is the issue's "synthetic_validation" node in the
+	// evaluation → invocation → synthetic_validation → apply|discard tree.
+	SpanSyntheticValidation = "code_improvement.synthetic_validation"
+	// SpanApply is the PROMOTE leaf: the experiment improved fitness past the
+	// threshold, so the cycle resolves to apply. NOTE M7-7 does NOT itself change
+	// the real defaultVariant — that gated promotion is M7-8's (#936) job; here a
+	// PROMOTE outcome means "this experiment earned promotion", recorded so the
+	// trace shows the decision even though the real-default move happens later.
+	SpanApply = "code_improvement.apply"
+	// SpanDiscard is the DISCARD/REVERT leaf: the experiment did not clear the
+	// threshold (DISCARD) or actively degraded fitness with revert_on_degradation
+	// on (REVERT). Either way nothing is promoted; the leaf records which.
+	SpanDiscard = "code_improvement.discard"
+)
+
+// Attribute keys of the synthetic-validation span schema (#935). The #935 AC
+// requires fitness_before/fitness_after on the span and the cycle visible as one
+// trace; these carry them.
+const (
+	// AttrFitnessBefore is the BASELINE fitness, drawn from the last N real games
+	// (the injected Baseline source). Recorded on the validation span so a Jaeger
+	// trace shows what the experiment was measured against. (#935 AC: "fitness_before
+	// recorded on the span".)
+	AttrFitnessBefore = "code_improvement.fitness_before"
+	// AttrFitnessAfter is the fitness measured AFTER running the synthetic suite
+	// with the experiment active (the injected FitnessMeasurer over the
+	// SyntheticRunner's result). (#935 AC: "fitness_after recorded on the span".)
+	AttrFitnessAfter = "code_improvement.fitness_after"
+	// AttrFitnessDelta is fitness_after - fitness_before: the improvement the
+	// promote/discard decision keys on. Recorded alongside before/after so the
+	// decision is self-explaining in the trace (no client-side subtraction needed).
+	AttrFitnessDelta = "code_improvement.fitness_delta"
+	// AttrValidationGames is the COUNT of synthetic games actually run this cycle
+	// (the resolved code_improvement.validation_games flag value). On the span so
+	// the trace shows the sample size the fitness_after rests on.
+	AttrValidationGames = "code_improvement.validation_games"
+	// AttrImprovementThreshold is the resolved
+	// code_improvement.fitness_improvement_threshold the delta was compared
+	// against — recorded so the trace shows the bar the experiment had to clear.
+	AttrImprovementThreshold = "code_improvement.fitness_improvement_threshold"
+	// AttrOutcome is the cycle's decision, one of the Outcome* string constants
+	// (promote/discard/revert). The single attribute a dashboard groups by to see
+	// "what did the agent decide for this experiment". (#935 AC: the apply|discard
+	// branch of the trace.)
+	AttrOutcome = "code_improvement.outcome"
+	// AttrReverted is true ONLY on a REVERT outcome: the experiment degraded
+	// fitness and revert_on_degradation was set, so the active experiment was
+	// rolled back. Absent/false on PROMOTE and plain DISCARD. (#935 AC: "revert on
+	// degradation when revert_on_degradation = true".)
+	AttrReverted = "code_improvement.reverted"
+	// AttrValidationError carries the typed reason the cycle could not complete
+	// (baseline unavailable, synthetic run failed, measurement failed). Present
+	// only on the error path; its presence means the cycle FAILED CLOSED — no
+	// promotion, outcome=discard — never silently promoted on a broken signal.
+	AttrValidationError = "code_improvement.validation_error"
+)

--- a/services/agent/experiment/validate_test.go
+++ b/services/agent/experiment/validate_test.go
@@ -1,0 +1,367 @@
+package experiment
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+// ---- Fakes for the three injectable seams (#935). The Validator owns only the
+// decision logic; the game run, fitness reads, and rollback are faked here so the
+// promote/discard/revert paths are exercised against exact numbers with no clock,
+// network, or game stack (the live wiring is the documented follow-up). ----
+
+// fakeBaseline returns a fixed baseline fitness (or an error to exercise the
+// fail-closed path).
+type fakeBaseline struct {
+	fitness float64
+	err     error
+}
+
+func (b fakeBaseline) Fitness(context.Context, Proposal) (float64, error) {
+	return b.fitness, b.err
+}
+
+// fakeRunner records the game count it was asked to run and returns a Run handle
+// (or an error). realizedGames, when >0, simulates a runner that completed a
+// different count than requested.
+type fakeRunner struct {
+	gotGames      int
+	realizedGames int
+	err           error
+}
+
+func (r *fakeRunner) Run(_ context.Context, _ Proposal, games int) (Run, error) {
+	r.gotGames = games
+	if r.err != nil {
+		return Run{}, r.err
+	}
+	g := games
+	if r.realizedGames > 0 {
+		g = r.realizedGames
+	}
+	return Run{ID: "synthetic-batch", Games: g}, nil
+}
+
+// fakeMeasurer returns a fixed post-experiment fitness (or an error).
+type fakeMeasurer struct {
+	fitness float64
+	err     error
+}
+
+func (m fakeMeasurer) Measure(context.Context, Run) (float64, error) {
+	return m.fitness, m.err
+}
+
+// fakeReverter records whether Revert was called (and can return an error).
+type fakeReverter struct {
+	called bool
+	err    error
+}
+
+func (r *fakeReverter) Revert(context.Context, Proposal) error {
+	r.called = true
+	return r.err
+}
+
+// validatorWithRecorder wires a Validator over the given seams with an in-memory
+// span recorder, using the recording-tracer pattern from experiment_test.go /
+// decision/*_test.go.
+func validatorWithRecorder(t *testing.T, b Baseline, r SyntheticRunner, m FitnessMeasurer, rev Reverter) (*Validator, *tracetest.SpanRecorder) {
+	t.Helper()
+	rec := tracetest.NewSpanRecorder()
+	tp := trace.NewTracerProvider(trace.WithSpanProcessor(rec))
+	v := NewValidator(b, r, m, rev, tp.Tracer("test"), discardLogger())
+	return v, rec
+}
+
+var testProposal = Proposal{FlagKey: "death_grace_period_ms", ExperimentalValue: 500, Rationale: "longer grace may extend sessions"}
+
+// findSpan returns the first recorded span with the given name, or fails.
+func findSpan(t *testing.T, rec *tracetest.SpanRecorder, name string) trace.ReadOnlySpan {
+	t.Helper()
+	for _, s := range rec.Ended() {
+		if s.Name() == name {
+			return s
+		}
+	}
+	t.Fatalf("span %q not found", name)
+	return nil
+}
+
+// floatAttr reads a float64 span attribute by key, failing if absent.
+func floatAttr(t *testing.T, s trace.ReadOnlySpan, key string) float64 {
+	t.Helper()
+	for _, a := range s.Attributes() {
+		if string(a.Key) == key {
+			return a.Value.AsFloat64()
+		}
+	}
+	t.Fatalf("span %q missing float attr %q", s.Name(), key)
+	return 0
+}
+
+// stringAttr reads a string span attribute by key (returns "" if absent).
+func stringAttr(s trace.ReadOnlySpan, key string) string {
+	for _, a := range s.Attributes() {
+		if string(a.Key) == key {
+			return a.Value.AsString()
+		}
+	}
+	return ""
+}
+
+func defaultCfg() Config {
+	return Config{ValidationGames: 5, ImprovementThreshold: 0.05, RevertOnDegradation: true}
+}
+
+// TestValidatePromote: improvement strictly above the threshold → PROMOTE, and
+// the apply leaf (not discard) is emitted. (#935 AC: promote only if improvement
+// exceeds threshold.)
+func TestValidatePromote(t *testing.T) {
+	v, rec := validatorWithRecorder(t,
+		fakeBaseline{fitness: 0.50},
+		&fakeRunner{},
+		fakeMeasurer{fitness: 0.70}, // delta 0.20 > 0.05
+		&fakeReverter{})
+
+	dec := v.Validate(context.Background(), testProposal, defaultCfg())
+
+	if dec.Outcome != OutcomePromote {
+		t.Fatalf("outcome = %q, want promote", dec.Outcome)
+	}
+	if dec.Err != nil {
+		t.Fatalf("unexpected err: %v", dec.Err)
+	}
+	// apply leaf present, discard leaf absent.
+	findSpan(t, rec, SpanApply)
+	for _, s := range rec.Ended() {
+		if s.Name() == SpanDiscard {
+			t.Fatalf("discard leaf should not be emitted on promote")
+		}
+	}
+}
+
+// TestValidateDiscardBelowThreshold: a positive but insufficient improvement →
+// DISCARD (not promote). Covers the strict ">" boundary: delta exactly at the
+// threshold must NOT promote.
+func TestValidateDiscardBelowThreshold(t *testing.T) {
+	// Each case: {baseline, after}. The "at threshold" case uses baseline 0 so the
+	// delta is EXACTLY the float literal 0.05 — `delta > 0.05` is then false, proving
+	// the strict boundary without floating-point slop (0.55-0.50 is NOT exactly 0.05).
+	cases := map[string][2]float64{
+		"below threshold": {0.50, 0.53}, // delta 0.03 < 0.05
+		"at threshold":    {0.00, 0.05}, // delta exactly 0.05, not strictly greater
+	}
+	for name, fc := range cases {
+		t.Run(name, func(t *testing.T) {
+			v, rec := validatorWithRecorder(t,
+				fakeBaseline{fitness: fc[0]},
+				&fakeRunner{},
+				fakeMeasurer{fitness: fc[1]},
+				&fakeReverter{})
+
+			dec := v.Validate(context.Background(), testProposal, defaultCfg())
+			if dec.Outcome != OutcomeDiscard {
+				t.Fatalf("outcome = %q, want discard", dec.Outcome)
+			}
+			findSpan(t, rec, SpanDiscard)
+		})
+	}
+}
+
+// TestValidateRevertOnDegradation: degradation + revert flag → REVERT, and the
+// Reverter is invoked. (#935 AC: revert on degradation when the flag is true.)
+func TestValidateRevertOnDegradation(t *testing.T) {
+	rev := &fakeReverter{}
+	v, rec := validatorWithRecorder(t,
+		fakeBaseline{fitness: 0.50},
+		&fakeRunner{},
+		fakeMeasurer{fitness: 0.40}, // strictly worse than baseline
+		rev)
+
+	dec := v.Validate(context.Background(), testProposal, defaultCfg())
+
+	if dec.Outcome != OutcomeRevert {
+		t.Fatalf("outcome = %q, want revert", dec.Outcome)
+	}
+	if !dec.Reverted || !rev.called {
+		t.Fatalf("expected revert invoked: dec.Reverted=%v reverter.called=%v", dec.Reverted, rev.called)
+	}
+	leaf := findSpan(t, rec, SpanDiscard)
+	if got := stringAttr(leaf, AttrOutcome); got != string(OutcomeRevert) {
+		t.Fatalf("discard leaf outcome = %q, want revert", got)
+	}
+}
+
+// TestValidateDegradationWithoutRevertFlag: degradation but revert_on_degradation
+// false → plain DISCARD, Reverter NOT called.
+func TestValidateDegradationWithoutRevertFlag(t *testing.T) {
+	rev := &fakeReverter{}
+	cfg := defaultCfg()
+	cfg.RevertOnDegradation = false
+	v, _ := validatorWithRecorder(t,
+		fakeBaseline{fitness: 0.50},
+		&fakeRunner{},
+		fakeMeasurer{fitness: 0.40},
+		rev)
+
+	dec := v.Validate(context.Background(), testProposal, cfg)
+	if dec.Outcome != OutcomeDiscard {
+		t.Fatalf("outcome = %q, want discard", dec.Outcome)
+	}
+	if dec.Reverted || rev.called {
+		t.Fatalf("reverter must not run without the flag: reverted=%v called=%v", dec.Reverted, rev.called)
+	}
+}
+
+// TestValidateRevertNoReverterWired: degradation + revert flag but a nil Reverter
+// → still REVERT verdict (recorded), no panic. Covers the "no rollback wired yet"
+// follow-up state.
+func TestValidateRevertNoReverterWired(t *testing.T) {
+	v, rec := validatorWithRecorder(t,
+		fakeBaseline{fitness: 0.50},
+		&fakeRunner{},
+		fakeMeasurer{fitness: 0.40},
+		nil) // no reverter
+
+	dec := v.Validate(context.Background(), testProposal, defaultCfg())
+	if dec.Outcome != OutcomeRevert || !dec.Reverted {
+		t.Fatalf("outcome = %q reverted=%v, want revert/true", dec.Outcome, dec.Reverted)
+	}
+	span := findSpan(t, rec, SpanSyntheticValidation)
+	if got := stringAttr(span, AttrValidationError); got == "" {
+		t.Fatalf("expected validation_error noting missing reverter")
+	}
+}
+
+// TestValidateRecordsFitnessOnSpan: fitness_before/after/delta and the resolved
+// flags ride the validation span. (#935 AC: fitness_before/after on the span.)
+func TestValidateRecordsFitnessOnSpan(t *testing.T) {
+	v, rec := validatorWithRecorder(t,
+		fakeBaseline{fitness: 0.40},
+		&fakeRunner{},
+		fakeMeasurer{fitness: 0.62},
+		&fakeReverter{})
+
+	v.Validate(context.Background(), testProposal, defaultCfg())
+
+	span := findSpan(t, rec, SpanSyntheticValidation)
+	if got := floatAttr(t, span, AttrFitnessBefore); got != 0.40 {
+		t.Errorf("fitness_before = %v, want 0.40", got)
+	}
+	if got := floatAttr(t, span, AttrFitnessAfter); got != 0.62 {
+		t.Errorf("fitness_after = %v, want 0.62", got)
+	}
+	if got := floatAttr(t, span, AttrFitnessDelta); got < 0.21 || got > 0.23 {
+		t.Errorf("fitness_delta = %v, want ~0.22", got)
+	}
+	if got := floatAttr(t, span, AttrImprovementThreshold); got != 0.05 {
+		t.Errorf("improvement_threshold = %v, want 0.05", got)
+	}
+	if got := stringAttr(span, AttrOutcome); got != string(OutcomePromote) {
+		t.Errorf("outcome attr = %q, want promote", got)
+	}
+}
+
+// TestValidateSingleTraceTree: the apply|discard leaf is a CHILD of the
+// synthetic_validation span (same trace, leaf's parent == validation's span id),
+// proving the cycle is one trace tree. (#935 AC: full cycle visible as a single
+// trace tree.)
+func TestValidateSingleTraceTree(t *testing.T) {
+	v, rec := validatorWithRecorder(t,
+		fakeBaseline{fitness: 0.50},
+		&fakeRunner{},
+		fakeMeasurer{fitness: 0.70},
+		&fakeReverter{})
+
+	v.Validate(context.Background(), testProposal, defaultCfg())
+
+	parent := findSpan(t, rec, SpanSyntheticValidation)
+	leaf := findSpan(t, rec, SpanApply)
+
+	if parent.SpanContext().TraceID() != leaf.SpanContext().TraceID() {
+		t.Fatalf("leaf and parent are in different traces")
+	}
+	if leaf.Parent().SpanID() != parent.SpanContext().SpanID() {
+		t.Fatalf("apply leaf is not a child of the synthetic_validation span")
+	}
+}
+
+// TestValidateGameCountFromConfig: the runner is asked for exactly
+// cfg.ValidationGames, and the realized count is recorded on the span. (#935 AC:
+// game count controlled by validation_games.)
+func TestValidateGameCountFromConfig(t *testing.T) {
+	runner := &fakeRunner{realizedGames: 7}
+	cfg := defaultCfg()
+	cfg.ValidationGames = 7
+	v, rec := validatorWithRecorder(t,
+		fakeBaseline{fitness: 0.50}, runner, fakeMeasurer{fitness: 0.70}, &fakeReverter{})
+
+	dec := v.Validate(context.Background(), testProposal, cfg)
+	if runner.gotGames != 7 {
+		t.Errorf("runner asked for %d games, want 7", runner.gotGames)
+	}
+	if dec.Games != 7 {
+		t.Errorf("decision games = %d, want 7", dec.Games)
+	}
+	span := findSpan(t, rec, SpanSyntheticValidation)
+	var got int
+	for _, a := range span.Attributes() {
+		if string(a.Key) == AttrValidationGames {
+			got = int(a.Value.AsInt64())
+		}
+	}
+	if got != 7 {
+		t.Errorf("span validation_games = %d, want 7", got)
+	}
+}
+
+// TestValidateClampsNonPositiveGames: a misconfigured zero/negative game count
+// runs at least one game rather than validating on no evidence.
+func TestValidateClampsNonPositiveGames(t *testing.T) {
+	runner := &fakeRunner{}
+	cfg := defaultCfg()
+	cfg.ValidationGames = 0
+	v, _ := validatorWithRecorder(t,
+		fakeBaseline{fitness: 0.50}, runner, fakeMeasurer{fitness: 0.70}, &fakeReverter{})
+
+	v.Validate(context.Background(), testProposal, cfg)
+	if runner.gotGames != 1 {
+		t.Errorf("runner asked for %d games, want clamp to 1", runner.gotGames)
+	}
+}
+
+// TestValidateFailsClosed: any seam error → DISCARD with Err set and
+// validation_error on the span; NEVER a promote on a broken fitness signal.
+func TestValidateFailsClosed(t *testing.T) {
+	boom := errors.New("boom")
+	cases := map[string]struct {
+		b Baseline
+		r SyntheticRunner
+		m FitnessMeasurer
+	}{
+		"baseline error": {fakeBaseline{err: boom}, &fakeRunner{}, fakeMeasurer{fitness: 0.9}},
+		"runner error":   {fakeBaseline{fitness: 0.1}, &fakeRunner{err: boom}, fakeMeasurer{fitness: 0.9}},
+		"measure error":  {fakeBaseline{fitness: 0.1}, &fakeRunner{}, fakeMeasurer{err: boom}},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			v, rec := validatorWithRecorder(t, tc.b, tc.r, tc.m, &fakeReverter{})
+			dec := v.Validate(context.Background(), testProposal, defaultCfg())
+			if dec.Outcome != OutcomeDiscard {
+				t.Fatalf("outcome = %q, want discard (fail closed)", dec.Outcome)
+			}
+			if dec.Err == nil {
+				t.Fatalf("expected Decision.Err on fail-closed path")
+			}
+			span := findSpan(t, rec, SpanSyntheticValidation)
+			if stringAttr(span, AttrValidationError) == "" {
+				t.Fatalf("expected validation_error attr on the span")
+			}
+		})
+	}
+}

--- a/services/agent/flags/flags.go
+++ b/services/agent/flags/flags.go
@@ -77,6 +77,18 @@ const (
 	keyBluetoothMaxDroppedEventsPct = "fitness.bluetooth.max_dropped_events_pct"
 	keyBluetoothMinMovementUpdateHz = "fitness.bluetooth.min_movement_update_hz"
 
+	// M7-7 synthetic validation gate flags (#935). Read live (never cached) so a
+	// stage retune of the validation cadence/bar takes effect on the next
+	// validation cycle — same contract as the #847 llm.* numeric gate flags, and
+	// the numeric ones use the TYPED getters (the flagd numeric-flag gotcha: a
+	// numeric flag read via ObjectValue silently TYPE_MISMATCHes to its default —
+	// see llmGate). They govern experiment.Validator: how many synthetic/shadow
+	// games to validate an experiment against, the fitness improvement required to
+	// promote it, and whether a degrading experiment is rolled back.
+	keyValidationGames             = "code_improvement.validation_games"
+	keyFitnessImprovementThreshold = "code_improvement.fitness_improvement_threshold"
+	keyRevertOnDegradation         = "code_improvement.revert_on_degradation"
+
 	// Lifecycle + throttle calibration flags (#766 F5, hot-reloaded since #927).
 	// Unlike the per-cycle layers above, these are NOT re-read on the decision hot
 	// path; they are primed once at startup and then refreshed by the OpenFeature
@@ -169,6 +181,28 @@ const (
 	// DefaultBluetoothMinMovementUpdateHz: an update rate below this fails infra
 	// fitness (fitness.bluetooth.min_movement_update_hz).
 	DefaultBluetoothMinMovementUpdateHz = 10.0
+
+	// M7-7 synthetic validation defaults (#935), mirroring the
+	// services/flagd/agent.json code_improvement.* defaultVariants. Applied when
+	// flagd is unreachable or a flag is undefined.
+
+	// DefaultValidationGames is how many synthetic/shadow games an experiment is
+	// validated against (code_improvement.validation_games). 5 matches the #935
+	// suggested default — enough games to smooth single-game variance, few enough
+	// to keep a validation cycle cheap.
+	DefaultValidationGames = 5
+	// DefaultFitnessImprovementThreshold is the minimum fitness improvement
+	// (after-before) an experiment must EXCEED to be promoted
+	// (code_improvement.fitness_improvement_threshold). 0.05 (a 5% fitness-point
+	// improvement on the 0..1 progress scale, see decision/fitness.go) is a
+	// conservative bar: a noisy near-zero delta does not graduate. Tunable live.
+	DefaultFitnessImprovementThreshold = 0.05
+	// DefaultRevertOnDegradation is fail-safe-leaning: roll back an experiment that
+	// degrades shadow fitness (code_improvement.revert_on_degradation). Shadow
+	// scoping means a degrading experiment never reached real players, so this is
+	// hygiene rather than safety, but defaulting it on keeps the shadow surface
+	// clean for the next proposal.
+	DefaultRevertOnDegradation = true
 
 	// Lifecycle + throttle defaults (#766 F5), mirroring the former hardcoded
 	// constants in main.go (playerTTL/sessionGrace/evictEvery) and decision.go
@@ -369,6 +403,46 @@ func (f *Flags) Lifecycle(ctx context.Context) Lifecycle {
 		EvictInterval:    f.durationFlag(ctx, keyEvictIntervalSeconds, DefaultEvictIntervalSeconds),
 		DecisionThrottle: f.durationFlag(ctx, keyDecisionThrottleSecs, DefaultDecisionThrottleSeconds),
 	}
+}
+
+// ValidationConfig is the M7-7 synthetic validation gate configuration (#935):
+// how many synthetic games to validate an experiment against, the fitness
+// improvement bar to promote it, and whether to revert a degrading experiment.
+// It mirrors the experiment.Config shape (the experiment package stays free of an
+// OpenFeature dependency — the caller resolves the flags here and passes the value
+// in, the same "package owns logic, caller owns flagd" split the Gate/Writer use).
+type ValidationConfig struct {
+	// ValidationGames is code_improvement.validation_games (default 5).
+	ValidationGames int
+	// ImprovementThreshold is code_improvement.fitness_improvement_threshold
+	// (default 0.05): the minimum fitness improvement to promote an experiment.
+	ImprovementThreshold float64
+	// RevertOnDegradation is code_improvement.revert_on_degradation (default true):
+	// roll back an experiment that degrades shadow fitness.
+	RevertOnDegradation bool
+}
+
+// Validation evaluates the three M7-7 synthetic-validation flags (#935) for one
+// validation cycle. Read live (never cached) so a stage retune takes effect on
+// the next cycle. Each flag falls back to its safe default on any evaluation
+// error (flagd unreachable / undefined). The numeric flags use the TYPED getters
+// (the flagd numeric-flag gotcha — see llmGate); the boolean uses BooleanValue.
+func (f *Flags) Validation(ctx context.Context) ValidationConfig {
+	return ValidationConfig{
+		ValidationGames:      f.intFlag(ctx, keyValidationGames, DefaultValidationGames),
+		ImprovementThreshold: f.floatFlag(ctx, keyFitnessImprovementThreshold, DefaultFitnessImprovementThreshold),
+		RevertOnDegradation:  f.boolFlag(ctx, keyRevertOnDegradation, DefaultRevertOnDegradation),
+	}
+}
+
+// boolFlag resolves a boolean flag, falling back to def on any error.
+func (f *Flags) boolFlag(ctx context.Context, key string, def bool) bool {
+	v, err := f.client.BooleanValue(ctx, key, def, openfeature.EvaluationContext{})
+	if err != nil {
+		f.log.Debug("flags bool fell back to default", "key", key, "error", err, "default", def)
+		return def
+	}
+	return v
 }
 
 // durationFlag resolves a float "seconds" flag into a time.Duration, falling

--- a/services/agent/flags/flags_test.go
+++ b/services/agent/flags/flags_test.go
@@ -535,3 +535,38 @@ func TestLifecycle_NonPositiveFallsBack(t *testing.T) {
 		t.Errorf("Lifecycle = %+v, want %+v", got, want)
 	}
 }
+
+// TestValidationFlags covers the M7-7 synthetic-validation gate flags (#935):
+// the typed getters resolve configured values, and each flag falls back to its
+// safe default on an evaluation error (flagd unreachable / undefined).
+func TestValidation(t *testing.T) {
+	t.Run("configured values resolve", func(t *testing.T) {
+		ev := stubEvaluator{
+			ints:     map[string]int64{keyValidationGames: 8},
+			floats:   map[string]float64{keyFitnessImprovementThreshold: 0.2},
+			booleans: map[string]bool{keyRevertOnDegradation: false},
+		}
+		got := New(ev, nil).Validation(context.Background())
+		want := ValidationConfig{ValidationGames: 8, ImprovementThreshold: 0.2, RevertOnDegradation: false}
+		if got != want {
+			t.Errorf("Validation = %+v, want %+v", got, want)
+		}
+	})
+
+	t.Run("errors fall back to safe defaults", func(t *testing.T) {
+		ev := stubEvaluator{errs: map[string]error{
+			keyValidationGames:             errors.New("flagd down"),
+			keyFitnessImprovementThreshold: errors.New("flagd down"),
+			keyRevertOnDegradation:         errors.New("flagd down"),
+		}}
+		got := New(ev, nil).Validation(context.Background())
+		want := ValidationConfig{
+			ValidationGames:      DefaultValidationGames,
+			ImprovementThreshold: DefaultFitnessImprovementThreshold,
+			RevertOnDegradation:  DefaultRevertOnDegradation,
+		}
+		if got != want {
+			t.Errorf("Validation defaults = %+v, want %+v", got, want)
+		}
+	})
+}

--- a/services/flagd/agent.json
+++ b/services/flagd/agent.json
@@ -382,6 +382,32 @@
         "quiet": 5
       },
       "defaultVariant": "default"
+    },
+    "code_improvement.validation_games": {
+      "state": "ENABLED",
+      "variants": {
+        "default": 5,
+        "quick": 3,
+        "thorough": 10
+      },
+      "defaultVariant": "default"
+    },
+    "code_improvement.fitness_improvement_threshold": {
+      "state": "ENABLED",
+      "variants": {
+        "default": 0.05,
+        "lenient": 0.01,
+        "strict": 0.1
+      },
+      "defaultVariant": "default"
+    },
+    "code_improvement.revert_on_degradation": {
+      "state": "ENABLED",
+      "variants": {
+        "on": true,
+        "off": false
+      },
+      "defaultVariant": "on"
     }
   }
 }


### PR DESCRIPTION
## M7-7: Synthetic validation gate (#935)

Adds `experiment.Validator`: given a Gate-accepted shadow experiment `Proposal`, it establishes a fitness **baseline** from recent real games, runs the experiment through the synthetic/shadow suite, **measures** fitness, and **decides** the verdict.

### Rescoped design (#931/#932 "Refined design 2026-06-12")
The original #935 body says "apply the proposed diff to a staging copy" and "patch the code" — that is **superseded**. There is no source-code diff. The experiment is a shadow-scoped **game-flag value** the Writer/Gate already apply (M7-4/M7-5, #932), targeted `game_kind != "real"` so real games are untouched by construction. So validation = run shadow games with the experiment active and compare fitness to the real-game baseline (#731 fitness eval).

`Validate` is **one trace tree** — `code_improvement.synthetic_validation -> apply | discard` — carrying `code_improvement.fitness_before` / `fitness_after` / `fitness_delta`, the resolved flags, and the `outcome`:
- **PROMOTE** when `fitness_after - fitness_before > fitness_improvement_threshold` (strict).
- **DISCARD** otherwise.
- **REVERT** instead of discard when fitness degraded **and** `revert_on_degradation` is true (rolls back via the optional `Reverter`).

This component does **not** change the real `defaultVariant` — that gated promotion is **M7-8 (#936)**. Here PROMOTE is the verdict only.

### Injectable seams (unit-testable logic; live wiring is a documented follow-up)
The Validator owns only the decision logic. The three effects it cannot perform deterministically in a unit test are interfaces — tests supply fakes:
- `Baseline.Fitness` — baseline from last N real games. **Follow-up:** read recent-real-game fitness from #731 / the gamesummary window.
- `SyntheticRunner.Run` — run N shadow games with the experiment active. **Follow-up:** trigger headless shadow games via the coordinator (M6 harness, #774–#893); the experiment is already shadow-scoped so real games stay untouched.
- `FitnessMeasurer.Measure` — read aggregate fitness of the run. **Follow-up:** read shadow-game fitness from the #731 evaluator / telemetry.
- `Reverter.Revert` (optional, nil = "no rollback wired yet") — roll back the experiment on degradation.

The Validator **fails closed**: any seam error → DISCARD with the error on the span, never a promote on a broken fitness signal.

### Flags (read live, #847 numeric-flag pattern)
Added to `flags/flags.go` (+ `Flags.Validation(ctx)`) and `services/flagd/agent.json`, additively:
- `code_improvement.validation_games` (int, default 5)
- `code_improvement.fitness_improvement_threshold` (float, default 0.05)
- `code_improvement.revert_on_degradation` (bool, default true)

### Files
New: `experiment/validate.go`, `experiment/validate_telemetry.go`, `experiment/validate_test.go`. Modified additively: `flags/flags.go`, `flags/flags_test.go`, `services/flagd/agent.json`. Does **not** touch `experiment/gate.go` or `experiment/proposal.go`.

### Tests (fakes; no clock/network/stack, recording-tracer pattern)
Promote / discard (incl. strict at-threshold boundary) / revert / degradation-without-flag / nil-reverter / fitness recorded on span / single trace tree (leaf is child of validation span) / game count from flag + clamp / fail-closed on each seam error; flags read live with safe-default fallback. `gofmt` / `go vet` / `go build` / `go test -race ./...` green from `services/agent/`.

Part of #935 (M7-7). Builds on #932 (M7-4/M7-5 Writer+Gate), #731 (fitness), M6 shadow games (#774–#893). Promotion to real default is #936 (M7-8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)