### PR TITLE
fix(ci): run proto-gen container as host user to avoid root-owned files (#795)

### DIFF
--- a/scripts/ci/validate-packages.sh
+++ b/scripts/ci/validate-packages.sh
@@ -7,7 +7,13 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 echo "Validating Python packages..."
 
+# Run as the host user (#795): like validate-protos.sh, this `uv sync` would
+# otherwise create a root-owned .venv/ in the mounted tree, breaking later
+# `uv` runs and needing `sudo rm`. A passwd-less UID has no writable HOME, so
+# point HOME at /tmp for uv's cache.
 docker run --rm \
+    --user "$(id -u):$(id -g)" \
+    -e HOME=/tmp \
     -v "$PROJECT_ROOT:/workspace" \
     -w /workspace \
     joustmania/ci-proto:latest \

--- a/scripts/ci/validate-protos.sh
+++ b/scripts/ci/validate-protos.sh
@@ -39,7 +39,14 @@ echo "Validating proto generation..."
 STUB_GLOBS=('proto/*_pb2.py' 'proto/*_pb2_grpc.py')
 
 # --- Regenerate inside the pinned CI container -------------------------------
+# Run as the host user (#795): the container previously ran as root, so files it
+# created in the mounted tree (notably the uv-managed .venv/ and proto/__pycache__)
+# ended up root-owned on the host, breaking later `uv` runs and needing `sudo rm`.
+# A passwd-less UID has no writable HOME, so uv can't create its cache; point HOME
+# at /tmp (and let uv default UV_CACHE_DIR under it) so generation still works.
 docker run --rm \
+    --user "$(id -u):$(id -g)" \
+    -e HOME=/tmp \
     -v "$PROJECT_ROOT:/workspace" \
     -w /workspace \
     joustmania/ci-proto:latest \


### PR DESCRIPTION
## Problem

`make ci-validate-protos` (and the sibling `ci-validate-packages`) run inside the `joustmania/ci-proto` container as **root**. From a local checkout/worktree the container clobbered ownership of files it created in the mounted tree — most notably the uv-managed `.venv/` and `proto/__pycache__`. That left root-owned files behind, breaking subsequent `uv` runs in the checkout and requiring `sudo rm -rf` to clean up (observed during #777 work).

Part of #795.

## Fix

Run the container as the host user via `--user $(id -u):$(id -g)` so everything the generator/installer writes is host-owned. Applied to **both** scripts invoked by the same CI step (`make ci-validate-protos ci-validate-packages`):

- `scripts/ci/validate-protos.sh` — regenerates the proto stubs.
- `scripts/ci/validate-packages.sh` — runs `uv sync --all-packages` (this one writes the root-owned `.venv/` directly).

A passwd-less UID has no writable `HOME`, so `uv` fails to create its cache (`failed to create directory /.cache/uv: Permission denied`). Setting `-e HOME=/tmp` gives uv a writable home (and default cache dir under it) so both scripts still succeed. This mirrors the existing repo convention of keeping generated files host-owned (see the `chown`-back in the `protos-agent` Makefile target).

The `protos` target was checked: it runs `bash proto/generate_proto.sh` directly on the host (no container), so it never had the ownership problem and is left unchanged.

## CI safety

The `--user` value is computed at runtime via command substitution, so it adapts to whatever UID the GitHub Actions runner uses; the `/workspace` bind mount is the runner-owned checkout, which the runner UID can write to. No CI step relies on a root-only mount path here.

## Verification (real Docker run)

Ran both scripts end-to-end on a Docker host:
- `validate-protos.sh` → `✅ Proto files validated!`, no drift.
- `validate-packages.sh` → `✅ All packages validated!`.
- `find . -user root` → **zero** files; `.venv/`, `proto/__pycache__/` and generated `*_pb2.py` stubs all owned by the host user.
- A follow-up `uv run` works with **no** `sudo` cleanup — the exact symptom from the issue.

`make lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)