### PR TITLE
feat(agent): code-improvement promotion flow — issue/pr/autonomous, env-gated (#936)

### DIFF
--- a/services/agent/flags/flags.go
+++ b/services/agent/flags/flags.go
@@ -97,6 +97,15 @@ const (
 	keyCodeImprovementEngine      = "code_improvement.engine"
 	keyCodeImprovementMinInterval = "code_improvement.min_interval_seconds"
 
+	// M7-8 promotion flow flags (#936). Read LIVE (never cached) so flipping the
+	// mode flag takes effect on the NEXT promotion with no restart — the demo
+	// moment. mode selects issue|pr|autonomous; target selects local|github. Both
+	// are STRING flags read via the typed getter. The SAFE defaults (see
+	// DefaultPromotionMode/Target) are baked here: mode never defaults to autonomous,
+	// target never defaults to github — the safety rail.
+	keyPromotionMode   = "code_improvement.mode"
+	keyPromotionTarget = "code_improvement.target"
+
 	// Lifecycle + throttle calibration flags (#766 F5, hot-reloaded since #927).
 	// Unlike the per-cycle layers above, these are NOT re-read on the decision hot
 	// path; they are primed once at startup and then refreshed by the OpenFeature
@@ -228,6 +237,22 @@ const (
 	// this interval. Proposing is an LLM call, so it is far rarer than a decision
 	// cycle — 300s (5 min) keeps the agent from proposing every game. Tunable live.
 	DefaultCodeImprovementMinIntervalSeconds = 300.0
+
+	// M7-8 promotion-flow defaults (#936), the SAFETY RAIL's safe flag defaults —
+	// mirror the services/flagd/agent.json code_improvement.{mode,target}
+	// defaultVariants. Applied when flagd is unreachable or the flag is undefined.
+
+	// DefaultPromotionMode is "issue" — the SAFEST mode: a missing/unreachable
+	// control plane opens an issue (no code/flag change), NEVER autonomous (which
+	// would change the real default). The safety rail requires mode to never default
+	// to autonomous.
+	DefaultPromotionMode = "issue"
+	// DefaultPromotionTarget is "local" — NEVER "github". A missing/unreachable
+	// control plane keeps a promotion off github.com; the real GitHub path requires
+	// both this flag set to github AND the explicit env gate + token (see
+	// promote.NewGitHubClientFromEnv). The safety rail requires target to never
+	// default to github.
+	DefaultPromotionTarget = "local"
 
 	// Lifecycle + throttle defaults (#766 F5), mirroring the former hardcoded
 	// constants in main.go (playerTTL/sessionGrace/evictEvery) and decision.go
@@ -485,6 +510,32 @@ func (f *Flags) CodeImprovement(ctx context.Context) CodeImprovementConfig {
 	return CodeImprovementConfig{
 		Engine:      f.stringFlag(ctx, keyCodeImprovementEngine, DefaultCodeImprovementEngine),
 		MinInterval: f.durationFlag(ctx, keyCodeImprovementMinInterval, DefaultCodeImprovementMinIntervalSeconds),
+	}
+}
+
+// PromotionConfig is the M7-8 promotion-flow configuration (#936): the live mode
+// (issue|pr|autonomous) and target (local|github) the promoter acts under. It
+// mirrors the promote.Config shape (the promote package stays free of an
+// OpenFeature dependency — the caller resolves the flags here, adds the kill-switch
+// from the Snapshot, and passes the value in: the same "package owns logic, caller
+// owns flagd" split the Gate/Writer/Validator use). The SAFE defaults are applied
+// on any flagd error: mode→issue (never autonomous), target→local (never github).
+type PromotionConfig struct {
+	// Mode is code_improvement.mode (default issue).
+	Mode string
+	// Target is code_improvement.target (default local).
+	Target string
+}
+
+// Promotion evaluates the two M7-8 promotion-flow flags (#936) for one promotion.
+// Read LIVE (never cached) so flipping the mode flag mid-session takes effect on
+// the NEXT promotion with no restart — the demo moment. Each flag falls back to
+// its SAFE default on any evaluation error (flagd unreachable / undefined): the
+// safety rail's mode→issue / target→local defaults.
+func (f *Flags) Promotion(ctx context.Context) PromotionConfig {
+	return PromotionConfig{
+		Mode:   f.stringFlag(ctx, keyPromotionMode, DefaultPromotionMode),
+		Target: f.stringFlag(ctx, keyPromotionTarget, DefaultPromotionTarget),
 	}
 }
 

--- a/services/agent/flags/flags_test.go
+++ b/services/agent/flags/flags_test.go
@@ -602,3 +602,40 @@ func TestCodeImprovement(t *testing.T) {
 		}
 	})
 }
+
+// TestPromotion covers the M7-8 promotion-flow flags (#936): the live mode/target
+// resolve, and — critically for the SAFETY RAIL — each falls back to its SAFE
+// default on an evaluation error (mode→issue, NEVER autonomous; target→local,
+// NEVER github).
+func TestPromotion(t *testing.T) {
+	t.Run("configured values resolve live", func(t *testing.T) {
+		ev := stubEvaluator{strings: map[string]string{
+			keyPromotionMode:   "autonomous",
+			keyPromotionTarget: "github",
+		}}
+		got := New(ev, nil).Promotion(context.Background())
+		want := PromotionConfig{Mode: "autonomous", Target: "github"}
+		if got != want {
+			t.Errorf("Promotion = %+v, want %+v", got, want)
+		}
+	})
+
+	t.Run("errors fall back to SAFE defaults (issue/local, never autonomous/github)", func(t *testing.T) {
+		ev := stubEvaluator{errs: map[string]error{
+			keyPromotionMode:   errors.New("flagd down"),
+			keyPromotionTarget: errors.New("flagd down"),
+		}}
+		got := New(ev, nil).Promotion(context.Background())
+		want := PromotionConfig{Mode: DefaultPromotionMode, Target: DefaultPromotionTarget}
+		if got != want {
+			t.Errorf("Promotion defaults = %+v, want %+v", got, want)
+		}
+		// The safety rail's hard invariant: the fail-closed defaults are the SAFE ones.
+		if got.Mode == "autonomous" {
+			t.Fatal("SAFETY: promotion mode defaulted to autonomous")
+		}
+		if got.Target == "github" {
+			t.Fatal("SAFETY: promotion target defaulted to github")
+		}
+	})
+}

--- a/services/agent/main.go
+++ b/services/agent/main.go
@@ -177,10 +177,14 @@ func rolloutActuator(logger *slog.Logger) decision.RolloutActuator {
 // watch+revert seams (Watcher/RealDefaultReverter) are nil until that live
 // measurement is wired, so autonomous applies-and-records without a watch for now.
 func buildPromoter(logger *slog.Logger) *promote.Promoter {
-	// Resolve the live target ONCE for client construction. The GitHub real client is
-	// gated on target=github so it is never built for a local-target deployment even
-	// with the env gate + token present. The mode/target are STILL read live per
-	// promotion inside Promote — this only decides which real client to construct.
+	// Resolve the target for client construction from the ENV (AGENT_CODE_IMPROVEMENT_TARGET),
+	// distinct from the LIVE flag (code_improvement.target) that Promote dispatches on.
+	// This is a deliberate DOUBLE gate and is STRICTER than a single switch: opening a
+	// real GitHub PR needs BOTH the env target=github at construction (so the http
+	// client is even built) AND the live flag target=github at dispatch. If they
+	// diverge (env=local, flag=github) the dispatch hits the inert no-op and degrades
+	// to a RECORDED no-op — safe, but an operator who flips only the live flag will see
+	// recorded no-ops; flipping to real GitHub requires the env target too.
 	target := promote.Target(getEnv("AGENT_CODE_IMPROVEMENT_TARGET", string(promote.TargetLocal)))
 
 	github, err := promote.NewGitHubClientFromEnv(target, logger)

--- a/services/agent/main.go
+++ b/services/agent/main.go
@@ -43,6 +43,7 @@ import (
 	"github.com/joustmania/agent/gate"
 	"github.com/joustmania/agent/infracontext"
 	"github.com/joustmania/agent/llm"
+	"github.com/joustmania/agent/promote"
 )
 
 // probeInterval rate-limits the AGENT_PROBE_DECISIONS demo probe.
@@ -148,6 +149,91 @@ func rolloutActuator(logger *slog.Logger) decision.RolloutActuator {
 	}
 	logger.Info("Agent rollout expansion disabled (dry-run; decisions spanned, not applied)")
 	return actions.NewDryRunRolloutWriter(logger)
+}
+
+// buildPromoter constructs the M7-8 code-improvement Promoter (#936) with the
+// SAFETY RAIL applied at the one place it can be: this is the ONLY site where the
+// real, consequential clients (GitHub API, local git, real-default writer) are
+// ever built, each behind its explicit env gate. Everything else (tests, the
+// default path) gets the inert recording no-ops.
+//
+// The real clients are built ONLY when AGENT_CODE_IMPROVEMENT_ENABLED=true AND the
+// per-target conditions hold (GitHub: GITHUB_TOKEN + GITHUB_REPOSITORY + the live
+// target=github flag; local: AGENT_LOCAL_REPO_DIR; autonomous real-default:
+// AGENT_AUTONOMOUS_ENABLED + AGENT_REAL_DEFAULT_FLAG_PATH). Absent any condition,
+// the corresponding FromEnv constructor returns nil and NewPromoter substitutes the
+// inert no-op / leaves autonomous as a recorded no-op — fail-closed, never a silent
+// real action. The promotion mode/target are read LIVE per promotion (flags), so
+// flipping the mode flag takes effect on the next promotion with no restart.
+//
+// The default flag values are the SAFE ones (mode=issue, target=local; see
+// services/flagd/agent.json + flags.DefaultPromotion*), so even a fully-enabled
+// agent only opens an issue until an operator deliberately flips the flags.
+//
+// NOTE on the live trigger: the propose→validate→PROMOTE pipeline that CALLS
+// Promote on a validated experiment is the documented follow-up (the proposer is
+// #931, parallel; the SyntheticRunner/Watcher live wiring reuses M7-7's seams where
+// merged). buildPromoter wires the env-gated promotion SURFACE; the autonomous
+// watch+revert seams (Watcher/RealDefaultReverter) are nil until that live
+// measurement is wired, so autonomous applies-and-records without a watch for now.
+func buildPromoter(logger *slog.Logger) *promote.Promoter {
+	// Resolve the live target ONCE for client construction. The GitHub real client is
+	// gated on target=github so it is never built for a local-target deployment even
+	// with the env gate + token present. The mode/target are STILL read live per
+	// promotion inside Promote — this only decides which real client to construct.
+	target := promote.Target(getEnv("AGENT_CODE_IMPROVEMENT_TARGET", string(promote.TargetLocal)))
+
+	github, err := promote.NewGitHubClientFromEnv(target, logger)
+	if err != nil {
+		logger.Error("code_improvement GitHub client misconfigured; using inert no-op", "error", err)
+		github = nil // NewPromoter substitutes the recording no-op
+	}
+	git, err := promote.NewGitClientFromEnv(target, logger)
+	if err != nil {
+		logger.Error("code_improvement local git client misconfigured; using inert no-op", "error", err)
+		git = nil
+	}
+	realDef, err := promote.NewRealDefaultWriterFromEnv(logger)
+	if err != nil {
+		logger.Error("code_improvement real-default writer misconfigured; autonomous stays a no-op", "error", err)
+		realDef = nil
+	}
+
+	// FromEnv returns a typed-nil *concrete pointer when ungated; pass nil interfaces
+	// to NewPromoter so its nil checks substitute the no-ops (a typed-nil in an
+	// interface is non-nil and would defeat them).
+	var ghIface promote.GitHubClient
+	if github != nil {
+		ghIface = github
+	}
+	var gitIface promote.GitClient
+	if git != nil {
+		gitIface = git
+	}
+	var realDefIface promote.RealDefaultWriter
+	if realDef != nil {
+		realDefIface = realDef
+	}
+
+	repo := promote.RepoRef{
+		Owner: firstField(getEnv("GITHUB_REPOSITORY", ""), 0),
+		Name:  firstField(getEnv("GITHUB_REPOSITORY", ""), 1),
+		Base:  getEnv("GITHUB_BASE_BRANCH", "main"),
+	}
+	// Watcher + RealDefaultReverter (autonomous live watch+revert) reuse M7-7's
+	// fitness measurement seams; they are nil until that live wiring lands, so
+	// autonomous applies+records without a watch (documented follow-up).
+	return promote.NewPromoter(ghIface, gitIface, realDefIface, nil, nil, repo, nil, logger)
+}
+
+// firstField splits an "owner/repo" string and returns the owner (i==0) or repo
+// (i==1), or "" when absent.
+func firstField(repo string, i int) string {
+	parts := strings.SplitN(repo, "/", 2)
+	if i < len(parts) {
+		return parts[i]
+	}
+	return ""
 }
 
 // rolloutDwell reads the per-stage dwell from AGENT_ROLLOUT_DWELL_SECONDS,
@@ -496,6 +582,23 @@ func main() {
 		}()
 	}
 	slog.Info("Shadow-experiment proposer enabled (#931, M7-4)", "game_flag_path", getEnv("GAME_FLAG_PATH", experiment.DefaultGamePath))
+
+	// M7-8 code-improvement promotion surface (#936): build the Promoter with the
+	// env-gated real clients (or the inert recording no-ops when not gated — the
+	// SAFETY RAIL). The promotion mode/target are read LIVE per promotion, so an
+	// operator can flip code_improvement.mode (issue→pr→autonomous) at runtime with
+	// no restart. The live propose→validate→PROMOTE trigger that calls
+	// promoter.Promote on a validated experiment is the documented follow-up (the
+	// proposer is #931; the autonomous watch+revert reuses M7-7's seams); here the
+	// gated promotion surface is constructed and held so the wiring + the env gate
+	// are in place and observable.
+	promoter := buildPromoter(logger)
+	_ = promoter // held for the live promotion trigger (follow-up); see buildPromoter.
+	slog.Info("Code-improvement promotion surface enabled (#936, M7-8)",
+		"code_improvement_enabled", getEnv("AGENT_CODE_IMPROVEMENT_ENABLED", "false"),
+		"target", getEnv("AGENT_CODE_IMPROVEMENT_TARGET", string(promote.TargetLocal)),
+		"autonomous_enabled", getEnv("AGENT_AUTONOMOUS_ENABLED", "false"),
+	)
 
 	// GameContext multiplexer (#845 PR B): one Store partition per game_id, plus the
 	// fallback partition "" for unlabeled signals (zero-regression — single-game

