### PR TITLE
feat(agent): wire dispatched/blocked interventions into the game timeline (#945)

### DIFF
--- a/services/agent/decision/decision.go
+++ b/services/agent/decision/decision.go
@@ -250,6 +250,28 @@ type Loop struct {
 	// (rules-only / unwired / tests): the prompt carries no PRIOR GAMES section and
 	// context_games is 0.
 	contextWindow ContextWindow
+
+	// interventionRecorder is the PER-GAME seam into the #916 rolling narrative
+	// timeline (#945): runDecision calls it with each decision's outcome (the
+	// intervention id, its target serial, and whether a permission gate BLOCKED it)
+	// so the timeline accumulates the agent's own intervention history alongside the
+	// state deltas / eliminations / phase transitions the Store observes itself.
+	//
+	// The Loop and the per-game Store are SEPARATE objects: the receiver pipeline
+	// holds both (the gamecontext.Multiplexer's Store per game_id, and this LoopSet's
+	// Loop). The factory in main.go closes this over the SAME game_id the Loop serves
+	// (mux.AppendInterventionEvent(gameID, ...)), exactly mirroring how #917 wired the
+	// per-game ContextProvider (SetContextProvider) into each Loop. That closure is
+	// what preserves per-game isolation (#845): an intervention lands in the timeline
+	// of the game it targeted, never a shared/global one, so two concurrent games keep
+	// independent intervention histories.
+	//
+	// Nil-safe: a Loop without a recorder (the construction default, rules-only
+	// deployments, and all existing tests) simply does not record — purely additive
+	// over the pre-#945 behavior. The Store's AppendInterventionEvent it ultimately
+	// reaches is mutex-guarded (#916), so this is race-safe under the concurrent
+	// trace + metrics Export-handler goroutines that drive runDecision.
+	interventionRecorder func(intervention, serial string, blocked bool)
 }
 
 // NewLoop builds a Loop with the no-op rules/actions stubs, the global tracer,
@@ -299,6 +321,33 @@ func (l *Loop) SetResolver(r *Resolver) { l.resolver = r }
 // context_games is 0 — purely additive over the #739 path. Not safe to call
 // concurrently with OnEvaluate — set it during construction, before the loop serves.
 func (l *Loop) SetContextWindow(w ContextWindow) { l.contextWindow = w }
+
+// SetInterventionRecorder installs the PER-GAME seam that feeds each decision's
+// dispatched/blocked outcome into the #916 rolling narrative timeline (#945).
+// main.go's loopFactory passes a closure over the Multiplexer and THIS loop's
+// game_id (mux.AppendInterventionEvent(gameID, ...)), so the outcome lands in the
+// timeline of the game the Loop serves and nowhere else — the per-game isolation
+// (#845) the multiplexer already enforces for signals, extended to interventions.
+// This mirrors SetContextProvider's #917 wiring (a per-game closure over the same
+// mux+gameID). A nil recorder (the construction default and all existing tests)
+// leaves the loop recording nothing, so this is purely additive. Set at
+// construction, before the loop serves; not safe to call concurrently with
+// OnEvaluate.
+func (l *Loop) SetInterventionRecorder(rec func(intervention, serial string, blocked bool)) {
+	l.interventionRecorder = rec
+}
+
+// recordIntervention feeds one decision's outcome into the per-game timeline via
+// the #945 recorder seam, if one is wired. Nil-safe so an un-wired Loop records
+// nothing. The recorder it calls ultimately reaches the per-game Store's
+// mutex-guarded AppendInterventionEvent (#916), so this is safe to call from the
+// concurrent Export-handler goroutines that drive runDecision.
+func (l *Loop) recordIntervention(intervention, serial string, blocked bool) {
+	if l.interventionRecorder == nil {
+		return
+	}
+	l.interventionRecorder(intervention, serial, blocked)
+}
 
 // SetThrottle overrides the log/span throttle interval. It is read once at
 // startup from decision.throttle_seconds (#766 F5); a non-positive value leaves
@@ -750,6 +799,12 @@ func (l *Loop) runDecision(ctx context.Context, snapshot flags.Snapshot, c gamec
 
 	if blocked {
 		state.recordBlocked(d, reason, cost)
+		// Feed the BLOCKED outcome into this game's #916 rolling narrative timeline
+		// (#945): blocked interventions are recorded, never silently dropped, so the
+		// timeline (and the #916/#928/#929 narratives + the #960 proposer prompt)
+		// shows what the agent WANTED to do but a permission gate refused. The
+		// recorder closes over THIS loop's game_id (per-game isolation, #845/#917).
+		l.recordIntervention(d.Intervention, d.TargetSerial, true)
 		l.Log.Warn("agent.decision_blocked",
 			"blocked", true,
 			"reason", string(reason),
@@ -761,6 +816,15 @@ func (l *Loop) runDecision(ctx context.Context, snapshot flags.Snapshot, c gamec
 	}
 
 	state.recordDispatched(d, cost)
+	// Feed the DISPATCHED outcome into this game's #916 rolling narrative timeline
+	// (#945): recorded BEFORE the action sink applies it (it passed every gate, so it
+	// IS dispatched regardless of a downstream apply error — the timeline tracks the
+	// agent's INTENT, mirroring recordDispatched). The recorder is the per-game seam
+	// from SetInterventionRecorder, closing over this loop's game_id so the event
+	// lands in the timeline of the game it targeted (#845/#917 isolation). This single
+	// hook also covers the async apply path (#917), since applyOneAsync /
+	// fallbackToRules both dispatch through runDecision.
+	l.recordIntervention(d.Intervention, d.TargetSerial, false)
 	if err := l.Actions.Apply(dCtx, d); err != nil {
 		aSpan.RecordError(err)
 		// semconv.ErrorType derives the low-cardinality error class from the

--- a/services/agent/decision/intervention_record_test.go
+++ b/services/agent/decision/intervention_record_test.go
@@ -1,0 +1,218 @@
+package decision
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/joustmania/agent/gamecontext"
+)
+
+// TestAsync_RecordsDispatchedThroughApply covers the in-scope #945 async wiring: the
+// async apply path (#917) dispatches re-validated model decisions through the SAME
+// runDecision, so the per-game recorder fires there too. A fresh, applied async
+// result records a DISPATCHED intervention into the timeline, consistent with the
+// synchronous path — no separate async hook needed.
+func TestAsync_RecordsDispatchedThroughApply(t *testing.T) {
+	be := newBlockingBackend("phi4-mini", validShieldResponse)
+	provider := newFakeContextProvider()
+	provider.set("g1", activeContext("g1", "AAAA"))
+	l, _, _ := asyncLoop(t, asyncSnapshot(), resolverWith(be), provider, "g1", nil)
+	rec := &fakeRecorder{}
+	l.SetInterventionRecorder(rec.record)
+
+	l.OnEvaluate(context.Background(), activeContext("g1", "AAAA"), testTrigger())
+	close(be.release)
+	l.AwaitInflight()
+
+	hits := rec.snapshot()
+	if len(hits) != 1 {
+		t.Fatalf("recorder hits = %d, want 1 (async-applied decision recorded)", len(hits))
+	}
+	if hits[0].intervention != "grant_shield" || hits[0].blocked {
+		t.Errorf("hit = %+v, want dispatched grant_shield via async apply", hits[0])
+	}
+}
+
+// intervention_record_test.go covers the #945 wiring: the per-game recorder seam
+// (SetInterventionRecorder) feeds each decision's dispatched/blocked outcome into
+// the #916 rolling narrative timeline. These tests assert the Loop->recorder
+// contract directly (recorder is called with the right intervention/serial/blocked
+// for both outcomes, is nil-safe, isolates per game, and is race-safe); the
+// receiver-side routing into the right partition's Store is covered in
+// gamecontext/multiplexer_test.go (TestMux_AppendInterventionEvent*).
+
+// recordedIntervention is one captured recorder call.
+type recordedIntervention struct {
+	intervention string
+	serial       string
+	blocked      bool
+}
+
+// fakeRecorder captures every recorder call under its own mutex, mirroring the
+// Store.AppendInterventionEvent mutex guarantee so the -race tests are honest.
+type fakeRecorder struct {
+	mu   sync.Mutex
+	hits []recordedIntervention
+}
+
+func (r *fakeRecorder) record(intervention, serial string, blocked bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.hits = append(r.hits, recordedIntervention{intervention, serial, blocked})
+}
+
+func (r *fakeRecorder) snapshot() []recordedIntervention {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]recordedIntervention, len(r.hits))
+	copy(out, r.hits)
+	return out
+}
+
+// TestRunDecision_RecordsDispatched: a decision that passes the permission chain is
+// recorded as a DISPATCHED intervention (blocked=false) with its id + target serial.
+func TestRunDecision_RecordsDispatched(t *testing.T) {
+	l, _, fl := newTestLoop(t)
+	fl.snap.InterventionsAllowed = []string{"grant_shield"}
+	rec := &fakeRecorder{}
+	l.SetInterventionRecorder(rec.record)
+	l.Actions = &fakeSink{}
+	l.Rules = fakeRules{out: []Decision{{Intervention: "grant_shield", TargetSerial: "AA:11", Reason: "test"}}}
+
+	l.OnEvaluate(context.Background(), gamecontext.GameContext{SessionID: "game-1"}, testTrigger())
+
+	hits := rec.snapshot()
+	if len(hits) != 1 {
+		t.Fatalf("recorder hits = %d, want 1", len(hits))
+	}
+	if hits[0] != (recordedIntervention{"grant_shield", "AA:11", false}) {
+		t.Errorf("hit = %+v, want dispatched grant_shield -> AA:11", hits[0])
+	}
+}
+
+// TestRunDecision_RecordsBlocked: a decision blocked by a permission gate (here the
+// allow-list: the intervention is not in interventions_allowed) is recorded as a
+// BLOCKED intervention (blocked=true), never silently dropped.
+func TestRunDecision_RecordsBlocked(t *testing.T) {
+	l, _, fl := newTestLoop(t)
+	// Empty allow-list -> ReasonNotAllowed blocks the decision.
+	fl.snap.InterventionsAllowed = nil
+	rec := &fakeRecorder{}
+	l.SetInterventionRecorder(rec.record)
+	sink := &fakeSink{}
+	l.Actions = sink
+	l.Rules = fakeRules{out: []Decision{{Intervention: "grant_shield", TargetSerial: "BB:22", Reason: "test"}}}
+
+	l.OnEvaluate(context.Background(), gamecontext.GameContext{SessionID: "game-1"}, testTrigger())
+
+	hits := rec.snapshot()
+	if len(hits) != 1 {
+		t.Fatalf("recorder hits = %d, want 1", len(hits))
+	}
+	if hits[0] != (recordedIntervention{"grant_shield", "BB:22", true}) {
+		t.Errorf("hit = %+v, want blocked grant_shield -> BB:22", hits[0])
+	}
+	// A blocked decision must NOT have reached the action sink, but MUST be recorded.
+	if c := sink.calls.Load(); c != 0 {
+		t.Errorf("blocked decision reached sink %d times, want 0", c)
+	}
+}
+
+// TestRunDecision_BlockedByRateLimit: the rate-limit gate also records a blocked
+// intervention, confirming the recorder fires for every BlockReason (allow-list,
+// battery, rate-limit), not just the allow-list.
+func TestRunDecision_BlockedByRateLimit(t *testing.T) {
+	l, _, fl := newTestLoop(t)
+	fl.snap.InterventionsAllowed = []string{"grant_shield"}
+	fl.snap.Policy.MaxInterventionsPerMinute = 0 // budget 0 -> every dispatch is rate-limited
+	rec := &fakeRecorder{}
+	l.SetInterventionRecorder(rec.record)
+	l.Actions = &fakeSink{}
+	l.Rules = fakeRules{out: []Decision{{Intervention: "grant_shield", Reason: "test"}}}
+
+	l.OnEvaluate(context.Background(), gamecontext.GameContext{SessionID: "game-1"}, testTrigger())
+
+	hits := rec.snapshot()
+	if len(hits) != 1 || !hits[0].blocked {
+		t.Fatalf("recorder hits = %+v, want one blocked", hits)
+	}
+}
+
+// TestRunDecision_NilRecorderUnchanged: a Loop without a recorder (the construction
+// default and all pre-#945 tests) records nothing and otherwise behaves exactly as
+// before — the dispatch still reaches the action sink.
+func TestRunDecision_NilRecorderUnchanged(t *testing.T) {
+	l, _, fl := newTestLoop(t)
+	fl.snap.InterventionsAllowed = []string{"grant_shield"}
+	sink := &fakeSink{}
+	l.Actions = sink
+	l.Rules = fakeRules{out: []Decision{{Intervention: "grant_shield", Reason: "test"}}}
+	// No SetInterventionRecorder call: l.interventionRecorder stays nil.
+
+	l.OnEvaluate(context.Background(), gamecontext.GameContext{SessionID: "game-1"}, testTrigger())
+
+	if c := sink.calls.Load(); c != 1 {
+		t.Errorf("dispatch reached sink %d times, want 1 (nil recorder must not change behavior)", c)
+	}
+}
+
+// TestRunDecision_PerGameRecorderIsolation: two Loops with DIFFERENT recorders (as
+// the per-game factory builds them, each closing over its own partition's Store)
+// record to their own sinks with no cross-bleed — the #845 isolation the #917
+// ContextProvider wiring also preserves, extended to interventions (#945).
+func TestRunDecision_PerGameRecorderIsolation(t *testing.T) {
+	makeLoop := func(rec *fakeRecorder) *Loop {
+		l, _, fl := newTestLoop(t)
+		fl.snap.InterventionsAllowed = []string{"grant_shield"}
+		l.SetInterventionRecorder(rec.record)
+		l.Actions = &fakeSink{}
+		return l
+	}
+	recA, recB := &fakeRecorder{}, &fakeRecorder{}
+	loopA := makeLoop(recA)
+	loopB := makeLoop(recB)
+	loopA.Rules = fakeRules{out: []Decision{{Intervention: "grant_shield", TargetSerial: "AA:11"}}}
+	loopB.Rules = fakeRules{out: []Decision{{Intervention: "grant_shield", TargetSerial: "BB:22"}}}
+
+	loopA.OnEvaluate(context.Background(), gamecontext.GameContext{SessionID: "game-A"}, testTrigger())
+	loopB.OnEvaluate(context.Background(), gamecontext.GameContext{SessionID: "game-B"}, testTrigger())
+
+	a, b := recA.snapshot(), recB.snapshot()
+	if len(a) != 1 || a[0].serial != "AA:11" {
+		t.Errorf("recorder A = %+v, want only AA:11 (no bleed from B)", a)
+	}
+	if len(b) != 1 || b[0].serial != "BB:22" {
+		t.Errorf("recorder B = %+v, want only BB:22 (no bleed from A)", b)
+	}
+}
+
+// TestRunDecision_ConcurrentRecordRaceFree drives one Loop from many goroutines
+// (as the concurrent trace + metrics Export handlers do) to confirm the recorder
+// path is race-safe under -race. The recorder reaches the mutex-guarded
+// Store.AppendInterventionEvent in production; the fakeRecorder mirrors that lock.
+func TestRunDecision_ConcurrentRecordRaceFree(t *testing.T) {
+	l, _, fl := newTestLoop(t)
+	fl.snap.InterventionsAllowed = []string{"grant_shield"}
+	rec := &fakeRecorder{}
+	l.SetInterventionRecorder(rec.record)
+	l.Actions = &fakeSink{}
+	l.Rules = fakeRules{out: []Decision{{Intervention: "grant_shield", TargetSerial: "CC:33"}}}
+
+	const goroutines = 16
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			l.OnEvaluate(context.Background(), gamecontext.GameContext{SessionID: "game-1"}, testTrigger())
+		}()
+	}
+	wg.Wait()
+
+	// Every cycle whose decision was admitted by the (generous) rate limit records
+	// exactly once; the count is bounded by goroutines and must be at least 1.
+	if n := len(rec.snapshot()); n < 1 || n > goroutines {
+		t.Fatalf("recorder hits = %d, want 1..%d", n, goroutines)
+	}
+}

