### PR TITLE
fix(menu): migrate off FLAGD_DIR onto single FLAGD_FLAG_DIR source of truth (#966)

### DIFF
--- a/docker-compose.lite.yml
+++ b/docker-compose.lite.yml
@@ -146,7 +146,9 @@ services:
       - AUDIO_PORT=50056
       - FLAGD_HOST=flagd
       - FLAGD_PORT=8015
-      - FLAGD_DIR=/etc/flagd
+      # Single source of truth for the active flag directory (#959/#966):
+      # the menu writes $FLAGD_FLAG_DIR/<domain>.json via lib/flagd_paths.py.
+      - FLAGD_FLAG_DIR=/etc/flagd
     volumes:
       - ./services/flagd/game.json:/etc/flagd/game.json
       - ./services/flagd/user.json:/etc/flagd/user.json

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -383,7 +383,11 @@ services:
       - AUDIO_PORT=50056
       - FLAGD_HOST=flagd
       - FLAGD_PORT=8015
-      - FLAGD_DIR=/etc/flagd
+      # Single source of truth for the active flag directory (#959/#966). The
+      # menu resolves which host flag file to write as $FLAGD_FLAG_DIR/<domain>.json
+      # (lib/flagd_paths.py) — the same plain join flagd, the agent writers, and
+      # the integration tests use, so writers and the served files never desync.
+      - FLAGD_FLAG_DIR=/etc/flagd
     volumes:
       - ./services/flagd:/etc/flagd
     depends_on:

--- a/services/menu/servicer.py
+++ b/services/menu/servicer.py
@@ -18,6 +18,7 @@ from lib.feature_flags import (
     set_game_transaction_context,
 )
 from lib.flag_config_writer import FlagConfigWriter
+from lib.flagd_paths import active_flag_file
 from lib.telemetry import get_tracer
 from lib.types import Games
 from proto import menu_pb2, menu_pb2_grpc
@@ -80,10 +81,13 @@ class MenuServicer(menu_pb2_grpc.MenuServiceServicer):
         init_flag_domain("user")
         init_flag_domain("system")
 
-        # FlagConfigWriter instances for persisting settings changes
-        flagd_dir = os.getenv("FLAGD_DIR", "/etc/flagd")
-        self.game_settings_writer = FlagConfigWriter(os.path.join(flagd_dir, "game.json"))
-        self.user_prefs_writer = FlagConfigWriter(os.path.join(flagd_dir, "user.json"))
+        # FlagConfigWriter instances for persisting settings changes. Resolve the
+        # active flag directory through the single source of truth (#959/#966):
+        # $FLAGD_FLAG_DIR/<domain>.json — the same plain join flagd, the agent
+        # writers, and the integration tests use, so a menu-driven flag write
+        # lands in the file flagd actually serves.
+        self.game_settings_writer = FlagConfigWriter(str(active_flag_file("game")))
+        self.user_prefs_writer = FlagConfigWriter(str(active_flag_file("user")))
 
         # OpenFeature clients for reading settings
         self.game_settings_client = get_flag_client("game")


### PR DESCRIPTION
## What

The menu service was the last holdout still reading the old `FLAGD_DIR` env var directly:

```python
flagd_dir = os.getenv("FLAGD_DIR", "/etc/flagd")
self.game_settings_writer = FlagConfigWriter(os.path.join(flagd_dir, "game.json"))
self.user_prefs_writer = FlagConfigWriter(os.path.join(flagd_dir, "user.json"))
```

After #962 made `lib/flagd_paths.py` the single source of truth for the active flag directory (`FLAGD_FLAG_DIR`, plain join `$FLAGD_FLAG_DIR/<domain>.json`), this left **two knobs for the same thing**.

## Changes

- **`services/menu/servicer.py`**: resolve the `game.json`/`user.json` write paths via `active_flag_file("game")` / `active_flag_file("user")` from `lib.flagd_paths`, so the menu uses the **same** directory as flagd, the agent writers, and the integration tests.
- **`docker-compose.yml` / `docker-compose.lite.yml`**: rename the menu's redundant `FLAGD_DIR=/etc/flagd` to `FLAGD_FLAG_DIR=/etc/flagd`, matching the agent service's convention.

### Why rename (not drop) the env

`flag_dir()`'s default (`_DEFAULT_FLAG_DIR`) is **repo-root-relative** (`services/flagd`), the host-tooling default — not `/etc/flagd`. In-container there is no repo at that path, so the menu container must explicitly set `FLAGD_FLAG_DIR=/etc/flagd` (exactly as the agent already does). Dropping it would break in-container resolution.

## Single-knob outcome

`FLAGD_DIR` no longer appears anywhere functional. The only remaining matches are a local path constant `_FLAGD_DIR`/`FLAGD_DIR` in `lib/tests/test_flagd_ci_drift.py` (a `Path`, not the env var) — left untouched.

## Behavior preserved (prod + CI)

`docker compose config` renders confirm the menu resolves `$FLAGD_FLAG_DIR/<domain>.json` = `/etc/flagd/<domain>.json` identically to before:

- **Production** (base compose): `services/flagd -> /etc/flagd` mount -> `/etc/flagd/game.json` = `services/flagd/game.json`.
- **CI** (`docker-compose.ci.yml` menu `!override`): `services/flagd/ci -> /etc/flagd` mount -> `/etc/flagd/game.json` = `services/flagd/ci/game.json`. The #962 CI menu fix is unchanged — a menu-driven write still lands in the file CI flagd serves.

## Validation

- `cd services/menu && uv run --extra test pytest -q` -> **358 passed**
- `make lint` (ruff) -> **All checks passed!**
- YAML sanity on both touched compose files -> OK
- `rg -n FLAGD_DIR .` -> no functional leftovers
- `docker compose -f docker-compose.yml -f docker-compose.override.yml -f docker-compose.ci.yml config` -> menu renders `FLAGD_FLAG_DIR: /etc/flagd` with `source: services/flagd/ci -> target: /etc/flagd`

Part of #966.

🤖 Generated with [Claude Code](https://claude.com/claude-code)