--- a/services/agent/promote/actions.go
+++ b/services/agent/promote/actions.go
@@ -1,0 +1,153 @@
+package promote
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/joustmania/agent/experiment"
+)
+
+// actions.go holds the per-mode promotion logic. Each helper mutates the passed
+// *Result (the span attributes are stamped by record()). Every consequential
+// effect routes through an injected seam, so these methods are exercised in unit
+// tests with recording fakes — ZERO network, ZERO real git, ZERO real-default
+// mutation (the SAFETY RAIL, see promote.go).
+
+// promoteIssue opens a GitHub issue describing the hypothesis + implicated flag.
+// NO code/flag is applied (#936: "issue — open an issue describing the hypothesis
+// and the implicated file; no code applied"). The issue is ALWAYS opened through
+// the GitHubClient seam: with the real client disabled (the default), that seam is
+// the inert recording no-op, so this degrades to a RECORDED no-op (empty URL +
+// reason), never a silent or accidental real action.
+func (pr *Promoter) promoteIssue(ctx context.Context, p experiment.Proposal, ev Evidence, res *Result) {
+	req := IssueReq{
+		Title:  fmt.Sprintf("Flag experiment: %s", p.FlagKey),
+		Body:   renderIssueBody(p, ev),
+		Labels: []string{"agent", "code-improvement"},
+	}
+	url, err := pr.github.OpenIssue(ctx, req)
+	if err != nil {
+		// Fail-safe: a failed/declined open (incl. the no-op fake's recorded decline)
+		// is a recorded no-op, never a crash and never a different action.
+		res.Outcome = OutcomeDiscarded
+		res.Reason = fmt.Sprintf("open issue: %v", err)
+		return
+	}
+	res.Outcome = OutcomeApplied
+	res.URL = url
+}
+
+// promotePR opens a PR with the STRUCTURED evidence body (#936 AC). Nothing is
+// merged. Routing depends on target:
+//   - github: open the PR via the GitHubClient (env-gated real client, else no-op).
+//   - local:  commit the change into the local working tree via the GitClient
+//     (a throwaway git repo in tests; no push). A local PR has no URL — the commit
+//     SHA is recorded as the artifact.
+func (pr *Promoter) promotePR(ctx context.Context, p experiment.Proposal, ev Evidence, target Target, res *Result) {
+	body := renderPRBody(p, ev)
+
+	switch target {
+	case TargetGitHub:
+		req := PRReq{
+			Title: fmt.Sprintf("Flag experiment: %s", p.FlagKey),
+			Body:  body,
+			Head:  branchName(p),
+			Base:  pr.repo.Base,
+		}
+		url, err := pr.github.OpenPR(ctx, req)
+		if err != nil {
+			res.Outcome = OutcomeDiscarded
+			res.Reason = fmt.Sprintf("open pr: %v", err)
+			return
+		}
+		res.Outcome = OutcomeApplied
+		res.URL = url
+	default: // TargetLocal
+		req := CommitReq{
+			Message: fmt.Sprintf("flag experiment: %s\n\n%s", p.FlagKey, body),
+			Files:   map[string]string{evidenceFilePath(p): body},
+		}
+		sha, err := pr.git.Commit(ctx, req)
+		if err != nil {
+			res.Outcome = OutcomeDiscarded
+			res.Reason = fmt.Sprintf("local commit: %v", err)
+			return
+		}
+		res.Outcome = OutcomeApplied
+		res.URL = "local:" + sha // not a network URL; the recorded local artifact
+	}
+}
+
+// promoteAutonomous applies the validated change to the REAL default, watches real
+// games, and reverts on degradation (#936: "autonomous — apply, watch, revert per
+// M7-7"). This is the consequential real-player-affecting path, so it is the most
+// heavily guarded:
+//
+//   - KILL-SWITCH: a disabled agent (cfg.Enabled == false) NEVER mutates the real
+//     default — degrades to a recorded no-op. autonomous is default-OFF AND behind
+//     the kill-switch (the safety rail).
+//   - SEPARATE WRITER: the real-default change goes through the injected
+//     RealDefaultWriter — explicitly NOT the shadow experiment.Writer (which is
+//     structurally shadow-only). A nil RealDefaultWriter (real path not wired) → a
+//     recorded no-op; the shadow Writer is never reused to sneak a real change.
+//   - WATCH + REVERT: after applying, the Watcher observes real games; on
+//     degradation the RealDefaultReverter rolls the real default back (reusing M7-7's
+//     watch/revert seams where wired). A nil Watcher means no live watch is wired yet
+//     (documented follow-up) — applied without a watch.
+func (pr *Promoter) promoteAutonomous(ctx context.Context, p experiment.Proposal, cfg Config, ev Evidence, res *Result) {
+	if !cfg.Enabled {
+		res.Outcome = OutcomeDiscarded
+		res.Reason = "autonomous requested but agent disabled (kill-switch); real default not changed"
+		return
+	}
+	if pr.realDef == nil {
+		res.Outcome = OutcomeDiscarded
+		res.Reason = "autonomous requested but no real-default writer wired; real default not changed"
+		return
+	}
+
+	// The one sanctioned real-player-affecting write, through the gated seam.
+	if err := pr.realDef.SetRealDefault(ctx, p.FlagKey, ev.RealDefaultValue); err != nil {
+		res.Outcome = OutcomeDiscarded
+		res.Reason = fmt.Sprintf("set real default: %v", err)
+		return
+	}
+	res.Outcome = OutcomeApplied
+
+	// No live watch wired yet: apply and record. The watch+revert wiring reuses
+	// M7-7's Validator/Reverter seams and is the documented follow-up (main.go).
+	if pr.watcher == nil {
+		return
+	}
+
+	degraded, err := pr.watcher.Degraded(ctx, p.FlagKey)
+	// An error means we cannot CONFIRM the change is healthy; fail safe by treating
+	// it as a degradation so a real-player change is rolled back rather than left
+	// unverified.
+	if err != nil || degraded {
+		pr.revertReal(ctx, p, res, err, degraded)
+	}
+}
+
+// revertReal rolls the autonomous real-default change back on a degradation (or an
+// unconfirmable watch). A nil RealDefaultReverter (no rollback wired) records the
+// degradation but cannot undo it — logged + reasoned so it is visible, never
+// silent. On a successful revert the outcome becomes OutcomeReverted.
+func (pr *Promoter) revertReal(ctx context.Context, p experiment.Proposal, res *Result, watchErr error, degraded bool) {
+	reason := "real-game fitness degraded after autonomous change"
+	if watchErr != nil {
+		reason = fmt.Sprintf("could not confirm real-game fitness healthy (%v); reverting fail-safe", watchErr)
+	}
+	if pr.reverter == nil {
+		// Applied but cannot roll back — record the degradation so it is actionable.
+		res.Reason = reason + "; no real-default reverter wired"
+		return
+	}
+	if err := pr.reverter.RevertRealDefault(ctx, p.FlagKey); err != nil {
+		res.Reason = fmt.Sprintf("%s; revert failed: %v", reason, err)
+		return
+	}
+	res.Outcome = OutcomeReverted
+	res.Reason = reason
+	_ = degraded
+}

--- a/services/agent/promote/body.go
+++ b/services/agent/promote/body.go
@@ -1,0 +1,135 @@
+package promote
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/joustmania/agent/experiment"
+)
+
+// body.go renders the STRUCTURED issue/PR bodies (#936 AC: "PR description is
+// structured: fitness before/after, synthetic results, reasoning summary, flag
+// state"). The bodies are deterministic Markdown so they are golden-testable and a
+// reviewer (or a downstream parser) reads the same fields every time.
+
+// renderIssueBody renders the ModeIssue body: the hypothesis + the implicated flag
+// + the fitness evidence that motivated proposing the experiment. NO change is
+// applied in issue mode, so the body frames this as a PROPOSAL for a human to act
+// on (#936: "open an issue describing the hypothesis and the implicated flag").
+func renderIssueBody(p experiment.Proposal, ev Evidence) string {
+	var b strings.Builder
+	b.WriteString("## Agent flag-experiment hypothesis\n\n")
+	b.WriteString("The agent's self-improvement loop validated a shadow-scoped flag ")
+	b.WriteString("experiment and is surfacing it for human review (mode=issue: no ")
+	b.WriteString("code or flag change has been applied).\n\n")
+
+	b.WriteString("### Implicated flag\n\n")
+	fmt.Fprintf(&b, "- **Flag:** `%s`\n", p.FlagKey)
+	fmt.Fprintf(&b, "- **Proposed experimental value:** `%v`\n\n", p.ExperimentalValue)
+
+	b.WriteString("### Hypothesis (proposer reasoning)\n\n")
+	b.WriteString(reasoningOrFallback(p, ev))
+	b.WriteString("\n\n")
+
+	b.WriteString(renderFitnessSection(ev))
+	b.WriteString(renderFlagStateSection(ev))
+	return b.String()
+}
+
+// renderPRBody renders the ModePR body: the full machine-readable evidence the
+// #936 AC enumerates — fitness before/after, synthetic game results, the
+// proposer/coding-agent reasoning summary, and the flag state at improvement time.
+// Structured headings so it parses predictably and reviews at a glance.
+func renderPRBody(p experiment.Proposal, ev Evidence) string {
+	var b strings.Builder
+	b.WriteString("## Agent flag-experiment promotion\n\n")
+	b.WriteString("This PR was opened by the agent's self-improvement loop after a ")
+	b.WriteString("shadow-scoped flag experiment cleared synthetic validation. ")
+	b.WriteString("Nothing is merged automatically — a human reviews + merges.\n\n")
+
+	b.WriteString("### Proposed change\n\n")
+	fmt.Fprintf(&b, "- **Flag:** `%s`\n", p.FlagKey)
+	fmt.Fprintf(&b, "- **Experimental value:** `%v`\n\n", p.ExperimentalValue)
+
+	b.WriteString(renderFitnessSection(ev))
+
+	b.WriteString("### Synthetic game results\n\n")
+	fmt.Fprintf(&b, "- **Synthetic games run:** %d\n", ev.SyntheticGames)
+	fmt.Fprintf(&b, "- **Fitness measured over the synthetic suite (after):** %.4f\n\n", ev.FitnessAfter)
+
+	b.WriteString("### Reasoning summary\n\n")
+	b.WriteString(reasoningOrFallback(p, ev))
+	b.WriteString("\n\n")
+
+	b.WriteString(renderFlagStateSection(ev))
+	return b.String()
+}
+
+// renderFitnessSection renders the fitness before/after/delta block shared by the
+// issue and PR bodies (#936 AC: "fitness before/after").
+func renderFitnessSection(ev Evidence) string {
+	var b strings.Builder
+	b.WriteString("### Fitness before/after\n\n")
+	fmt.Fprintf(&b, "- **Before (real-game baseline):** %.4f\n", ev.FitnessBefore)
+	fmt.Fprintf(&b, "- **After (synthetic suite):** %.4f\n", ev.FitnessAfter)
+	fmt.Fprintf(&b, "- **Delta:** %+.4f\n\n", ev.FitnessDelta)
+	return b.String()
+}
+
+// renderFlagStateSection renders the flag-state-at-improvement-time block (#936
+// AC: "flag state"). The caller assembles ev.FlagState from the live flag snapshot;
+// an empty value renders an explicit marker rather than a blank section, so the
+// body is never ambiguous about whether the context was captured.
+func renderFlagStateSection(ev Evidence) string {
+	var b strings.Builder
+	b.WriteString("### Flag state at improvement time\n\n")
+	if strings.TrimSpace(ev.FlagState) == "" {
+		b.WriteString("_(flag state not captured)_\n")
+	} else {
+		fmt.Fprintf(&b, "```\n%s\n```\n", strings.TrimSpace(ev.FlagState))
+	}
+	return b.String()
+}
+
+// reasoningOrFallback returns the proposer reasoning, falling back to the
+// Proposal's rationale, then to an explicit marker — the body always has a
+// reasoning section even when the proposer side (#931) supplied nothing.
+func reasoningOrFallback(p experiment.Proposal, ev Evidence) string {
+	if s := strings.TrimSpace(ev.Reasoning); s != "" {
+		return s
+	}
+	if s := strings.TrimSpace(p.Rationale); s != "" {
+		return s
+	}
+	return "_(no reasoning summary supplied)_"
+}
+
+// branchName derives a deterministic, filesystem/git-safe head branch name for a
+// github-target PR from the flag key.
+func branchName(p experiment.Proposal) string {
+	return "agent/experiment-" + sanitize(p.FlagKey)
+}
+
+// evidenceFilePath is the repo-relative path a TargetLocal commit writes the
+// evidence body to (a record of the experiment in the working tree; the real
+// flag-change wiring is a follow-up — here the committed artifact is the evidence).
+func evidenceFilePath(p experiment.Proposal) string {
+	return "agent-experiments/" + sanitize(p.FlagKey) + ".md"
+}
+
+// sanitize lowercases a flag key and replaces any non-alphanumeric run with a
+// single hyphen, so it is safe in a branch name / file path.
+func sanitize(s string) string {
+	var b strings.Builder
+	lastHyphen := false
+	for _, r := range strings.ToLower(s) {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			b.WriteRune(r)
+			lastHyphen = false
+		} else if !lastHyphen {
+			b.WriteByte('-')
+			lastHyphen = true
+		}
+	}
+	return strings.Trim(b.String(), "-")
+}

--- a/services/agent/promote/body_test.go
+++ b/services/agent/promote/body_test.go
@@ -1,0 +1,74 @@
+package promote
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/joustmania/agent/experiment"
+)
+
+// TestRenderPRBodyStructured asserts the PR body contains every #936-mandated
+// section (fitness before/after, synthetic results, reasoning, flag state).
+func TestRenderPRBodyStructured(t *testing.T) {
+	body := renderPRBody(promoteProposal, testEvidence())
+	for _, want := range []string{
+		"### Fitness before/after",
+		"Before (real-game baseline):** 0.5000",
+		"After (synthetic suite):** 0.7200",
+		"Delta:** +0.2200",
+		"### Synthetic game results",
+		"Synthetic games run:** 5",
+		"### Reasoning summary",
+		"longer grace reduces early eliminations",
+		"### Flag state at improvement time",
+		"death_grace_period_ms: default=300, experimental=500",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("PR body missing %q:\n%s", want, body)
+		}
+	}
+}
+
+// TestRenderIssueBodyHasHypothesisAndFlag asserts the issue body names the
+// hypothesis and the implicated flag (#936 issue-mode contract).
+func TestRenderIssueBodyHasHypothesisAndFlag(t *testing.T) {
+	body := renderIssueBody(promoteProposal, testEvidence())
+	if !strings.Contains(body, promoteProposal.FlagKey) {
+		t.Errorf("issue body missing flag key:\n%s", body)
+	}
+	if !strings.Contains(body, "longer grace reduces early eliminations") {
+		t.Errorf("issue body missing reasoning:\n%s", body)
+	}
+	if !strings.Contains(body, "no code or flag change has been applied") {
+		t.Errorf("issue body should state nothing was applied:\n%s", body)
+	}
+}
+
+// TestReasoningFallback: with no Evidence reasoning, the body falls back to the
+// Proposal rationale, then to an explicit marker.
+func TestReasoningFallback(t *testing.T) {
+	if got := reasoningOrFallback(promoteProposal, Evidence{}); got != promoteProposal.Rationale {
+		t.Errorf("fallback to rationale = %q, want %q", got, promoteProposal.Rationale)
+	}
+	if got := reasoningOrFallback(experiment.Proposal{}, Evidence{}); !strings.Contains(got, "no reasoning") {
+		t.Errorf("empty fallback = %q, want a no-reasoning marker", got)
+	}
+}
+
+// TestFlagStateMarkerWhenAbsent: an empty flag state renders an explicit marker.
+func TestFlagStateMarkerWhenAbsent(t *testing.T) {
+	if got := renderFlagStateSection(Evidence{}); !strings.Contains(got, "not captured") {
+		t.Errorf("absent flag state = %q, want a not-captured marker", got)
+	}
+}
+
+// TestBranchAndPathSanitize: branch/file names are derived safely from the flag key.
+func TestBranchAndPathSanitize(t *testing.T) {
+	p := experiment.Proposal{FlagKey: "Policy.Battery_Threshold!!"}
+	if got := branchName(p); got != "agent/experiment-policy-battery-threshold" {
+		t.Errorf("branchName = %q", got)
+	}
+	if got := evidenceFilePath(p); got != "agent-experiments/policy-battery-threshold.md" {
+		t.Errorf("evidenceFilePath = %q", got)
+	}
+}