--- a/services/agent/gamecontext/multiplexer.go
+++ b/services/agent/gamecontext/multiplexer.go
@@ -163,6 +163,29 @@ func (m *Multiplexer) Snapshot(gameID string) (GameContext, bool) {
 	return s.Snapshot(), true
 }
 
+// AppendInterventionEvent routes a dispatched/blocked intervention to the
+// game_id partition's Store and records it in that partition's #916 rolling
+// narrative timeline (#945). It is the receiver-side half of the decision-Loop
+// seam: main.go's loopFactory hands each per-game Loop a recorder closure over
+// (this Multiplexer, that loop's game_id), so when runDecision decides an
+// intervention's outcome the event lands in the timeline of the game it targeted
+// and nowhere else.
+//
+// PER-GAME ISOLATION (#845): the partition is selected by game_id with the SAME
+// lazy store() routing every signal uses — an unlabeled game_id (FallbackGameID)
+// lands in the fallback partition, exactly like an unlabeled signal — so two
+// concurrent games keep independent intervention histories. The partition is
+// created on demand if it does not yet exist (a decision could in principle reach
+// the seam before any signal created the partition; routing it the same way keeps
+// the event with its game rather than dropping it).
+//
+// Concurrency: store() is mutex-guarded for lazy create, and Store.
+// AppendInterventionEvent is guarded by the Store's own mutex (#916), so this is
+// race-safe under the concurrent Export-handler goroutines that drive runDecision.
+func (m *Multiplexer) AppendInterventionEvent(gameID, intervention, serial string, blocked bool) {
+	m.store(gameID).AppendInterventionEvent(intervention, serial, blocked)
+}
+
 // Partitions returns the current set of partition game_ids (including
 // FallbackGameID when present). Order is unspecified.
 func (m *Multiplexer) Partitions() []string {

--- a/services/agent/gamecontext/multiplexer_test.go
+++ b/services/agent/gamecontext/multiplexer_test.go
@@ -46,6 +46,76 @@ func newTestMux(clk *muxClock, playerTTL, grace time.Duration, ends *[]string, e
 	})
 }
 
