### PR TITLE
feat(agent): LLM-driven shadow experiment proposer (#931)

### DIFF
--- a/services/agent/experiment/proposer.go
+++ b/services/agent/experiment/proposer.go
@@ -1,0 +1,373 @@
+package experiment
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/joustmania/agent/llm"
+)
+
+// proposer.go is M7-4 (#931): the agent turns its rolling game NARRATIVE (#916/
+// #929) + fitness signals into a structured flag-experiment Proposal and submits
+// it through Gate.Review — shadow-scoped, safe by construction (#932).
+//
+// THE RESCOPED DESIGN (#931/#932 "Refined design 2026-06-12", encoded in
+// proposal.go + the testing-strategy doc docs/research/m7-4-testing-strategy.md):
+// the original "remote coding agent edits SOURCE" is superseded. There is NO
+// source diff. The agent emits a structured {flag, value, rationale} over the
+// EXISTING Backend.Infer + defensive-decode seam (#739) — a full coding agent is
+// overkill for flag deltas. The Proposer is a THIN wrapper over that seam:
+//
+//	narrative + fitness  --Build prompt-->  Backend.Infer  --decodeProposal-->
+//	    Proposal  --Gate.Review-->  shadow-scoped game.json write (or blocked span)
+//
+// SAFETY (the whole point of routing through the Gate, never writing game.json
+// directly): the Gate enforces THE INVARIANT — a write can never change what a
+// game_kind="real" game resolves — and the type guard (#955). So even a malicious
+// or hallucinated model reply can, at worst, write a well-typed shadow-only
+// variant; it can NEVER affect real players. The decoder is the first line
+// (unparseable/out-of-vocab => no proposal at all); the Gate is the structural
+// backstop.
+//
+// DEGRADES TO NOTHING WITHOUT A REAL BACKEND: the production Backend
+// (decision.endpointBackend.Infer) is a sentinel stub until #738/#742 wire a real
+// Ollama/cloud transport. A backend error (the stub, a transport failure, a
+// timeout) is recorded and produces NO proposal and NO error to the caller — the
+// agent simply does not propose this cycle, exactly like the #739 llm path
+// degrades to rules. The engine is flag-selectable via agent.code_improvement.engine
+// (#931 AC); main.go reads that flag and selects the backend (today it only
+// selects the stub).
+
+// Backend is the inference seam the Proposer needs: send a constrained prompt,
+// get the model's RAW response text back. It is deliberately a NARROW local
+// interface (just Infer) rather than an import of decision.Backend — Go's
+// structural typing means decision's backends (endpointBackend, the resolver's
+// chosen tier) satisfy it for free, and keeping it local avoids an
+// experiment->decision import (decision already does not import experiment; this
+// keeps it that way). The Proposer reuses llm.Prompt as the prompt carrier so the
+// same Backend implementations the #739 path drives also drive proposals.
+type Backend interface {
+	// Infer sends prompt to the resolved inference tier and returns the model's
+	// raw response text, decoded DEFENSIVELY by decodeProposal (unparseable/
+	// out-of-vocab never proposes). An error (the sentinel stub, transport
+	// failure, timeout) makes the Proposer degrade to no-proposal SAFELY. ctx
+	// bounds the call (timeout/cancel).
+	Infer(ctx context.Context, prompt llm.Prompt) (string, error)
+}
+
+// Narrative is the per-cycle input the Proposer reasons over: the rolling
+// cross-game narrative block (#916/#929, already assembled by the decision side
+// via gamewindow.Render) plus the current fitness signals. It is passed in
+// PRE-ASSEMBLED so this package stays free of the gamecontext/gamewindow/flags
+// dependencies and the prompt build is a PURE function of its inputs (same
+// "caller owns context assembly, package owns logic" split llm.BuildInput uses).
+type Narrative struct {
+	// ContextBlock is the rendered cross-game narrative (gamewindow.Render output):
+	// the last N game summaries the agent has memory of. Empty = no prior-games
+	// section (the model then has only the current fitness to reason from).
+	ContextBlock string
+	// FitnessSignals are the current fitness/objective readings that motivate an
+	// experiment (e.g. {"endurance": 0.42, "balance": 0.81}). Rendered sorted for a
+	// deterministic prompt. Empty = no explicit fitness section.
+	FitnessSignals map[string]float64
+	// GameMode is the mode the recent games were (e.g. "joust"), for grounding the
+	// model's flag choice. Optional.
+	GameMode string
+}
+
+// ProposerConfig is the live, per-cycle flag configuration the Proposer reads
+// (#931 flags), resolved fresh each cycle by the caller (flags side) so a retune
+// takes effect on the next cycle — same never-cached contract as the #847 llm.*
+// gate flags and the #935 validation flags. The experiment package stays free of
+// an OpenFeature dependency: the caller resolves these and passes the value in.
+// (Named ProposerConfig, not Config — the validate stage already owns Config.)
+type ProposerConfig struct {
+	// Engine is agent.code_improvement.engine — the flag-selectable backend
+	// identifier (#931 AC). The Proposer records it on the span for attribution;
+	// the actual backend selection happens in main.go (today every value selects
+	// the stub backend, so a non-stub value still degrades to no-proposal until a
+	// real transport lands). Recorded, not branched on, here.
+	Engine string
+	// MinInterval is agent.code_improvement.min_interval_seconds — the per-Proposer
+	// cadence floor (#847 gating concept). Proposing is expensive (an LLM call), so
+	// at most one proposal attempt per this interval; cycles inside the window are
+	// gated with no Infer call. <= 0 disables the floor (propose every cycle the
+	// caller invokes us).
+	MinInterval time.Duration
+}
+
+// ProposeOutcome is what one ProposeOnce cycle did, returned for telemetry/
+// branching by the caller. The set is closed so dashboards can enumerate every
+// result. (Named ProposeOutcome, not Outcome — the validate stage already owns
+// the Outcome type for its promote/discard/revert verdict; both ride the shared
+// AttrOutcome span key, distinguished by the span name.)
+type ProposeOutcome string
+
+const (
+	// ProposeProposed — the model returned a valid in-vocab proposal AND the Gate
+	// ACCEPTED it: the shadow-scoped experiment was written to game.json. This is
+	// the only outcome that mutates the (shadow) flag surface.
+	ProposeProposed ProposeOutcome = "proposed"
+	// ProposeGated — the cadence floor (MinInterval) suppressed this cycle; no
+	// Infer call was made. The cheap, common "not yet" outcome.
+	ProposeGated ProposeOutcome = "gated"
+	// ProposeNoBackend — Backend.Infer failed (the sentinel stub, transport error,
+	// timeout). Degrades to NO proposal, NO error to the caller — the agent does
+	// not propose this cycle. This is the steady state until #738/#742 wire a real
+	// backend.
+	ProposeNoBackend ProposeOutcome = "no_backend"
+	// ProposeUndecodable — the model replied but the response was unparseable,
+	// incomplete, or named an out-of-vocab flag (decodeProposal rejected it). No
+	// proposal, recorded — we never fabricate one from a broken reply (#739 rule).
+	ProposeUndecodable ProposeOutcome = "undecodable"
+	// ProposeBlocked — the decoded proposal reached Gate.Review and the Gate
+	// REJECTED it (invariant/type guard). The Gate already emitted its
+	// code_improvement.proposed blocked span; the Proposer records the reason and
+	// does NOT retry blindly.
+	ProposeBlocked ProposeOutcome = "blocked"
+)
+
+// Result is the full outcome of one ProposeOnce cycle. Proposal is non-nil only
+// on ProposeProposed (or ProposeBlocked, carrying what was rejected, for the
+// caller's telemetry). Err is the underlying cause for the non-proposing outcomes
+// (already recorded on the span); the Proposer NEVER returns an error from
+// ProposeOnce itself — a failed cycle is a normal, recorded no-op, matching the
+// #739 degrade-to-rules contract.
+type Result struct {
+	Outcome  ProposeOutcome
+	Proposal *Proposal // set on ProposeProposed / ProposeBlocked
+	Err      error     // set on ProposeNoBackend / ProposeUndecodable / ProposeBlocked
+}
+
+// Proposer turns a Narrative into a shadow-scoped flag experiment and submits it
+// through the Gate. It is the M7-4 propose-side seam. Safe for concurrent use:
+// the cadence state is mutex-guarded (the agent may run per-game loops that all
+// share one Proposer, like the shared Resolver/llmBudget).
+type Proposer struct {
+	backend Backend
+	gate    *Gate
+	// vocab returns the LIVE set of game.json flag keys the model is constrained
+	// to. Injected as a func (not a static set) because the flag surface is read
+	// from the game flag file each cycle — the decoder rejects any flag not in it,
+	// and the prompt lists it so the model picks an existing flag. Returning a
+	// fresh map each call keeps the Proposer free of a file dependency (the caller/
+	// Gate's Writer owns the file).
+	vocab  func() map[string]struct{}
+	tracer trace.Tracer
+	log    *slog.Logger
+
+	// clock is injected for deterministic cadence tests (no wall-clock read on the
+	// hot path otherwise). Defaults to time.Now.
+	clock func() time.Time
+
+	mu          sync.Mutex
+	lastAttempt time.Time // last time the cadence floor ADMITTED a proposal attempt
+}
+
+// NewProposer builds a Proposer over the inference backend, the experiment Gate
+// (the ONLY sanctioned write path — the Proposer never touches game.json
+// directly), and a vocab provider (the live game-flag key set). tracer nil uses
+// the global tracer; log nil uses slog.Default(). The clock defaults to time.Now;
+// tests inject a fake via SetClock.
+func NewProposer(backend Backend, gate *Gate, vocab func() map[string]struct{}, tracer trace.Tracer, log *slog.Logger) *Proposer {
+	if tracer == nil {
+		tracer = otel.Tracer(instrumentationName)
+	}
+	if log == nil {
+		log = slog.Default()
+	}
+	if vocab == nil {
+		// Fail-closed: no vocabulary means nothing is proposable (decodeProposal
+		// rejects every flag), so a nil provider degrades to "never propose".
+		vocab = func() map[string]struct{} { return nil }
+	}
+	return &Proposer{
+		backend: backend,
+		gate:    gate,
+		vocab:   vocab,
+		tracer:  tracer,
+		log:     log,
+		clock:   time.Now,
+	}
+}
+
+// SetClock overrides the clock for deterministic cadence tests. Production never
+// calls it (defaults to time.Now).
+func (p *Proposer) SetClock(clock func() time.Time) { p.clock = clock }
+
+// ProposeOnce runs one propose cycle: cadence-gate, build the prompt, infer,
+// defensively decode, and submit through Gate.Review. It NEVER returns an error —
+// every failure mode is a recorded, normal no-op (Result.Outcome + Result.Err),
+// because a missing/failing backend or a garbage reply must degrade the agent to
+// "did not propose this cycle", never crash a decision loop (the #739/#741
+// degrade-to-rules discipline). The only state mutation on the real flag surface
+// is a SHADOW-SCOPED write the Gate accepted.
+func (p *Proposer) ProposeOnce(ctx context.Context, n Narrative, cfg ProposerConfig) Result {
+	// Cadence floor FIRST (cheapest gate): suppress cycles inside MinInterval with
+	// no Infer call, so proposing — an expensive LLM round-trip — happens at most
+	// occasionally, not every decision cycle (#847 gating concept; mirrors the
+	// per-game llm.min_decision_interval_seconds floor in decision.go). Charged only
+	// on admission, so a gated cycle does not advance the window.
+	now := p.clock()
+	if !p.admit(now, cfg.MinInterval) {
+		p.log.Debug("code_improvement gated by cadence", "min_interval", cfg.MinInterval)
+		return Result{Outcome: ProposeGated}
+	}
+
+	ctx, span := p.tracer.Start(ctx, SpanProposeAttempt, trace.WithAttributes(
+		attribute.String(AttrEngine, cfg.Engine),
+	))
+	defer span.End()
+
+	// Build the constrained prompt: ask for ONE {flag, value, rationale} over the
+	// live flag vocabulary. The vocabulary is read ONCE here and reused for the
+	// decoder so the prompt and the validation agree on the surface.
+	vocab := p.vocab()
+	prompt := buildProposalPrompt(n, vocab)
+
+	raw, err := p.backend.Infer(ctx, prompt)
+	if err != nil {
+		// DEGRADES TO NOTHING: the sentinel stub (no real backend yet), a transport
+		// error, or a timeout. Record and no-op — no proposal, no error to caller.
+		span.SetAttributes(attribute.String(AttrOutcome, string(ProposeNoBackend)))
+		p.log.Debug("code_improvement: backend unavailable, no proposal", "error", err, "engine", cfg.Engine)
+		return Result{Outcome: ProposeNoBackend, Err: err}
+	}
+
+	proposal, err := decodeProposal(raw, vocab)
+	if err != nil {
+		// Untrusted-output rule (#739): unparseable / incomplete / out-of-vocab =>
+		// NO proposal, never fabricated. Recorded; no Gate.Review.
+		span.SetAttributes(attribute.String(AttrOutcome, string(ProposeUndecodable)))
+		p.log.Info("code_improvement: model reply not a valid proposal, no dispatch", "error", err)
+		return Result{Outcome: ProposeUndecodable, Err: err}
+	}
+
+	// Record the model's reasoning on the attempt span BEFORE submitting (the AC's
+	// code_improvement.proposed_diff_summary — here the "diff summary" is the
+	// structured experiment, since the rescope has no source diff). Gate.Review
+	// emits its OWN code_improvement.proposed span with the blocked/reason verdict.
+	span.SetAttributes(
+		attribute.String(AttrFlagKey, proposal.FlagKey),
+		attribute.String(AttrRationale, proposal.Rationale),
+		attribute.String(AttrProposedDiffSummary, summarizeProposal(proposal)),
+	)
+
+	// Submit through the Gate — the ONLY sanctioned write path. The Gate enforces
+	// the shadow-scoping invariant + type guard and writes game.json on accept. We
+	// never call the Writer directly.
+	if err := p.gate.Review(ctx, proposal); err != nil {
+		// A Gate rejection (RejectError) is RECORDED, not retried blindly. The Gate
+		// already emitted its blocked span with the typed reason.
+		span.SetAttributes(attribute.String(AttrOutcome, string(ProposeBlocked)))
+		if rej, ok := AsReject(err); ok {
+			span.SetAttributes(attribute.String(AttrReason, string(rej.Reason)))
+			p.log.Info("code_improvement: proposal blocked by gate", "reason", string(rej.Reason), "flag", proposal.FlagKey)
+		} else {
+			p.log.Warn("code_improvement: proposal apply failed", "error", err, "flag", proposal.FlagKey)
+		}
+		pr := proposal
+		return Result{Outcome: ProposeBlocked, Proposal: &pr, Err: err}
+	}
+
+	span.SetAttributes(attribute.String(AttrOutcome, string(ProposeProposed)))
+	p.log.Info("code_improvement: shadow experiment proposed", "flag", proposal.FlagKey, "rationale", proposal.Rationale)
+	pr := proposal
+	return Result{Outcome: ProposeProposed, Proposal: &pr}
+}
+
+// admit applies the cadence floor under the mutex: returns true (and advances
+// lastAttempt) when this cycle may attempt a proposal, false when it is inside the
+// MinInterval window. A non-positive interval disables the floor (always admit). A
+// zero lastAttempt (first ever call) always admits. Mirrors the
+// llm.min_decision_interval_seconds check in decision.go, charged on admission.
+func (p *Proposer) admit(now time.Time, interval time.Duration) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if interval > 0 && !p.lastAttempt.IsZero() && now.Sub(p.lastAttempt) < interval {
+		return false
+	}
+	p.lastAttempt = now
+	return true
+}
+
+// summarizeProposal renders the structured experiment as a compact human-readable
+// "diff summary" for the span (AttrProposedDiffSummary, #931 AC). Since the
+// rescope has no source diff, the "diff" IS the shadow-scoped flag change:
+// flag=value (shadow only).
+func summarizeProposal(p Proposal) string {
+	return fmt.Sprintf("set %s=%v for shadow games (game_kind != real); rationale: %s",
+		p.FlagKey, p.ExperimentalValue, p.Rationale)
+}
+
+// buildProposalPrompt renders the System/User prompt pair asking the model for
+// exactly ONE flag experiment over the supplied flag vocabulary. It is PURE
+// (deterministic given its inputs — vocabulary and fitness signals are sorted) so
+// the prompt is stable for golden/round-trip tests, matching llm.Build's
+// determinism contract. It reuses llm.Prompt as the carrier so the same Backend
+// implementations drive both the #739 intervention path and the proposal path.
+func buildProposalPrompt(n Narrative, vocab map[string]struct{}) llm.Prompt {
+	var sys strings.Builder
+	sys.WriteString("You are the JoustMania game-balance agent. From the game narrative and ")
+	sys.WriteString("fitness signals below, propose EXACTLY ONE experiment that tunes a single ")
+	sys.WriteString("game flag to a new value, with a one-sentence hypothesis.\n\n")
+
+	sys.WriteString("You MUST choose a flag from this list (any other flag is rejected):\n")
+	for _, k := range sortedKeys(vocab) {
+		sys.WriteString("  - ")
+		sys.WriteString(k)
+		sys.WriteString("\n")
+	}
+	sys.WriteString("\n")
+
+	// RESPONSE CONTRACT — mirrors decodeProposal's schema. Reply with EXACTLY ONE
+	// JSON object and nothing else (the decoder tolerates surrounding prose/fences
+	// but the contract asks for clean JSON). The value's type must match the flag's
+	// existing values (the Gate rejects a mistyped value).
+	sys.WriteString("Respond with EXACTLY ONE JSON object and no other text:\n")
+	sys.WriteString(`{"flag":"<one of the flags above>","value":<the experimental value>,"rationale":"<one sentence>"}` + "\n")
+	sys.WriteString("The value's JSON type MUST match the flag's existing values. Propose only ONE flag.\n")
+
+	var usr strings.Builder
+	if n.GameMode != "" {
+		fmt.Fprintf(&usr, "Game mode: %s\n\n", n.GameMode)
+	}
+	if n.ContextBlock != "" {
+		usr.WriteString(n.ContextBlock)
+		usr.WriteString("\n\n")
+	}
+	if len(n.FitnessSignals) > 0 {
+		usr.WriteString("Current fitness signals:\n")
+		// Sort keys for a deterministic prompt (no map-iteration-order dependence).
+		keys := make([]string, 0, len(n.FitnessSignals))
+		for k := range n.FitnessSignals {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			fmt.Fprintf(&usr, "  %s = %.3f\n", k, n.FitnessSignals[k])
+		}
+	}
+
+	return llm.Prompt{System: sys.String(), User: usr.String()}
+}
+
+// sortedKeys returns the keys of a set in a stable order for a deterministic
+// prompt.
+func sortedKeys(set map[string]struct{}) []string {
+	keys := make([]string, 0, len(set))
+	for k := range set {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/services/agent/experiment/proposer_decode.go
+++ b/services/agent/experiment/proposer_decode.go
@@ -1,0 +1,164 @@
+package experiment
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// proposer_decode.go is the DEFENSIVE response parser for the M7-4 (#931)
+// flag-experiment PROPOSAL path. It is the exact analogue of the #739 intervention
+// decoder (services/agent/llm/decode.go): the model is asked (by the RESPONSE
+// CONTRACT the Proposer builds) to reply with EXACTLY ONE JSON object shaped like
+// proposalResponse below. A real model does not always comply — it may wrap the
+// JSON in prose or ```json fences, omit a field, emit malformed JSON, or name a
+// flag that does not exist on the game surface.
+//
+// The cardinal safety rule (same untrusted-output discipline as #739/#932): an
+// unparseable, invalid, or out-of-vocabulary response must NEVER produce a
+// Proposal. So decodeProposal is strict and total — it returns a usable Proposal
+// ONLY when the reply is well-formed, complete, AND names a flag that exists in
+// the supplied vocabulary; on anything else it returns a typed error and the
+// Proposer records "no proposal this cycle" (no Gate.Review, no write). We never
+// fabricate a proposal from a broken response.
+//
+// Defence in depth: even though the Gate independently rejects unknown flags
+// (ReasonUnknownFlag), type mismatches (ReasonTypeMismatch), and non-game targets
+// (ReasonNonGameTarget), we reject an out-of-vocab flag HERE too so a malformed
+// model reply never even reaches Gate.Review — the Gate's blocked span is for
+// genuine invariant violations, not for routine model garbage. The flag
+// vocabulary is passed in (the live set of game.json flag keys), so this file has
+// no flagd dependency and is exhaustively table-tested, exactly like decode.go.
+
+// proposalResponse is the strict JSON schema the model must return — one object
+// naming the game flag to tune, the value to try, and the hypothesis. It maps 1:1
+// onto experiment.Proposal{FlagKey, ExperimentalValue, Rationale}; the experiment
+// package owns the Proposal carrier, so the decoder produces a Proposal directly.
+type proposalResponse struct {
+	// Flag is the game.json flag key to experiment on. Required, non-empty, and
+	// validated against the known-flag vocabulary (out-of-vocab => rejected, never
+	// proposed). The model must pick an EXISTING flag — the agent explores the
+	// parameterized surface, it does not invent flags (see Proposal.FlagKey doc).
+	Flag string `json:"flag"`
+	// Value is the experimental value to try for Flag. Required (a proposal with no
+	// value is meaningless). Left as a raw message so any JSON kind round-trips
+	// unchanged into Proposal.ExperimentalValue — the Gate's type guard
+	// (ReasonTypeMismatch) is the authority on whether the kind matches the flag's
+	// existing variants; the decoder only insists the field is PRESENT.
+	Value json.RawMessage `json:"value"`
+	// Rationale is the model's one-sentence hypothesis ("why this value might
+	// improve the game"). Required: a proposed experiment with no recorded
+	// rationale is not auditable (it lands on the code_improvement.proposed span).
+	Rationale string `json:"rationale"`
+}
+
+// Decode-time rejection reasons for the proposal path. All are wrapped in the
+// returned error so the Proposer can log the precise cause; they collapse to a
+// single "no proposal" outcome on the span (the model failed the contract).
+var (
+	// errEmptyProposal: the model returned nothing usable (empty/whitespace-only).
+	errEmptyProposal = errors.New("experiment: empty proposal response")
+	// errNotJSONProposal: no JSON object could be extracted/parsed from the reply.
+	errNotJSONProposal = errors.New("experiment: proposal response is not a single JSON object")
+	// errMissingProposalField: a required field (flag, value, rationale) was absent
+	// or empty.
+	errMissingProposalField = errors.New("experiment: proposal response missing required field")
+	// errUnknownProposalFlag: flag is not in the supplied game-flag vocabulary. The
+	// model named a flag nothing reads — reject before Gate.Review (which would
+	// independently reject it as ReasonUnknownFlag, but we keep model garbage off
+	// the blocked span).
+	errUnknownProposalFlag = errors.New("experiment: proposal names an unknown game flag")
+)
+
+// decodeProposal parses a raw model response into a validated Proposal, or returns
+// a typed error. knownFlags is the live set of game.json flag keys (the
+// vocabulary the model was constrained to). The result is safe to submit to
+// Gate.Review ONLY when err is nil. Validation, in order (mirrors llm.Decode):
+//
+//  1. non-empty                         -> errEmptyProposal
+//  2. extractable + parseable JSON obj  -> errNotJSONProposal
+//  3. flag present                      -> errMissingProposalField
+//  4. value present                     -> errMissingProposalField
+//  5. rationale present                 -> errMissingProposalField
+//  6. flag in knownFlags vocabulary     -> errUnknownProposalFlag
+//
+// It is intentionally forgiving about SURROUNDING prose/fences (extractJSONObject)
+// but strict about the object's required fields and the flag vocabulary. The
+// experimental value's TYPE is NOT checked here — that is the Gate's type guard
+// (#955); the decoder only insists value is present and JSON-decodable.
+func decodeProposal(raw string, knownFlags map[string]struct{}) (Proposal, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return Proposal{}, errEmptyProposal
+	}
+
+	obj, err := extractProposalObject(trimmed)
+	if err != nil {
+		return Proposal{}, err
+	}
+
+	var r proposalResponse
+	// DisallowUnknownFields is intentionally NOT used: a compliant model may add
+	// commentary keys, and we only consume the contracted ones (same call as
+	// llm.Decode). MISSING required fields are the failure mode we guard below.
+	if err := json.Unmarshal(obj, &r); err != nil {
+		return Proposal{}, fmt.Errorf("%w: %v", errNotJSONProposal, err)
+	}
+
+	if strings.TrimSpace(r.Flag) == "" {
+		return Proposal{}, fmt.Errorf("%w: flag", errMissingProposalField)
+	}
+	// A missing value field decodes to a nil/empty RawMessage; an explicit JSON
+	// null is also rejected (a null experimental value carries no experiment, and
+	// the Gate's type guard treats null as kindless — never a useful proposal).
+	if len(r.Value) == 0 || string(r.Value) == "null" {
+		return Proposal{}, fmt.Errorf("%w: value", errMissingProposalField)
+	}
+	if strings.TrimSpace(r.Rationale) == "" {
+		return Proposal{}, fmt.Errorf("%w: rationale", errMissingProposalField)
+	}
+
+	// Out-of-vocab flag: the model named a flag not on the game surface. Reject
+	// here so a hallucinated flag never reaches Gate.Review. A nil/empty vocabulary
+	// rejects everything (fail-closed: with no known flags, nothing is proposable).
+	if _, ok := knownFlags[r.Flag]; !ok {
+		return Proposal{}, fmt.Errorf("%w: %q", errUnknownProposalFlag, r.Flag)
+	}
+
+	// Unmarshal the raw value into a Go any so ExperimentalValue carries the same
+	// shape the Writer will re-marshal (numbers as float64, etc.) — matching how a
+	// proposal value flows through the Gate's type guard and the Writer's
+	// applyProposal. A value that fails to decode here is malformed JSON we already
+	// would have caught, but guard it for totality.
+	var value any
+	if err := json.Unmarshal(r.Value, &value); err != nil {
+		return Proposal{}, fmt.Errorf("%w: value: %v", errNotJSONProposal, err)
+	}
+
+	return Proposal{
+		FlagKey:           r.Flag,
+		ExperimentalValue: value,
+		Rationale:         r.Rationale,
+	}, nil
+}
+
+// extractProposalObject pulls the single JSON object out of a model reply. Models
+// frequently wrap the object in prose or a ```json fence despite a "no prose"
+// instruction, so we locate the first '{' and the matching last '}' and parse the
+// span between them — forgiving about SURROUNDING text, strict about the object
+// itself (it must parse as a JSON object). Identical strategy to
+// llm.extractJSONObject; duplicated (not shared) to keep this package free of an
+// llm-decode dependency and independently table-tested.
+func extractProposalObject(s string) ([]byte, error) {
+	start := strings.IndexByte(s, '{')
+	end := strings.LastIndexByte(s, '}')
+	if start < 0 || end < start {
+		return nil, errNotJSONProposal
+	}
+	candidate := s[start : end+1]
+	if !json.Valid([]byte(candidate)) {
+		return nil, errNotJSONProposal
+	}
+	return []byte(candidate), nil
+}

--- a/services/agent/experiment/proposer_decode_test.go
+++ b/services/agent/experiment/proposer_decode_test.go
@@ -1,0 +1,155 @@
+package experiment
+
+import (
+	"errors"
+	"testing"
+)
+
+// proposer_decode_test.go exhaustively table-tests the pure proposal decoder,
+// mirroring services/agent/llm/decode_test.go. The contract under test is the
+// #931/#739 untrusted-output rule: ONLY a well-formed, complete, in-vocab reply
+// yields a Proposal; everything else returns a typed error and (in the Proposer)
+// produces no proposal. No flagd, no network, no clock.
+
+// vocab is the known-flag set the decoder validates against — a small stand-in
+// for the live game.json flag keys.
+var vocab = map[string]struct{}{
+	"death_grace_period_seconds": {},
+	"invincibility_seconds":      {},
+	"random_assignment":          {},
+}
+
+func TestDecodeProposal(t *testing.T) {
+	tests := []struct {
+		name     string
+		raw      string
+		wantErr  error  // sentinel the returned error must wrap; nil = expect success
+		wantFlag string // asserted only on success
+	}{
+		{
+			name:     "valid bare JSON",
+			raw:      `{"flag":"death_grace_period_seconds","value":0.75,"rationale":"longer grace may extend sessions"}`,
+			wantFlag: "death_grace_period_seconds",
+		},
+		{
+			name:     "valid wrapped in prose and fences",
+			raw:      "Sure! Here is my proposal:\n```json\n{\"flag\":\"invincibility_seconds\",\"value\":5.0,\"rationale\":\"more mercy windows\"}\n```\nHope that helps.",
+			wantFlag: "invincibility_seconds",
+		},
+		{
+			name:     "valid boolean value",
+			raw:      `{"flag":"random_assignment","value":false,"rationale":"try deterministic team assignment"}`,
+			wantFlag: "random_assignment",
+		},
+		{
+			name:    "empty",
+			raw:     "   \n\t ",
+			wantErr: errEmptyProposal,
+		},
+		{
+			name:    "not json",
+			raw:     "I think you should tune the grace period higher.",
+			wantErr: errNotJSONProposal,
+		},
+		{
+			name:    "malformed json object",
+			raw:     `{"flag":"death_grace_period_seconds","value":}`,
+			wantErr: errNotJSONProposal,
+		},
+		{
+			name:    "missing flag",
+			raw:     `{"value":0.75,"rationale":"why"}`,
+			wantErr: errMissingProposalField,
+		},
+		{
+			name:    "empty flag",
+			raw:     `{"flag":"  ","value":0.75,"rationale":"why"}`,
+			wantErr: errMissingProposalField,
+		},
+		{
+			name:    "missing value",
+			raw:     `{"flag":"death_grace_period_seconds","rationale":"why"}`,
+			wantErr: errMissingProposalField,
+		},
+		{
+			name:    "explicit null value",
+			raw:     `{"flag":"death_grace_period_seconds","value":null,"rationale":"why"}`,
+			wantErr: errMissingProposalField,
+		},
+		{
+			name:    "missing rationale",
+			raw:     `{"flag":"death_grace_period_seconds","value":0.75}`,
+			wantErr: errMissingProposalField,
+		},
+		{
+			name:    "unknown flag (out of vocab)",
+			raw:     `{"flag":"totally_made_up_flag","value":1,"rationale":"hallucinated"}`,
+			wantErr: errUnknownProposalFlag,
+		},
+		{
+			name:    "agent.json smuggle attempt is out of vocab",
+			raw:     `{"flag":"enabled","value":true,"rationale":"turn myself off? no"}`,
+			wantErr: errUnknownProposalFlag,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p, err := decodeProposal(tt.raw, vocab)
+			if tt.wantErr != nil {
+				if !errors.Is(err, tt.wantErr) {
+					t.Fatalf("decodeProposal err = %v, want wrap of %v", err, tt.wantErr)
+				}
+				if p.FlagKey != "" {
+					t.Fatalf("decodeProposal returned a non-empty Proposal on error: %+v", p)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("decodeProposal unexpected err: %v", err)
+			}
+			if p.FlagKey != tt.wantFlag {
+				t.Fatalf("FlagKey = %q, want %q", p.FlagKey, tt.wantFlag)
+			}
+			if p.ExperimentalValue == nil {
+				t.Fatalf("ExperimentalValue is nil on a valid proposal")
+			}
+			if p.Rationale == "" {
+				t.Fatalf("Rationale is empty on a valid proposal")
+			}
+		})
+	}
+}
+
+// TestDecodeProposal_EmptyVocabRejectsEverything pins the fail-closed reading: with
+// no known flags, every flag is out of vocab (nothing is proposable), so even a
+// structurally valid reply is rejected.
+func TestDecodeProposal_EmptyVocabRejectsEverything(t *testing.T) {
+	raw := `{"flag":"death_grace_period_seconds","value":0.75,"rationale":"why"}`
+	if _, err := decodeProposal(raw, nil); !errors.Is(err, errUnknownProposalFlag) {
+		t.Fatalf("empty vocab: err = %v, want errUnknownProposalFlag", err)
+	}
+	if _, err := decodeProposal(raw, map[string]struct{}{}); !errors.Is(err, errUnknownProposalFlag) {
+		t.Fatalf("empty-map vocab: err = %v, want errUnknownProposalFlag", err)
+	}
+}
+
+// TestDecodeProposal_PreservesNumberAndObjectValues confirms the experimental
+// value round-trips through the decoder with its JSON shape intact (numbers as
+// float64, objects as maps), so the Writer re-marshals the same value the model
+// proposed.
+func TestDecodeProposal_PreservesNumberAndObjectValues(t *testing.T) {
+	objVocab := map[string]struct{}{"nonstop.scoring": {}}
+	raw := `{"flag":"nonstop.scoring","value":{"base":120,"death_penalty":5},"rationale":"reward survival more"}`
+	p, err := decodeProposal(raw, objVocab)
+	if err != nil {
+		t.Fatalf("decodeProposal: %v", err)
+	}
+	m, ok := p.ExperimentalValue.(map[string]any)
+	if !ok {
+		t.Fatalf("ExperimentalValue type = %T, want map[string]any", p.ExperimentalValue)
+	}
+	if m["base"].(float64) != 120 {
+		t.Fatalf("base = %v, want 120", m["base"])
+	}
+}

--- a/services/agent/experiment/proposer_telemetry.go
+++ b/services/agent/experiment/proposer_telemetry.go
@@ -1,0 +1,44 @@
+package experiment
+
+// proposer_telemetry.go adds the M7-4 (#931) PROPOSE-side span schema, extending
+// the existing code_improvement.* trace family (telemetry.go) rather than
+// inventing a new one. Two spans exist in the proposal pipeline:
+//
+//   - SpanProposeAttempt (THIS file): one per Proposer.ProposeOnce cycle — wraps
+//     the inference + decode + Gate submission. Carries the engine, the model's
+//     reasoning (the AC's code_improvement.proposed_diff_summary), and the cycle
+//     OUTCOME (proposed/gated/no_backend/undecodable/blocked). It is the audit of
+//     "the agent tried to propose; here is what happened end to end".
+//   - SpanProposed (telemetry.go, emitted by Gate.Review): the existing per-write
+//     span carrying blocked/reason. SpanProposeAttempt is the PARENT span; the
+//     Gate's SpanProposed nests under it on an accepted/blocked decode, so a Jaeger
+//     trace shows the whole propose→gate flow.
+//
+// Kept in a separate file from telemetry.go so the merged Gate/Writer ownership
+// (gate.go/proposal.go/validate.go are owned elsewhere) is untouched; the consts
+// reuse the AttrFlagKey/AttrRationale/AttrReason keys from telemetry.go so the two
+// spans share one attribute vocabulary.
+const (
+	// SpanProposeAttempt wraps one Proposer.ProposeOnce cycle (#931, M7-4). The
+	// Gate's SpanProposed nests under it.
+	SpanProposeAttempt = "code_improvement.propose_attempt"
+)
+
+const (
+	// AttrEngine is the resolved agent.code_improvement.engine identifier (#931 AC
+	// "engine backend is flag-selectable"). Attribution only — the backend
+	// selection happens in main.go.
+	AttrEngine = "code_improvement.engine"
+	// AttrProposedDiffSummary records the structured experiment the model proposed
+	// (#931 AC "proposed diff summary + full reasoning visible as a span"). Since
+	// the rescope has no source diff, this is the compact "set flag=value for
+	// shadow games" summary plus the rationale.
+	AttrProposedDiffSummary = "code_improvement.proposed_diff_summary"
+	// NOTE: the cycle outcome rides on the EXISTING AttrOutcome key
+	// ("code_improvement.outcome", defined in validate_telemetry.go) — the propose
+	// and validate stages share one outcome attribute vocabulary so a dashboard can
+	// enumerate every code_improvement.* cycle result on one key. The propose-side
+	// values are the ProposeOutcome* constants (proposed/gated/no_backend/
+	// undecodable/blocked); the validate-side values are the Outcome* constants
+	// (promote/discard/revert). The span NAME distinguishes the stage.
+)

--- a/services/agent/experiment/proposer_test.go
+++ b/services/agent/experiment/proposer_test.go
@@ -1,0 +1,338 @@
+package experiment
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"github.com/joustmania/agent/llm"
+)
+
+// proposer_test.go drives the M7-4 (#931) Proposer end to end with in-process
+// fakes only — no network, no flagd, no clock (per the testing-strategy doc:
+// inferBackend-style fake + tracetest recorder + temp game.json). It asserts the
+// four contracts from the brief:
+//
+//  1. valid reply  -> a Proposal that PASSES Gate.Review and WRITES the shadow
+//     experiment to the temp game.json (ProposeProposed).
+//  2. unparseable/invalid reply -> NO proposal, NO write, recorded
+//     (ProposeUndecodable).
+//  3. out-of-vocab/unknown-flag reply -> no proposal (rejected by the decoder
+//     before the Gate; the Gate's ReasonUnknownFlag is the defense-in-depth
+//     backstop, exercised separately).
+//  4. cadence gating -> two cycles inside MinInterval => exactly one proposal.
+
+// fakeProposerBackend is the inferBackend-style fake (mirrors decision's
+// fakeBackend / the validate_test.go fakes): a canned raw response or an error,
+// recording the call count so cadence tests can assert Infer was/was not invoked.
+type fakeProposerBackend struct {
+	response string
+	err      error
+	calls    int
+}
+
+func (b *fakeProposerBackend) Infer(context.Context, llm.Prompt) (string, error) {
+	b.calls++
+	if b.err != nil {
+		return "", b.err
+	}
+	return b.response, nil
+}
+
+// gameVocab reads the live flag keys from the temp game.json at path — the same
+// surface the Gate validates against, so the prompt/decoder vocabulary and the
+// Gate's known-flag set agree.
+func gameVocab(t *testing.T, path string) func() map[string]struct{} {
+	t.Helper()
+	return func() map[string]struct{} {
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			return nil
+		}
+		var doc struct {
+			Flags map[string]json.RawMessage `json:"flags"`
+		}
+		if err := json.Unmarshal(raw, &doc); err != nil {
+			return nil
+		}
+		set := make(map[string]struct{}, len(doc.Flags))
+		for k := range doc.Flags {
+			set[k] = struct{}{}
+		}
+		return set
+	}
+}
+
+// proposerWithRecorder wires a Proposer over a temp game.json + the given fake
+// backend, with an in-memory span recorder and a frozen clock the test advances.
+func proposerWithRecorder(t *testing.T, backend Backend) (*Proposer, string, *tracetest.SpanRecorder, *fakeClock) {
+	t.Helper()
+	path := newGameFile(t)
+	rec := tracetest.NewSpanRecorder()
+	tp := trace.NewTracerProvider(trace.WithSpanProcessor(rec))
+	w := NewWriter(path, discardLogger())
+	gate := NewGate(w, tp.Tracer("test"), discardLogger())
+	p := NewProposer(backend, gate, gameVocab(t, path), tp.Tracer("test"), discardLogger())
+	clk := &fakeClock{now: time.Unix(1_700_000_000, 0)}
+	p.SetClock(clk.Now)
+	return p, path, rec, clk
+}
+
+// fakeClock is a deterministic, advanceable clock for cadence tests.
+type fakeClock struct{ now time.Time }
+
+func (c *fakeClock) Now() time.Time          { return c.now }
+func (c *fakeClock) advance(d time.Duration) { c.now = c.now.Add(d) }
+
+// experimentVariantValue returns the experimental variant's value for flagKey in
+// the file at path, or ("", false) if no experiment was written.
+func experimentVariantValue(t *testing.T, path, flagKey string) (string, bool) {
+	t.Helper()
+	raw := readFlagRaw(t, path, flagKey)
+	var flag struct {
+		Variants map[string]json.RawMessage `json:"variants"`
+	}
+	if err := json.Unmarshal(raw, &flag); err != nil {
+		t.Fatalf("decode flag: %v", err)
+	}
+	v, ok := flag.Variants[ExperimentVariant]
+	return string(v), ok
+}
+
+func TestProposeOnce_ValidProposalWritesShadowExperiment(t *testing.T) {
+	backend := &fakeProposerBackend{
+		response: `{"flag":"death_grace_period_seconds","value":0.75,"rationale":"longer grace may extend sessions"}`,
+	}
+	p, path, rec, _ := proposerWithRecorder(t, backend)
+
+	res := p.ProposeOnce(context.Background(), Narrative{GameMode: "joust"}, ProposerConfig{Engine: "stub"})
+
+	if res.Outcome != ProposeProposed {
+		t.Fatalf("outcome = %q, want proposed (err=%v)", res.Outcome, res.Err)
+	}
+	if res.Proposal == nil || res.Proposal.FlagKey != "death_grace_period_seconds" {
+		t.Fatalf("proposal = %+v, want death_grace_period_seconds", res.Proposal)
+	}
+	// The shadow experiment must be WRITTEN to game.json (the Gate accepted + applied).
+	val, ok := experimentVariantValue(t, path, "death_grace_period_seconds")
+	if !ok {
+		t.Fatalf("expected experimental variant written to game.json, found none")
+	}
+	if val != "0.75" {
+		t.Fatalf("experimental value = %s, want 0.75", val)
+	}
+	// The attempt span records the engine, the diff summary, and the proposed outcome.
+	span := findSpan(t, rec, SpanProposeAttempt)
+	assertSpanAttr(t, span, AttrEngine, "stub")
+	assertSpanAttr(t, span, AttrOutcome, string(ProposeProposed))
+	if !hasNonEmptyAttr(span, AttrProposedDiffSummary) {
+		t.Fatalf("expected non-empty %s on attempt span", AttrProposedDiffSummary)
+	}
+	// The Gate's own SpanProposed (blocked=false) nests under the attempt.
+	gateSpan := findSpan(t, rec, SpanProposed)
+	assertSpanBoolAttr(t, gateSpan, AttrBlocked, false)
+}
+
+func TestProposeOnce_UndecodableReplyMakesNoProposal(t *testing.T) {
+	backend := &fakeProposerBackend{response: "I really think you should raise the grace period."}
+	p, path, rec, _ := proposerWithRecorder(t, backend)
+
+	res := p.ProposeOnce(context.Background(), Narrative{}, ProposerConfig{Engine: "stub"})
+
+	if res.Outcome != ProposeUndecodable {
+		t.Fatalf("outcome = %q, want undecodable", res.Outcome)
+	}
+	if res.Proposal != nil {
+		t.Fatalf("expected nil proposal, got %+v", res.Proposal)
+	}
+	// NO write: no experiment variant on any flag.
+	if _, ok := experimentVariantValue(t, path, "death_grace_period_seconds"); ok {
+		t.Fatalf("undecodable reply must not write an experiment")
+	}
+	// Recorded: attempt span carries the undecodable outcome; the Gate never ran.
+	span := findSpan(t, rec, SpanProposeAttempt)
+	assertSpanAttr(t, span, AttrOutcome, string(ProposeUndecodable))
+	if spanExists(rec, SpanProposed) {
+		t.Fatalf("Gate.Review must not run on an undecodable reply")
+	}
+}
+
+func TestProposeOnce_UnknownFlagRejectedByDecoderNoWrite(t *testing.T) {
+	// The model names a flag that does not exist on the game surface. The decoder
+	// rejects it (out-of-vocab) BEFORE the Gate, so no proposal, no write.
+	backend := &fakeProposerBackend{
+		response: `{"flag":"made_up_flag","value":1,"rationale":"hallucinated"}`,
+	}
+	p, path, rec, _ := proposerWithRecorder(t, backend)
+
+	res := p.ProposeOnce(context.Background(), Narrative{}, ProposerConfig{Engine: "stub"})
+
+	if res.Outcome != ProposeUndecodable {
+		t.Fatalf("outcome = %q, want undecodable (decoder rejects out-of-vocab)", res.Outcome)
+	}
+	if !errors.Is(res.Err, errUnknownProposalFlag) {
+		t.Fatalf("err = %v, want errUnknownProposalFlag", res.Err)
+	}
+	if _, ok := experimentVariantValue(t, path, "death_grace_period_seconds"); ok {
+		t.Fatalf("unknown-flag reply must not write an experiment")
+	}
+	if spanExists(rec, SpanProposed) {
+		t.Fatalf("Gate.Review must not run on an out-of-vocab reply")
+	}
+}
+
+// TestProposeOnce_TypeMismatchBlockedByGate exercises the defense-in-depth path:
+// a KNOWN flag but a MISTYPED value passes the decoder (it only checks presence +
+// vocab) and reaches the Gate, which blocks it as ReasonTypeMismatch and emits the
+// blocked span. No experiment is written.
+func TestProposeOnce_TypeMismatchBlockedByGate(t *testing.T) {
+	backend := &fakeProposerBackend{
+		// death_grace_period_seconds variants are numbers; a string is a type mismatch.
+		response: `{"flag":"death_grace_period_seconds","value":"way too long","rationale":"oops a string"}`,
+	}
+	p, path, rec, _ := proposerWithRecorder(t, backend)
+
+	res := p.ProposeOnce(context.Background(), Narrative{}, ProposerConfig{Engine: "stub"})
+
+	if res.Outcome != ProposeBlocked {
+		t.Fatalf("outcome = %q, want blocked", res.Outcome)
+	}
+	rej, ok := AsReject(res.Err)
+	if !ok || rej.Reason != ReasonTypeMismatch {
+		t.Fatalf("err = %v, want RejectError{TypeMismatch}", res.Err)
+	}
+	if _, ok := experimentVariantValue(t, path, "death_grace_period_seconds"); ok {
+		t.Fatalf("type-mismatched proposal must not write an experiment")
+	}
+	// The Gate emitted its blocked span; the attempt span records the blocked outcome.
+	gateSpan := findSpan(t, rec, SpanProposed)
+	assertSpanBoolAttr(t, gateSpan, AttrBlocked, true)
+	assertSpanAttr(t, gateSpan, AttrReason, string(ReasonTypeMismatch))
+	attemptSpan := findSpan(t, rec, SpanProposeAttempt)
+	assertSpanAttr(t, attemptSpan, AttrOutcome, string(ProposeBlocked))
+}
+
+func TestProposeOnce_NoBackendDegradesToNothing(t *testing.T) {
+	// The sentinel-stub case: Backend.Infer errors (no real Ollama/cloud transport
+	// until #738/#742). The Proposer degrades to NO proposal, NO error to the caller.
+	backend := &fakeProposerBackend{err: errors.New("inference not implemented")}
+	p, path, rec, _ := proposerWithRecorder(t, backend)
+
+	res := p.ProposeOnce(context.Background(), Narrative{}, ProposerConfig{Engine: "stub"})
+
+	if res.Outcome != ProposeNoBackend {
+		t.Fatalf("outcome = %q, want no_backend", res.Outcome)
+	}
+	if res.Proposal != nil {
+		t.Fatalf("no proposal expected when backend errors")
+	}
+	if _, ok := experimentVariantValue(t, path, "death_grace_period_seconds"); ok {
+		t.Fatalf("a failed backend must not write an experiment")
+	}
+	span := findSpan(t, rec, SpanProposeAttempt)
+	assertSpanAttr(t, span, AttrOutcome, string(ProposeNoBackend))
+}
+
+func TestProposeOnce_CadenceGatesSecondCycleWithinInterval(t *testing.T) {
+	backend := &fakeProposerBackend{
+		response: `{"flag":"death_grace_period_seconds","value":0.75,"rationale":"longer grace"}`,
+	}
+	p, _, _, clk := proposerWithRecorder(t, backend)
+	cfg := ProposerConfig{Engine: "stub", MinInterval: 60 * time.Second}
+
+	// First cycle: admitted (no prior attempt) -> proposes, calls Infer once.
+	r1 := p.ProposeOnce(context.Background(), Narrative{}, cfg)
+	if r1.Outcome != ProposeProposed {
+		t.Fatalf("cycle 1 outcome = %q, want proposed", r1.Outcome)
+	}
+
+	// Second cycle 30s later (inside the 60s floor): GATED, no Infer call.
+	clk.advance(30 * time.Second)
+	r2 := p.ProposeOnce(context.Background(), Narrative{}, cfg)
+	if r2.Outcome != ProposeGated {
+		t.Fatalf("cycle 2 outcome = %q, want gated", r2.Outcome)
+	}
+	if backend.calls != 1 {
+		t.Fatalf("Infer calls = %d, want 1 (gated cycle must not infer)", backend.calls)
+	}
+
+	// Third cycle past the floor: admitted again.
+	clk.advance(31 * time.Second)
+	r3 := p.ProposeOnce(context.Background(), Narrative{}, cfg)
+	if r3.Outcome != ProposeProposed {
+		t.Fatalf("cycle 3 outcome = %q, want proposed", r3.Outcome)
+	}
+	if backend.calls != 2 {
+		t.Fatalf("Infer calls = %d, want 2", backend.calls)
+	}
+}
+
+func TestProposeOnce_ZeroIntervalDisablesCadence(t *testing.T) {
+	backend := &fakeProposerBackend{
+		response: `{"flag":"death_grace_period_seconds","value":0.75,"rationale":"longer grace"}`,
+	}
+	p, _, _, _ := proposerWithRecorder(t, backend)
+	cfg := ProposerConfig{Engine: "stub"} // MinInterval 0 => no floor
+
+	for i := 0; i < 3; i++ {
+		if got := p.ProposeOnce(context.Background(), Narrative{}, cfg).Outcome; got != ProposeProposed {
+			t.Fatalf("cycle %d outcome = %q, want proposed (no cadence floor)", i, got)
+		}
+	}
+	if backend.calls != 3 {
+		t.Fatalf("Infer calls = %d, want 3", backend.calls)
+	}
+}
+
+// ---- span assertion helpers (mirror the experiment_test.go / validate_test.go
+// recorder pattern) ----
+
+func spanExists(rec *tracetest.SpanRecorder, name string) bool {
+	for _, s := range rec.Ended() {
+		if s.Name() == name {
+			return true
+		}
+	}
+	return false
+}
+
+func assertSpanAttr(t *testing.T, span trace.ReadOnlySpan, key, want string) {
+	t.Helper()
+	for _, a := range span.Attributes() {
+		if string(a.Key) == key {
+			if a.Value.AsString() != want {
+				t.Fatalf("span attr %s = %q, want %q", key, a.Value.AsString(), want)
+			}
+			return
+		}
+	}
+	t.Fatalf("span %q missing attr %s", span.Name(), key)
+}
+
+func assertSpanBoolAttr(t *testing.T, span trace.ReadOnlySpan, key string, want bool) {
+	t.Helper()
+	for _, a := range span.Attributes() {
+		if string(a.Key) == key {
+			if a.Value.AsBool() != want {
+				t.Fatalf("span attr %s = %v, want %v", key, a.Value.AsBool(), want)
+			}
+			return
+		}
+	}
+	t.Fatalf("span %q missing attr %s", span.Name(), key)
+}
+
+func hasNonEmptyAttr(span trace.ReadOnlySpan, key string) bool {
+	for _, a := range span.Attributes() {
+		if string(a.Key) == key && a.Value.AsString() != "" {
+			return true
+		}
+	}
+	return false
+}