--- a/services/agent/promote/git.go
+++ b/services/agent/promote/git.go
@@ -1,0 +1,106 @@
+package promote
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// git.go is the REAL local-target git client (TargetLocal): write files into a
+// working tree and `git commit` them. It NEVER pushes — local target by definition
+// does not reach a remote (a `git push` is structurally absent from this file, the
+// safety rail for the local path). It is built ONLY by NewGitClientFromEnv behind
+// the env gate, mirroring the GitHub client. Tests exercise it against a throwaway
+// `git init` temp repo (real git, NO network).
+
+// execGitClient runs git in a fixed working-tree directory.
+type execGitClient struct {
+	dir string // the working-tree root; files are written relative to it
+	log *slog.Logger
+}
+
+// NewGitClientFromEnv returns the REAL local git client IFF the env gate is
+// satisfied for a local-target apply, else nil (the caller substitutes the no-op).
+// This is the ONLY constructor for a real local-git client.
+//
+// Gate conditions:
+//   - target == TargetLocal
+//   - AGENT_CODE_IMPROVEMENT_ENABLED == "true"   (same explicit opt-in as github)
+//   - AGENT_LOCAL_REPO_DIR points at a directory  (where to commit)
+//
+// Returns (nil, nil) when not gated (the fail-closed default). Returns (nil, err)
+// only when gated-on but the configured directory is missing/invalid.
+func NewGitClientFromEnv(target Target, log *slog.Logger) (*execGitClient, error) {
+	if log == nil {
+		log = slog.Default()
+	}
+	if target != TargetLocal {
+		return nil, nil
+	}
+	if !strings.EqualFold(strings.TrimSpace(os.Getenv("AGENT_CODE_IMPROVEMENT_ENABLED")), "true") {
+		log.Info("code_improvement local git real client NOT built: AGENT_CODE_IMPROVEMENT_ENABLED != true")
+		return nil, nil
+	}
+	dir := strings.TrimSpace(os.Getenv("AGENT_LOCAL_REPO_DIR"))
+	if dir == "" {
+		log.Info("code_improvement local git real client NOT built: AGENT_LOCAL_REPO_DIR unset (fail-closed to no-op)")
+		return nil, nil
+	}
+	info, err := os.Stat(dir)
+	if err != nil || !info.IsDir() {
+		return nil, fmt.Errorf("AGENT_LOCAL_REPO_DIR=%q is not a directory: %v", dir, err)
+	}
+	log.Warn("code_improvement local git real client ENABLED (#936): local-target promotions WILL commit (no push)", "dir", dir)
+	return NewGitClient(dir, log), nil
+}
+
+// NewGitClient builds a local git client over a working-tree directory. Exported
+// so TESTS can point it at a t.TempDir() `git init` repo (real git, no network) —
+// the strategy doc's "local-git tests may use a throwaway git init temp repo".
+// This is a LOCAL-ONLY commit client; it does not and cannot push.
+func NewGitClient(dir string, log *slog.Logger) *execGitClient {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &execGitClient{dir: dir, log: log}
+}
+
+// Commit writes req.Files (paths relative to the working tree), stages them, and
+// commits with req.Message. Returns the new commit SHA. NO push.
+func (c *execGitClient) Commit(ctx context.Context, req CommitReq) (string, error) {
+	for rel, content := range req.Files {
+		abs := filepath.Join(c.dir, filepath.Clean("/"+rel)) // confine to the tree
+		if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+			return "", fmt.Errorf("mkdir for %q: %w", rel, err)
+		}
+		if err := os.WriteFile(abs, []byte(content), 0o644); err != nil {
+			return "", fmt.Errorf("write %q: %w", rel, err)
+		}
+		if _, err := c.run(ctx, "add", "--", rel); err != nil {
+			return "", err
+		}
+	}
+	if _, err := c.run(ctx, "commit", "-m", req.Message); err != nil {
+		return "", err
+	}
+	sha, err := c.run(ctx, "rev-parse", "HEAD")
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(sha), nil
+}
+
+// run executes `git <args>` in the working-tree dir and returns stdout.
+func (c *execGitClient) run(ctx context.Context, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Dir = c.dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("git %s: %w: %s", strings.Join(args, " "), err, strings.TrimSpace(string(out)))
+	}
+	return string(out), nil
+}

--- a/services/agent/promote/git_test.go
+++ b/services/agent/promote/git_test.go
@@ -1,0 +1,101 @@
+package promote
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// git_test.go exercises the REAL local git client against a throwaway `git init`
+// temp repo (real git, NO network — there is no push). This is the strategy doc's
+// "local-git tests may use a throwaway git init temp repo".
+
+// initTempRepo creates an isolated git repo in t.TempDir() with an initial commit,
+// or skips the test if git is unavailable.
+func initTempRepo(t *testing.T) string {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := t.TempDir()
+	run := func(args ...string) {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		// Pin identity + no signing so the commit succeeds in any CI env.
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@example.com",
+			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@example.com",
+			"GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null",
+		)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %s: %v: %s", strings.Join(args, " "), err, out)
+		}
+	}
+	run("init")
+	run("commit", "--allow-empty", "-m", "init")
+	return dir
+}
+
+func TestLocalGitClientCommits(t *testing.T) {
+	dir := initTempRepo(t)
+	// The exec client inherits the test's pinned git identity env via the process.
+	t.Setenv("GIT_AUTHOR_NAME", "test")
+	t.Setenv("GIT_AUTHOR_EMAIL", "test@example.com")
+	t.Setenv("GIT_COMMITTER_NAME", "test")
+	t.Setenv("GIT_COMMITTER_EMAIL", "test@example.com")
+
+	c := NewGitClient(dir, discardLogger())
+	sha, err := c.Commit(context.Background(), CommitReq{
+		Message: "flag experiment: death_grace_period_ms",
+		Files:   map[string]string{"agent-experiments/death-grace-period-ms.md": "# evidence\n"},
+	})
+	if err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	if len(strings.TrimSpace(sha)) < 7 {
+		t.Errorf("commit SHA looks wrong: %q", sha)
+	}
+	// The file landed in the working tree.
+	if _, err := os.Stat(filepath.Join(dir, "agent-experiments/death-grace-period-ms.md")); err != nil {
+		t.Errorf("committed file not written: %v", err)
+	}
+	// And NO remote was added (local target never pushes).
+	cmd := exec.Command("git", "remote")
+	cmd.Dir = dir
+	out, _ := cmd.CombinedOutput()
+	if strings.TrimSpace(string(out)) != "" {
+		t.Errorf("local git client added a remote: %q", out)
+	}
+}
+
+// TestPromoterPRLocalUsesRealGit wires the Promoter over the REAL local git client
+// (temp repo) end to end: mode=pr, target=local commits the evidence body.
+func TestPromoterPRLocalUsesRealGit(t *testing.T) {
+	dir := initTempRepo(t)
+	t.Setenv("GIT_AUTHOR_NAME", "test")
+	t.Setenv("GIT_AUTHOR_EMAIL", "test@example.com")
+	t.Setenv("GIT_COMMITTER_NAME", "test")
+	t.Setenv("GIT_COMMITTER_EMAIL", "test@example.com")
+
+	p := NewPromoter(nil, NewGitClient(dir, discardLogger()), nil, nil, nil, testRepo(), nil, discardLogger())
+	res := p.Promote(context.Background(), promoteProposal, promoteVerdict,
+		Config{Mode: ModePR, Target: TargetLocal}, testEvidence())
+
+	if res.Outcome != OutcomeApplied {
+		t.Fatalf("outcome = %q, want applied", res.Outcome)
+	}
+	if !strings.HasPrefix(res.URL, "local:") {
+		t.Errorf("local URL = %q, want local: prefix", res.URL)
+	}
+	// The evidence file exists with the structured body.
+	data, err := os.ReadFile(filepath.Join(dir, "agent-experiments/death-grace-period-ms.md"))
+	if err != nil {
+		t.Fatalf("evidence file: %v", err)
+	}
+	if !strings.Contains(string(data), "Fitness before/after") {
+		t.Errorf("committed evidence missing fitness section")
+	}
+}

--- a/services/agent/promote/github.go
+++ b/services/agent/promote/github.go
@@ -1,0 +1,159 @@
+package promote
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+// github.go is the REAL GitHub API client — the consequential, network-touching
+// path of the safety rail. It is built ONLY by NewGitHubClientFromEnv, which
+// returns a real client ONLY when ALL of the gate conditions hold:
+//
+//	AGENT_CODE_IMPROVEMENT_ENABLED=true   (explicit opt-in beyond the kill-switch)
+//	GITHUB_TOKEN present                  (the credential)
+//	target == github                      (the runtime flag, checked by the caller)
+//
+// Absent any one, NewGitHubClientFromEnv returns nil and main.go falls back to the
+// inert recording no-op (NewNoopGitHubClient). There is NO other constructor for a
+// real client — a test cannot instantiate one, so no unit/integration test can
+// reach github.com (the safety rail's structural guarantee). Stdlib net/http only:
+// two simple endpoints (issues, pulls) do not justify a new dependency (the M7-4
+// testing-strategy doc §4 "skip Microcks / go-github").
+
+// httpGitHubClient posts to the GitHub REST API. Constructed only via
+// NewGitHubClientFromEnv behind the env gate + token.
+type httpGitHubClient struct {
+	httpClient *http.Client
+	baseURL    string // https://api.github.com (overridable for a sandbox/e2e host)
+	token      string
+	owner      string
+	repo       string
+	log        *slog.Logger
+}
+
+// NewGitHubClientFromEnv returns the REAL GitHub client IFF the env gate is fully
+// satisfied, else nil (the caller substitutes the no-op). This is the ONLY place a
+// real GitHub client is ever constructed. It deliberately takes the resolved
+// target so the gate includes the runtime flag: a real client is never built for a
+// local-target promotion even with the env gate + token set.
+//
+// Gate conditions (ALL required):
+//   - target == TargetGitHub                         (runtime flag)
+//   - AGENT_CODE_IMPROVEMENT_ENABLED == "true"       (explicit env opt-in)
+//   - GITHUB_TOKEN non-empty                          (credential)
+//   - GITHUB_REPOSITORY == "owner/repo"               (where to act)
+//
+// Returns (nil, nil) when the gate is not satisfied — that is the EXPECTED,
+// fail-closed default, not an error. Returns (nil, err) only when the gate IS
+// satisfied but a required value is malformed (e.g. a bad GITHUB_REPOSITORY), so a
+// misconfigured opt-in fails loudly rather than silently dialing nothing.
+func NewGitHubClientFromEnv(target Target, log *slog.Logger) (*httpGitHubClient, error) {
+	if log == nil {
+		log = slog.Default()
+	}
+	if target != TargetGitHub {
+		return nil, nil // not a github target — no real client (use the no-op)
+	}
+	if !strings.EqualFold(strings.TrimSpace(os.Getenv("AGENT_CODE_IMPROVEMENT_ENABLED")), "true") {
+		log.Info("code_improvement github real client NOT built: AGENT_CODE_IMPROVEMENT_ENABLED != true")
+		return nil, nil
+	}
+	token := strings.TrimSpace(os.Getenv("GITHUB_TOKEN"))
+	if token == "" {
+		log.Warn("code_improvement github real client NOT built: GITHUB_TOKEN absent (fail-closed to no-op)")
+		return nil, nil
+	}
+	owner, repo, ok := splitRepo(os.Getenv("GITHUB_REPOSITORY"))
+	if !ok {
+		return nil, fmt.Errorf("AGENT_CODE_IMPROVEMENT_ENABLED is set but GITHUB_REPOSITORY=%q is not owner/repo", os.Getenv("GITHUB_REPOSITORY"))
+	}
+	baseURL := strings.TrimRight(getenvDefault("GITHUB_API_URL", "https://api.github.com"), "/")
+	log.Warn("code_improvement GitHub real client ENABLED (#936): promotions with target=github WILL open real issues/PRs",
+		"repo", owner+"/"+repo, "api", baseURL)
+	return &httpGitHubClient{
+		httpClient: &http.Client{Timeout: 15 * time.Second},
+		baseURL:    baseURL,
+		token:      token,
+		owner:      owner,
+		repo:       repo,
+		log:        log,
+	}, nil
+}
+
+// OpenIssue POSTs to /repos/{owner}/{repo}/issues and returns the html_url.
+func (c *httpGitHubClient) OpenIssue(ctx context.Context, req IssueReq) (string, error) {
+	payload := map[string]any{"title": req.Title, "body": req.Body}
+	if len(req.Labels) > 0 {
+		payload["labels"] = req.Labels
+	}
+	return c.post(ctx, fmt.Sprintf("/repos/%s/%s/issues", c.owner, c.repo), payload)
+}
+
+// OpenPR POSTs to /repos/{owner}/{repo}/pulls and returns the html_url.
+func (c *httpGitHubClient) OpenPR(ctx context.Context, req PRReq) (string, error) {
+	payload := map[string]any{
+		"title": req.Title,
+		"body":  req.Body,
+		"head":  req.Head,
+		"base":  req.Base,
+	}
+	return c.post(ctx, fmt.Sprintf("/repos/%s/%s/pulls", c.owner, c.repo), payload)
+}
+
+// post sends a JSON POST to the GitHub API and returns the response's html_url.
+func (c *httpGitHubClient) post(ctx context.Context, path string, payload any) (string, error) {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("marshal payload: %w", err)
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+path, bytes.NewReader(body))
+	if err != nil {
+		return "", fmt.Errorf("build request: %w", err)
+	}
+	httpReq.Header.Set("Authorization", "Bearer "+c.token)
+	httpReq.Header.Set("Accept", "application/vnd.github+json")
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return "", fmt.Errorf("github POST %s: %w", path, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", fmt.Errorf("github POST %s: status %d: %s", path, resp.StatusCode, string(respBody))
+	}
+	var parsed struct {
+		HTMLURL string `json:"html_url"`
+	}
+	if err := json.Unmarshal(respBody, &parsed); err != nil {
+		return "", fmt.Errorf("parse github response: %w", err)
+	}
+	return parsed.HTMLURL, nil
+}
+
+// splitRepo parses "owner/repo" into its parts.
+func splitRepo(s string) (owner, repo string, ok bool) {
+	parts := strings.SplitN(strings.TrimSpace(s), "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", false
+	}
+	return parts[0], parts[1], true
+}
+
+// getenvDefault returns the env var or def if empty.
+func getenvDefault(key, def string) string {
+	if v := strings.TrimSpace(os.Getenv(key)); v != "" {
+		return v
+	}
+	return def
+}

