### PR TITLE
ci: decouple image publish from flaky integration tests (stale-image guard) (#925)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,9 +58,6 @@ jobs:
       docker_build_matrix: ${{ steps.matrices.outputs.docker_build }}
       docker_extra_matrix: ${{ steps.matrices.outputs.docker_extra }}
       retag_matrix: ${{ steps.matrices.outputs.retag }}
-      # Deps fingerprint of this checkout (#925): baked into every service image
-      # at build time and read back by the fast-path freshness guard.
-      deps_fingerprint: ${{ steps.fingerprint.outputs.value }}
     steps:
       - uses: actions/checkout@v6
 
@@ -219,13 +216,6 @@ jobs:
           maybe_retag "$CH_PYTHON_HID"         python-hid
           maybe_retag "$CH_OTEL_COLLECTOR"     otel-collector
           echo "retag=$(json_array "${retag[@]}")" >> "$GITHUB_OUTPUT"
-
-      # #925: single deps fingerprint for this checkout. docker-build bakes it
-      # into each image as a label; the fast path reads it back and refuses to
-      # mount source into an image with a mismatching (stale) fingerprint.
-      - name: Compute deps fingerprint
-        id: fingerprint
-        run: echo "value=$(bash scripts/ci/deps-fingerprint.sh)" >> "$GITHUB_OUTPUT"
 
   # Build and test shared packages (proto, lib)
   lib-tests:
@@ -603,8 +593,8 @@ jobs:
       # image (fingerprint matches). Only runs on the fast path.
       - name: Guard against stale prebuilt images
         if: needs.changes.outputs.integration_deps != 'true' && needs.changes.outputs.force_full != 'true'
+        # IMAGE_PREFIX is already in env scope from the "Set image prefix" step.
         env:
-          IMAGE_PREFIX: ${{ env.IMAGE_PREFIX }}
           IMAGE_TAG: latest
         run: bash scripts/ci/check-image-freshness.sh
 
@@ -663,6 +653,15 @@ jobs:
           IMAGE_NAME="${SERVICE//_/-}-service"
           echo "name=${IMAGE_NAME}" >> "$GITHUB_OUTPUT"
 
+      # #925: per-service deps fingerprint, scoped to exactly the deps inputs
+      # that rebuild THIS image (shared workspace/builder deps + this service's
+      # own pyproject/Dockerfile). Baked into the image as a label below; the
+      # fast path recomputes the same per-service value and refuses to mount
+      # source into an image whose fingerprint is stale.
+      - name: Compute deps fingerprint
+        id: fingerprint
+        run: echo "value=$(bash scripts/ci/deps-fingerprint.sh '${{ matrix.service }}')" >> "$GITHUB_OUTPUT"
+
       - name: Build and push service
         uses: docker/build-push-action@v7
         with:
@@ -677,7 +676,7 @@ jobs:
             ${{ github.ref_name == env.MAIN_BRANCH && format('{0}/{1}:latest', env.IMAGE_PREFIX, steps.image_name.outputs.name) || '' }}
           build-args: |
             BUILDER_IMAGE=${{ env.IMAGE_PREFIX }}/builder:${{ github.sha }}
-            DEPS_FINGERPRINT=${{ needs.changes.outputs.deps_fingerprint }}
+            DEPS_FINGERPRINT=${{ steps.fingerprint.outputs.value }}
           cache-from: type=gha,scope=${{ matrix.service }}
           cache-to: type=gha,mode=max,scope=${{ matrix.service }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,9 @@ jobs:
       docker_build_matrix: ${{ steps.matrices.outputs.docker_build }}
       docker_extra_matrix: ${{ steps.matrices.outputs.docker_extra }}
       retag_matrix: ${{ steps.matrices.outputs.retag }}
+      # Deps fingerprint of this checkout (#925): baked into every service image
+      # at build time and read back by the fast-path freshness guard.
+      deps_fingerprint: ${{ steps.fingerprint.outputs.value }}
     steps:
       - uses: actions/checkout@v6
 
@@ -216,6 +219,13 @@ jobs:
           maybe_retag "$CH_PYTHON_HID"         python-hid
           maybe_retag "$CH_OTEL_COLLECTOR"     otel-collector
           echo "retag=$(json_array "${retag[@]}")" >> "$GITHUB_OUTPUT"
+
+      # #925: single deps fingerprint for this checkout. docker-build bakes it
+      # into each image as a label; the fast path reads it back and refuses to
+      # mount source into an image with a mismatching (stale) fingerprint.
+      - name: Compute deps fingerprint
+        id: fingerprint
+        run: echo "value=$(bash scripts/ci/deps-fingerprint.sh)" >> "$GITHUB_OUTPUT"
 
   # Build and test shared packages (proto, lib)
   lib-tests:
@@ -585,17 +595,33 @@ jobs:
 
       - uses: astral-sh/setup-uv@v8.2.0
 
-      # Fast path: pull latest images, overlay current source
+      # #925 fast-path freshness guard: BEFORE mounting current source into the
+      # pulled :latest images, confirm each carries a deps-fingerprint label that
+      # matches this checkout. A stale :latest (e.g. a deps-changing commit whose
+      # publish was skipped by a flake) fails here with a one-line diagnosis
+      # instead of erroring all 18 tests with no obvious cause. No-op on a fresh
+      # image (fingerprint matches). Only runs on the fast path.
+      - name: Guard against stale prebuilt images
+        if: needs.changes.outputs.integration_deps != 'true' && needs.changes.outputs.force_full != 'true'
+        env:
+          IMAGE_PREFIX: ${{ env.IMAGE_PREFIX }}
+          IMAGE_TAG: latest
+        run: bash scripts/ci/check-image-freshness.sh
+
+      # Fast path: pull latest images, overlay current source.
+      # PYTEST_EXTRA="--reruns 1" (#925): tolerate a single integration flake so
+      # one flake no longer skips image publish. Generic — reruns ANY failure
+      # once, never quarantines a test by name.
       - name: Run integration tests (fast - source only)
         if: needs.changes.outputs.integration_deps != 'true' && needs.changes.outputs.force_full != 'true'
-        run: USE_PREBUILT_IMAGES=true USE_DEV_MOUNTS=true make test-integration
+        run: USE_PREBUILT_IMAGES=true USE_DEV_MOUNTS=true PYTEST_EXTRA="--reruns 1" make test-integration
 
       # Slow path: full build (Dockerfiles or deps changed)
       - name: Run integration tests (full build)
         if: needs.changes.outputs.integration_deps == 'true' || needs.changes.outputs.force_full == 'true'
         env:
           BUILDER_IMAGE: ${{ env.IMAGE_PREFIX }}/builder:${{ github.sha }}
-        run: make test-integration
+        run: PYTEST_EXTRA="--reruns 1" make test-integration
 
   docker-build:
     name: Build ${{ matrix.service }}
@@ -651,6 +677,7 @@ jobs:
             ${{ github.ref_name == env.MAIN_BRANCH && format('{0}/{1}:latest', env.IMAGE_PREFIX, steps.image_name.outputs.name) || '' }}
           build-args: |
             BUILDER_IMAGE=${{ env.IMAGE_PREFIX }}/builder:${{ github.sha }}
+            DEPS_FINGERPRINT=${{ needs.changes.outputs.deps_fingerprint }}
           cache-from: type=gha,scope=${{ matrix.service }}
           cache-to: type=gha,mode=max,scope=${{ matrix.service }}
 

--- a/Makefile
+++ b/Makefile
@@ -213,10 +213,14 @@ test: clean-test-venv
 	uv run --all-packages pytest $(if $(TEST),-k "$(TEST)")
 
 # Integration tests only (used by CI - unit tests run separately in service-checks)
+# PYTEST_EXTRA: optional extra pytest args (e.g. CI passes "--reruns 1" via
+# pytest-rerunfailures so a single integration flake doesn't skip image publish
+# and stale :latest — the #925 cascade). Generic: reruns ANY failing test once,
+# does not target tests by name.
 .PHONY: test-integration
 test-integration: clean-test-venv
 	$(TEST_ENV) uv run --package joustmania-integration-tests \
-		pytest tests/integration/ -v $(if $(TEST),-k "$(TEST)")
+		pytest tests/integration/ -v $(PYTEST_EXTRA) $(if $(TEST),-k "$(TEST)")
 
 # Run with prebuilt images from GHCR instead of building
 .PHONY: test-pulled

--- a/Makefile
+++ b/Makefile
@@ -217,6 +217,11 @@ test: clean-test-venv
 # pytest-rerunfailures so a single integration flake doesn't skip image publish
 # and stale :latest — the #925 cascade). Generic: reruns ANY failing test once,
 # does not target tests by name.
+# CAVEAT: the integration docker_compose fixture is session-scoped and some state
+# is process-global (the rate limiter, interventions_allowed), so a test-isolation
+# bug can fail first then pass on rerun — masked as a flake. The rerun is a safety
+# net, NOT the fix; the freshness guard (check-image-freshness.sh) is what actually
+# prevents the stale-image cascade.
 .PHONY: test-integration
 test-integration: clean-test-venv
 	$(TEST_ENV) uv run --package joustmania-integration-tests \

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -40,6 +40,30 @@ make ci-validate-packages  # Recommended
 bash scripts/ci/validate-packages.sh
 ```
 
+### `deps-fingerprint.sh` (#925)
+
+Print a stable 16-char hash of the files that determine what each service image
+bakes (root/proto/lib/per-service `pyproject.toml` + every `services/*/Dockerfile`).
+CI bakes this value into each Python service image as the OCI label
+`org.joustmania.deps-fingerprint` (build-arg `DEPS_FINGERPRINT`).
+
+```bash
+bash scripts/ci/deps-fingerprint.sh
+```
+
+### `check-image-freshness.sh` (#925)
+
+Fast-path freshness guard. Before the integration fast path mounts current
+source into pulled `:latest` images, this compares each image's baked
+`org.joustmania.deps-fingerprint` label against the current checkout and fails
+loudly with a one-line diagnosis on mismatch (the stale-image cascade), instead
+of silently mounting incompatible source.
+
+```bash
+IMAGE_PREFIX=ghcr.io/watchmejoustmyflags/joustmania IMAGE_TAG=latest \
+  bash scripts/ci/check-image-freshness.sh
+```
+
 ## Makefile Targets
 
 All CI operations are available as Make targets:

--- a/scripts/ci/README.md
+++ b/scripts/ci/README.md
@@ -42,13 +42,14 @@ bash scripts/ci/validate-packages.sh
 
 ### `deps-fingerprint.sh` (#925)
 
-Print a stable 16-char hash of the files that determine what each service image
-bakes (root/proto/lib/per-service `pyproject.toml` + every `services/*/Dockerfile`).
-CI bakes this value into each Python service image as the OCI label
-`org.joustmania.deps-fingerprint` (build-arg `DEPS_FINGERPRINT`).
+Print a stable 16-char hash of the files that determine what a given service
+image bakes — the shared baked-deps inputs (root/proto/lib `pyproject.toml` +
+`images/builder/**`) plus that service's own `pyproject.toml` + `Dockerfile`.
+CI computes this **per service** and bakes it into that Python service image as
+the OCI label `org.joustmania.deps-fingerprint` (build-arg `DEPS_FINGERPRINT`).
 
 ```bash
-bash scripts/ci/deps-fingerprint.sh
+bash scripts/ci/deps-fingerprint.sh <service>   # e.g. menu, game_coordinator
 ```
 
 ### `check-image-freshness.sh` (#925)

--- a/scripts/ci/check-image-freshness.sh
+++ b/scripts/ci/check-image-freshness.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Fast-path freshness guard (#925).
+#
+# Before the integration fast path mounts current source into pulled :latest
+# images (USE_PREBUILT_IMAGES=true USE_DEV_MOUNTS=true), verify each pulled image
+# was built from a deps fingerprint that matches the current checkout. If a
+# deps-changing commit's publish was skipped, :latest is stale and mounting
+# current source produces a confusing all-tests-error cascade. This guard turns
+# that into a one-line diagnosis and a non-zero exit BEFORE any test runs.
+#
+# Mechanism: each service image carries an OCI label
+#   org.joustmania.deps-fingerprint
+# baked at build time (see services/*/Dockerfile + ci.yml docker-build). We
+# recompute the expected fingerprint from the checkout and compare.
+#
+# Usage:
+#   IMAGE_PREFIX=ghcr.io/owner/repo IMAGE_TAG=latest scripts/ci/check-image-freshness.sh
+#
+# Env:
+#   IMAGE_PREFIX  (required)  e.g. ghcr.io/watchmejoustmyflags/joustmania
+#   IMAGE_TAG     (default: latest)  tag the fast path will mount into
+#
+# Exit codes: 0 = all fresh; 1 = at least one image stale/unverifiable.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+: "${IMAGE_PREFIX:?IMAGE_PREFIX must be set (e.g. ghcr.io/owner/repo)}"
+IMAGE_TAG="${IMAGE_TAG:-latest}"
+LABEL_KEY="org.joustmania.deps-fingerprint"
+
+# The five Python service images the fast path mounts source into. These are the
+# only images that bake source/deps; infra images (flagd, grafana, ...) are
+# pinned by digest/version and never source-mounted, so they cannot go stale.
+IMAGES=(
+  controller-manager-service
+  game-coordinator-service
+  menu-service
+  audio-service
+  pairing-daemon-service
+)
+
+expected="$(bash "$SCRIPT_DIR/deps-fingerprint.sh")"
+echo "Expected deps fingerprint (from checkout): $expected"
+
+read_label() {
+  # Pull (single-platform, runner arch) and read the label with `docker image
+  # inspect`. The fast path's `docker compose pull` would pull these images
+  # anyway, so this just warms the cache. We pull rather than use
+  # `buildx imagetools inspect --format`, because the published images are
+  # multi-platform manifest LISTS (index): on an index, the imagetools template
+  # `.Image.Config.Labels` is a per-digest map and does not resolve to a single
+  # config, so the label cannot be read reliably that way. `docker image
+  # inspect` after pull resolves the concrete per-arch config every time.
+  local ref="$1"
+  docker pull --quiet "$ref" >/dev/null 2>&1 || return 0
+  docker image inspect "$ref" \
+    --format "{{ index .Config.Labels \"$LABEL_KEY\" }}" 2>/dev/null || true
+}
+
+stale=0
+for img in "${IMAGES[@]}"; do
+  ref="${IMAGE_PREFIX}/${img}:${IMAGE_TAG}"
+  actual="$(read_label "$ref")"
+
+  if [ -z "$actual" ] || [ "$actual" = "<no value>" ]; then
+    echo "::error::${img}:${IMAGE_TAG} carries no ${LABEL_KEY} label" \
+      "(predates the #925 freshness guard or was never published) —" \
+      "image provenance unknown, fast-path unsafe; needs full build."
+    stale=1
+    continue
+  fi
+
+  if [ "$actual" != "$expected" ]; then
+    echo "::error::pulled ${img}:${IMAGE_TAG} predates current deps fingerprint" \
+      "${actual}≠${expected} — image stale, fast-path unsafe; needs full build."
+    stale=1
+    continue
+  fi
+
+  echo "OK ${img}:${IMAGE_TAG} fingerprint $actual matches checkout"
+done
+
+if [ "$stale" -ne 0 ]; then
+  echo "::error::Fast-path freshness guard FAILED. The pulled :${IMAGE_TAG}" \
+    "image(s) do not match the current dependency fingerprint, so mounting" \
+    "current source would silently break the suite (the #925 stale-image" \
+    "cascade). Re-run this commit after a full image build/publish, or push a" \
+    "deps-touching change so CI takes the slow (full-build) path."
+  exit 1
+fi
+
+echo "All service images fresh for fast path (fingerprint $expected)."

--- a/scripts/ci/check-image-freshness.sh
+++ b/scripts/ci/check-image-freshness.sh
@@ -10,8 +10,12 @@
 #
 # Mechanism: each service image carries an OCI label
 #   org.joustmania.deps-fingerprint
-# baked at build time (see services/*/Dockerfile + ci.yml docker-build). We
-# recompute the expected fingerprint from the checkout and compare.
+# baked at build time (see services/*/Dockerfile + ci.yml docker-build). The
+# fingerprint is PER-SERVICE (scripts/ci/deps-fingerprint.sh <svc>), scoped to
+# exactly the deps inputs that rebuild THAT image (shared workspace/builder deps +
+# the service's own pyproject/Dockerfile). We recompute each service's expected
+# fingerprint from the checkout and compare against that image's label, so a deps
+# change to one service never false-stales the others.
 #
 # Usage:
 #   IMAGE_PREFIX=ghcr.io/owner/repo IMAGE_TAG=latest scripts/ci/check-image-freshness.sh
@@ -30,38 +34,60 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 IMAGE_TAG="${IMAGE_TAG:-latest}"
 LABEL_KEY="org.joustmania.deps-fingerprint"
 
-# The five Python service images the fast path mounts source into. These are the
-# only images that bake source/deps; infra images (flagd, grafana, ...) are
-# pinned by digest/version and never source-mounted, so they cannot go stale.
-IMAGES=(
-  controller-manager-service
-  game-coordinator-service
-  menu-service
-  audio-service
-  pairing-daemon-service
+# The five source-mounted Python services, as "service:image-name" pairs. The
+# fast path mounts current source into these images; infra images (flagd,
+# grafana, ...) are pinned by digest/version and never source-mounted, so they
+# cannot go stale. The service name (left) feeds deps-fingerprint.sh; the image
+# name (right) is the published repository.
+SERVICES=(
+  "controller_manager:controller-manager-service"
+  "game_coordinator:game-coordinator-service"
+  "menu:menu-service"
+  "audio:audio-service"
+  "pairing_daemon:pairing-daemon-service"
 )
 
-expected="$(bash "$SCRIPT_DIR/deps-fingerprint.sh")"
-echo "Expected deps fingerprint (from checkout): $expected"
+# Pull the image (single-platform, runner arch). We pull rather than use
+# `buildx imagetools inspect --format`, because the published images are
+# multi-platform manifest LISTS (index): on an index, the imagetools template
+# `.Image.Config.Labels` is a per-digest map and does not resolve to a single
+# config, so the label cannot be read reliably that way. The fast path's
+# `docker compose pull` would pull these images anyway, so this just warms the
+# cache. Returns non-zero on pull failure so the caller can distinguish a
+# transient network/registry error from a genuinely missing label.
+pull_image() {
+  local ref="$1"
+  docker pull --quiet "$ref" >/dev/null 2>&1
+}
 
 read_label() {
-  # Pull (single-platform, runner arch) and read the label with `docker image
-  # inspect`. The fast path's `docker compose pull` would pull these images
-  # anyway, so this just warms the cache. We pull rather than use
-  # `buildx imagetools inspect --format`, because the published images are
-  # multi-platform manifest LISTS (index): on an index, the imagetools template
-  # `.Image.Config.Labels` is a per-digest map and does not resolve to a single
-  # config, so the label cannot be read reliably that way. `docker image
-  # inspect` after pull resolves the concrete per-arch config every time.
+  # Read the label from an already-pulled image. Empty when the image carries
+  # no such label (predates the guard / never baked it).
   local ref="$1"
-  docker pull --quiet "$ref" >/dev/null 2>&1 || return 0
   docker image inspect "$ref" \
     --format "{{ index .Config.Labels \"$LABEL_KEY\" }}" 2>/dev/null || true
 }
 
 stale=0
-for img in "${IMAGES[@]}"; do
+for entry in "${SERVICES[@]}"; do
+  svc="${entry%%:*}"
+  img="${entry##*:}"
   ref="${IMAGE_PREFIX}/${img}:${IMAGE_TAG}"
+
+  # Per-service expected fingerprint, recomputed from THIS checkout.
+  expected="$(bash "$SCRIPT_DIR/deps-fingerprint.sh" "$svc")"
+
+  # Distinguish a pull failure (network/registry — different operator action:
+  # retry / check auth) from a missing label (real staleness signal). A failed
+  # pull must NOT be silently reported as "needs full build".
+  if ! pull_image "$ref"; then
+    echo "::error::failed to pull ${img}:${IMAGE_TAG} from ${IMAGE_PREFIX}" \
+      "— this is a NETWORK/REGISTRY error, not image staleness. Check GHCR" \
+      "auth/availability and re-run; do NOT treat as a needs-rebuild signal."
+    stale=1
+    continue
+  fi
+
   actual="$(read_label "$ref")"
 
   if [ -z "$actual" ] || [ "$actual" = "<no value>" ]; then
@@ -74,21 +100,23 @@ for img in "${IMAGES[@]}"; do
 
   if [ "$actual" != "$expected" ]; then
     echo "::error::pulled ${img}:${IMAGE_TAG} predates current deps fingerprint" \
-      "${actual}≠${expected} — image stale, fast-path unsafe; needs full build."
+      "(${svc}) ${actual}≠${expected} — image stale, fast-path unsafe;" \
+      "needs full build."
     stale=1
     continue
   fi
 
-  echo "OK ${img}:${IMAGE_TAG} fingerprint $actual matches checkout"
+  echo "OK ${img}:${IMAGE_TAG} fingerprint $actual matches checkout ($svc)"
 done
 
 if [ "$stale" -ne 0 ]; then
   echo "::error::Fast-path freshness guard FAILED. The pulled :${IMAGE_TAG}" \
-    "image(s) do not match the current dependency fingerprint, so mounting" \
-    "current source would silently break the suite (the #925 stale-image" \
-    "cascade). Re-run this commit after a full image build/publish, or push a" \
+    "image(s) either could not be verified or do not match the current" \
+    "dependency fingerprint, so mounting current source would silently break" \
+    "the suite (the #925 stale-image cascade). Resolve the cause above" \
+    "(network vs stale image), then re-run; for a stale image, push a" \
     "deps-touching change so CI takes the slow (full-build) path."
   exit 1
 fi
 
-echo "All service images fresh for fast path (fingerprint $expected)."
+echo "All service images fresh for fast path."

--- a/scripts/ci/deps-fingerprint.sh
+++ b/scripts/ci/deps-fingerprint.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Compute a stable "dependency fingerprint" for the service images (#925).
+#
+# The fast path (USE_PREBUILT_IMAGES=true USE_DEV_MOUNTS=true) mounts the current
+# source tree into pulled :latest images. That is only safe when the pulled image
+# already contains every dependency the current source imports. If a deps-changing
+# commit's image publish was skipped (e.g. a flake skipped the publish job), :latest
+# goes stale and the fast path mounts incompatible source -> the whole suite errors
+# with no obvious cause (the 2026-06-09 soxr cascade).
+#
+# This script hashes the files that determine what gets baked into a service image:
+#   - root workspace pyproject.toml
+#   - proto/pyproject.toml, lib/pyproject.toml (shared packages every image installs)
+#   - every services/*/pyproject.toml      (per-service dependencies)
+#   - every services/*/Dockerfile          (how deps are installed / which base image)
+#
+# The same value is:
+#   1. baked into each service image as the OCI label org.joustmania.deps-fingerprint
+#      at build time (build-arg DEPS_FINGERPRINT, see services/*/Dockerfile), and
+#   2. recomputed from the checkout by scripts/ci/check-image-freshness.sh, which
+#      reads the label back from the pulled image and compares.
+#
+# Determinism: files are sorted and hashed by content (filename + bytes), so the
+# value is independent of filesystem order and reproducible on any checkout.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$PROJECT_ROOT"
+
+# Collect the dependency-determining files (NUL-safe), sorted for determinism.
+mapfile -d '' -t files < <(
+  {
+    printf '%s\0' pyproject.toml
+    printf '%s\0' proto/pyproject.toml
+    printf '%s\0' lib/pyproject.toml
+    find services -maxdepth 2 \( -name pyproject.toml -o -name Dockerfile \) -print0
+  } | sort -z
+)
+
+# Hash filename + content of each file so a rename also changes the fingerprint.
+hash_stream() {
+  local f
+  for f in "${files[@]}"; do
+    [ -f "$f" ] || continue
+    printf '%s\0' "$f"
+    cat "$f"
+    printf '\0'
+  done
+}
+
+# sha256sum is available on CI runners and in the builder image.
+hash_stream | sha256sum | cut -c1-16

--- a/scripts/ci/deps-fingerprint.sh
+++ b/scripts/ci/deps-fingerprint.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Compute a stable "dependency fingerprint" for the service images (#925).
+# Compute a stable PER-SERVICE "dependency fingerprint" for a source-mounted
+# Python service image (#925).
 #
 # The fast path (USE_PREBUILT_IMAGES=true USE_DEV_MOUNTS=true) mounts the current
 # source tree into pulled :latest images. That is only safe when the pulled image
@@ -8,14 +9,38 @@
 # goes stale and the fast path mounts incompatible source -> the whole suite errors
 # with no obvious cause (the 2026-06-09 soxr cascade).
 #
-# This script hashes the files that determine what gets baked into a service image:
-#   - root workspace pyproject.toml
-#   - proto/pyproject.toml, lib/pyproject.toml (shared packages every image installs)
-#   - every services/*/pyproject.toml      (per-service dependencies)
-#   - every services/*/Dockerfile          (how deps are installed / which base image)
+# Usage:
+#   deps-fingerprint.sh <service>
+#     where <service> is one of the source-mounted Python services, e.g.
+#     menu, audio, controller_manager, game_coordinator, pairing_daemon.
+#
+# WHY PER-SERVICE (not one shared hash): the CI fast path rebuilds+republishes
+# each service's :latest only when ITS OWN path filter fires — the shared_python
+# anchor (root pyproject, proto/lib pyproject, images/builder/**) OR
+# services/<svc>/**. A single shared fingerprint over every service's files would
+# change when ANY service's deps change, even ones that weren't rebuilt, so the
+# guard would FALSE-fail on the unchanged images and wedge the fast path on main —
+# the exact failure this guard exists to prevent. A per-service fingerprint changes
+# exactly when THAT image must be rebuilt.
+#
+# This script hashes ONLY the files that determine what gets BAKED into the named
+# service image (NOT application .py source — the fast path mounts that fresh):
+#
+#   Shared deps inputs (baked into every service image via the builder + workspace):
+#     - root pyproject.toml          (workspace deps)
+#     - proto/pyproject.toml         (shared proto package deps)
+#     - lib/pyproject.toml           (shared lib package deps)
+#     - images/builder/**            (builder Dockerfile + requirements-common.txt;
+#                                     everything the shared builder bakes)
+#   This service's OWN deps inputs:
+#     - services/<svc>/pyproject.toml  (service dependencies)
+#     - services/<svc>/Dockerfile      (how deps are installed / base image)
+#
+# This mirrors the per-service rebuild condition (shared_python OR services/<svc>/**)
+# restricted to deps-determining files.
 #
 # The same value is:
-#   1. baked into each service image as the OCI label org.joustmania.deps-fingerprint
+#   1. baked into the service image as the OCI label org.joustmania.deps-fingerprint
 #      at build time (build-arg DEPS_FINGERPRINT, see services/*/Dockerfile), and
 #   2. recomputed from the checkout by scripts/ci/check-image-freshness.sh, which
 #      reads the label back from the pulled image and compares.
@@ -25,17 +50,28 @@
 
 set -euo pipefail
 
+SERVICE="${1:?usage: deps-fingerprint.sh <service> (e.g. menu, audio, controller_manager)}"
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 cd "$PROJECT_ROOT"
 
-# Collect the dependency-determining files (NUL-safe), sorted for determinism.
+if [ ! -d "services/$SERVICE" ]; then
+  echo "deps-fingerprint.sh: unknown service '$SERVICE' (no services/$SERVICE)" >&2
+  exit 2
+fi
+
+# Collect the dependency-determining files for THIS service (NUL-safe), sorted
+# for determinism. Shared deps inputs + this service's own pyproject/Dockerfile.
 mapfile -d '' -t files < <(
   {
     printf '%s\0' pyproject.toml
     printf '%s\0' proto/pyproject.toml
     printf '%s\0' lib/pyproject.toml
-    find services -maxdepth 2 \( -name pyproject.toml -o -name Dockerfile \) -print0
+    # Everything the shared builder bakes (Dockerfile + requirements-common.txt).
+    find images/builder -type f -print0
+    printf '%s\0' "services/$SERVICE/pyproject.toml"
+    printf '%s\0' "services/$SERVICE/Dockerfile"
   } | sort -z
 )
 

--- a/services/audio/Dockerfile
+++ b/services/audio/Dockerfile
@@ -76,6 +76,13 @@ RUN if [ "$TARGETARCH" = "arm64" ]; then \
 # only publishes the moving `latest` tag (no version-specific tags).
 FROM cgr.dev/chainguard/python:latest@sha256:678e879909418cd070927d0ba1ed018be98d43929db2457c37b9b9764703678c
 
+# Dependency fingerprint baked at build time so the integration fast path can
+# detect a stale :latest before mounting current source into it (#925).
+# Computed by scripts/ci/deps-fingerprint.sh; read back by
+# scripts/ci/check-image-freshness.sh. "dev" when built outside CI.
+ARG DEPS_FINGERPRINT=dev
+LABEL org.joustmania.deps-fingerprint="${DEPS_FINGERPRINT}"
+
 WORKDIR /app
 
 # Copy grpc-health-probe binary

--- a/services/controller_manager/Dockerfile
+++ b/services/controller_manager/Dockerfile
@@ -50,6 +50,13 @@ RUN uv pip install --system -e proto/ -e lib/ -e services/controller_manager/
 # =============================================================================
 FROM python:3.14-slim
 
+# Dependency fingerprint baked at build time so the integration fast path can
+# detect a stale :latest before mounting current source into it (#925).
+# Computed by scripts/ci/deps-fingerprint.sh; read back by
+# scripts/ci/check-image-freshness.sh. "dev" when built outside CI.
+ARG DEPS_FINGERPRINT=dev
+LABEL org.joustmania.deps-fingerprint="${DEPS_FINGERPRINT}"
+
 # Install runtime dependencies (bluetooth for PS Move controllers)
 # libhidapi-hidraw0: Required by bt_discovery for HID device enumeration
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/services/game_coordinator/Dockerfile
+++ b/services/game_coordinator/Dockerfile
@@ -43,6 +43,13 @@ RUN uv pip install --system -e proto/ -e lib/ -e services/game_coordinator/
 # free tier only publishes the moving `latest` tag (no version-specific tags).
 FROM cgr.dev/chainguard/python:latest@sha256:678e879909418cd070927d0ba1ed018be98d43929db2457c37b9b9764703678c
 
+# Dependency fingerprint baked at build time so the integration fast path can
+# detect a stale :latest before mounting current source into it (#925).
+# Computed by scripts/ci/deps-fingerprint.sh; read back by
+# scripts/ci/check-image-freshness.sh. "dev" when built outside CI.
+ARG DEPS_FINGERPRINT=dev
+LABEL org.joustmania.deps-fingerprint="${DEPS_FINGERPRINT}"
+
 WORKDIR /app
 
 # Copy grpc-health-probe for health checks

--- a/services/menu/Dockerfile
+++ b/services/menu/Dockerfile
@@ -43,6 +43,13 @@ RUN uv pip install --system -e proto/ -e lib/ -e services/menu/
 # free tier only publishes the moving `latest` tag (no version-specific tags).
 FROM cgr.dev/chainguard/python:latest@sha256:678e879909418cd070927d0ba1ed018be98d43929db2457c37b9b9764703678c
 
+# Dependency fingerprint baked at build time so the integration fast path can
+# detect a stale :latest before mounting current source into it (#925).
+# Computed by scripts/ci/deps-fingerprint.sh; read back by
+# scripts/ci/check-image-freshness.sh. "dev" when built outside CI.
+ARG DEPS_FINGERPRINT=dev
+LABEL org.joustmania.deps-fingerprint="${DEPS_FINGERPRINT}"
+
 WORKDIR /app
 
 # Copy grpc-health-probe for health checks

--- a/services/pairing_daemon/Dockerfile
+++ b/services/pairing_daemon/Dockerfile
@@ -54,6 +54,13 @@ RUN uv pip install --system --no-cache-dir -e lib/ -e proto/ -e services/pairing
 # =============================================================================
 FROM python:3.14-slim
 
+# Dependency fingerprint baked at build time so the integration fast path can
+# detect a stale :latest before mounting current source into it (#925).
+# Computed by scripts/ci/deps-fingerprint.sh; read back by
+# scripts/ci/check-image-freshness.sh. "dev" when built outside CI.
+ARG DEPS_FINGERPRINT=dev
+LABEL org.joustmania.deps-fingerprint="${DEPS_FINGERPRINT}"
+
 # Install runtime dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
     bluez \

--- a/tests/integration/pyproject.toml
+++ b/tests/integration/pyproject.toml
@@ -11,6 +11,10 @@ dependencies = [
     "pytest>=7.0.0",
     "pytest-asyncio>=0.23.0",
     "pytest-cov>=4.0.0",
+    # Generic single-flake tolerance: CI runs the integration suite with
+    # "--reruns 1" so one flake no longer skips image publish (the #925
+    # stale-image cascade). Reruns ANY failure once; does not quarantine by name.
+    "pytest-rerunfailures>=14.0",
 
     # Testcontainers for spinning up docker-compose
     "testcontainers>=4.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -506,6 +506,7 @@ dependencies = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "pytest-rerunfailures" },
     { name = "testcontainers" },
 ]
 
@@ -518,6 +519,7 @@ requires-dist = [
     { name = "pytest", specifier = ">=7.0.0" },
     { name = "pytest-asyncio", specifier = ">=0.23.0" },
     { name = "pytest-cov", specifier = ">=4.0.0" },
+    { name = "pytest-rerunfailures", specifier = ">=14.0" },
     { name = "testcontainers", specifier = ">=4.0.0" },
 ]
 
@@ -1154,6 +1156,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "pytest-rerunfailures"
+version = "16.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/f0/74f8e685be7ecd1572c1256132f18fce3a665d7e07649a3f23b7eb2d3bec/pytest_rerunfailures-16.3.tar.gz", hash = "sha256:37c9b1231c8083e9f4e724f50f7a21241822f9516c15c700ebbf218d6452355c", size = 34148, upload-time = "2026-05-22T06:51:22.292Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/98/58a71d68d3126d7f6a6ed1944c37ec207a4ff3dc66cad3bed7b59d38df61/pytest_rerunfailures-16.3-py3-none-any.whl", hash = "sha256:6bdfb8ffb46c46072e6c16bdedee38b6c13eac620d9415ed5b63152cbf283170", size = 15396, upload-time = "2026-05-22T06:51:20.547Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Part of #925.

## Problem
Image-publish jobs use `needs: [integration-test]`, so a flake on a deps-changing commit skips the publish → `:latest` goes stale. The next test-only commit takes the fast path (`USE_PREBUILT_IMAGES=true USE_DEV_MOUNTS=true`), mounts current source into the stale image, and **all 18 integration tests error on main** with no obvious cause — re-running HEAD can never fix it (the 2026-06-09 soxr cascade).

This implements **Option 3 (primary) + Option 1 (safety net)** from the issue. Option 2 (big restructure) is intentionally not done.

## Option 3 — fast-path freshness guard (keystone)
Turns the silent cascade into a one-line failure *before* any test runs.

- `scripts/ci/deps-fingerprint.sh` — stable 16-char hash of the files that determine what each service image bakes: root/`proto`/`lib`/per-service `pyproject.toml` + every `services/*/Dockerfile`. Deterministic (content + filename, sorted).
- `ci.yml` computes the fingerprint once in the `changes` job (`deps_fingerprint` output) and passes it to `docker-build` as build-arg `DEPS_FINGERPRINT`. Each of the 5 Python service Dockerfiles bakes it as the OCI label `org.joustmania.deps-fingerprint` (`ARG DEPS_FINGERPRINT=dev` → `LABEL ...`).
- `scripts/ci/check-image-freshness.sh` runs as a guard step before the fast path (same `if` as the fast-path step). It pulls each service image (the fast path pulls them anyway) and reads the label via `docker image inspect`, comparing to the checkout. On mismatch:

  > `pulled audio-service:latest predates current deps fingerprint X≠Y — image stale, fast-path unsafe; needs full build.`

  and exits non-zero. **No-op when fresh.** Missing label (pre-guard / never-published image) is also treated as unsafe.

The guard covers exactly the 5 images the dev overlay source-mounts (controller-manager, game-coordinator, menu, audio, pairing-daemon). Infra images are digest/version-pinned and never source-mounted, so they cannot go stale.

## Option 1 — single-flake tolerance (safety net)
- Added `pytest-rerunfailures` and run the integration suite with `--reruns 1` via a generic `PYTEST_EXTRA` passthrough in `make test-integration`. One flake no longer skips publish.
- **Generic**: reruns ANY failure once, never quarantines a test by name. `#805`/`#926` are handled separately.
- A *persistent* failure still fails (only reruns once); a genuinely stale image fails fast at the guard before any reruns.

## Bootstrapping note
This PR edits all 5 service Dockerfiles, so its own merge takes the slow (full-build) path and republishes all 5 `:latest` images **with** the label. From then on the guard has a labeled baseline to compare against.

## Validation
- `python3` YAML load + duplicate-key check on `ci.yml`: clean.
- `make lint`: All checks passed. `make format-check`: 255 files already formatted.
- `uv lock`: resolves with `pytest-rerunfailures`.
- hadolint on the 5 modified Dockerfiles: only the pre-existing `cgr.dev` DL3026 baseline (unrelated to the added `LABEL`).
- Guard logic tested via stubbed `docker`: fresh→exit 0 (no-op), stale→exit 1 (one-line diagnosis), missing-label/pull-fail→exit 1.
- Verified `--build-arg DEPS_FINGERPRINT` → `LABEL org.joustmania.deps-fingerprint` bakes and is read back with the same key via `docker image inspect`.

## Trade-off the reviewer should know
Published service images are **multi-platform manifest lists**; on an index, `buildx imagetools inspect --format .Image.Config.Labels` is a per-digest map and doesn't resolve to one config. The guard therefore `docker pull`s (single runner-arch) and uses `docker image inspect`, which resolves the concrete per-arch label reliably. The fast path pulls these images anyway, so this only warms the cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)