--- a/services/agent/flags/flags.go
+++ b/services/agent/flags/flags.go
@@ -89,6 +89,14 @@ const (
 	keyFitnessImprovementThreshold = "code_improvement.fitness_improvement_threshold"
 	keyRevertOnDegradation         = "code_improvement.revert_on_degradation"
 
+	// M7-4 propose-stage flags (#931). Read live (never cached) so a retune of the
+	// propose engine / cadence takes effect on the next propose cycle — same
+	// contract as the #847 llm.* gate flags and the #935 validation flags. They
+	// govern experiment.Proposer: which inference backend generates the proposal,
+	// and how often the (expensive) propose call may fire.
+	keyCodeImprovementEngine      = "code_improvement.engine"
+	keyCodeImprovementMinInterval = "code_improvement.min_interval_seconds"
+
 	// Lifecycle + throttle calibration flags (#766 F5, hot-reloaded since #927).
 	// Unlike the per-cycle layers above, these are NOT re-read on the decision hot
 	// path; they are primed once at startup and then refreshed by the OpenFeature
@@ -203,6 +211,23 @@ const (
 	// hygiene rather than safety, but defaulting it on keeps the shadow surface
 	// clean for the next proposal.
 	DefaultRevertOnDegradation = true
+
+	// M7-4 propose-stage defaults (#931), mirroring the services/flagd/agent.json
+	// code_improvement.* defaultVariants. Applied when flagd is unreachable or a
+	// flag is undefined.
+
+	// DefaultCodeImprovementEngine selects the propose-stage inference backend
+	// (code_improvement.engine). "stub" is the only meaningful value today — the
+	// production endpointBackend.Infer is a sentinel until a real Ollama/cloud
+	// transport lands (#738/#742), so a non-stub value still degrades to
+	// no-proposal. Fail-safe: a missing control plane keeps the agent on the
+	// inert stub rather than dialing a backend it cannot reach.
+	DefaultCodeImprovementEngine = "stub"
+	// DefaultCodeImprovementMinIntervalSeconds is the propose cadence floor
+	// (code_improvement.min_interval_seconds): at most one experiment proposal per
+	// this interval. Proposing is an LLM call, so it is far rarer than a decision
+	// cycle — 300s (5 min) keeps the agent from proposing every game. Tunable live.
+	DefaultCodeImprovementMinIntervalSeconds = 300.0
 
 	// Lifecycle + throttle defaults (#766 F5), mirroring the former hardcoded
 	// constants in main.go (playerTTL/sessionGrace/evictEvery) and decision.go
@@ -432,6 +457,34 @@ func (f *Flags) Validation(ctx context.Context) ValidationConfig {
 		ValidationGames:      f.intFlag(ctx, keyValidationGames, DefaultValidationGames),
 		ImprovementThreshold: f.floatFlag(ctx, keyFitnessImprovementThreshold, DefaultFitnessImprovementThreshold),
 		RevertOnDegradation:  f.boolFlag(ctx, keyRevertOnDegradation, DefaultRevertOnDegradation),
+	}
+}
+
+// CodeImprovementConfig is the M7-4 propose-stage configuration (#931): which
+// inference backend generates the experiment proposal, and the cadence floor
+// between proposals. It mirrors experiment.ProposerConfig (the experiment package
+// stays free of an OpenFeature dependency — the caller resolves the flags here
+// and maps them, the same "package owns logic, caller owns flagd" split the
+// Gate/Writer/Validator use).
+type CodeImprovementConfig struct {
+	// Engine is code_improvement.engine — the flag-selectable propose backend
+	// (default "stub"). main.go uses it to select the backend; today every value
+	// resolves to the inert stub until a real transport lands (#738/#742).
+	Engine string
+	// MinInterval is code_improvement.min_interval_seconds as a Duration (default
+	// 300s): the propose cadence floor. <= 0 in the flag falls back to the default
+	// (durationFlag guards a non-positive value).
+	MinInterval time.Duration
+}
+
+// CodeImprovement evaluates the M7-4 propose-stage flags (#931) for one propose
+// cycle. Read live (never cached) so a retune of the engine/cadence takes effect
+// on the next cycle. Each flag falls back to its safe default on any evaluation
+// error (flagd unreachable / undefined).
+func (f *Flags) CodeImprovement(ctx context.Context) CodeImprovementConfig {
+	return CodeImprovementConfig{
+		Engine:      f.stringFlag(ctx, keyCodeImprovementEngine, DefaultCodeImprovementEngine),
+		MinInterval: f.durationFlag(ctx, keyCodeImprovementMinInterval, DefaultCodeImprovementMinIntervalSeconds),
 	}
 }
 

--- a/services/agent/flags/flags_test.go
+++ b/services/agent/flags/flags_test.go
@@ -570,3 +570,35 @@ func TestValidation(t *testing.T) {
 		}
 	})
 }