--- a/services/agent/promote/noop.go
+++ b/services/agent/promote/noop.go
@@ -1,0 +1,84 @@
+package promote
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+)
+
+// noop.go holds the INERT recording no-op clients that are the DEFAULT GitHubClient
+// / GitClient (see NewPromoter). They are the safety rail's fail-closed floor: a
+// Promoter built without an explicit real client — i.e. every test, and main.go
+// whenever the env gate/token/target are not all present — can only RECORD that it
+// "would have" acted, never touch github.com or a real git remote.
+//
+// errNoopGitHub / errNoopGit are returned so the per-mode logic degrades to a
+// RECORDED no-op (OutcomeDiscarded + reason on the span), making an unreachable
+// real path VISIBLE in the trace rather than silent (#936 safety rail).
+
+var (
+	// errNoopGitHub is returned by the no-op GitHub client. Its presence in a Result
+	// reason proves the github target degraded to an inert recorded no-op because the
+	// real client was not enabled.
+	errNoopGitHub = errors.New("github target not enabled (no real client wired; set AGENT_CODE_IMPROVEMENT_ENABLED=true + GITHUB_TOKEN + target=github)")
+	// errNoopGit is returned by the no-op local git client.
+	errNoopGit = errors.New("local git target not enabled (no real git client wired)")
+)
+
+// noopGitHubClient records the requests it WOULD have sent and declines them. It
+// has ZERO network code by construction — there is no http client, no URL, no
+// token anywhere in this type, so no bug or test can make it dial github.com.
+type noopGitHubClient struct {
+	log *slog.Logger
+	// Issues / PRs record what would have been opened, for tests that assert "the
+	// agent would open an issue/PR with body X" against the DEFAULT (disabled) path.
+	Issues []IssueReq
+	PRs    []PRReq
+}
+
+// NewNoopGitHubClient builds the inert recording GitHub client. This is the default
+// the Promoter falls back to; it is also exported so tests can assert against the
+// recorded requests. log nil uses slog.Default().
+func NewNoopGitHubClient(log *slog.Logger) *noopGitHubClient {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &noopGitHubClient{log: log}
+}
+
+// OpenIssue records the request and declines (no network).
+func (c *noopGitHubClient) OpenIssue(_ context.Context, req IssueReq) (string, error) {
+	c.Issues = append(c.Issues, req)
+	c.log.Info("code_improvement github DISABLED: would open issue (recorded no-op)", "title", req.Title)
+	return "", errNoopGitHub
+}
+
+// OpenPR records the request and declines (no network).
+func (c *noopGitHubClient) OpenPR(_ context.Context, req PRReq) (string, error) {
+	c.PRs = append(c.PRs, req)
+	c.log.Info("code_improvement github DISABLED: would open PR (recorded no-op)", "title", req.Title)
+	return "", errNoopGitHub
+}
+
+// noopGitClient records the commits it WOULD have made and declines them. ZERO git
+// shell-out by construction.
+type noopGitClient struct {
+	log *slog.Logger
+	// Commits records what would have been committed.
+	Commits []CommitReq
+}
+
+// NewNoopGitClient builds the inert recording local-git client (the default).
+func NewNoopGitClient(log *slog.Logger) *noopGitClient {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &noopGitClient{log: log}
+}
+
+// Commit records the request and declines (no git).
+func (c *noopGitClient) Commit(_ context.Context, req CommitReq) (string, error) {
+	c.Commits = append(c.Commits, req)
+	c.log.Info("code_improvement local git DISABLED: would commit (recorded no-op)", "files", len(req.Files))
+	return "", errNoopGit
+}

--- a/services/agent/promote/promote.go
+++ b/services/agent/promote/promote.go
@@ -1,0 +1,411 @@
+// Package promote implements M7-8 (#936): the PROMOTION flow for the agent's
+// shadow-scoped flag experiments. It takes a VALIDATED (PROMOTE) experiment plus
+// its fitness Evidence and ACTS according to two live flags:
+//
+//		code_improvement.mode   = issue | pr | autonomous   (the "gate")
+//		code_improvement.target = local | github
+//
+//	  - issue       — open a GitHub issue describing the hypothesis + implicated
+//	                  flag; NO code/flag applied.
+//	  - pr          — open a PR with a STRUCTURED body (fitness before/after,
+//	                  synthetic results, proposer reasoning, flag state); nothing
+//	                  merged.
+//	  - autonomous  — apply the validated change to the REAL default, watch real
+//	                  games, and revert if fitness degrades (per M7-7's
+//	                  Validator/Reverter seams).
+//
+// THE SAFETY RAIL (agreed, non-negotiable — see docs/research/m7-4-testing-strategy.md
+// §3.3). Promotion is the one consequential, REAL-affecting piece of the track,
+// so the design makes a real action impossible to reach by accident or from a
+// test:
+//
+//   - The seams are interfaces (GitHubClient, GitClient, RealDefaultWriter). Unit
+//     tests use RECORDING FAKES that assert "would open an issue/PR with body X" /
+//     "would commit Y" / "would write real default Z" — ZERO network, ZERO real
+//     git, ZERO real-default mutation.
+//   - The REAL GitHub client + real git + real-default write are constructed ONLY
+//     in main.go behind an EXPLICIT env gate (AGENT_CODE_IMPROVEMENT_ENABLED=true),
+//     a token (GITHUB_TOKEN), and target=github — via NewGitHubClientFromEnv /
+//     NewGitClientFromEnv / NewRealDefaultWriterFromEnv. There is NO test-reachable
+//     constructor for any of them; a test that wants a real client cannot get one.
+//   - The SAFE flag DEFAULTS are baked in: mode defaults to issue (NEVER
+//     autonomous), target defaults to local (NEVER github). autonomous (apply-to-
+//     real + watch) is additionally behind the agent `enabled` kill-switch — the
+//     caller passes Config.Enabled, and a disabled agent degrades autonomous to a
+//     recorded no-op.
+//   - Real GitHub is default-off, fail-closed: with the env gate/token absent, the
+//     real client is not built; main.go passes the inert recording no-op fakes, and
+//     a github-target promotion degrades to a RECORDED no-op (logged + span reason),
+//     never a silent or accidental real action.
+//   - autonomous changing the real defaultVariant is a SEPARATE, higher-privilege
+//     path than the shadow Writer (which is structurally shadow-only). It is the
+//     injected RealDefaultWriter, mutated explicitly + gated — the shadow Writer is
+//     NEVER reused to sneak a real-default change.
+package promote
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/joustmania/agent/experiment"
+)
+
+// Mode is the resolved code_improvement.mode — the "gate" that selects promotion
+// behaviour. The set is closed so dashboards can enumerate every gate.
+type Mode string
+
+const (
+	// ModeIssue opens a GitHub issue describing the hypothesis + implicated flag.
+	// NO code or flag change is applied. This is the SAFE default mode.
+	ModeIssue Mode = "issue"
+	// ModePR opens a PR with the structured fitness-evidence body. Nothing is merged
+	// — a human reviews + merges. Lands per target (github → GitHub API, local →
+	// local apply/commit).
+	ModePR Mode = "pr"
+	// ModeAutonomous applies the validated change to the REAL default, watches real
+	// games, and reverts on degradation. The highest-privilege path; default-OFF and
+	// additionally behind the agent kill-switch (Config.Enabled).
+	ModeAutonomous Mode = "autonomous"
+)
+
+// Target is the resolved code_improvement.target — where a pr/commit lands.
+type Target string
+
+const (
+	// TargetLocal applies/commits locally (a local git repo or in-process). The SAFE
+	// default target — never reaches github.com.
+	TargetLocal Target = "local"
+	// TargetGitHub commits + opens a PR/issue via the GitHub API. Only reaches a real
+	// client when the env gate + token are present (see NewGitHubClientFromEnv).
+	TargetGitHub Target = "github"
+)
+
+// Outcome is what the promotion ACHIEVED (#936 AC: code_improvement.outcome). The
+// set is closed; distinct from experiment.Outcome (the M7-7 verdict).
+type Outcome string
+
+const (
+	// OutcomeApplied — the requested action happened: an issue/PR was opened, or the
+	// autonomous real-default change was applied.
+	OutcomeApplied Outcome = "applied"
+	// OutcomeDiscarded — the promotion did NOT act: the verdict was not PROMOTE, the
+	// agent was disabled (autonomous), or a github action degraded to an inert
+	// recorded no-op because the real path was not enabled. The Reason explains which.
+	OutcomeDiscarded Outcome = "discarded"
+	// OutcomeReverted — autonomous applied to the real default but a degradation was
+	// observed, so the real-default change was rolled back (per M7-7's Reverter seam).
+	OutcomeReverted Outcome = "reverted"
+)
+
+// Config is the live, per-promotion flag configuration the Promoter acts under
+// (#936 flags), resolved fresh each promotion so flipping the mode flag takes
+// effect on the NEXT promotion with no restart — the same never-cached contract
+// as the #847/#935 gate flags. The caller resolves these via flags.Promotion(ctx)
+// (see flags/flags.go) + the agent kill-switch and passes the value in, so this
+// package stays free of an OpenFeature dependency (the Gate/Writer/Validator all
+// follow this "package owns logic, caller owns flagd" split).
+type Config struct {
+	// Mode is code_improvement.mode (default issue). Selects issue/pr/autonomous.
+	Mode Mode
+	// Target is code_improvement.target (default local). Selects local/github.
+	Target Target
+	// Enabled is the agent `enabled` kill-switch (flags.Snapshot.Enabled). It gates
+	// ONLY the autonomous mode: a real-default mutation must never happen while the
+	// agent is disabled. issue/pr do not consume it (opening an issue/PR is not a
+	// live real-player change). A disabled agent degrades autonomous to a recorded
+	// no-op (OutcomeDiscarded + reason), never a silent real change.
+	Enabled bool
+}
+
+// Evidence is the fitness + provenance the promotion records into an issue/PR
+// body (#936 AC: "PR description is structured: fitness before/after, synthetic
+// results, reasoning summary, flag state"). It is assembled by the caller from the
+// M7-7 Decision + the live flag snapshot and threaded into the body renderer.
+type Evidence struct {
+	// FitnessBefore / FitnessAfter / FitnessDelta are the M7-7 baseline-vs-synthetic
+	// fitness numbers (experiment.Decision). Recorded in the body AND on the span.
+	FitnessBefore float64
+	FitnessAfter  float64
+	FitnessDelta  float64
+	// SyntheticGames is how many synthetic/shadow games the experiment was validated
+	// against (experiment.Decision.Games) — the sample size behind FitnessAfter.
+	SyntheticGames int
+	// Reasoning is the coding-agent/proposer reasoning summary — the agent's
+	// hypothesis for why the change helps. Sourced from Proposal.Rationale (the
+	// proposer side, #931, is a parallel PR; here we render whatever rationale the
+	// validated proposal carried).
+	Reasoning string
+	// FlagState is a human-readable snapshot of the relevant flag state at improvement
+	// time (e.g. "death_grace_period_ms: default=300ms, experimental=500ms;
+	// objectives=balanced_focused"). The caller assembles it from the live flag
+	// snapshot so a reviewer sees the control-plane context the experiment ran under.
+	FlagState string
+	// RealDefaultValue is the value the autonomous path would write as the REAL
+	// defaultVariant for the flag (typically the experiment's experimental value once
+	// validated). Used only by ModeAutonomous; ignored by issue/pr.
+	RealDefaultValue any
+}
+
+// IssueReq is the GitHub issue a ModeIssue promotion opens.
+type IssueReq struct {
+	// Title is the issue title (e.g. "Flag experiment: death_grace_period_ms").
+	Title string
+	// Body is the structured hypothesis + implicated-flag description.
+	Body string
+	// Labels tag the issue for triage (e.g. agent, code-improvement).
+	Labels []string
+}
+
+// PRReq is the GitHub pull request a ModePR / TargetGitHub promotion opens.
+type PRReq struct {
+	// Title is the PR title.
+	Title string
+	// Body is the STRUCTURED, machine-readable evidence body (see renderPRBody):
+	// fitness before/after, synthetic results, reasoning, flag state.
+	Body string
+	// Head is the branch carrying the change; Base is the branch to merge into.
+	Head string
+	Base string
+}
+
+// CommitReq is a local-target commit (TargetLocal): the change written + committed
+// into a working tree (no network). Used by the GitClient seam.
+type CommitReq struct {
+	// Message is the commit message.
+	Message string
+	// Files maps repo-relative path -> new file contents written before the commit.
+	Files map[string]string
+}
+
+// Result is the recorded outcome of one Promote, returned to the caller for the
+// span/log and any follow-up. Never nil-meaningful: even a no-op returns a Result
+// with OutcomeDiscarded + a Reason, so a promotion is always attributable.
+type Result struct {
+	// Mode / Target are the resolved flags the promotion acted under (echoed for the
+	// caller's log without re-reading flagd).
+	Mode   Mode
+	Target Target
+	// Outcome is applied | discarded | reverted.
+	Outcome Outcome
+	// URL is the opened issue/PR URL (empty for local/no-op).
+	URL string
+	// Reason explains a no-op / degrade / revert (empty on a clean applied). Its
+	// presence on a github-target Result is the SAFETY RAIL's visible proof that the
+	// real path was unreachable and the promotion degraded to an inert recorded no-op.
+	Reason string
+}
+
+// GitHubClient is the GitHub API wire boundary (the SAFETY RAIL's network seam).
+// Unit tests inject a recording fake; the REAL client is built ONLY in main.go
+// behind the env gate + token (NewGitHubClientFromEnv) and is never reachable from
+// a test constructor.
+type GitHubClient interface {
+	// OpenIssue opens a GitHub issue and returns its URL.
+	OpenIssue(ctx context.Context, req IssueReq) (string, error)
+	// OpenPR opens a GitHub pull request and returns its URL.
+	OpenPR(ctx context.Context, req PRReq) (string, error)
+}
+
+// GitClient is the local-target git seam (TargetLocal): write files + commit into
+// a working tree. Unit tests use a throwaway `git init` temp repo (real git, NO
+// network — there is no push); the real client is built only in main.go.
+type GitClient interface {
+	// Commit writes req.Files and commits them, returning the commit SHA. It MUST
+	// NOT push (local target never reaches a remote).
+	Commit(ctx context.Context, req CommitReq) (string, error)
+}
+
+// RealDefaultWriter performs the autonomous mode's REAL defaultVariant mutation —
+// the SEPARATE, higher-privilege path the safety rail isolates from the shadow
+// Writer. It is explicitly NOT experiment.Writer (which is structurally shadow-
+// scoped and can never change a real resolution). A nil RealDefaultWriter means
+// "no real-default mechanism wired", so autonomous degrades to a recorded no-op.
+// The real implementation is built only in main.go behind the env gate.
+type RealDefaultWriter interface {
+	// SetRealDefault changes the REAL defaultVariant for flagKey to value. This is the
+	// one sanctioned real-player-affecting write; it is gated by the env gate at
+	// construction AND the kill-switch at call time.
+	SetRealDefault(ctx context.Context, flagKey string, value any) error
+}
+
+// Watcher observes real games after an autonomous real-default change and reports
+// whether fitness DEGRADED (so the change should be reverted). It reuses M7-7's
+// fitness measurement seam where wired; a nil Watcher means "no live watch wired
+// yet" — autonomous applies and records OutcomeApplied without a watch (the live
+// watch+revert wiring is the documented follow-up; see main.go).
+type Watcher interface {
+	// Degraded reports whether real-game fitness degraded after the change (true →
+	// the Promoter reverts via RealDefaultReverter). An error is treated as "cannot
+	// confirm healthy" → fail-safe revert.
+	Degraded(ctx context.Context, flagKey string) (bool, error)
+}
+
+// RealDefaultReverter rolls back an autonomous real-default change on degradation.
+// nil means no revert mechanism wired (a degradation is then recorded but not
+// rolled back — logged so it is visible). Distinct from experiment.Reverter (the
+// shadow rollback): this reverts the REAL default.
+type RealDefaultReverter interface {
+	// RevertRealDefault restores the prior real defaultVariant for flagKey.
+	RevertRealDefault(ctx context.Context, flagKey string) error
+}
+
+// Promoter orchestrates a promotion per the live mode/target. It owns ONLY the
+// dispatch + outcome logic; every consequential effect (open issue/PR, commit,
+// write real default, watch, revert) is an injected seam, so the whole flow is
+// unit-testable with recording fakes and the real path is built only in main.go.
+type Promoter struct {
+	github   GitHubClient        // wire boundary; recording fake in tests, env-gated real client in main.go
+	git      GitClient           // local-target commit; temp git repo in tests
+	realDef  RealDefaultWriter   // autonomous real-default mutation (nil = not wired)
+	watcher  Watcher             // autonomous live watch (nil = not wired; applies without watch)
+	reverter RealDefaultReverter // autonomous degradation rollback (nil = not wired)
+	repo     RepoRef             // owner/name/base used to build issue/PR/commit requests
+	tracer   trace.Tracer
+	log      *slog.Logger
+}
+
+// RepoRef identifies the GitHub repo + default base branch a promotion targets.
+// Populated from env in main.go (GITHUB_REPOSITORY / GITHUB_BASE_BRANCH); the
+// fakes in tests use a fixed value.
+type RepoRef struct {
+	Owner string
+	Name  string
+	Base  string
+}
+
+// NewPromoter builds a Promoter over the injected seams. github/git default to the
+// inert recording no-ops when nil (so a Promoter is ALWAYS safe to construct in a
+// test or when the real path is disabled — it can only no-op). realDef/watcher/
+// reverter may be nil (autonomous degrades accordingly). tracer nil uses the global
+// tracer; log nil uses slog.Default().
+func NewPromoter(github GitHubClient, git GitClient, realDef RealDefaultWriter, watcher Watcher, reverter RealDefaultReverter, repo RepoRef, tracer trace.Tracer, log *slog.Logger) *Promoter {
+	if github == nil {
+		// Default to the inert recording no-op: a Promoter built without an explicit
+		// client can NEVER reach github.com. The real client is opt-in (main.go only).
+		github = NewNoopGitHubClient(log)
+	}
+	if git == nil {
+		git = NewNoopGitClient(log)
+	}
+	if tracer == nil {
+		tracer = otel.Tracer(instrumentationName)
+	}
+	if log == nil {
+		log = slog.Default()
+	}
+	return &Promoter{
+		github:   github,
+		git:      git,
+		realDef:  realDef,
+		watcher:  watcher,
+		reverter: reverter,
+		repo:     repo,
+		tracer:   tracer,
+		log:      log,
+	}
+}
+
+// Promote acts on a validated experiment per the live cfg. p is the PROMOTE'd
+// Proposal, dec is the M7-7 verdict, ev is the assembled fitness Evidence. It
+// emits the code_improvement.promote span carrying gate (mode) + target + outcome
+// (+ the fitness evidence + any degrade reason), and returns the recorded Result.
+//
+// FAIL-SAFE / RECORDED: a promotion NEVER silently acts or silently no-ops. If the
+// verdict was not PROMOTE, or a github target is unreachable (real client absent),
+// or autonomous is requested while disabled, the promotion degrades to
+// OutcomeDiscarded with a Reason on the span — visible, never silent. The real,
+// consequential paths run only through the env-gated injected seams.
+func (pr *Promoter) Promote(ctx context.Context, p experiment.Proposal, dec experiment.Decision, cfg Config, ev Evidence) Result {
+	mode := normalizeMode(cfg.Mode)
+	target := normalizeTarget(cfg.Target)
+
+	ctx, span := pr.tracer.Start(ctx, SpanPromote, trace.WithAttributes(
+		attribute.String(AttrGate, string(mode)),
+		attribute.String(AttrTarget, string(target)),
+		attribute.String(AttrFlagKey, p.FlagKey),
+		attribute.Float64(AttrFitnessBefore, ev.FitnessBefore),
+		attribute.Float64(AttrFitnessAfter, ev.FitnessAfter),
+		attribute.Float64(AttrFitnessDelta, ev.FitnessDelta),
+	))
+	defer span.End()
+
+	res := Result{Mode: mode, Target: target}
+
+	// GUARD 1: only a validated PROMOTE verdict is ever promoted (#936 depends on
+	// M7-7: "only validated changes are promoted"). Anything else is a recorded
+	// no-op — the agent does not act on a discard/revert verdict.
+	if dec.Outcome != experiment.OutcomePromote {
+		res.Outcome = OutcomeDiscarded
+		res.Reason = fmt.Sprintf("verdict %q is not promote; nothing promoted", dec.Outcome)
+		return pr.record(span, res)
+	}
+
+	switch mode {
+	case ModeIssue:
+		pr.promoteIssue(ctx, p, ev, &res)
+	case ModePR:
+		pr.promotePR(ctx, p, ev, target, &res)
+	case ModeAutonomous:
+		pr.promoteAutonomous(ctx, p, cfg, ev, &res)
+	default:
+		// Unreachable after normalizeMode, but fail safe: an unknown mode acts as the
+		// safest mode (no real change), recorded.
+		res.Outcome = OutcomeDiscarded
+		res.Reason = fmt.Sprintf("unknown mode %q; treated as no-op", mode)
+	}
+
+	return pr.record(span, res)
+}
+
+// record stamps the outcome/url/reason on the span and logs the promotion, then
+// returns the Result. A non-applied github-target outcome marks the span with an
+// error status so a degraded/unreachable promotion is visible in Jaeger (it is a
+// recorded no-op, not a failure of the agent, so the message is the reason).
+func (pr *Promoter) record(span trace.Span, res Result) Result {
+	span.SetAttributes(
+		attribute.String(AttrOutcome, string(res.Outcome)),
+		attribute.String(AttrURL, res.URL),
+		attribute.String(AttrReason, res.Reason),
+	)
+	if res.Reason != "" {
+		span.SetStatus(codes.Error, res.Reason)
+	}
+	pr.log.Info("code_improvement.promoted",
+		"gate", string(res.Mode),
+		"target", string(res.Target),
+		"outcome", string(res.Outcome),
+		"url", res.URL,
+		"reason", res.Reason,
+	)
+	return res
+}
+
+// normalizeMode coerces an unknown/empty mode to the SAFE default (issue) — the
+// safety rail's "default mode is never autonomous". A garbled flag value can never
+// silently become a real-default mutation.
+func normalizeMode(m Mode) Mode {
+	switch m {
+	case ModeIssue, ModePR, ModeAutonomous:
+		return m
+	default:
+		return ModeIssue
+	}
+}
+
+// normalizeTarget coerces an unknown/empty target to the SAFE default (local) —
+// the safety rail's "default target is never github". A garbled flag value can
+// never silently route to github.com.
+func normalizeTarget(t Target) Target {
+	switch t {
+	case TargetLocal, TargetGitHub:
+		return t
+	default:
+		return TargetLocal
+	}
+}

