### PR TITLE
test(integration): experiment reaches shadow games, never real (#932)

### DIFF
--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -132,6 +132,40 @@ The integration tests cover:
 - ✅ Distributed tracing propagation across services
 - ✅ Multiple games in sequence
 
+## Experiment shadow-isolation (agent experiment safety boundary, #932)
+
+`test_experiment_shadow_isolation.py` covers the ONE agent-experiment safety link
+no other automated gate covered before it (the #954 review follow-up): that a
+*written* game-flag experiment reaches a SHADOW game and NEVER a REAL game,
+end-to-end through the REAL flagd — not an inline JSONLogic model.
+
+**Scope decision.** Like the intervention/rollout live-flagd tests, the agent
+service (`services/agent`, Go) does NOT run in the integration compose, so we do
+not run the Go experiment Writer here. We REPRODUCE its exact mutation
+(`services/agent/experiment/targeting.go` `buildShadowTargeting`: add the reserved
+`agent_experiment` variant + `{"if":[{"!=":[{"var":"game_kind"},"real"]},
+"agent_experiment", <pre-existing-else-or-null>]}`) into `game.json`, then resolve
+via the flagd RPC resolver (`flagSetId=game`, port 8013) under the EXACT
+`game_kind` eval-context values the #954 wiring sets (`"shadow"` for a shadow
+session, `"real"` for a real game / the fail-safe API-level default). The writer's
+own correctness is the Go unit tests' job (`services/agent/experiment/*_test.go`);
+the #954 context plumbing is covered by Python unit tests — NEITHER exercises the
+actual live-flagd resolution of the written rule under the real context values.
+
+**What this test DOES assert:** a SHADOW context resolves the EXPERIMENTAL value
+(`invincibility_seconds` 8.0, `sensitivity` 0) while a REAL context resolves the
+BASELINE (4.0 / medium), and a REAL game with pre-existing targeting
+(`game_mode=Werewolf`) keeps that targeted value verbatim (the experiment wraps it
+as the else-branch). It also documents WHERE the fail-safe lives: a context with
+no `game_kind` resolves EXPERIMENTAL at raw flagd (rule is `!= real`), so the
+real-by-default protection is enforced by the application context
+(`lib/feature_flags` defaults the API-level context to `game_kind="real"`), not by
+flagd — which would catch a writer that mistakenly used `== shadow`. A companion
+`test_game_kind_constants_match_source` pins the `game_kind` var/value strings to
+their single source of truth in both languages. Kept sequential (mutates the
+global `game` flagset); `game.json` is snapshotted and restored byte-for-byte by
+the `game_flags` fixture so the experiment never leaks.
+
 ## Rollout plumbing (agent remediation control plane, #737)
 
 `test_rollout_plumbing.py` covers the CONTROL-PLANE half of the agent's

--- a/tests/integration/test_experiment_shadow_isolation.py
+++ b/tests/integration/test_experiment_shadow_isolation.py
@@ -1,0 +1,360 @@
+"""
+Experiment shadow-isolation integration test (#932, closes the #954 review gap).
+
+Proves the ONE agent-experiment safety link that no other automated gate covered
+before this test: that a *written* game-flag experiment actually reaches a SHADOW
+game and NEVER a REAL game, end-to-end through the REAL flagd server — not an
+inline JSONLogic model (the Go `experiment.Gate`'s belt-and-suspenders eval in
+`services/agent/experiment/gate.go` evaluates jsonlogic in-process; this test
+proves the SAME targeting block resolves identically on the live flagd that the
+game services actually read through).
+
+The safety boundary, end-to-end:
+
+    agent experiment writer (services/agent/experiment/writer.go) adds an
+    `agent_experiment` variant + a shadow-scoped targeting rule to game.json
+      ->  flagd file-watch reload (live server, flagSetId=game)
+      ->  a SHADOW game's eval context (game_kind="shadow", set by the #954
+          GameSession wiring) resolves the EXPERIMENTAL value
+      ->  a REAL game's eval context (game_kind="real", set by the menu / the
+          fail-safe API-level default in lib/feature_flags) resolves the
+          BASELINE (defaultVariant) value — byte-identical to pre-experiment.
+
+What makes this the #954 follow-up: PR #954 (`feat/game-kind-eval-context`) wired
+`game_kind` into the OpenFeature eval context (`lib/feature_flags`,
+`GameSession`, the menu). Its review noted that the one link still lacking an
+automated gate was the runtime join — that the wiring + the writer's targeting
+rule + real flagd together honour the "shadow only, never real" invariant. The
+Go unit tests cover the writer/gate against an inline jsonlogic model; the #954
+Python unit tests cover the context plumbing in isolation. NEITHER exercises the
+actual flagd resolution of the written rule under the real context values. This
+test does, and is the agent-experiment sibling of
+`test_per_player_targeting_resolves_against_live_flagd` (intervention domain,
+#730) and `test_rollout_plumbing.py` (rollout domain, #737).
+
+Scope decision (mirrors the intervention/rollout live-flagd tests):
+
+- The agent service (services/agent, Go) is NOT run in the integration compose —
+  it lives behind the `agent` compose profile, exactly like the intervention
+  ActionSink and the rollout writer. So we do not run the Go writer here; we
+  REPRODUCE the exact mutation it makes (`buildShadowTargeting` in
+  `services/agent/experiment/targeting.go`: add the reserved `agent_experiment`
+  variant + `{"if":[{"!=":[{"var":"game_kind"},"real"]},"agent_experiment",
+  <pre-existing-else-or-null>]}`). The point of THIS test is the flagd + #954
+  game_kind wiring join, not the writer — the writer's own correctness is the Go
+  unit tests' job (`services/agent/experiment/*_test.go`).
+
+- We resolve via the flagd RPC resolver (port 8013, `flagSetId=game`) with
+  explicit `game_kind` eval contexts. resolver="rpc" is deliberate: this test's
+  PURPOSE is flagd's server-side evaluation of the written `!= real` targeting
+  rule (in-process would evaluate the jsonlogic client-side and mask a
+  server-side rule rejection — the same reason
+  test_per_player_targeting_resolves_against_live_flagd uses rpc).
+
+  The `game_kind` values used are the EXACT strings the #954 wiring puts on the
+  context: `"shadow"` for a shadow session and `"real"` for a real game / the
+  fail-safe API-level default. `test_game_kind_constants_match_source` pins them
+  to the single source of truth in BOTH languages (Python `lib.feature_flags`
+  GAME_KIND_* and the Go `experiment` GameKindVar/GameKindReal contract), so a
+  drift fails loudly rather than silently testing a stale value.
+
+Kept sequential (not batched per-game like #893/#778): it mutates the GLOBAL
+`game` flagset's targeting and asserts file-level flagd resolution for distinct
+context values, so it is order-dependent on global flag state — exactly the
+constraint that keeps test_per_player_targeting_resolves_against_live_flagd
+sequential. The autouse `coordinator_idle` quiesce + the `game_flags` snapshot
+fixture keep it from leaking into neighbours.
+
+game.json is a bind-mounted host file; the `game_flags` fixture snapshots and
+restores it byte-for-byte so the experiment mutation never leaks into the repo
+or later tests (mirrors the `flag_files` / `rollout_file` fixtures).
+"""
+
+import json
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+
+from tests.integration.helpers import (  # noqa: E402
+    FLAGD_RESOLVE_TIMEOUT_SECONDS,
+    flagd_probe_client,
+    poll_until,
+    wait_flag_file_restored,
+)
+
+# game_kind context var + values — the SAME contract the #954 wiring sets on the
+# eval context (lib/feature_flags GAME_KIND_*) and that the experiment writer
+# scopes targeting on (services/agent/experiment/targeting.go GameKindVar/Real).
+# We define them here rather than importing lib.feature_flags because the
+# integration-tests venv intentionally does NOT install the full app dependency
+# stack (lib.feature_flags pulls openfeature.contrib.hook, absent here). The
+# values are pinned to source by test_game_kind_constants_match_source below, so
+# any drift fails loudly — the import-free equivalent of the #954 cross-language
+# constant-match unit test.
+GAME_KIND_VAR = "game_kind"
+GAME_KIND_REAL = "real"
+GAME_KIND_SHADOW = "shadow"
+
+# Repo-root-relative path to the bind-mounted flagd config dir. The compose
+# flagd service mounts ./services/flagd into the container, so writing here on
+# the host is exactly what the Go experiment Writer does inside the container.
+_FLAGD_DIR = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "../../services/flagd")
+)
+GAME_PATH = os.path.join(_FLAGD_DIR, "game.json")
+
+# The single reserved variant name the experiment Writer adds/overwrites. MUST
+# match services/agent/experiment/targeting.go ExperimentVariant.
+EXPERIMENT_VARIANT = "agent_experiment"
+
+# How long flagd's file-watch reload of the experiment write is given to be
+# served before asserting. We use the harness-wide FLAGD_RESOLVE_TIMEOUT_SECONDS
+# (30s): flagd v0.16.0 can briefly serve a STATIC/defaultVariant state mid-reload
+# before the new targeting rule takes effect (observed: a transient resolve to
+# the first variant under the loaded warmup), and poll_until's rewrite self-heal
+# re-issues the write every couple of seconds to produce a fresh inotify event
+# if a reload was missed/coalesced — a generous deadline avoids a flaky timeout.
+RESOLVE_TIMEOUT_SECONDS = FLAGD_RESOLVE_TIMEOUT_SECONDS
+
+
+# =============================================================================
+# Experiment-write helper (mirrors services/agent/experiment/writer.go +
+# targeting.go buildShadowTargeting). Pure read-modify-write, in place.
+# =============================================================================
+
+
+def _load() -> dict:
+    with open(GAME_PATH) as fh:
+        return json.load(fh)
+
+
+def _dump_in_place(doc: dict) -> None:
+    """In-place truncate+write — matches Writer.writeInPlace (no temp+rename,
+    which EBUSYs on the flagd bind mount)."""
+    text = json.dumps(doc, indent=2) + "\n"
+    with open(GAME_PATH, "w") as fh:
+        fh.write(text)
+
+
+def _build_shadow_targeting(existing_targeting):
+    """Reproduce targeting.go buildShadowTargeting.
+
+    Returns {"if":[{"!=":[{"var":"game_kind"},"real"]}, "agent_experiment",
+    <else>]} where <else> is the flag's PRE-EXISTING targeting verbatim (so a
+    flag that already targets game_mode keeps doing so for real games) or null
+    when there was none. The "!= real" condition is shadow-scoped BY
+    CONSTRUCTION: a real context makes it false, so flagd evaluates <else> —
+    byte-identical to the pre-write resolution.
+    """
+    else_branch = existing_targeting if existing_targeting is not None else None
+    return {
+        "if": [
+            {"!=": [{"var": GAME_KIND_VAR}, GAME_KIND_REAL]},
+            EXPERIMENT_VARIANT,
+            else_branch,
+        ]
+    }
+
+
+def write_experiment(flag_key: str, experimental_value) -> None:
+    """Apply a shadow-scoped experiment to a `game` flag, exactly as the Go
+    Writer.Apply does: ADD the reserved `agent_experiment` variant (never
+    mutating an existing variant or the defaultVariant) and wrap any
+    pre-existing targeting in the shadow branch. Idempotent (overwrite, not
+    accumulate), so it doubles as poll_until's rewrite self-heal.
+    """
+    doc = _load()
+    flag = doc["flags"][flag_key]
+    # Merge the reserved variant in — every game-authored variant is preserved.
+    flag.setdefault("variants", {})[EXPERIMENT_VARIANT] = experimental_value
+    flag["targeting"] = _build_shadow_targeting(flag.get("targeting"))
+    _dump_in_place(doc)
+
+
+# =============================================================================
+# Fixture: snapshot/restore game.json byte-for-byte (mirrors flag_files /
+# rollout_file). Waits until flagd serves the restored baseline so the
+# experiment mutation never leaks into a neighbouring test.
+# =============================================================================
+
+
+@pytest.fixture
+def game_flags(docker_compose):
+    with open(GAME_PATH) as fh:
+        backup = fh.read()
+
+    yield
+
+    def _restore():
+        with open(GAME_PATH, "w") as fh:
+            fh.write(backup)
+
+    with open(GAME_PATH) as fh:
+        mutated = fh.read()
+    _restore()
+    # Wait until flagd serves the restored baseline for every flag this test
+    # observably mutated (defaultVariant value unchanged here, but the added
+    # `agent_experiment` variant + targeting are gone) before the next test runs.
+    wait_flag_file_restored(docker_compose, "game", backup, mutated, _restore)
+
+
+# =============================================================================
+# Contract pin: the game_kind constants used here MUST match the single source
+# of truth in both languages (Go writer/gate + Python #954 wiring). This is the
+# import-free equivalent of the #954 cross-language constant-match unit test —
+# it fails loudly if the var name / "real" / "shadow" values ever drift, so the
+# resolution assertions below can never silently test a stale contract.
+# =============================================================================
+
+
+def test_game_kind_constants_match_source():
+    repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
+
+    go_targeting = os.path.join(
+        repo_root, "services/agent/experiment/targeting.go"
+    )
+    with open(go_targeting) as fh:
+        go_src = fh.read()
+    assert f'GameKindVar = "{GAME_KIND_VAR}"' in go_src, (
+        "Go GameKindVar drifted from the test's GAME_KIND_VAR"
+    )
+    assert f'GameKindReal = "{GAME_KIND_REAL}"' in go_src, (
+        "Go GameKindReal drifted from the test's GAME_KIND_REAL"
+    )
+    assert f'ExperimentVariant = "{EXPERIMENT_VARIANT}"' in go_src, (
+        "Go ExperimentVariant drifted from the test's EXPERIMENT_VARIANT"
+    )
+
+    py_flags = os.path.join(repo_root, "lib/feature_flags.py")
+    with open(py_flags) as fh:
+        py_src = fh.read()
+    assert f'GAME_KIND_VAR = "{GAME_KIND_VAR}"' in py_src, (
+        "Python GAME_KIND_VAR drifted from the test's GAME_KIND_VAR"
+    )
+    assert f'GAME_KIND_REAL = "{GAME_KIND_REAL}"' in py_src, (
+        "Python GAME_KIND_REAL drifted from the test's GAME_KIND_REAL"
+    )
+    assert f'GAME_KIND_SHADOW = "{GAME_KIND_SHADOW}"' in py_src, (
+        "Python GAME_KIND_SHADOW drifted from the test's GAME_KIND_SHADOW"
+    )
+
+
+# =============================================================================
+# The test
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_experiment_reaches_shadow_never_real(game_flags, docker_compose):
+    """A written shadow-scoped experiment resolves the EXPERIMENTAL value for a
+    shadow game and the BASELINE value for a real game, via the REAL flagd.
+
+    Two flags, chosen to cover both branches of buildShadowTargeting:
+
+    - ``invincibility_seconds``: NO pre-existing targeting → the experiment's
+      else-branch is ``null`` → real falls through to defaultVariant ("4s"=4.0).
+      Experimental value 8.0 is an existing variant value but written into the
+      reserved ``agent_experiment`` variant, proving the variant routing (not
+      the value) is what the targeting selects.
+    - ``sensitivity``: HAS pre-existing targeting (game_mode==Werewolf → "fast"
+      =3) → the experiment wraps it as the else-branch. This proves a real game
+      keeps its prior targeted behaviour verbatim AND a shadow game overrides to
+      the experiment — the structural half of the experiment Gate's invariant,
+      now confirmed on live flagd.
+    """
+    from openfeature.evaluation_context import EvaluationContext
+
+    inv_baseline = 4.0  # invincibility_seconds defaultVariant "4s"
+    inv_experiment = 8.0
+    sens_baseline_default = 2  # sensitivity defaultVariant "medium"
+    sens_real_werewolf = 3  # sensitivity real Werewolf targeting -> "fast"
+    sens_experiment = 0  # write experimental sensitivity = "ultra_slow" value
+
+    def _write():
+        write_experiment("invincibility_seconds", inv_experiment)
+        write_experiment("sensitivity", sens_experiment)
+
+    _write()
+
+    shadow_ctx = EvaluationContext(attributes={GAME_KIND_VAR: GAME_KIND_SHADOW})
+    real_ctx = EvaluationContext(attributes={GAME_KIND_VAR: GAME_KIND_REAL})
+    # A real game whose menu config also set game_mode=Werewolf: proves the
+    # experiment's else-branch preserves the pre-existing real targeting.
+    real_werewolf_ctx = EvaluationContext(
+        attributes={GAME_KIND_VAR: GAME_KIND_REAL, "game_mode": "Werewolf"}
+    )
+    # No game_kind at all: at the RAW flagd layer this resolves EXPERIMENTAL
+    # (the rule is "!= real", and a missing var is not "real"). The fail-safe
+    # "real-by-default" property lives in the APPLICATION context, NOT in flagd —
+    # lib.feature_flags defaults the always-present API-level context to
+    # game_kind="real" so an unlabeled evaluation is protected by construction.
+    # Asserting the raw-flagd behaviour here documents exactly where the
+    # safety boundary is enforced (and would catch a writer that mistakenly
+    # used "== shadow", which would silently flip this).
+    empty_ctx = EvaluationContext()
+
+    with flagd_probe_client(docker_compose, "game", resolver="rpc") as client:
+
+        def _inv(ctx) -> float:
+            return client.get_float_value("invincibility_seconds", float("nan"), ctx)
+
+        def _sens(ctx) -> int:
+            return int(client.get_integer_value("sensitivity", -1, ctx))
+
+        # Poll until flagd serves the written experiment (provider connect +
+        # file-watch reload may lag the write), then assert the full matrix.
+        def _served() -> bool:
+            return (
+                abs(_inv(shadow_ctx) - inv_experiment) <= 0.01
+                and abs(_inv(real_ctx) - inv_baseline) <= 0.01
+            )
+
+        assert poll_until(_served, RESOLVE_TIMEOUT_SECONDS, rewrite=_write), (
+            "experiment did not resolve as expected on live flagd: "
+            f"shadow invincibility={_inv(shadow_ctx)} (want {inv_experiment}), "
+            f"real invincibility={_inv(real_ctx)} (want {inv_baseline})"
+        )
+
+        # --- invincibility_seconds (no pre-existing targeting, else=null) ---
+        # SHADOW resolves the experiment...
+        assert abs(_inv(shadow_ctx) - inv_experiment) <= 0.01, (
+            f"shadow did NOT get the experiment: {_inv(shadow_ctx)}"
+        )
+        # ...REAL resolves the baseline default (the safety boundary).
+        assert abs(_inv(real_ctx) - inv_baseline) <= 0.01, (
+            f"REAL leaked the experiment: invincibility={_inv(real_ctx)} "
+            f"(MUST be baseline {inv_baseline})"
+        )
+
+        # --- sensitivity (pre-existing Werewolf targeting wrapped as else) ---
+        # SHADOW overrides to the experiment regardless of game_mode...
+        assert _sens(shadow_ctx) == sens_experiment, (
+            f"shadow sensitivity did NOT get the experiment: {_sens(shadow_ctx)}"
+        )
+        # ...a REAL game keeps its plain default ("medium")...
+        assert _sens(real_ctx) == sens_baseline_default, (
+            f"REAL sensitivity leaked: {_sens(real_ctx)} "
+            f"(MUST be baseline default {sens_baseline_default})"
+        )
+        # ...and a REAL Werewolf game keeps its PRE-EXISTING targeted value
+        # ("fast"), proving the experiment's else-branch preserved real targeting
+        # verbatim — the structural half of the experiment Gate's invariant.
+        assert _sens(real_werewolf_ctx) == sens_real_werewolf, (
+            f"REAL Werewolf targeting was clobbered: {_sens(real_werewolf_ctx)} "
+            f"(MUST stay {sens_real_werewolf})"
+        )
+
+        # --- where the fail-safe lives: raw flagd vs application context ---
+        # No game_kind on the raw context => flagd's "!= real" rule selects the
+        # experiment. This is correct and intentional: the real-by-default
+        # protection is the APPLICATION's job (lib.feature_flags defaults the
+        # API-level context to game_kind="real"), not flagd's. Asserting it makes
+        # the boundary explicit and would catch a "== shadow" writer mistake.
+        assert abs(_inv(empty_ctx) - inv_experiment) <= 0.01, (
+            "raw flagd should resolve EXPERIMENTAL for a context with no "
+            f"game_kind (rule is != real): got {_inv(empty_ctx)}. The real-by-"
+            "default fail-safe is enforced by the application context, not flagd."
+        )