+
+// TestCodeImprovement covers the M7-4 propose-stage flags (#931): the engine and
+// cadence resolve from configured values, and fall back to safe defaults on an
+// evaluation error (flagd unreachable / undefined).
+func TestCodeImprovement(t *testing.T) {
+	t.Run("configured values resolve", func(t *testing.T) {
+		ev := stubEvaluator{
+			strings: map[string]string{keyCodeImprovementEngine: "ollama"},
+			floats:  map[string]float64{keyCodeImprovementMinInterval: 60},
+		}
+		got := New(ev, nil).CodeImprovement(context.Background())
+		want := CodeImprovementConfig{Engine: "ollama", MinInterval: 60 * time.Second}
+		if got != want {
+			t.Errorf("CodeImprovement = %+v, want %+v", got, want)
+		}
+	})
+
+	t.Run("errors fall back to safe defaults", func(t *testing.T) {
+		ev := stubEvaluator{errs: map[string]error{
+			keyCodeImprovementEngine:      errors.New("flagd down"),
+			keyCodeImprovementMinInterval: errors.New("flagd down"),
+		}}
+		got := New(ev, nil).CodeImprovement(context.Background())
+		want := CodeImprovementConfig{
+			Engine:      DefaultCodeImprovementEngine,
+			MinInterval: time.Duration(DefaultCodeImprovementMinIntervalSeconds * float64(time.Second)),
+		}
+		if got != want {
+			t.Errorf("CodeImprovement defaults = %+v, want %+v", got, want)
+		}
+	})
+}