--- a/services/agent/promote/promote_test.go
+++ b/services/agent/promote/promote_test.go
@@ -1,0 +1,385 @@
+package promote
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"github.com/joustmania/agent/experiment"
+)
+
+// ---- RECORDING FAKES for the three promotion seams (#936 safety rail). The
+// Promoter owns only the dispatch logic; opening an issue/PR, committing, and the
+// real-default write are faked here so every mode is exercised against EXACTLY what
+// it "would" do — ZERO network, ZERO real git, ZERO real-default mutation. None of
+// these fakes touch github.com or run git; they only record. ----
+
+// recordingGitHub records the issue/PR it was asked to open and returns a canned
+// URL (or a configured error). It is the unit-test stand-in for the GitHubClient
+// wire boundary.
+type recordingGitHub struct {
+	issues   []IssueReq
+	prs      []PRReq
+	issueURL string
+	prURL    string
+	issueErr error
+	prErr    error
+}
+
+func (g *recordingGitHub) OpenIssue(_ context.Context, req IssueReq) (string, error) {
+	g.issues = append(g.issues, req)
+	return g.issueURL, g.issueErr
+}
+
+func (g *recordingGitHub) OpenPR(_ context.Context, req PRReq) (string, error) {
+	g.prs = append(g.prs, req)
+	return g.prURL, g.prErr
+}
+
+// recordingGit records the commits it was asked to make and returns a canned SHA.
+type recordingGit struct {
+	commits []CommitReq
+	sha     string
+	err     error
+}
+
+func (g *recordingGit) Commit(_ context.Context, req CommitReq) (string, error) {
+	g.commits = append(g.commits, req)
+	return g.sha, g.err
+}
+
+// recordingRealDefault records the real-default writes it was asked to make. This
+// is the highest-privilege seam; the fake NEVER writes a real file — it only
+// records that a real-default change "would" have happened.
+type recordingRealDefault struct {
+	calls []struct {
+		flag  string
+		value any
+	}
+	err error
+}
+
+func (w *recordingRealDefault) SetRealDefault(_ context.Context, flag string, value any) error {
+	w.calls = append(w.calls, struct {
+		flag  string
+		value any
+	}{flag, value})
+	return w.err
+}
+
+// fakeWatcher reports a configured degradation verdict.
+type fakeWatcher struct {
+	degraded bool
+	err      error
+}
+
+func (w fakeWatcher) Degraded(context.Context, string) (bool, error) { return w.degraded, w.err }
+
+// recordingReverter records real-default reverts.
+type recordingReverter struct {
+	calls int
+	err   error
+}
+
+func (r *recordingReverter) RevertRealDefault(context.Context, string) error {
+	r.calls++
+	return r.err
+}
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func testRepo() RepoRef {
+	return RepoRef{Owner: "WatchMeJoustMyFlags", Name: "JoustMania", Base: "main"}
+}
+
+var promoteProposal = experiment.Proposal{
+	FlagKey:           "death_grace_period_ms",
+	ExperimentalValue: 500,
+	Rationale:         "longer grace may extend sessions",
+}
+
+var promoteVerdict = experiment.Decision{
+	Outcome:       experiment.OutcomePromote,
+	FitnessBefore: 0.50,
+	FitnessAfter:  0.72,
+	Games:         5,
+}
+
+func testEvidence() Evidence {
+	return Evidence{
+		FitnessBefore:    0.50,
+		FitnessAfter:     0.72,
+		FitnessDelta:     0.22,
+		SyntheticGames:   5,
+		Reasoning:        "longer grace reduces early eliminations",
+		FlagState:        "death_grace_period_ms: default=300, experimental=500",
+		RealDefaultValue: 500,
+	}
+}
+
+// promoterWithRecorder wires a Promoter over the given seams with an in-memory span
+// recorder, mirroring the validate_test.go recorder pattern.
+func promoterWithRecorder(t *testing.T, gh GitHubClient, git GitClient, realDef RealDefaultWriter, w Watcher, rev RealDefaultReverter) (*Promoter, *tracetest.SpanRecorder) {
+	t.Helper()
+	rec := tracetest.NewSpanRecorder()
+	tp := trace.NewTracerProvider(trace.WithSpanProcessor(rec))
+	p := NewPromoter(gh, git, realDef, w, rev, testRepo(), tp.Tracer("test"), discardLogger())
+	return p, rec
+}
+
+func spanByName(t *testing.T, rec *tracetest.SpanRecorder, name string) trace.ReadOnlySpan {
+	t.Helper()
+	for _, s := range rec.Ended() {
+		if s.Name() == name {
+			return s
+		}
+	}
+	t.Fatalf("span %q not found", name)
+	return nil
+}
+
+func stringAttr(s trace.ReadOnlySpan, key string) string {
+	for _, a := range s.Attributes() {
+		if string(a.Key) == key {
+			return a.Value.AsString()
+		}
+	}
+	return ""
+}
+
+// --- mode=issue: opens an issue with hypothesis + flag, applies NOTHING else. ---
+func TestPromoteIssueMode(t *testing.T) {
+	gh := &recordingGitHub{issueURL: "https://github.com/WatchMeJoustMyFlags/JoustMania/issues/42"}
+	git := &recordingGit{}
+	realDef := &recordingRealDefault{}
+	p, rec := promoterWithRecorder(t, gh, git, realDef, nil, nil)
+
+	res := p.Promote(context.Background(), promoteProposal, promoteVerdict,
+		Config{Mode: ModeIssue, Target: TargetLocal}, testEvidence())
+
+	if res.Outcome != OutcomeApplied {
+		t.Fatalf("outcome = %q, want applied", res.Outcome)
+	}
+	if len(gh.issues) != 1 {
+		t.Fatalf("OpenIssue calls = %d, want 1", len(gh.issues))
+	}
+	// The issue body must name the hypothesis and the implicated flag.
+	body := gh.issues[0].Body
+	if !strings.Contains(body, promoteProposal.FlagKey) {
+		t.Errorf("issue body missing flag key:\n%s", body)
+	}
+	if !strings.Contains(body, "longer grace reduces early eliminations") {
+		t.Errorf("issue body missing reasoning:\n%s", body)
+	}
+	// Nothing else applied: no PR, no commit, no real-default change.
+	if len(gh.prs) != 0 || len(git.commits) != 0 || len(realDef.calls) != 0 {
+		t.Errorf("issue mode applied more than an issue: prs=%d commits=%d realDef=%d",
+			len(gh.prs), len(git.commits), len(realDef.calls))
+	}
+	span := spanByName(t, rec, SpanPromote)
+	if got := stringAttr(span, AttrGate); got != "issue" {
+		t.Errorf("gate attr = %q, want issue", got)
+	}
+	if got := stringAttr(span, AttrOutcome); got != "applied" {
+		t.Errorf("outcome attr = %q, want applied", got)
+	}
+	if got := stringAttr(span, AttrURL); got != gh.issueURL {
+		t.Errorf("url attr = %q, want %q", got, gh.issueURL)
+	}
+}
+
+// --- mode=pr, target=github: opens a PR with a STRUCTURED body, merges nothing. ---
+func TestPromotePRModeGitHub(t *testing.T) {
+	gh := &recordingGitHub{prURL: "https://github.com/WatchMeJoustMyFlags/JoustMania/pull/99"}
+	git := &recordingGit{}
+	realDef := &recordingRealDefault{}
+	p, rec := promoterWithRecorder(t, gh, git, realDef, nil, nil)
+
+	res := p.Promote(context.Background(), promoteProposal, promoteVerdict,
+		Config{Mode: ModePR, Target: TargetGitHub}, testEvidence())
+
+	if res.Outcome != OutcomeApplied {
+		t.Fatalf("outcome = %q, want applied", res.Outcome)
+	}
+	if len(gh.prs) != 1 {
+		t.Fatalf("OpenPR calls = %d, want 1", len(gh.prs))
+	}
+	body := gh.prs[0].Body
+	// The #936 AC: structured body with fitness before/after, synthetic results,
+	// reasoning, flag state.
+	for _, want := range []string{
+		"Fitness before/after", "0.5000", "0.7200", // before/after
+		"Synthetic game results", "Synthetic games run:** 5",
+		"Reasoning summary", "longer grace reduces early eliminations",
+		"Flag state at improvement time", "death_grace_period_ms: default=300, experimental=500",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("PR body missing %q:\n%s", want, body)
+		}
+	}
+	// No local commit, no real-default change, and the PR is opened — not merged
+	// (the fake only records OpenPR; there is no merge call in the interface).
+	if len(git.commits) != 0 || len(realDef.calls) != 0 {
+		t.Errorf("pr/github mode applied locally: commits=%d realDef=%d", len(git.commits), len(realDef.calls))
+	}
+	span := spanByName(t, rec, SpanPromote)
+	if got := stringAttr(span, AttrTarget); got != "github" {
+		t.Errorf("target attr = %q, want github", got)
+	}
+}
+
+// --- mode=pr, target=local: commits to the local git seam, opens no PR. ---
+func TestPromotePRModeLocal(t *testing.T) {
+	gh := &recordingGitHub{}
+	git := &recordingGit{sha: "abc123"}
+	p, _ := promoterWithRecorder(t, gh, git, nil, nil, nil)
+
+	res := p.Promote(context.Background(), promoteProposal, promoteVerdict,
+		Config{Mode: ModePR, Target: TargetLocal}, testEvidence())
+
+	if res.Outcome != OutcomeApplied {
+		t.Fatalf("outcome = %q, want applied", res.Outcome)
+	}
+	if len(git.commits) != 1 {
+		t.Fatalf("Commit calls = %d, want 1", len(git.commits))
+	}
+	if len(gh.prs) != 0 || len(gh.issues) != 0 {
+		t.Errorf("local target reached github: prs=%d issues=%d", len(gh.prs), len(gh.issues))
+	}
+	if !strings.HasPrefix(res.URL, "local:") {
+		t.Errorf("local commit URL = %q, want local: prefix", res.URL)
+	}
+	// The committed file carries the structured body.
+	if got := git.commits[0].Files; len(got) != 1 {
+		t.Errorf("commit files = %d, want 1", len(got))
+	}
+}
+
+// --- mode=autonomous: applies to the REAL default (separate writer), outcome
+// applied; a degradation reverts. ---
+func TestPromoteAutonomousApplied(t *testing.T) {
+	realDef := &recordingRealDefault{}
+	p, rec := promoterWithRecorder(t, &recordingGitHub{}, &recordingGit{}, realDef, nil, nil)
+
+	res := p.Promote(context.Background(), promoteProposal, promoteVerdict,
+		Config{Mode: ModeAutonomous, Target: TargetLocal, Enabled: true}, testEvidence())
+
+	if res.Outcome != OutcomeApplied {
+		t.Fatalf("outcome = %q, want applied", res.Outcome)
+	}
+	if len(realDef.calls) != 1 {
+		t.Fatalf("SetRealDefault calls = %d, want 1", len(realDef.calls))
+	}
+	if realDef.calls[0].flag != promoteProposal.FlagKey || realDef.calls[0].value != 500 {
+		t.Errorf("real-default call = %+v, want flag=%s value=500", realDef.calls[0], promoteProposal.FlagKey)
+	}
+	span := spanByName(t, rec, SpanPromote)
+	if got := stringAttr(span, AttrGate); got != "autonomous" {
+		t.Errorf("gate attr = %q, want autonomous", got)
+	}
+}
+
+func TestPromoteAutonomousRevertsOnDegradation(t *testing.T) {
+	realDef := &recordingRealDefault{}
+	rev := &recordingReverter{}
+	p, _ := promoterWithRecorder(t, &recordingGitHub{}, &recordingGit{}, realDef, fakeWatcher{degraded: true}, rev)
+
+	res := p.Promote(context.Background(), promoteProposal, promoteVerdict,
+		Config{Mode: ModeAutonomous, Target: TargetLocal, Enabled: true}, testEvidence())
+
+	if res.Outcome != OutcomeReverted {
+		t.Fatalf("outcome = %q, want reverted", res.Outcome)
+	}
+	if len(realDef.calls) != 1 {
+		t.Errorf("SetRealDefault calls = %d, want 1 (applied then reverted)", len(realDef.calls))
+	}
+	if rev.calls != 1 {
+		t.Errorf("RevertRealDefault calls = %d, want 1", rev.calls)
+	}
+}
+
+func TestPromoteAutonomousRevertsOnUnconfirmableWatch(t *testing.T) {
+	realDef := &recordingRealDefault{}
+	rev := &recordingReverter{}
+	// Watch errors → cannot confirm healthy → fail-safe revert.
+	p, _ := promoterWithRecorder(t, &recordingGitHub{}, &recordingGit{}, realDef, fakeWatcher{err: errors.New("telemetry unreachable")}, rev)
+
+	res := p.Promote(context.Background(), promoteProposal, promoteVerdict,
+		Config{Mode: ModeAutonomous, Target: TargetLocal, Enabled: true}, testEvidence())
+
+	if res.Outcome != OutcomeReverted {
+		t.Fatalf("outcome = %q, want reverted (fail-safe)", res.Outcome)
+	}
+	if rev.calls != 1 {
+		t.Errorf("RevertRealDefault calls = %d, want 1", rev.calls)
+	}
+}
+
+// --- only a PROMOTE verdict is ever acted on. ---
+func TestPromoteNonPromoteVerdictIsNoop(t *testing.T) {
+	gh := &recordingGitHub{}
+	realDef := &recordingRealDefault{}
+	p, _ := promoterWithRecorder(t, gh, &recordingGit{}, realDef, nil, nil)
+
+	for _, verdict := range []experiment.Outcome{experiment.OutcomeDiscard, experiment.OutcomeRevert} {
+		res := p.Promote(context.Background(), promoteProposal,
+			experiment.Decision{Outcome: verdict},
+			Config{Mode: ModeAutonomous, Target: TargetGitHub, Enabled: true}, testEvidence())
+		if res.Outcome != OutcomeDiscarded {
+			t.Errorf("verdict %q: outcome = %q, want discarded", verdict, res.Outcome)
+		}
+	}
+	if len(gh.issues)+len(gh.prs)+len(realDef.calls) != 0 {
+		t.Errorf("a non-promote verdict acted: issues=%d prs=%d realDef=%d",
+			len(gh.issues), len(gh.prs), len(realDef.calls))
+	}
+}
+
+// --- a client error degrades to a recorded no-op, never a different action. ---
+func TestPromoteClientErrorIsRecordedNoop(t *testing.T) {
+	gh := &recordingGitHub{issueErr: errors.New("rate limited")}
+	p, _ := promoterWithRecorder(t, gh, &recordingGit{}, nil, nil, nil)
+	res := p.Promote(context.Background(), promoteProposal, promoteVerdict,
+		Config{Mode: ModeIssue, Target: TargetGitHub}, testEvidence())
+	if res.Outcome != OutcomeDiscarded {
+		t.Fatalf("outcome = %q, want discarded on client error", res.Outcome)
+	}
+	if !strings.Contains(res.Reason, "rate limited") {
+		t.Errorf("reason = %q, want it to carry the client error", res.Reason)
+	}
+	if len(gh.issues) != 1 {
+		t.Errorf("the attempt should still be recorded: %d", len(gh.issues))
+	}
+}
+
+// --- target selects github vs local fake (#936 AC). ---
+func TestTargetSelectsClient(t *testing.T) {
+	t.Run("github target uses GitHubClient", func(t *testing.T) {
+		gh := &recordingGitHub{prURL: "u"}
+		git := &recordingGit{}
+		p, _ := promoterWithRecorder(t, gh, git, nil, nil, nil)
+		p.Promote(context.Background(), promoteProposal, promoteVerdict,
+			Config{Mode: ModePR, Target: TargetGitHub}, testEvidence())
+		if len(gh.prs) != 1 || len(git.commits) != 0 {
+			t.Errorf("github target: prs=%d commits=%d, want 1,0", len(gh.prs), len(git.commits))
+		}
+	})
+	t.Run("local target uses GitClient", func(t *testing.T) {
+		gh := &recordingGitHub{}
+		git := &recordingGit{sha: "s"}
+		p, _ := promoterWithRecorder(t, gh, git, nil, nil, nil)
+		p.Promote(context.Background(), promoteProposal, promoteVerdict,
+			Config{Mode: ModePR, Target: TargetLocal}, testEvidence())
+		if len(git.commits) != 1 || len(gh.prs) != 0 {
+			t.Errorf("local target: commits=%d prs=%d, want 1,0", len(git.commits), len(gh.prs))
+		}
+	})
+}

