### PR TITLE
fix(controller-manager): suppress reserved controllers on button-event path (#805)

### DIFF
--- a/services/controller_manager/button_detector.py
+++ b/services/controller_manager/button_detector.py
@@ -185,8 +185,19 @@ class ButtonDetector:
                 f"Button event {serial}: T={trigger} M={move} X={cross} O={circle} []={square} /\\={triangle} PS={ps}"
             )
 
-        # Publish events to all subscribers
-        if events:
+        # Publish events to all subscribers — but never announce reserved
+        # controllers to button-stream consumers (the menu). #784 suppressed
+        # reserved controllers from connect/disconnect events and the
+        # connected_serials roster, but left this regular button-event path
+        # un-filtered. That asymmetry let a reserved controller's button press
+        # auto-register it in the menu's connected set (StateManager registers
+        # any controller it receives a button for), while the reconcile path —
+        # driven by the reserved-free roster — could prune it again. The
+        # resulting nondeterministic connected/ready mismatch broke
+        # all_ready() (ready_count == connected_count) and intermittently
+        # prevented game start (#805). Reserved controllers stay fully usable
+        # via the gameplay-data stream and explicit-serial commands.
+        if events and not info.get(ControllerInfoKey.RESERVED, False):
             for event in events:
                 self.event_publisher.publish_to_subscribers(self._subscribers, event, "button")
 

--- a/services/controller_manager/tests/test_button_detector.py
+++ b/services/controller_manager/tests/test_button_detector.py
@@ -7,7 +7,7 @@ Tests button state transition detection and event publishing.
 import asyncio
 from unittest.mock import MagicMock, patch
 
-from lib.controller_constants import ButtonKey, ButtonTrackingKey
+from lib.controller_constants import ButtonKey, ButtonTrackingKey, ControllerInfoKey
 from proto import controller_manager_pb2
 from services.controller_manager.button_detector import ButtonDetector
 from services.controller_manager.event_publisher import EventPublisher
@@ -381,3 +381,74 @@ class TestMultipleControllers:
 
         assert "SERIAL1" not in detector.button_states
         assert "SERIAL2" in detector.button_states
+
+
+class TestReservedControllerSuppression:
+    """Regression tests for #805 / #784.
+
+    #784 hid reserved controllers from the menu on the connect/disconnect
+    event path and from the connected_serials roster, but left the regular
+    button-event path un-filtered. Because the menu auto-registers any
+    controller it receives a button for, a reserved controller's button press
+    leaked it into the menu's connected set, while the reconcile path (driven
+    by the reserved-free roster) could prune it — a nondeterministic
+    connected/ready mismatch that intermittently blocked game start (#805).
+
+    Reserved controllers must therefore be suppressed on EVERY button-stream
+    path, including ordinary button presses.
+    """
+
+    @staticmethod
+    def _tracked(serial: str, reserved: bool) -> dict:
+        return {serial: {ControllerInfoKey.SERIAL: serial, ControllerInfoKey.RESERVED: reserved}}
+
+    @patch("services.controller_manager.button_detector.metrics")
+    def test_reserved_controller_button_press_not_published(self, _mock_metrics):
+        """A reserved controller's button press is never sent to subscribers."""
+        publisher = MagicMock(spec=EventPublisher)
+        detector = ButtonDetector(publisher)
+        detector._subscribers = {"sub1": MagicMock()}
+
+        tracked = self._tracked("RESERVED1", reserved=True)
+
+        # First poll initializes state (no transition yet).
+        detector.detect_transitions_from_state("RESERVED1", {ButtonKey.TRIGGER: False}, tracked)
+        publisher.reset_mock()
+
+        # Trigger press transition — would normally publish, but must be
+        # suppressed for a reserved controller.
+        detector.detect_transitions_from_state("RESERVED1", {ButtonKey.TRIGGER: True}, tracked)
+
+        assert not publisher.publish_to_subscribers.called
+
+    @patch("services.controller_manager.button_detector.metrics")
+    def test_unreserved_controller_button_press_still_published(self, _mock_metrics):
+        """A normal (non-reserved) controller's button press is still published."""
+        publisher = MagicMock(spec=EventPublisher)
+        detector = ButtonDetector(publisher)
+        detector._subscribers = {"sub1": MagicMock()}
+
+        tracked = self._tracked("VISIBLE1", reserved=False)
+
+        detector.detect_transitions_from_state("VISIBLE1", {ButtonKey.TRIGGER: False}, tracked)
+        publisher.reset_mock()
+        detector.detect_transitions_from_state("VISIBLE1", {ButtonKey.TRIGGER: True}, tracked)
+
+        assert publisher.publish_to_subscribers.called
+        event = publisher.publish_to_subscribers.call_args[0][1]
+        assert event.serial == "VISIBLE1"
+        assert event.action == controller_manager_pb2.ACTION_PRESS
+
+    @patch("services.controller_manager.button_detector.metrics")
+    def test_missing_reserved_metadata_defaults_to_published(self, _mock_metrics):
+        """Absent reserved metadata is treated as visible (backward compatible)."""
+        publisher = MagicMock(spec=EventPublisher)
+        detector = ButtonDetector(publisher)
+        detector._subscribers = {"sub1": MagicMock()}
+
+        # No reservation info at all (e.g. older info dicts / empty tracking).
+        detector.detect_transitions_from_state("LEGACY1", {ButtonKey.TRIGGER: False}, {})
+        publisher.reset_mock()
+        detector.detect_transitions_from_state("LEGACY1", {ButtonKey.TRIGGER: True}, {})
+
+        assert publisher.publish_to_subscribers.called

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -325,7 +325,15 @@ async def get_controller_client(docker_compose):
 
 
 async def get_mock_controller_serials(docker_compose) -> list[str]:
-    """Get list of mock controller serials via ListMockControllers."""
+    """Get list of *menu-visible* (non-reserved) mock controller serials.
+
+    Reserved controllers (#784) are hidden from the menu and must never be
+    treated as lobby controllers by menu-flow helpers — counting or readying
+    a reserved serial through the menu path is exactly what caused #805. The
+    detailed ``controllers`` list carries the reserved flag, so filter on it
+    and fall back to the flat ``serials`` only when no detail is available
+    (older servers / backward compatibility).
+    """
     host = docker_compose.get_service_host("controller-manager", 50062)
     port = docker_compose.get_service_port("controller-manager", 50062)
     channel = grpc.aio.insecure_channel(f"{host}:{port}")
@@ -336,6 +344,8 @@ async def get_mock_controller_serials(docker_compose) -> list[str]:
     )
     await channel.close()
 
+    if response.controllers:
+        return [c.serial for c in response.controllers if not c.reserved]
     return list(response.serials)
 
 
@@ -372,20 +382,30 @@ async def setup_mock_controllers(
         existing = await mock_client.ListMockControllers(
             controller_manager_mock_pb2.ListRequest()
         )
-        if existing.count >= count:
+        # Only reuse *non-reserved* controllers. Reserved controllers (#784)
+        # are hidden from the menu, so counting them toward the lobby roster
+        # (or returning their serials) hands the menu-flow helpers serials the
+        # menu can never see ready — the root cause of #805. When detailed
+        # controller info is unavailable, fall back to the flat serial list.
+        if existing.controllers:
+            unreserved = [c.serial for c in existing.controllers if not c.reserved]
+        else:
+            unreserved = list(existing.serials)
+
+        if len(unreserved) >= count:
             await channel.close()
-            return list(existing.serials[:count])
+            return unreserved[:count]
 
         # Add the needed controllers
-        needed = count - existing.count
+        needed = count - len(unreserved)
         response = await mock_client.AddControllers(
             controller_manager_mock_pb2.AddControllersRequest(count=needed)
         )
         assert response.success, f"Failed to add controllers: {response.error}"
         await channel.close()
 
-        # Return all serials (existing + newly added)
-        all_serials = list(existing.serials) + list(response.serials)
+        # Return all serials (existing unreserved + newly added)
+        all_serials = unreserved + list(response.serials)
         return all_serials[:count]
 
     response = await mock_client.AddControllers(


### PR DESCRIPTION
## Summary

Fixes the intermittent `game_started` timeout in `test_full_game_lifecycle[JoustFFA]` (#805) — distinct from the death-detection flake #757.

**Root cause (CONFIRMED):** #784 (#777) hid reserved mock controllers from the menu on the connect/disconnect event path and excluded them from the `connected_serials` roster, but left the **regular button-event path un-filtered**. The menu's `StateManager.handle_button_event` auto-registers *any* controller it receives a button for (`-> on_controller_connected`). So a reserved controller's button press leaked it into the menu's connected set, while the reconcile path — driven by the reserved-free roster (`visible_serials`) — could prune it again. That nondeterministic connected/ready mismatch broke `all_ready()` (which requires `ready_count == connected_count`) and intermittently prevented game start.

The asymmetry is the bug: #784 suppressed reserved controllers on connection events but not on ordinary button events — the one button-stream path that can still register a controller in the menu.

## Fix

- **`button_detector.py`**: never publish button events for reserved controllers, closing the last leak path. The menu now never learns of a reserved controller through any button-stream route. Reserved controllers remain fully usable via the gameplay-data stream and explicit-serial commands (unchanged from #784's intent).
- **`tests/integration/helpers.py`**: `get_mock_controller_serials()` and `setup_mock_controllers()` filter reserved controllers via the `ListResponse.controllers` detail (added in #784), so menu-flow helpers never count or ready a reserved serial leaked from a prior/parallel test. Backward compatible: falls back to the flat serial list when no detail is present.

## Regression test

`TestReservedControllerSuppression` in `test_button_detector.py`:
- a reserved controller's button press is **not** published,
- a non-reserved one's press **is** published,
- absent reserved metadata defaults to visible (backward compatible).

This fails on the pre-fix code (reserved press was published) and passes after.

## Validation

- `controller_manager`: **646 passed** (3 new)
- `menu`: **358 passed**
- `make lint`: clean
- Integration `test_full_game_lifecycle` + `test_parallel_lifecycle` (the reserved-leak cross-test condition) green across repeated dev-mount runs.

Part of #805. Cause: #784.

🤖 Generated with [Claude Code](https://claude.com/claude-code)