--- a/services/agent/main.go
+++ b/services/agent/main.go
@@ -14,6 +14,8 @@ package main
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"log/slog"
 	"net"
 	"net/http"
@@ -32,6 +34,7 @@ import (
 
 	"github.com/joustmania/agent/actions"
 	"github.com/joustmania/agent/decision"
+	"github.com/joustmania/agent/experiment"
 	"github.com/joustmania/agent/flags"
 	"github.com/joustmania/agent/gamecontext"
 	"github.com/joustmania/agent/gamerunner"
@@ -39,6 +42,7 @@ import (
 	"github.com/joustmania/agent/gamewindow"
 	"github.com/joustmania/agent/gate"
 	"github.com/joustmania/agent/infracontext"
+	"github.com/joustmania/agent/llm"
 )
 
 // probeInterval rate-limits the AGENT_PROBE_DECISIONS demo probe.
@@ -449,6 +453,50 @@ func main() {
 	slog.Info("Game narrative builder enabled (#928, M7-1)", "summary_dir", summaryDir)
 	slog.Info("Rolling game context window enabled (#929, M7-2)", "retention_cap", gamewindow.RetentionCap)
 
+	// M7-4 shadow-experiment proposer (#931). The agent turns its rolling game
+	// narrative (#929 window) + fitness signals into a structured {flag, value}
+	// experiment and submits it through the experiment Gate — shadow-scoped, safe
+	// by construction (#932). The Gate writes the game flagset (GAME_FLAG_PATH /
+	// game.json); the Proposer NEVER writes it directly.
+	//
+	// The Backend is the inference seam (Backend.Infer): today proposeBackend is the
+	// sentinel stub (no real Ollama/cloud transport until #738/#742), so every
+	// propose cycle degrades to NO proposal, NO error — the agent does not propose.
+	// The engine flag (agent.code_improvement.engine) selects the backend; it is
+	// read live and recorded on the span even though it only selects the stub now.
+	// The vocab provider reads the LIVE game.json flag keys so the model is
+	// constrained to (and the decoder validates against) the actual flag surface.
+	experimentGate := experiment.NewGate(experiment.NewWriterFromEnv(logger), nil, logger)
+	proposer := experiment.NewProposer(
+		proposeBackend{},
+		experimentGate,
+		gameFlagVocab(getEnv("GAME_FLAG_PATH", experiment.DefaultGamePath)),
+		nil,
+		logger,
+	)
+	// Propose on each GAME END, behind the cadence floor (code_improvement.
+	// min_interval_seconds, read live): proposing is an expensive LLM call, so it
+	// fires far less often than a decision cycle. The hook renders the current
+	// cross-game window as the narrative and fires ProposeOnce in a ctx-bounded
+	// goroutine so a slow inference never blocks the game-end path. ProposeOnce
+	// never returns an error (a failed/gated cycle is a recorded no-op).
+	proposeOnGameEnd := func(c gamecontext.GameContext) {
+		go func() {
+			cfg := agentFlags.CodeImprovement(ctx)
+			n := experiment.Narrative{
+				ContextBlock: gamewindow.Render(sharedContextWindow.Recent(gamewindow.RetentionCap)),
+			}
+			if c.Session.GameMode != nil {
+				n.GameMode = *c.Session.GameMode
+			}
+			proposer.ProposeOnce(ctx, n, experiment.ProposerConfig{
+				Engine:      cfg.Engine,
+				MinInterval: cfg.MinInterval,
+			})
+		}()
+	}
+	slog.Info("Shadow-experiment proposer enabled (#931, M7-4)", "game_flag_path", getEnv("GAME_FLAG_PATH", experiment.DefaultGamePath))
+
 	// GameContext multiplexer (#845 PR B): one Store partition per game_id, plus the
 	// fallback partition "" for unlabeled signals (zero-regression — single-game
 	// mode collapses to exactly today's single-store behavior). The factory applies
@@ -472,7 +520,7 @@ func main() {
 		// pre-reset snapshot. Each has its OWN once-per-game dedupe, so chaining cannot
 		// make either double-fire. Order is retro-then-summary, but they are independent
 		// (neither reads the other's state).
-		s.OnGameEnd = chainGameEnd(retro.OnGameEnd, summaries.OnGameEnd)
+		s.OnGameEnd = chainGameEnd(retro.OnGameEnd, summaries.OnGameEnd, proposeOnGameEnd)
 		return s
 	})
 	mux.SetOwnService(ownService)
@@ -569,5 +617,52 @@ func main() {
 	if err := grpcServer.Serve(lis); err != nil {
 		slog.Error("gRPC server failed", "error", err)
 		os.Exit(1)
+	}
+}
+
+// errProposeBackendNotImplemented is the sentinel proposeBackend.Infer returns: no
+// real propose-stage inference transport exists yet (the Ollama/cloud backend is
+// hardware-/credential-blocked, #738/#742), exactly like decision.endpointBackend.
+// The Proposer treats this as "degrade to no proposal this cycle" (recorded, no
+// error), so the M7-4 propose path is fully wired and inert until a real backend
+// lands. Mirrors the #739 intervention path, which degrades to rules identically.
+var errProposeBackendNotImplemented = errors.New("code_improvement: propose backend not implemented (real Ollama/cloud transport blocked on #738/#742)")
+
+// proposeBackend is the production propose-stage inference backend selected by
+// agent.code_improvement.engine. It satisfies experiment.Backend structurally
+// (Infer(ctx, llm.Prompt) (string, error)). Today every engine value resolves to
+// this inert stub — Infer always returns the sentinel, so the agent proposes
+// nothing. When a real generative backend is wired (#738/#742) this is where the
+// engine flag would select it; until then the wiring degrades to nothing SAFELY.
+type proposeBackend struct{}
+
+func (proposeBackend) Infer(context.Context, llm.Prompt) (string, error) {
+	return "", errProposeBackendNotImplemented
+}
+
+// gameFlagVocab returns the live set of game.json flag keys at path — the
+// vocabulary the proposer constrains the model to and the decoder validates
+// against. It re-reads the file on every call so a hot-reloaded game.json (the
+// agent writes experiments into it) is reflected immediately. Any read/parse
+// error returns an empty set, which fail-closes the decoder (nothing is
+// proposable until the file is readable again) — the safe reading, since a model
+// reply naming a flag we cannot confirm exists must never reach the Gate.
+func gameFlagVocab(path string) func() map[string]struct{} {
+	return func() map[string]struct{} {
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			return nil
+		}
+		var doc struct {
+			Flags map[string]json.RawMessage `json:"flags"`
+		}
+		if err := json.Unmarshal(raw, &doc); err != nil {
+			return nil
+		}
+		set := make(map[string]struct{}, len(doc.Flags))
+		for k := range doc.Flags {
+			set[k] = struct{}{}
+		}
+		return set
 	}
 }