--- a/services/agent/promote/realdefault.go
+++ b/services/agent/promote/realdefault.go
@@ -1,0 +1,179 @@
+package promote
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+	"sync"
+	"syscall"
+)
+
+// realdefault.go is the autonomous mode's REAL defaultVariant mutation — the
+// SEPARATE, higher-privilege write the safety rail isolates from the shadow
+// experiment.Writer.
+//
+// WHY A SEPARATE WRITER (the safety rail's core distinction): experiment.Writer is
+// structurally shadow-only — it ONLY ever emits a `game_kind != "real"` targeting
+// rule and ADDS a variant, so a real (`game_kind="real"`) evaluation always falls
+// through to the untouched defaultVariant. That writer CANNOT change a real
+// resolution by construction (the Gate enforces the invariant). Autonomous
+// promotion deliberately DOES change what real games resolve, so it must be a
+// DIFFERENT, explicitly-gated mechanism — never the shadow Writer "tricked" into a
+// real change. This writer changes the flag's defaultVariant (and the variant's
+// value), which is exactly the real-affecting write the shadow path forbids.
+//
+// It is built ONLY by NewRealDefaultWriterFromEnv behind the env gate, and it is
+// invoked only on the autonomous path, which is additionally behind the agent
+// kill-switch (Config.Enabled, checked in promoteAutonomous). Two independent gates
+// (env + kill-switch) guard every real-default mutation.
+
+// fileRealDefaultWriter writes the REAL defaultVariant of a flag in a flagd JSON
+// file in place. It mirrors the in-place write discipline of experiment.Writer
+// (O_NOFOLLOW, no temp+rename — EBUSY on the bind mount flagd watches) but writes
+// the REAL default, not a shadow rule.
+type fileRealDefaultWriter struct {
+	path string
+	log  *slog.Logger
+	mu   sync.Mutex
+}
+
+// NewRealDefaultWriterFromEnv returns the REAL-default writer IFF the autonomous
+// env gate is satisfied, else nil (autonomous then degrades to a recorded no-op —
+// promoteAutonomous handles the nil). This is the ONLY constructor for a
+// real-default writer; a test cannot build one (it would have to set the env gate
+// AND supply a path), so no test mutates a real default.
+//
+// Gate conditions:
+//   - AGENT_CODE_IMPROVEMENT_ENABLED == "true"        (explicit opt-in)
+//   - AGENT_AUTONOMOUS_ENABLED == "true"               (a SECOND opt-in specific to
+//     the real-default mutation — autonomous is the most privileged path, so it
+//     requires its own switch beyond the shared code-improvement gate)
+//   - AGENT_REAL_DEFAULT_FLAG_PATH points at a flagd file
+//
+// Returns (nil, nil) when not gated (the fail-closed default), (nil, err) on a
+// gated-but-misconfigured path.
+func NewRealDefaultWriterFromEnv(log *slog.Logger) (*fileRealDefaultWriter, error) {
+	if log == nil {
+		log = slog.Default()
+	}
+	if !strings.EqualFold(strings.TrimSpace(os.Getenv("AGENT_CODE_IMPROVEMENT_ENABLED")), "true") {
+		return nil, nil
+	}
+	if !strings.EqualFold(strings.TrimSpace(os.Getenv("AGENT_AUTONOMOUS_ENABLED")), "true") {
+		log.Info("code_improvement real-default writer NOT built: AGENT_AUTONOMOUS_ENABLED != true (autonomous stays a recorded no-op)")
+		return nil, nil
+	}
+	path := strings.TrimSpace(os.Getenv("AGENT_REAL_DEFAULT_FLAG_PATH"))
+	if path == "" {
+		log.Info("code_improvement real-default writer NOT built: AGENT_REAL_DEFAULT_FLAG_PATH unset (fail-closed)")
+		return nil, nil
+	}
+	if _, err := os.Stat(path); err != nil {
+		return nil, fmt.Errorf("AGENT_REAL_DEFAULT_FLAG_PATH=%q not readable: %w", path, err)
+	}
+	log.Warn("code_improvement AUTONOMOUS real-default writer ENABLED (#936): autonomous promotions WILL change the REAL defaultVariant for live players",
+		"path", path)
+	return &fileRealDefaultWriter{path: path, log: log}, nil
+}
+
+// SetRealDefault changes the REAL defaultVariant for flagKey to value: it ensures a
+// variant equal to value exists (adding a reserved "promoted" variant if needed)
+// and points defaultVariant at it, so a `game_kind="real"` evaluation now resolves
+// value. This is the one sanctioned real-player-affecting write.
+func (w *fileRealDefaultWriter) SetRealDefault(_ context.Context, flagKey string, value any) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	raw, err := os.ReadFile(w.path)
+	if err != nil {
+		return fmt.Errorf("read flag file %q: %w", w.path, err)
+	}
+	var doc struct {
+		Metadata json.RawMessage            `json:"metadata,omitempty"`
+		Flags    map[string]json.RawMessage `json:"flags"`
+	}
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		return fmt.Errorf("parse flag file: %w", err)
+	}
+	flagRaw, ok := doc.Flags[flagKey]
+	if !ok {
+		return fmt.Errorf("flag %q not present", flagKey)
+	}
+	var flag map[string]json.RawMessage
+	if err := json.Unmarshal(flagRaw, &flag); err != nil {
+		return fmt.Errorf("parse flag %q: %w", flagKey, err)
+	}
+
+	var variants map[string]json.RawMessage
+	if vr, ok := flag["variants"]; ok {
+		if err := json.Unmarshal(vr, &variants); err != nil {
+			return fmt.Errorf("parse variants of %q: %w", flagKey, err)
+		}
+	} else {
+		variants = map[string]json.RawMessage{}
+	}
+
+	valRaw, err := json.Marshal(value)
+	if err != nil {
+		return fmt.Errorf("marshal value: %w", err)
+	}
+	// Point at an existing variant if one already equals value (keeps the file tidy),
+	// else add a reserved "promoted" variant. Either way defaultVariant moves.
+	variantName := "promoted"
+	for name, vr := range variants {
+		if jsonEqual(vr, valRaw) {
+			variantName = name
+			break
+		}
+	}
+	variants[variantName] = valRaw
+
+	vrOut, _ := json.Marshal(variants)
+	flag["variants"] = vrOut
+	dvOut, _ := json.Marshal(variantName)
+	flag["defaultVariant"] = dvOut
+
+	flagOut, _ := json.Marshal(flag)
+	doc.Flags[flagKey] = flagOut
+	out, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal flag file: %w", err)
+	}
+
+	w.log.Warn("code_improvement.autonomous changing REAL defaultVariant (#936)",
+		"flag", flagKey, "variant", variantName)
+	return w.writeInPlace(append(out, '\n'))
+}
+
+// writeInPlace overwrites the file at the same path WITHOUT temp+rename (EBUSY on
+// the flagd bind mount) and refuses to follow a symlink (O_NOFOLLOW), mirroring
+// experiment.Writer.writeInPlace.
+func (w *fileRealDefaultWriter) writeInPlace(data []byte) error {
+	f, err := os.OpenFile(w.path, os.O_WRONLY|os.O_TRUNC|os.O_CREATE|syscall.O_NOFOLLOW, 0o644)
+	if err != nil {
+		return fmt.Errorf("open flag file for write: %w", err)
+	}
+	if _, err := f.Write(data); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("write flag file: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("close flag file: %w", err)
+	}
+	return nil
+}
+
+// jsonEqual reports whether two raw JSON messages are semantically equal (so a
+// re-promotion to an already-present variant value reuses it).
+func jsonEqual(a, b json.RawMessage) bool {
+	var av, bv any
+	if json.Unmarshal(a, &av) != nil || json.Unmarshal(b, &bv) != nil {
+		return false
+	}
+	am, _ := json.Marshal(av)
+	bm, _ := json.Marshal(bv)
+	return string(am) == string(bm)
+}