+// TestMux_AppendInterventionEventRoutesPerGame covers the #945 receiver-side seam:
+// the decision Loop's per-game recorder closure routes each intervention outcome
+// through mux.AppendInterventionEvent(gameID, ...), and the event must land in the
+// timeline of the partition for that game_id — never a shared/global one — so two
+// concurrent games keep independent intervention histories (#845 isolation).
+func TestMux_AppendInterventionEventRoutesPerGame(t *testing.T) {
+	clk := &muxClock{t: time.Unix(2000, 0)}
+	mux := newTestMux(clk, time.Hour, time.Hour, nil, nil)
+
+	// Bring both partitions into existence with a game-start signal (as a real
+	// session would), then record interventions against each by game_id.
+	mux.ApplyMetrics(gameActiveFor("game-A", 1))
+	mux.ApplyMetrics(gameActiveFor("game-B", 1))
+
+	// game-A: one dispatched session-scoped intervention.
+	mux.AppendInterventionEvent("game-A", "adjust_music_tempo", "", false)
+	// game-B: one blocked player-targeted intervention.
+	mux.AppendInterventionEvent("game-B", "grant_shield", "BB:22", true)
+
+	a, okA := mux.Snapshot("game-A")
+	b, okB := mux.Snapshot("game-B")
+	if !okA || !okB {
+		t.Fatalf("partitions missing: A=%v B=%v", okA, okB)
+	}
+
+	// game-A's intervention must be in game-A's timeline (dispatched, no serial) and
+	// must NOT have leaked into game-B.
+	a0 := interventionEvents(a.Timeline)
+	if len(a0) != 1 || a0[0].Detail != "adjust_music_tempo" || a0[0].Blocked || a0[0].Serial != "" {
+		t.Errorf("game-A interventions = %+v, want one dispatched adjust_music_tempo", a0)
+	}
+	// game-B's intervention must be in game-B's timeline (blocked, BB:22) and not in A.
+	b0 := interventionEvents(b.Timeline)
+	if len(b0) != 1 || b0[0].Detail != "grant_shield" || !b0[0].Blocked || b0[0].Serial != "BB:22" {
+		t.Errorf("game-B interventions = %+v, want one blocked grant_shield -> BB:22", b0)
+	}
+}
+
+// TestMux_AppendInterventionEventLazyPartition: an intervention can reach the seam
+// before any signal created the partition; routing it the same lazy way every
+// signal uses keeps the event with its game rather than dropping it (#945).
+func TestMux_AppendInterventionEventLazyPartition(t *testing.T) {
+	clk := &muxClock{t: time.Unix(3000, 0)}
+	mux := newTestMux(clk, time.Hour, time.Hour, nil, nil)
+
+	mux.AppendInterventionEvent("game-Z", "play_audio_cue", "ZZ:01", false)
+
+	z, ok := mux.Snapshot("game-Z")
+	if !ok {
+		t.Fatal("game-Z partition should have been lazily created by the intervention")
+	}
+	zi := interventionEvents(z.Timeline)
+	if len(zi) != 1 || zi[0].Detail != "play_audio_cue" || zi[0].Serial != "ZZ:01" {
+		t.Errorf("game-Z interventions = %+v, want one dispatched play_audio_cue -> ZZ:01", zi)
+	}
+}
+
+// interventionEvents filters a timeline to its EventIntervention entries so a test
+// asserts only on interventions, ignoring the phase/state events a started game
+// also accumulates.
+func interventionEvents(tl []TimelineEvent) []TimelineEvent {
+	var out []TimelineEvent
+	for _, e := range tl {
+		if e.Kind == EventIntervention {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
 // addGauge appends a single-datapoint gauge metric to md with the given attrs.
 func addGauge(md pmetric.Metrics, name string, value float64, attrs map[string]string) {
 	m := md.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()

--- a/services/agent/main.go
+++ b/services/agent/main.go
@@ -358,6 +358,20 @@ func main() {
 		loop.SetGameID(gameID)
 		loop.SetContextProvider(decision.MuxContextProvider{Mux: mux})
 		loop.SetRootContext(ctx)
+		// Intervention timeline wiring (#945): feed each decision's dispatched/blocked
+		// outcome into the #916 rolling narrative of the SAME game this loop serves.
+		// The closure captures THIS partition's game_id and routes through the
+		// Multiplexer (mux.AppendInterventionEvent), so the event lands in the timeline
+		// of the game it targeted and nowhere else — the per-game isolation (#845) the
+		// multiplexer already enforces for signals, extended to interventions. This
+		// mirrors SetContextProvider's #917 wiring (a per-game closure over the same
+		// mux+gameID). runDecision calls it for BOTH dispatched and blocked decisions,
+		// covering the sync path AND the async apply path (which also runs runDecision).
+		// The timeline (and thus the #916/#928/#929 narratives + the #960 proposer
+		// prompt) now includes the agent's own intervention history.
+		loop.SetInterventionRecorder(func(intervention, serial string, blocked bool) {
+			mux.AppendInterventionEvent(gameID, intervention, serial, blocked)
+		})
 		// Inject the SHARED rolling cross-game context window (#929, M7-2): every
 		// per-game loop reads the SAME recent-games window, so the llm path renders the
 		// last N game summaries into the prompt's narrative context block — the agent's


### PR DESCRIPTION
## What

Wires dispatched/blocked interventions into the #916 per-game rolling narrative timeline. #916 built the timeline on `gamecontext.Store` and shipped the seam `Store.AppendInterventionEvent(intervention, serial, blocked)` + the `EventIntervention` kind, but **deferred** the Loop→Store wiring: the decision `Loop` knew each intervention's outcome (dispatched vs blocked) but didn't yet feed it to the per-game Store's timeline. This finishes that thread, so the timeline — and thus the #916/#928/#929 narratives and the #960 proposer prompt — includes the agent's own intervention history.

## The seam (per-game recorder, mirroring #917's ContextProvider wiring)

The `Loop` and the per-game `Store` are separate objects; the receiver pipeline holds both (the `gamecontext.Multiplexer`'s Store per `game_id`, and the `decision.LoopSet`'s Loop). The wiring mirrors exactly how #917 threaded the per-game `ContextProvider` (`SetContextProvider`) into each Loop:

- **`decision.Loop`** gains an optional `interventionRecorder func(intervention, serial string, blocked bool)`, set via `SetInterventionRecorder`. `runDecision` calls it for **both** dispatched and blocked decisions (via the nil-safe `recordIntervention` helper).
- **`gamecontext.Multiplexer.AppendInterventionEvent(gameID, intervention, serial, blocked)`** routes to the partition's Store via the same lazy `store()` routing every signal uses.
- **`main.go`'s `loopFactory`** closes the recorder over `(mux, gameID)`: `loop.SetInterventionRecorder(func(i, s, b) { mux.AppendInterventionEvent(gameID, i, s, b) })`.

## How isolation is preserved (#845)

Each per-game Loop's recorder is keyed by **its own** `game_id`, so an intervention lands in the timeline of the game it targeted and nowhere else. The Multiplexer selects the partition by `game_id` with the identical routing it uses for signals, so two concurrent games keep independent intervention histories. A test (`TestRunDecision_PerGameRecorderIsolation`, `TestMux_AppendInterventionEventRoutesPerGame`) asserts no cross-bleed.

## Sync + async

A single hook in `runDecision` covers **both** paths: the synchronous path and the async apply path (#917), since `applyOneAsync` / `fallbackToRules` both dispatch through `runDecision`. `TestAsync_RecordsDispatchedThroughApply` confirms an async-applied result is recorded.

## Concurrency

`AppendInterventionEvent` is mutex-guarded by the Store (#916); `runDecision` runs from the concurrent trace + metrics Export-handler goroutines. `TestRunDecision_ConcurrentRecordRaceFree` drives one Loop from 16 goroutines under `-race`.

## Nil-safe

A Loop without a recorder (construction default, rules-only deployments, all existing tests) records nothing — purely additive over the pre-#945 behavior (`TestRunDecision_NilRecorderUnchanged`).

## Tests

`go test -race ./...` green from `services/agent`; `gofmt -l .` empty; `go vet ./...` clean; `make lint` (ruff) passes. New tests cover dispatched, blocked (allow-list + rate-limit), nil-recorder, per-game isolation, concurrent `-race`, async-apply, and Multiplexer routing/lazy-partition.

Closes the #916 deferral / Part of #945.

🤖 Generated with [Claude Code](https://claude.com/claude-code)