--- a/services/flagd/agent.json
+++ b/services/flagd/agent.json
@@ -408,6 +408,24 @@
         "off": false
       },
       "defaultVariant": "on"
+    },
+    "code_improvement.engine": {
+      "state": "ENABLED",
+      "variants": {
+        "stub": "stub",
+        "ollama": "ollama",
+        "cloud": "cloud"
+      },
+      "defaultVariant": "stub"
+    },
+    "code_improvement.min_interval_seconds": {
+      "state": "ENABLED",
+      "variants": {
+        "default": 300,
+        "fast": 60,
+        "slow": 900
+      },
+      "defaultVariant": "default"
     }
   }
 }


### PR DESCRIPTION
## What

M7-4 (#931), on the **agreed rescoped design** (flag experiments, NOT source edits — see the "Refined design 2026-06-12" comments on #931/#932 and `docs/research/m7-4-testing-strategy.md`, PR #958).

A thin **`Proposer`** that turns the agent's rolling game narrative (#929) + fitness signals into a structured `{flag, value, rationale}` experiment and submits it through the existing `experiment.Gate.Review` — **shadow-scoped, safe by construction (#932)**. A full "remote coding agent" is overkill for flag deltas; this reuses the `Backend.Infer` + defensive-decode seam (#739).

```
narrative + fitness  --build prompt-->  Backend.Infer  --decodeProposal-->
    Proposal  --Gate.Review-->  shadow-scoped game.json write (or blocked span)
```

## How it goes through the Gate (shadow-only)

The Proposer **never writes `game.json` directly** — every proposal goes through `Gate.Review`, which enforces THE INVARIANT (a write can never change what a `game_kind="real"` game resolves) + the type guard (#955). So even a hallucinated/malicious model reply can, at worst, write a well-typed **shadow-only** variant; it can never affect real players.

- **Defensive decode** (`proposer_decode.go`, mirrors `llm.Decode`, pure + table-tested): unparseable / incomplete / out-of-vocab => **NO proposal, never fabricated** (#739 discipline). Out-of-vocab flags are rejected before the Gate (kept off the blocked span); the Gate's `ReasonUnknownFlag` is defense-in-depth.
- **Cadence**: `code_improvement.min_interval_seconds` (read live) — proposing is an expensive LLM call, so it fires at most occasionally, not every cycle (mirrors the #847 `llm.min_decision_interval_seconds` floor). Wired on game-end.
- **Engine**: `code_improvement.engine` (read live, flag-selectable per #931 AC) selects the backend; recorded on the span.
- **Span**: `code_improvement.propose_attempt` carries engine + `code_improvement.proposed_diff_summary` (the structured experiment, since the rescope has no source diff) + outcome; the Gate's `code_improvement.proposed` blocked/reason span nests under it.

## What degrades without a real backend

The production `proposeBackend.Infer` is a **sentinel stub** (no real Ollama/cloud transport until #738/#742), exactly like `decision.endpointBackend`. A backend error => the Proposer records `no_backend` and produces **NO proposal, NO error** — the agent simply does not propose. The whole path is wired and inert until a real backend lands.

## File ownership

NEW files only in `experiment/` (`proposer.go`, `proposer_decode.go`, `proposer_telemetry.go` + tests). Added the two flags to `flags/flags.go` + `services/flagd/agent.json` and wired the Proposer in `main.go`. **Did NOT touch** `experiment/gate.go`, `proposal.go`, or `validate.go` (owned/merged), nor the promotion/GitHub side (#936).

## Out of scope (separate issues)

- Validation — #935 (merged; the Validator consumes a proposal separately).
- Promotion to real / GitHub — #936 (parallel PR).
- Real Ollama/cloud inference transport — #738/#742.

Strictly: narrative → propose → submit-to-Gate (shadow-only). It can never affect real games (the Gate guarantees it).

## Tests (in-process fakes, no network)

`inferBackend`-style fake + `tracetest` recorder + temp `game.json` (`GAME_FLAG_PATH`):
- valid reply → Proposal passes `Gate.Review`, writes the shadow experiment.
- undecodable / unknown-flag reply → NO proposal, NO write, recorded.
- known flag + mistyped value → Gate blocks it (`ReasonTypeMismatch` blocked span), no write.
- no backend → degrades to nothing.
- cadence → two cycles within the interval => exactly one proposal.
- pure decoder is exhaustively table-tested (empty / not-JSON / missing-field / null / unknown-flag / valid / object+number round-trip).

`go build`, `go vet`, `gofmt -l`, `go test -race ./...` all green from `services/agent/`.

Part of #931 (M7-4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)