--- a/services/agent/promote/realdefault.go
+++ b/services/agent/promote/realdefault.go
@@ -120,6 +120,23 @@ func (w *fileRealDefaultWriter) SetRealDefault(_ context.Context, flagKey string
 	if err != nil {
 		return fmt.Errorf("marshal value: %w", err)
 	}
+	// Defense-in-depth (#936 review note 2): this is the LAST line before a write
+	// real players resolve, so refuse a value whose JSON kind differs from the flag's
+	// CURRENT defaultVariant value. A mistyped value (e.g. a string on a numeric flag)
+	// would make flagd TYPE_MISMATCH at resolution and fall back to ITS default —
+	// degrading the flag for everyone. The experiment value reaching here is already
+	// type-correct upstream (the #955 gate), but this guards independently, mirroring
+	// that gate for the real-default path.
+	if curDef, ok := flag["defaultVariant"]; ok {
+		var curName string
+		if json.Unmarshal(curDef, &curName) == nil {
+			if curRaw, present := variants[curName]; present {
+				if ck, nk := jsonKind(curRaw), jsonKind(valRaw); ck != "" && nk != "" && ck != nk {
+					return fmt.Errorf("refusing real-default write for %q: value kind %q != current default %q kind %q", flagKey, nk, curName, ck)
+				}
+			}
+		}
+	}
 	// Point at an existing variant if one already equals value (keeps the file tidy),
 	// else add a reserved "promoted" variant. Either way defaultVariant moves.
 	variantName := "promoted"
@@ -176,4 +193,28 @@ func jsonEqual(a, b json.RawMessage) bool {
 	am, _ := json.Marshal(av)
 	bm, _ := json.Marshal(bv)
 	return string(am) == string(bm)
+}
+
+// jsonKind classifies a raw JSON value as number/string/bool/array/object, or ""
+// for null/unparseable (kindless — imposes no type constraint). All JSON numerics
+// are one "number" kind, so an int promoted value never mismatches a float default.
+func jsonKind(raw json.RawMessage) string {
+	var v any
+	if json.Unmarshal(raw, &v) != nil {
+		return ""
+	}
+	switch v.(type) {
+	case float64:
+		return "number"
+	case string:
+		return "string"
+	case bool:
+		return "bool"
+	case []any:
+		return "array"
+	case map[string]any:
+		return "object"
+	default:
+		return "" // null
+	}
 }

--- a/services/agent/promote/realdefault_test.go
+++ b/services/agent/promote/realdefault_test.go
@@ -82,6 +82,38 @@ func TestRealDefaultWriterChangesDefaultVariant(t *testing.T) {
 	}
 }
 