--- a/tests/integration/test_experiment_shadow_isolation.py
+++ b/tests/integration/test_experiment_shadow_isolation.py
@@ -65,12 +65,18 @@ constraint that keeps test_per_player_targeting_resolves_against_live_flagd
 sequential. The autouse `coordinator_idle` quiesce + the `game_flags` snapshot
 fixture keep it from leaking into neighbours.
 
-game.json is a bind-mounted host file; the `game_flags` fixture snapshots and
-restores it byte-for-byte so the experiment mutation never leaks into the repo
-or later tests (mirrors the `flag_files` / `rollout_file` fixtures).
+The `game` flagset is a bind-mounted host file, but WHICH host file flagd
+serves depends on the compose stack: the dev stack mounts game.json, while the
+CI stack (docker-compose.ci.yml) mounts game.ci.json OVER /etc/flagd/game.json.
+The `game_flags` fixture therefore snapshots and restores EVERY game*.json file
+byte-for-byte, and the test mutates every one + derives its baselines from the
+LIVE flagd, so it is correct against either file with no env branch (the proper
+single-source-of-truth for the active flag-file path is tracked in #959).
 """
 
+import glob
 import json
+import math
 import os
 import sys
 
@@ -82,7 +88,6 @@ from tests.integration.helpers import (  # noqa: E402
     FLAGD_RESOLVE_TIMEOUT_SECONDS,
     flagd_probe_client,
     poll_until,
-    wait_flag_file_restored,
 )
 
 # game_kind context var + values — the SAME contract the #954 wiring sets on the
@@ -104,7 +109,19 @@ GAME_KIND_SHADOW = "shadow"
 _FLAGD_DIR = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "../../services/flagd")
 )
-GAME_PATH = os.path.join(_FLAGD_DIR, "game.json")
+
+# The flagd container is fed the `game` flagset from a DIFFERENT host file
+# depending on the compose stack: the dev/local stack mounts game.json, but the
+# CI stack (docker-compose.ci.yml) mounts game.ci.json OVER /etc/flagd/game.json
+# (a shorter-timeout variant). So the host file flagd is actually serving is NOT
+# fixed. Rather than branch on an env var (the proper "which file is active"
+# config mechanism is tracked in #959), this test mutates EVERY game flagset
+# file (game.json AND game.ci.json) and restores each byte-for-byte. Whichever
+# one flagd happens to be serving therefore carries the experiment, and the
+# others are left identical to their committed state. STOPGAP: once #959 lands a
+# single source of truth for the active flag-file path, this glob collapses to
+# reading that one configured path.
+GAME_PATHS = sorted(glob.glob(os.path.join(_FLAGD_DIR, "game*.json")))
 
 # The single reserved variant name the experiment Writer adds/overwrites. MUST
 # match services/agent/experiment/targeting.go ExperimentVariant.
@@ -126,16 +143,16 @@ RESOLVE_TIMEOUT_SECONDS = FLAGD_RESOLVE_TIMEOUT_SECONDS
 # =============================================================================
 
 
-def _load() -> dict:
-    with open(GAME_PATH) as fh:
+def _load(path: str) -> dict:
+    with open(path) as fh:
         return json.load(fh)
 
 
-def _dump_in_place(doc: dict) -> None:
+def _dump_in_place(path: str, doc: dict) -> None:
     """In-place truncate+write — matches Writer.writeInPlace (no temp+rename,
     which EBUSYs on the flagd bind mount)."""
     text = json.dumps(doc, indent=2) + "\n"
-    with open(GAME_PATH, "w") as fh:
+    with open(path, "w") as fh:
         fh.write(text)
 
 
@@ -165,13 +182,18 @@ def write_experiment(flag_key: str, experimental_value) -> None:
     mutating an existing variant or the defaultVariant) and wrap any
     pre-existing targeting in the shadow branch. Idempotent (overwrite, not
     accumulate), so it doubles as poll_until's rewrite self-heal.
+
+    Applied to EVERY game flagset file so the experiment is present whichever
+    file flagd is serving (game.json locally, game.ci.json under the CI compose
+    overlay) — see GAME_PATHS for the #959 stopgap rationale.
     """
-    doc = _load()
-    flag = doc["flags"][flag_key]
-    # Merge the reserved variant in — every game-authored variant is preserved.
-    flag.setdefault("variants", {})[EXPERIMENT_VARIANT] = experimental_value
-    flag["targeting"] = _build_shadow_targeting(flag.get("targeting"))
-    _dump_in_place(doc)
+    for path in GAME_PATHS:
+        doc = _load(path)
+        flag = doc["flags"][flag_key]
+        # Merge the reserved variant in — every game-authored variant is kept.
+        flag.setdefault("variants", {})[EXPERIMENT_VARIANT] = experimental_value
+        flag["targeting"] = _build_shadow_targeting(flag.get("targeting"))
+        _dump_in_place(path, doc)
 
 
 # =============================================================================
@@ -183,22 +205,50 @@ def write_experiment(flag_key: str, experimental_value) -> None:
 
 @pytest.fixture
 def game_flags(docker_compose):
-    with open(GAME_PATH) as fh:
-        backup = fh.read()
+    # Snapshot EVERY game flagset file (game.json + game.ci.json) so whichever
+    # one flagd is serving is restored byte-for-byte — see GAME_PATHS.
+    backups = {}
+    for path in GAME_PATHS:
+        with open(path) as fh:
+            backups[path] = fh.read()
 
     yield
 
     def _restore():
-        with open(GAME_PATH, "w") as fh:
-            fh.write(backup)
+        for path, text in backups.items():
+            with open(path, "w") as fh:
+                fh.write(text)
 
-    with open(GAME_PATH) as fh:
-        mutated = fh.read()
     _restore()
-    # Wait until flagd serves the restored baseline for every flag this test
-    # observably mutated (defaultVariant value unchanged here, but the added
-    # `agent_experiment` variant + targeting are gone) before the next test runs.
-    wait_flag_file_restored(docker_compose, "game", backup, mutated, _restore)
+    # Wait until the LIVE flagd no longer serves the experiment (the added
+    # `agent_experiment` variant + shadow targeting are gone) before the next
+    # test runs — file-agnostic, so it is correct whichever game*.json flagd
+    # mounts. Signal: with the experiment present, a shadow context resolves
+    # invincibility_seconds to the experiment value while a real context
+    # resolves the baseline (shadow != real); once restored, the experiment
+    # variant is gone so BOTH fall through to the same defaultVariant
+    # (invincibility has no other targeting) — shadow == real again. We can't
+    # know the served file's exact value here, so we assert that equality rather
+    # than a hardcoded baseline. ``_restore`` doubles as poll_until's rewrite
+    # self-heal (fresh inotify event for a missed/coalesced reload).
+    from openfeature.evaluation_context import EvaluationContext
+
+    shadow_ctx = EvaluationContext(attributes={GAME_KIND_VAR: GAME_KIND_SHADOW})
+    real_ctx = EvaluationContext(attributes={GAME_KIND_VAR: GAME_KIND_REAL})
+    with flagd_probe_client(docker_compose, "game", resolver="rpc") as client:
+
+        def _restored() -> bool:
+            shadow = client.get_float_value(
+                "invincibility_seconds", float("nan"), shadow_ctx
+            )
+            real = client.get_float_value(
+                "invincibility_seconds", float("nan"), real_ctx
+            )
+            return abs(shadow - real) <= 0.01
+
+        assert poll_until(_restored, FLAGD_RESOLVE_TIMEOUT_SECONDS, rewrite=_restore), (
+            "flagd still served the experiment after restore (game*.json leak)"
+        )
 
 
 # =============================================================================
@@ -213,9 +263,7 @@ def game_flags(docker_compose):
 def test_game_kind_constants_match_source():
     repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
 
-    go_targeting = os.path.join(
-        repo_root, "services/agent/experiment/targeting.go"
-    )
+    go_targeting = os.path.join(repo_root, "services/agent/experiment/targeting.go")
     with open(go_targeting) as fh:
         go_src = fh.read()
     assert f'GameKindVar = "{GAME_KIND_VAR}"' in go_src, (
@@ -250,34 +298,28 @@ def test_game_kind_constants_match_source():
 @pytest.mark.asyncio
 async def test_experiment_reaches_shadow_never_real(game_flags, docker_compose):
     """A written shadow-scoped experiment resolves the EXPERIMENTAL value for a
-    shadow game and the BASELINE value for a real game, via the REAL flagd.
+    shadow game and leaves every REAL context resolving its pre-experiment
+    BASELINE — via the REAL flagd, whichever game flagset file is mounted.
+
+    Baselines are derived DYNAMICALLY from the live flagd BEFORE the mutation
+    (not hardcoded from game.json), because the CI compose overlay mounts
+    game.ci.json — which carries different defaultVariant values (e.g.
+    invincibility_seconds defaults to "2s" there, "4s" locally). Hardcoding the
+    game.json numbers is exactly what made this test time out under CI. By
+    snapshotting each context's live resolution first and asserting it is
+    UNCHANGED afterwards, the "real never moves" safety invariant holds against
+    either file with no env branch.
 
     Two flags, chosen to cover both branches of buildShadowTargeting:
 
     - ``invincibility_seconds``: NO pre-existing targeting → the experiment's
-      else-branch is ``null`` → real falls through to defaultVariant ("4s"=4.0).
-      Experimental value 8.0 is an existing variant value but written into the
-      reserved ``agent_experiment`` variant, proving the variant routing (not
-      the value) is what the targeting selects.
-    - ``sensitivity``: HAS pre-existing targeting (game_mode==Werewolf → "fast"
-      =3) → the experiment wraps it as the else-branch. This proves a real game
-      keeps its prior targeted behaviour verbatim AND a shadow game overrides to
-      the experiment — the structural half of the experiment Gate's invariant,
-      now confirmed on live flagd.
+      else-branch is ``null`` → real falls through to its defaultVariant.
+    - ``sensitivity``: HAS pre-existing targeting (game_mode==Werewolf → "fast")
+      → the experiment wraps it as the else-branch, so a real game keeps its
+      prior targeted behaviour verbatim while a shadow game overrides — the
+      structural half of the experiment Gate's invariant, on live flagd.
     """
     from openfeature.evaluation_context import EvaluationContext
-
-    inv_baseline = 4.0  # invincibility_seconds defaultVariant "4s"
-    inv_experiment = 8.0
-    sens_baseline_default = 2  # sensitivity defaultVariant "medium"
-    sens_real_werewolf = 3  # sensitivity real Werewolf targeting -> "fast"
-    sens_experiment = 0  # write experimental sensitivity = "ultra_slow" value
-
-    def _write():
-        write_experiment("invincibility_seconds", inv_experiment)
-        write_experiment("sensitivity", sens_experiment)
-
-    _write()
 
     shadow_ctx = EvaluationContext(attributes={GAME_KIND_VAR: GAME_KIND_SHADOW})
     real_ctx = EvaluationContext(attributes={GAME_KIND_VAR: GAME_KIND_REAL})
@@ -290,10 +332,10 @@ async def test_experiment_reaches_shadow_never_real(game_flags, docker_compose):
     # (the rule is "!= real", and a missing var is not "real"). The fail-safe
     # "real-by-default" property lives in the APPLICATION context, NOT in flagd —
     # lib.feature_flags defaults the always-present API-level context to
-    # game_kind="real" so an unlabeled evaluation is protected by construction.
-    # Asserting the raw-flagd behaviour here documents exactly where the
-    # safety boundary is enforced (and would catch a writer that mistakenly
-    # used "== shadow", which would silently flip this).
+    # game_kind="real" so an unlabeled evaluation is protected by construction
+    # (verified in #954). Asserting the raw-flagd behaviour here documents exactly
+    # where the safety boundary is enforced (and would catch a writer that
+    # mistakenly used "== shadow", which would silently flip this).
     empty_ctx = EvaluationContext()
 
     with flagd_probe_client(docker_compose, "game", resolver="rpc") as client:
@@ -304,18 +346,56 @@ async def test_experiment_reaches_shadow_never_real(game_flags, docker_compose):
         def _sens(ctx) -> int:
             return int(client.get_integer_value("sensitivity", -1, ctx))
 
+        # Wait for the RPC provider to actually connect before reading baselines:
+        # a cold probe resolves to the typed default (nan / -1) until the gRPC
+        # stream is up, which would otherwise poison the dynamically-derived
+        # baseline. Ready == both flags resolve a real (non-default) value.
+        def _provider_ready() -> bool:
+            return not math.isnan(_inv(real_ctx)) and _sens(real_ctx) != -1
+
+        assert poll_until(_provider_ready, RESOLVE_TIMEOUT_SECONDS), (
+            "flagd RPC provider did not connect / serve a baseline in time"
+        )
+
+        # --- Derive baselines from the live flagd BEFORE mutating. ---
+        # Each real context's pre-experiment value is whatever the mounted file
+        # serves; the safety invariant is that these do not move after the write.
+        inv_real_baseline = _inv(real_ctx)
+        sens_real_baseline = _sens(real_ctx)
+        sens_real_werewolf_baseline = _sens(real_werewolf_ctx)
+
+        # Choose experiment values DISTINCT from the live real baselines so
+        # shadow != real is observable. Both are existing variant values in
+        # every game flagset file; we pick the one furthest from the baseline.
+        inv_experiment = 8.0 if inv_real_baseline < 8.0 else 2.0
+        sens_experiment = 0 if sens_real_baseline != 0 else 4
+        assert abs(inv_experiment - inv_real_baseline) > 0.01, (
+            "invincibility experiment value must differ from the real baseline "
+            f"({inv_real_baseline}) for the shadow!=real assertion to be meaningful"
+        )
+        assert sens_experiment != sens_real_baseline, (
+            "sensitivity experiment value must differ from the real baseline "
+            f"({sens_real_baseline})"
+        )
+
+        def _write():
+            write_experiment("invincibility_seconds", inv_experiment)
+            write_experiment("sensitivity", sens_experiment)
+
+        _write()
+
         # Poll until flagd serves the written experiment (provider connect +
         # file-watch reload may lag the write), then assert the full matrix.
         def _served() -> bool:
             return (
                 abs(_inv(shadow_ctx) - inv_experiment) <= 0.01
-                and abs(_inv(real_ctx) - inv_baseline) <= 0.01
+                and abs(_inv(real_ctx) - inv_real_baseline) <= 0.01
             )
 
         assert poll_until(_served, RESOLVE_TIMEOUT_SECONDS, rewrite=_write), (
             "experiment did not resolve as expected on live flagd: "
             f"shadow invincibility={_inv(shadow_ctx)} (want {inv_experiment}), "
-            f"real invincibility={_inv(real_ctx)} (want {inv_baseline})"
+            f"real invincibility={_inv(real_ctx)} (want baseline {inv_real_baseline})"
         )
 
         # --- invincibility_seconds (no pre-existing targeting, else=null) ---
@@ -323,10 +403,10 @@ async def test_experiment_reaches_shadow_never_real(game_flags, docker_compose):
         assert abs(_inv(shadow_ctx) - inv_experiment) <= 0.01, (
             f"shadow did NOT get the experiment: {_inv(shadow_ctx)}"
         )
-        # ...REAL resolves the baseline default (the safety boundary).
-        assert abs(_inv(real_ctx) - inv_baseline) <= 0.01, (
+        # ...REAL resolves the SAME value it did before the mutation (safety).
+        assert abs(_inv(real_ctx) - inv_real_baseline) <= 0.01, (
             f"REAL leaked the experiment: invincibility={_inv(real_ctx)} "
-            f"(MUST be baseline {inv_baseline})"
+            f"(MUST stay pre-experiment baseline {inv_real_baseline})"
         )
 
         # --- sensitivity (pre-existing Werewolf targeting wrapped as else) ---
@@ -334,17 +414,19 @@ async def test_experiment_reaches_shadow_never_real(game_flags, docker_compose):
         assert _sens(shadow_ctx) == sens_experiment, (
             f"shadow sensitivity did NOT get the experiment: {_sens(shadow_ctx)}"
         )
-        # ...a REAL game keeps its plain default ("medium")...
-        assert _sens(real_ctx) == sens_baseline_default, (
+        # ...a REAL game resolves the SAME value it did before the mutation...
+        assert _sens(real_ctx) == sens_real_baseline, (
             f"REAL sensitivity leaked: {_sens(real_ctx)} "
-            f"(MUST be baseline default {sens_baseline_default})"
+            f"(MUST stay pre-experiment baseline {sens_real_baseline})"
         )
-        # ...and a REAL Werewolf game keeps its PRE-EXISTING targeted value
-        # ("fast"), proving the experiment's else-branch preserved real targeting
-        # verbatim — the structural half of the experiment Gate's invariant.
-        assert _sens(real_werewolf_ctx) == sens_real_werewolf, (
+        # ...and a REAL Werewolf game resolves the SAME value before & after,
+        # proving the experiment's else-branch preserved whatever real targeting
+        # the mounted file had verbatim — robust to game.json vs game.ci.json
+        # targeting differences (this is the structural half of the Gate's
+        # invariant: pre-existing real targeting is untouched).
+        assert _sens(real_werewolf_ctx) == sens_real_werewolf_baseline, (
             f"REAL Werewolf targeting was clobbered: {_sens(real_werewolf_ctx)} "
-            f"(MUST stay {sens_real_werewolf})"
+            f"(MUST stay pre-experiment baseline {sens_real_werewolf_baseline})"
         )
 
         # --- where the fail-safe lives: raw flagd vs application context ---


### PR DESCRIPTION
## What this proves

The agent-experiment **safety boundary, end-to-end through the REAL flagd**: a *written* game-flag experiment reaches a **SHADOW** game and **NEVER** a **REAL** game.

    agent experiment writer adds an `agent_experiment` variant + a shadow-scoped
    targeting rule to game.json
      -> flagd file-watch reload (live server, flagSetId=game)
      -> a SHADOW game's eval context (game_kind="shadow") resolves the EXPERIMENTAL value
      -> a REAL game's eval context  (game_kind="real")   resolves the BASELINE value

This is **not** an inline JSONLogic model: the Go `experiment.Gate` evaluates jsonlogic in-process; this test proves the **same targeting block resolves identically on the live flagd** that the game services actually read through, under the exact `game_kind` context values the wiring sets.

## The #954 review follow-up it closes

PR #954 (`feat/game-kind-eval-context`, now merged to `main`) wired `game_kind` into the OpenFeature eval context (`lib/feature_flags`, `GameSession`, the menu). Its review flagged the **one link still lacking an automated gate**: the runtime join — that the #954 wiring + the experiment writer's `!= real` targeting rule + real flagd together honour "shadow only, never real". The Go unit tests cover the writer/gate against an inline jsonlogic model; the #954 Python unit tests cover the context plumbing in isolation. **Neither exercises the actual flagd resolution of the written rule under the real context values.** This test does.

It is the agent-experiment sibling of `test_per_player_targeting_resolves_against_live_flagd` (intervention domain, #730) and `test_rollout_plumbing.py` (rollout domain, #737), following the same live-flagd-RPC + snapshot/restore conventions; kept sequential like the #778/#893 global-flagset tests.

## What it asserts (on live flagd, `flagSetId=game`, RPC resolver port 8013)

Reproduces the exact mutation `services/agent/experiment/targeting.go buildShadowTargeting` makes (no Go writer run — the agent isn't in the integration compose, same as the intervention ActionSink), then resolves under each context:

| context | `invincibility_seconds` | `sensitivity` | meaning |
|---|---|---|---|
| `game_kind=shadow` | 8.0 (experiment) | 0 (experiment) | shadow gets the experiment |
| `game_kind=real` | 4.0 (baseline) | medium=2 | **real protected** |
| `game_kind=real` + `game_mode=Werewolf` | 4.0 | fast=3 | pre-existing real targeting preserved verbatim (experiment wraps it as the else-branch) |
| no `game_kind` | 8.0 (experiment) | 0 | documents that the real-by-default fail-safe lives in the **application** context (`lib/feature_flags`), not flagd — would catch a `== shadow` writer mistake |

A companion `test_game_kind_constants_match_source` pins the `game_kind` var/value + `agent_experiment` variant strings to their single source of truth in **both** languages (Go `targeting.go` + Python `feature_flags.py`), so a contract drift fails loudly rather than silently testing a stale value.

`game.json` is snapshotted and restored byte-for-byte by the `game_flags` fixture so the experiment never leaks.

## How far it ran

Ran locally via the integration harness (`USE_PREBUILT_IMAGES=true USE_DEV_MOUNTS=true pytest tests/integration/test_experiment_shadow_isolation.py`): **2 passed in 26.39s** against the live docker-compose flagd. No flag-file leak after the run. `make lint` clean.

> Note: the original PR base `feat/game-kind-eval-context` merged + was deleted before push, so this was rebased `--onto origin/main` and **retargets `main`** (cascade per plan). #954's `game_kind` wiring is in `main` as commit `732ec03a`.

Part of #932.

🤖 Generated with [Claude Code](https://claude.com/claude-code)