+// TestRealDefaultWriterRejectsTypeMismatch: defense-in-depth (#936 review) — the
+// real-default write refuses a value whose JSON kind differs from the flag's
+// current default, so a mistyped promotion can't degrade the flag for live players
+// (flagd would TYPE_MISMATCH and fall back). The file must be left untouched.
+func TestRealDefaultWriterRejectsTypeMismatch(t *testing.T) {
+	dir := t.TempDir()
+	path := writeFlagFile(t, dir) // death_grace_period_ms has NUMERIC variants (300/600)
+	before, _ := os.ReadFile(path)
+
+	t.Setenv("AGENT_CODE_IMPROVEMENT_ENABLED", "true")
+	t.Setenv("AGENT_AUTONOMOUS_ENABLED", "true")
+	t.Setenv("AGENT_REAL_DEFAULT_FLAG_PATH", path)
+	w, err := NewRealDefaultWriterFromEnv(discardLogger())
+	if err != nil || w == nil {
+		t.Fatalf("writer build: err=%v nil=%v", err, w == nil)
+	}
+
+	// A STRING value on the numeric flag must be refused.
+	if err := w.SetRealDefault(context.Background(), "death_grace_period_ms", "banana"); err == nil {
+		t.Fatal("SetRealDefault accepted a string value on a numeric flag — must reject (type mismatch)")
+	}
+	// File unchanged — no partial/corrupting write.
+	after, _ := os.ReadFile(path)
+	if string(before) != string(after) {
+		t.Error("flag file was modified despite the type-mismatch rejection")
+	}
+	// A numeric value (int or float) of the right kind is still accepted.
+	if err := w.SetRealDefault(context.Background(), "death_grace_period_ms", 450); err != nil {
+		t.Errorf("SetRealDefault rejected a same-kind numeric value: %v", err)
+	}
+}
+
 // TestRealDefaultWriterRequiresAutonomousOptIn: even with the shared
 // code-improvement gate on, the SECOND autonomous-specific opt-in is required.
 func TestRealDefaultWriterRequiresAutonomousOptIn(t *testing.T) {

--- a/services/agent/promote/realdefault_test.go
+++ b/services/agent/promote/realdefault_test.go
@@ -1,0 +1,98 @@
+package promote
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// realdefault_test.go exercises the autonomous REAL-default writer against a temp
+// flagd JSON file (no flagd, no network) — the separate, higher-privilege write
+// the safety rail isolates from the shadow Writer. Built here via NewGitClient's
+// sibling NewRealDefaultWriter-equivalent: the struct is unexported and only
+// FromEnv constructs it, so the test builds it through the env gate against a temp
+// file (the env gate is set for THIS test only, via t.Setenv, restored after).
+
+func writeFlagFile(t *testing.T, dir string) string {
+	t.Helper()
+	path := filepath.Join(dir, "game.json")
+	doc := map[string]any{
+		"metadata": map[string]any{"flagSetId": "game"},
+		"flags": map[string]any{
+			"death_grace_period_ms": map[string]any{
+				"state":          "ENABLED",
+				"variants":       map[string]any{"default": 300, "long": 600},
+				"defaultVariant": "default",
+			},
+		},
+	}
+	raw, _ := json.MarshalIndent(doc, "", "  ")
+	if err := os.WriteFile(path, raw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestRealDefaultWriterChangesDefaultVariant(t *testing.T) {
+	dir := t.TempDir()
+	path := writeFlagFile(t, dir)
+
+	// Build the real-default writer through the env gate (set for this test only).
+	t.Setenv("AGENT_CODE_IMPROVEMENT_ENABLED", "true")
+	t.Setenv("AGENT_AUTONOMOUS_ENABLED", "true")
+	t.Setenv("AGENT_REAL_DEFAULT_FLAG_PATH", path)
+
+	w, err := NewRealDefaultWriterFromEnv(discardLogger())
+	if err != nil {
+		t.Fatalf("NewRealDefaultWriterFromEnv: %v", err)
+	}
+	if w == nil {
+		t.Fatal("writer is nil despite a satisfied env gate")
+	}
+
+	// Promote value 500 to the REAL default.
+	if err := w.SetRealDefault(context.Background(), "death_grace_period_ms", 500); err != nil {
+		t.Fatalf("SetRealDefault: %v", err)
+	}
+
+	// Re-read and assert the real default now resolves 500.
+	raw, _ := os.ReadFile(path)
+	var doc struct {
+		Flags map[string]struct {
+			Variants       map[string]json.RawMessage `json:"variants"`
+			DefaultVariant string                     `json:"defaultVariant"`
+		} `json:"flags"`
+	}
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("re-parse: %v", err)
+	}
+	flag := doc.Flags["death_grace_period_ms"]
+	defVal := flag.Variants[flag.DefaultVariant]
+	if string(defVal) != "500" {
+		t.Errorf("real default resolves %s, want 500", defVal)
+	}
+	// The pre-existing variants are preserved.
+	if _, ok := flag.Variants["default"]; !ok {
+		t.Error("pre-existing 'default' variant was dropped")
+	}
+	if _, ok := flag.Variants["long"]; !ok {
+		t.Error("pre-existing 'long' variant was dropped")
+	}
+}
+
+// TestRealDefaultWriterRequiresAutonomousOptIn: even with the shared
+// code-improvement gate on, the SECOND autonomous-specific opt-in is required.
+func TestRealDefaultWriterRequiresAutonomousOptIn(t *testing.T) {
+	dir := t.TempDir()
+	path := writeFlagFile(t, dir)
+	t.Setenv("AGENT_CODE_IMPROVEMENT_ENABLED", "true")
+	t.Setenv("AGENT_AUTONOMOUS_ENABLED", "") // the autonomous opt-in is OFF
+	t.Setenv("AGENT_REAL_DEFAULT_FLAG_PATH", path)
+
+	w, err := NewRealDefaultWriterFromEnv(discardLogger())
+	if w != nil || err != nil {
+		t.Errorf("writer built without AGENT_AUTONOMOUS_ENABLED: (%v, %v)", w, err)
+	}
+}

--- a/services/agent/promote/safety_test.go
+++ b/services/agent/promote/safety_test.go
@@ -1,0 +1,135 @@
+package promote
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/joustmania/agent/experiment"
+)
+
+// safety_test.go is the explicit proof of THE SAFETY RAIL (#936). It asserts that
+// with NO real client wired — the DEFAULT a test or a non-gated main.go gets — a
+// promotion can ONLY degrade to an inert RECORDED no-op, never a real GitHub call,
+// real git, or real-default mutation. If any of these tests could reach
+// github.com / a real git push, that is a blocker.
+
+// TestSafetyDefaultPromoterNeverActsForReal: a Promoter built with NO explicit
+// seams (the maximally-safe construction) falls back to the inert recording no-op
+// clients, so a github-target PR degrades to a RECORDED no-op with a visible reason
+// — never a network call.
+func TestSafetyDefaultPromoterNeverActsForReal(t *testing.T) {
+	// nil github + nil git => NewPromoter substitutes the inert recording no-ops.
+	// nil realDef => autonomous cannot mutate a real default.
+	p := NewPromoter(nil, nil, nil, nil, nil, testRepo(), nil, discardLogger())
+
+	t.Run("github PR degrades to recorded no-op", func(t *testing.T) {
+		res := p.Promote(context.Background(), promoteProposal, promoteVerdict,
+			Config{Mode: ModePR, Target: TargetGitHub}, testEvidence())
+		if res.Outcome != OutcomeDiscarded {
+			t.Fatalf("outcome = %q, want discarded (no real client)", res.Outcome)
+		}
+		if res.URL != "" {
+			t.Errorf("a no-op produced a URL %q — did it reach github?", res.URL)
+		}
+		if !strings.Contains(res.Reason, "github target not enabled") {
+			t.Errorf("reason = %q, want it to name the disabled github path", res.Reason)
+		}
+	})
+
+	t.Run("autonomous with no real-default writer degrades to recorded no-op", func(t *testing.T) {
+		res := p.Promote(context.Background(), promoteProposal, promoteVerdict,
+			Config{Mode: ModeAutonomous, Target: TargetLocal, Enabled: true}, testEvidence())
+		if res.Outcome != OutcomeDiscarded {
+			t.Fatalf("outcome = %q, want discarded (no real-default writer)", res.Outcome)
+		}
+		if !strings.Contains(res.Reason, "no real-default writer wired") {
+			t.Errorf("reason = %q, want it to name the missing real-default writer", res.Reason)
+		}
+	})
+}
+
+// TestSafetyAutonomousBlockedByKillSwitch: autonomous (the real-player-affecting
+// path) NEVER mutates the real default while the agent is disabled, even with a
+// real-default writer wired. The kill-switch is a hard gate independent of the env
+// gate.
+func TestSafetyAutonomousBlockedByKillSwitch(t *testing.T) {
+	realDef := &recordingRealDefault{}
+	p, _ := promoterWithRecorder(t, &recordingGitHub{}, &recordingGit{}, realDef, fakeWatcher{}, &recordingReverter{})
+
+	res := p.Promote(context.Background(), promoteProposal, promoteVerdict,
+		Config{Mode: ModeAutonomous, Target: TargetLocal, Enabled: false}, testEvidence())
+
+	if res.Outcome != OutcomeDiscarded {
+		t.Fatalf("outcome = %q, want discarded (kill-switch)", res.Outcome)
+	}
+	if len(realDef.calls) != 0 {
+		t.Fatalf("SAFETY: a disabled agent mutated the real default %d time(s)", len(realDef.calls))
+	}
+	if !strings.Contains(res.Reason, "kill-switch") {
+		t.Errorf("reason = %q, want it to name the kill-switch", res.Reason)
+	}
+}
+
+// TestSafetyEnvGatedConstructorsReturnNilWhenUngated: the ONLY constructors for the
+// real clients return nil unless the explicit env gate is satisfied. This is the
+// structural proof that, without the env gate, main.go gets a nil real client and
+// substitutes the no-op — a test (which sets no env) can NEVER build a real client.
+// We do NOT set the env here, so every gated constructor must return nil.
+func TestSafetyEnvGatedConstructorsReturnNilWhenUngated(t *testing.T) {
+	// Defensive: ensure the gate env is unset for this test (t.Setenv restores it).
+	t.Setenv("AGENT_CODE_IMPROVEMENT_ENABLED", "")
+	t.Setenv("GITHUB_TOKEN", "")
+	t.Setenv("AGENT_AUTONOMOUS_ENABLED", "")
+
+	if gh, err := NewGitHubClientFromEnv(TargetGitHub, discardLogger()); gh != nil || err != nil {
+		t.Errorf("NewGitHubClientFromEnv(ungated) = (%v, %v), want (nil, nil)", gh, err)
+	}
+	// Even a github target with the gate off must not build a client.
+	if gh, _ := NewGitHubClientFromEnv(TargetLocal, discardLogger()); gh != nil {
+		t.Error("NewGitHubClientFromEnv(local) returned a real github client")
+	}
+	if git, err := NewGitClientFromEnv(TargetLocal, discardLogger()); git != nil || err != nil {
+		t.Errorf("NewGitClientFromEnv(ungated) = (%v, %v), want (nil, nil)", git, err)
+	}
+	if w, err := NewRealDefaultWriterFromEnv(discardLogger()); w != nil || err != nil {
+		t.Errorf("NewRealDefaultWriterFromEnv(ungated) = (%v, %v), want (nil, nil)", w, err)
+	}
+}
+
+// TestSafetyEnvGateTokenStillRequired: with the explicit opt-in env set but the
+// TOKEN absent, the real GitHub client is STILL not built (fail-closed) — the
+// token is a required, separate condition.
+func TestSafetyEnvGateTokenStillRequired(t *testing.T) {
+	t.Setenv("AGENT_CODE_IMPROVEMENT_ENABLED", "true")
+	t.Setenv("GITHUB_TOKEN", "") // token absent
+	t.Setenv("GITHUB_REPOSITORY", "owner/repo")
+
+	gh, err := NewGitHubClientFromEnv(TargetGitHub, discardLogger())
+	if gh != nil || err != nil {
+		t.Errorf("NewGitHubClientFromEnv(enabled, no token) = (%v, %v), want (nil, nil)", gh, err)
+	}
+}
+
+// TestSafetyNoopClientsRecordButDoNotAct: the no-op clients record what they WOULD
+// do (so a disabled main.go is still observable) but always decline — proving the
+// recorded-no-op contract end to end.
+func TestSafetyNoopClientsRecordButDoNotAct(t *testing.T) {
+	gh := NewNoopGitHubClient(discardLogger())
+	if _, err := gh.OpenIssue(context.Background(), IssueReq{Title: "x"}); err == nil {
+		t.Error("no-op OpenIssue should decline")
+	}
+	if len(gh.Issues) != 1 {
+		t.Errorf("no-op did not RECORD the issue it would open: %d", len(gh.Issues))
+	}
+	git := NewNoopGitClient(discardLogger())
+	if _, err := git.Commit(context.Background(), CommitReq{Message: "x"}); err == nil {
+		t.Error("no-op Commit should decline")
+	}
+	if len(git.Commits) != 1 {
+		t.Errorf("no-op did not RECORD the commit it would make: %d", len(git.Commits))
+	}
+}
+
+// sanity: keep experiment import used even if a future edit drops the only use.
+var _ = experiment.OutcomePromote

--- a/services/agent/promote/telemetry.go
+++ b/services/agent/promote/telemetry.go
@@ -1,0 +1,73 @@
+package promote
+
+// Span names + attribute keys for the M7-8 PROMOTION flow (#936). Dot notation
+// matches the repo span convention (decision/telemetry.go, experiment/*.go).
+//
+// Where promotion sits in the #931/#932 self-improvement track:
+//
+//	M7-4/M7-5 (experiment/gate.go, writer.go): the agent forms a structured
+//	{flag, value} Proposal; the Writer/Gate apply it to game.json SHADOW-scoped
+//	(game_kind != "real") — real games untouched by construction.
+//	    ↓
+//	M7-7 (experiment/validate.go, #935): run the shadow experiment through the
+//	synthetic suite, measure fitness against a real-game baseline, and DECIDE —
+//	PROMOTE / DISCARD / REVERT. M7-7 returns the verdict ONLY; it does NOT change
+//	the real defaultVariant.
+//	    ↓
+//	M7-8 (THIS package, #936): take a PROMOTE verdict + its fitness evidence and
+//	ACT, per two live flags — open a GitHub issue (hypothesis), open a PR
+//	(structured fitness evidence), or apply autonomously to the REAL default +
+//	watch + revert. This is the consequential, real-affecting piece, so it is
+//	behind the SAFETY RAIL (see promote.go / NewGitHubClientFromEnv).
+//
+// The promotion is its own trace node so a Jaeger trace shows what the agent DID
+// with a validated experiment (the #936 AC: "Outcome visible in traces").
+const (
+	// SpanPromote wraps one Promoter.Promote of a validated experiment. It carries
+	// the resolved gate (mode) + target + the final outcome, so a single span answers
+	// "what did the agent do with this promotion, and where". It is the M7-8 node
+	// under the M7-7 synthetic_validation tree.
+	SpanPromote = "code_improvement.promote"
+)
+
+// Attribute keys of the promotion span schema (#936 AC: gate/target/outcome on
+// the trace). These intentionally do NOT collide with experiment.Attr* (the
+// VALIDATE-gate keys live in experiment/validate_telemetry.go) — distinct phases.
+const (
+	// AttrGate is the resolved code_improvement.mode the promotion acted under:
+	// issue | pr | autonomous. The #936 AC names this "code_improvement.gate" — the
+	// runtime "mode" flag is the gate that selects the promotion behaviour. The
+	// single attribute a dashboard groups by to see how a promotion was handled.
+	AttrGate = "code_improvement.gate"
+	// AttrTarget is the resolved code_improvement.target: local | github. Records
+	// WHERE a pr/commit landed (github → the GitHub API; local → a local apply).
+	AttrTarget = "code_improvement.target"
+	// AttrOutcome is the promotion result: applied | discarded | reverted (#936 AC:
+	// "code_improvement.outcome"). Distinct from experiment.AttrOutcome's
+	// promote/discard/revert verdict — THIS records what the ACTION achieved.
+	AttrOutcome = "code_improvement.outcome"
+	// AttrFlagKey is the game flag the promoted experiment concerns (echoed from the
+	// Proposal so the promotion span is self-describing without the validation span).
+	AttrFlagKey = "code_improvement.flag_key"
+	// AttrReason carries why a promotion degraded to a no-op / could not act
+	// (e.g. "github target requested but real client not enabled", "no real-default
+	// writer wired"). Present only when the outcome is not the requested action —
+	// the promotion is RECORDED, never silently dropped (mirrors the Gate's blocked
+	// contract). Its presence on a github-target span is the SAFETY RAIL's visible
+	// proof that an absent env gate degraded to an inert recorded no-op.
+	AttrReason = "code_improvement.reason"
+	// AttrURL is the issue/PR URL a github-target promotion opened (empty for a
+	// local apply or a no-op). On the span so a trace links straight to the artifact.
+	AttrURL = "code_improvement.url"
+	// AttrFitnessBefore / AttrFitnessAfter / AttrFitnessDelta echo the M7-7 evidence
+	// onto the promotion span so the trace shows what justified the action without a
+	// cross-span join (same keys as experiment/validate_telemetry.go by design —
+	// they describe the SAME fitness numbers, now carried on the promote node).
+	AttrFitnessBefore = "code_improvement.fitness_before"
+	AttrFitnessAfter  = "code_improvement.fitness_after"
+	AttrFitnessDelta  = "code_improvement.fitness_delta"
+)
+
+// instrumentationName scopes the promote tracer to the same instrumentation
+// library as the rest of the agent, so all agent spans share one scope.
+const instrumentationName = "github.com/joustmania/agent"

--- a/services/flagd/agent.json
+++ b/services/flagd/agent.json
@@ -426,6 +426,23 @@
         "slow": 900
       },
       "defaultVariant": "default"
+    },
+    "code_improvement.mode": {
+      "state": "ENABLED",
+      "variants": {
+        "issue": "issue",
+        "pr": "pr",
+        "autonomous": "autonomous"
+      },
+      "defaultVariant": "issue"
+    },
+    "code_improvement.target": {
+      "state": "ENABLED",
+      "variants": {
+        "local": "local",
+        "github": "github"
+      },
+      "defaultVariant": "local"
     }
   }
 }


### PR DESCRIPTION
## What

M7-8 (#936): the agent's PROMOTION flow. A VALIDATED (PROMOTE) experiment + its fitness evidence is acted on per two **live** flags, read fresh per promotion (flip the mode flag → effect on the next promotion, no restart):

- **`code_improvement.mode`** = `issue | pr | autonomous`
  - **issue** — open a GitHub issue (hypothesis + implicated flag); nothing applied.
  - **pr** — open a PR with a **structured** body: fitness before/after, synthetic game results, proposer reasoning summary, flag state at improvement time.
  - **autonomous** — apply the validated change to the **REAL default**, watch real games, revert on degradation (per M7-7).
- **`code_improvement.target`** = `local | github`
  - **github** — commit + open issue/PR via the GitHub API.
  - **local** — apply locally (commit into a working tree; **no push**).
- Observable on the `code_improvement.promote` span: `code_improvement.gate` (mode), `code_improvement.target`, `code_improvement.outcome` = `applied | discarded | reverted`, plus the fitness evidence + any degrade/no-op reason.

## THE SAFETY RAIL (the consequential, real-affecting piece)

- **Interfaces + recording fakes everywhere in tests.** `Promoter`, `GitHubClient` (OpenIssue/OpenPR), `GitClient` (Commit), `RealDefaultWriter` (SetRealDefault). Unit tests use recording fakes that assert "would open an issue/PR with body X" / "would commit Y" / "would write real default Z" — **ZERO network, ZERO real git, ZERO real-default mutation**.
- **The real path is built ONLY in `main.go`, behind an explicit env gate**, never reachable from a test constructor:
  - GitHub: `AGENT_CODE_IMPROVEMENT_ENABLED=true` **AND** `GITHUB_TOKEN` **AND** `GITHUB_REPOSITORY` **AND** the live `target=github`.
  - Local git: `AGENT_CODE_IMPROVEMENT_ENABLED=true` + `AGENT_LOCAL_REPO_DIR` (commit only, structurally no `git push`).
  - Autonomous real-default: `AGENT_CODE_IMPROVEMENT_ENABLED=true` + a **second** `AGENT_AUTONOMOUS_ENABLED=true` opt-in + `AGENT_REAL_DEFAULT_FLAG_PATH`.
  - Absent any condition, the `*FromEnv` constructor returns nil → `NewPromoter` substitutes the **inert recording no-op**; a github promotion degrades to a **recorded** no-op (logged + span reason), never a silent/accidental real action.
- **Safe flag defaults:** `mode` defaults to `issue` (never `autonomous`), `target` defaults to `local` (never `github`); both in `agent.json` and `flags.DefaultPromotion*`. **autonomous** is additionally behind the agent **`enabled` kill-switch** (a disabled agent never mutates the real default).
- **autonomous's real-default change is a SEPARATE, higher-privilege writer** (`RealDefaultWriter` / `fileRealDefaultWriter`) — explicitly **not** the shadow `experiment.Writer` (which is structurally shadow-only). The shadow Writer is never reused to sneak a real-default change.

`safety_test.go` proves it: ungated `*FromEnv` constructors return nil; a default Promoter degrades a github promotion to an inert recorded no-op; the kill-switch blocks autonomous even with a real-default writer wired; `grep` confirms no `git push` and the sole `http.Client` lives behind `NewGitHubClientFromEnv`.

## Files

- **New** `services/agent/promote/` (package + interfaces, env-gated real clients, no-op fakes, telemetry, tests).
- `services/agent/flags/flags.go` + `flags_test.go`: `code_improvement.{mode,target}` flags (live, safe defaults).
- `services/flagd/agent.json`: the two flags (defaults `issue` / `local`).
- `services/agent/main.go`: env-gated Promoter wiring (the one place real clients are built).

No changes to `experiment/gate.go`, `proposal.go`, `validate.go`, or the proposer (#931 — parallel PR).

## Out of scope (noted)

- "GitHub unreachable → apply local → retroactively open PR" reconnect fallback (#936 backlog).
- The proposer (#931) and the real Ollama backend.
- Live wiring of the propose→validate→PROMOTE **trigger** and autonomous's watch+revert measurement (reuses M7-7's Validator/Reverter seams where merged; nil until wired — autonomous applies+records without a watch for now). The gated promotion surface is constructed + observable.

## Tests

`go build` / `go vet` / `go test -race ./...` green from `services/agent/`. New: per-mode dispatch, target selection, structured PR/issue body, real-default writer (temp flagd file), local git commit (throwaway `git init` temp repo, no network), and the safety suite.

Part of #936 (M7-8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)