### PR TITLE
feat(agent): intervention-effect before/after fitness measurement (#918)

### DIFF
--- a/services/agent/README.md
+++ b/services/agent/README.md
@@ -812,6 +812,49 @@ Keys for an objective whose signals were missing that cycle are simply absent
 (the function was skipped, not fabricated). chaos has no fitness function and so
 no keys.
 
+### Intervention-effect feedback (#918) — the game-path measurement loop
+
+Outbound attribution (above) records the agent's *reasoning*; it does not measure
+whether an intervention **helped**. The infra path has a closed loop (Bluetooth
+fitness → rollback); the game path had nothing. #918 closes the **measurement** half
+(it is measurement only — it never reverts a bad intervention):
+
+1. **At dispatch** (the applied-decision path in `runDecision`) the loop stamps a
+   **baseline** of the game's fitness/objective signals — the same dotted-key
+   quantities `fitness.evaluated` carries — and tags it with a dispatch-unique
+   `decision.intervention_id` (also stamped on the `agent.decision` span, so a Jaeger
+   query joins *what the agent did* to *what happened next*).
+2. **After a follow-up window** (`DefaultEffectWindow` = 20 s, env-tunable via
+   `AGENT_EFFECT_WINDOW_SECONDS`) a per-game sampler re-reads the **same** game's
+   signals (through the same `ContextProvider` the #917 async path uses, so per-game
+   isolation holds) and recomputes the **same** fitness functions with the
+   dispatch-time thresholds.
+3. It emits an **effect record** attributed to the intervention id:
+
+   - **Span** `agent.intervention.effect`: one backdated root (to dispatch time) per
+     dispatched intervention, parenting one child span per evaluated fitness signal.
+     Attributes: `intervention.id`, `intervention.type`, `intervention.objective`,
+     `intervention.signal`, `intervention.fitness_baseline`,
+     `intervention.fitness_followup`, `intervention.fitness_delta`,
+     `intervention.window_seconds`, and `intervention.effect_aborted=true` when the
+     follow-up could not be measured (game ended/evicted before the window, or a
+     signal disappeared).
+   - **Metric** `agent_intervention_effect_delta` (`Float64Histogram`, unit `1`): the
+     `follow_up − baseline` change, labeled `intervention.type`,
+     `intervention.objective`, `intervention.signal`. No point is recorded for an
+     aborted follow-up.
+
+   The M5 intervention dashboard (#791/#792) plots the intervention → effect pairs, and
+   the #844 retro prompt reads per-intervention effect evidence; both consume this
+   span + metric.
+
+**Lifecycle safety (#923 goleak):** each follow-up runs in a goroutine tracked on a
+`WaitGroup` (joined by `AwaitInflight` at shutdown) and bounded by the agent root
+context. It selects on the follow-up timer **and** `rootCtx.Done()`: on shutdown it
+stops the timer and returns without emitting; the in-flight pending set is capped
+(`maxPendingEffects`) so a burst of dispatches cannot launch unbounded goroutines.
+Measurement is best-effort and never on the hot decision path.
+
 ### Semantic conventions
 
 OTel semantic conventions ([semconv v1.34.0](https://pkg.go.dev/go.opentelemetry.io/otel/semconv/v1.34.0))

--- a/services/agent/decision/async_infer.go
+++ b/services/agent/decision/async_infer.go
@@ -135,7 +135,13 @@ func (l *Loop) SetRootContext(ctx context.Context) { l.rootCtx = ctx }
 // goroutine outlives the process; tests call it to make the async result land
 // deterministically before asserting (no real sleeps). It is safe to call when
 // nothing is in flight (returns immediately).
-func (l *Loop) AwaitInflight() { l.inferWG.Wait() }
+func (l *Loop) AwaitInflight() {
+	l.inferWG.Wait()
+	// Also join the #918 intervention-effect follow-up samplers: they are the loop's
+	// other background goroutines and must not outlive the process (goleak, #923). Their
+	// timers are bounded by rootCtx, so a shutdown-cancelled sample returns promptly.
+	l.effectWG.Wait()
+}
 
 // asyncEnabled reports whether this loop is wired for async inference (#917): a
 // context provider must be present (the re-validation source). Without it the loop

--- a/services/agent/decision/decision.go
+++ b/services/agent/decision/decision.go
@@ -242,6 +242,14 @@ type Loop struct {
 	// #739 path, so a Loop not wired for async is behavior-unchanged.
 	asyncInferState
 
+	// effectSampler is the per-Loop intervention-effect MEASUREMENT machinery (#918):
+	// the follow-up window, the in-flight wait group, the bounded pending set, the
+	// effect-delta metric, and the timer test seam. Embedded so the effect surface lives
+	// in one place (see effect.go). It reuses asyncInferState's ctxProvider/rootCtx/gameID
+	// to re-read the game's CURRENT signals at +window. Inert without a context provider,
+	// so a Loop not wired for effect measurement is behavior-unchanged.
+	effectSampler
+
 	// contextWindow is the SHARED M7-2 rolling cross-game context source (#929),
 	// injected via SetContextWindow from the one gamewindow.Store main.go constructs
 	// (global cross-session memory, like budget/resolver). On a gate-admitted llm
@@ -294,6 +302,9 @@ func NewLoop(flagSource FlagSource, log *slog.Logger) *Loop {
 		now:      time.Now,
 		throttle: DefaultThrottleInterval,
 		llmGated: defaultLLMGatedCounter(),
+		effectSampler: effectSampler{
+			effectDelta: defaultEffectDeltaHistogram(),
+		},
 	}
 }
 
@@ -816,6 +827,23 @@ func (l *Loop) runDecision(ctx context.Context, snapshot flags.Snapshot, c gamec
 	}
 
 	state.recordDispatched(d, cost)
+	// Intervention-effect MEASUREMENT (#918): stamp a baseline of this game's
+	// fitness/objective signals NOW (the same fitness.evaluated quantities the decision
+	// span carries) and schedule a follow-up sample after the window to measure the
+	// delta, attributed to a dispatch-unique intervention id. This closes the game-path
+	// measurement loop the infra path already has (fitness->rollback). It is MEASUREMENT
+	// ONLY — it never reverts the intervention. Scheduled only for DISPATCHED decisions
+	// (a blocked one never moved the game). The id is stamped on this decision span so a
+	// Jaeger query joins decision->effect; "" means no sample was scheduled (effect
+	// measurement un-wired, no baseline signals this cycle, or the pending cap reached) —
+	// then the decision span simply carries no effect id. Reuses state.FitnessEvaluated,
+	// which OnEvaluate lifted from this cycle's engine evaluation, and the live
+	// thresholds from this cycle's snapshot, so baseline and follow-up sample the SAME
+	// fitness functions against the SAME thresholds. Off the hot path: a cheap map copy
+	// plus a goroutine + timer (bounded, leak-safe via effectWG + rootCtx).
+	if id := l.scheduleEffectSample(d, state.FitnessEvaluated, fitnessThresholds(snapshot.Fitness)); id != "" {
+		dSpan.SetAttributes(attribute.String(AttrDecisionInterventionID, id))
+	}
 	// Feed the DISPATCHED outcome into this game's #916 rolling narrative timeline
 	// (#945): recorded BEFORE the action sink applies it (it passed every gate, so it
 	// IS dispatched regardless of a downstream apply error — the timeline tracks the

--- a/services/agent/decision/effect.go
+++ b/services/agent/decision/effect.go
@@ -1,0 +1,345 @@
+package decision
+
+import (
+	"context"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"go.opentelemetry.io/otel/attribute"
+	otelmetric "go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// newInterventionID returns a fresh dispatch-unique id used to tie an intervention's
+// effect record to the decision that produced it (#918). A UUID v4 hex string —
+// opaque, collision-resistant across agent restarts, never compared for ordering.
+func newInterventionID() string { return uuid.NewString() }
+
+// effect.go closes the game-path intervention-effect MEASUREMENT loop (#918). The
+// agent attributes a decision's reasoning OUTBOUND (objectives / LayerState onto the
+// decision span, #729), but until now it never measured whether the intervention
+// HELPED: the infra path has fitness->rollback (#828), the game path had nothing.
+//
+// THE LOOP (measurement only — it never reverts an intervention):
+//
+//  1. At dispatch (runDecision, the applied-decision path) the loop STAMPS a baseline
+//     of the game's fitness/objective signals — the SAME dotted-key quantities the
+//     decision span carries as fitness.evaluated — tagged with a dispatch-unique
+//     intervention id.
+//  2. After a follow-up window (DefaultEffectWindow, env-tunable) the sampler reads the
+//     SAME signals for the SAME game again and computes the per-objective DELTA.
+//  3. It emits an effect record attributed to the intervention id: an
+//     agent.intervention.effect span (per evaluated objective) AND an
+//     agent_intervention_effect_delta metric, both carrying baseline/follow-up/delta +
+//     window, so the M5 dashboard (#791/#792) and the #844 retro can consume it.
+//
+// LEAK-FREENESS / LIFECYCLE SAFETY (#923 goleak): every scheduled follow-up runs in a
+// goroutine tracked on effectWG and bounded by rootCtx. The goroutine selects on the
+// follow-up timer AND rootCtx.Done(); on shutdown (rootCtx cancelled) or when the
+// game's partition is gone at follow-up time it emits a clearly-marked ABORTED record
+// (or, on shutdown, simply returns) — it never blocks shutdown and never leaks a timer
+// (the timer is always stopped). AwaitInflight joins effectWG alongside the #917
+// inference goroutines.
+//
+// PER-GAME ISOLATION (#845): the sampler re-reads the game's CURRENT signals through
+// the SAME ContextProvider (MuxContextProvider) the #917 async path uses, keyed by THIS
+// loop's gameID — so an effect sample for game A reads game A's signals only.
+//
+// BOUNDED MEMORY: the in-flight pending-effect set is capped (maxPendingEffects). When
+// the cap is reached a dispatch records no baseline (the decision still dispatches
+// normally — measurement is best-effort, never on the hot decision path's critical
+// route). The set is drained as samples complete and emptied when the loop is dropped.
+
+// DefaultEffectWindow is the follow-up window: how long after an intervention is
+// dispatched the loop samples the game's fitness signals again to measure the effect
+// (#918). 20s sits in the issue's 15-30s band — long enough for an intervention
+// (shield, sensitivity nudge, audio cue) to move the objective signals, short enough to
+// still attribute the change to that intervention. Override at startup with
+// AGENT_EFFECT_WINDOW_SECONDS (see SetEffectWindow / main.go).
+const DefaultEffectWindow = 20 * time.Second
+
+// maxPendingEffects bounds the in-flight follow-up samples PER LOOP (per game) so a
+// burst of dispatched interventions cannot launch unbounded goroutines/timers. At the
+// per-game weighted rate limit (max_interventions_per_minute) a 20s window holds only a
+// handful of samples in flight; 64 is comfortably above that while still a hard ceiling.
+const maxPendingEffects = 64
+
+// effectSampler is the per-Loop intervention-effect machinery (#918), embedded in Loop
+// like asyncInferState. It owns the follow-up window, the in-flight goroutine tracking,
+// the bounded pending set, the effect metric, and the test seams (now / afterFunc).
+type effectSampler struct {
+	// window is the follow-up delay; zero means DefaultEffectWindow. Set by
+	// SetEffectWindow at construction.
+	window time.Duration
+	// effectWG tracks every in-flight follow-up goroutine so AwaitInflight can join
+	// them at shutdown (no leak) and tests can wait for a sample to land deterministically.
+	effectWG sync.WaitGroup
+	// pendingMu guards pending; the concurrent trace+metrics Export handlers both drive
+	// runDecision and so both schedule samples.
+	pendingMu sync.Mutex
+	// pending counts in-flight follow-up samples for THIS loop (bounded by
+	// maxPendingEffects). A scheduled sample increments it; the goroutine decrements it
+	// when it completes. Never goes negative.
+	pending int
+	// effectDelta records agent_intervention_effect_delta. Never nil (NewLoop seeds a
+	// no-op), so the record path is always safe.
+	effectDelta otelmetric.Float64Histogram
+	// afterFunc schedules fn to run after d, returning a stop function. It is the test
+	// seam for the follow-up timer: production uses realAfterFunc (a context-cancellable
+	// time.Timer); tests inject a manual scheduler to fire the window deterministically
+	// with no real sleep. Nil means realAfterFunc.
+	afterFunc func(d time.Duration, fn func()) (stop func() bool)
+}
+
+// SetEffectWindow overrides the follow-up window (#918). A non-positive value leaves
+// DefaultEffectWindow in place. main.go reads AGENT_EFFECT_WINDOW_SECONDS and passes it
+// here. Set at construction, before the loop serves; not safe to call concurrently with
+// OnEvaluate.
+func (l *Loop) SetEffectWindow(d time.Duration) {
+	if d <= 0 {
+		return
+	}
+	l.window = d
+}
+
+// effectWindow returns the configured follow-up window, defaulting to
+// DefaultEffectWindow when unset.
+func (l *Loop) effectWindow() time.Duration {
+	if l.window <= 0 {
+		return DefaultEffectWindow
+	}
+	return l.window
+}
+
+// AwaitEffects blocks until every in-flight follow-up sample for this loop has
+// completed (#918), mirroring AwaitInflight for the #917 inference goroutines. Tests
+// call it to make a follow-up land deterministically before asserting; shutdown joins
+// it via AwaitInflight. Safe to call when nothing is pending (returns immediately).
+func (l *Loop) AwaitEffects() { l.effectWG.Wait() }
+
+// scheduleEffectSample stamps the baseline fitness signals for a just-DISPATCHED
+// intervention and schedules a follow-up sample after the window (#918). It is called
+// from runDecision on the applied-decision path ONLY (blocked decisions never moved the
+// game, so there is nothing to measure). It returns the dispatch-unique intervention id
+// so the decision span can carry it (joining decision->effect in Jaeger), or "" when no
+// sample was scheduled (effect measurement not wired, no baseline signals, or the
+// pending cap reached) — the caller treats "" as "no effect id to stamp".
+//
+// It NEVER blocks the hot decision path: the baseline is a cheap map copy and the
+// follow-up runs in its own goroutine. Without a context provider (the re-validation
+// source, same as the #917 async path) there is no way to read the game's future
+// signals, so it no-ops — an un-wired Loop is behavior-unchanged.
+func (l *Loop) scheduleEffectSample(d Decision, baselineVals map[string]float64, thresholds FitnessThresholds) string {
+	// No re-validation source => cannot read the future context => nothing to measure.
+	if l.ctxProvider == nil {
+		return ""
+	}
+	if len(baselineVals) == 0 {
+		// The cycle evaluated no fitness signals (e.g. the engine had no signals, or a
+		// Probe/Noop engine): there is no baseline to compare against, so skip — emitting
+		// an all-zero delta would be misleading, not measurement.
+		return ""
+	}
+
+	// Bound the in-flight set so a burst of dispatches cannot launch unbounded
+	// goroutines/timers. Over the cap we skip scheduling (the dispatch itself still
+	// happens; only the measurement is dropped, best-effort by design).
+	l.pendingMu.Lock()
+	if l.pending >= maxPendingEffects {
+		l.pendingMu.Unlock()
+		return ""
+	}
+	l.pending++
+	l.pendingMu.Unlock()
+
+	now := l.now
+	if now == nil {
+		now = time.Now
+	}
+	id := newInterventionID()
+	dispatchedAt := now()
+	objective := d.ObjectiveServed
+	if objective == "" {
+		objective = DefaultObjectives
+	}
+
+	// Defensive copy: the baseline is read by the follow-up goroutine seconds later, so
+	// it must not alias a map the caller may reuse/mutate on a later cycle.
+	baseline := make(map[string]float64, len(baselineVals))
+	for k, v := range baselineVals {
+		baseline[k] = v
+	}
+
+	root := l.rootCtx
+	if root == nil {
+		root = context.Background()
+	}
+	window := l.effectWindow()
+
+	sample := pendingEffect{
+		id:           id,
+		intervention: d.Intervention,
+		objective:    objective,
+		baseline:     baseline,
+		thresholds:   thresholds,
+		dispatchedAt: dispatchedAt,
+		window:       window,
+	}
+
+	l.effectWG.Add(1)
+	fired := make(chan struct{})
+
+	after := l.afterFunc
+	if after == nil {
+		after = realAfterFunc(root)
+	}
+	stop := after(window, func() { close(fired) })
+
+	go func() {
+		defer l.effectWG.Done()
+		defer l.releasePending()
+		select {
+		case <-root.Done():
+			// Shutdown / loop dropped before the window elapsed. Stop the timer (no leak)
+			// and emit nothing: a measurement we never took is not a result. The decision
+			// itself was already audited on its own trace.
+			stop()
+			return
+		case <-fired:
+			l.emitEffectSample(root, sample)
+		}
+	}()
+	return id
+}
+
+// releasePending decrements the in-flight pending counter, floored at zero.
+func (l *Loop) releasePending() {
+	l.pendingMu.Lock()
+	if l.pending > 0 {
+		l.pending--
+	}
+	l.pendingMu.Unlock()
+}
+
+// pendingEffect is one scheduled follow-up sample's captured state (#918): the baseline
+// signals stamped at dispatch, the thresholds to recompute the SAME fitness functions
+// against the follow-up context, and the attribution (id / intervention / objective).
+type pendingEffect struct {
+	id           string
+	intervention string
+	objective    string
+	baseline     map[string]float64
+	thresholds   FitnessThresholds
+	dispatchedAt time.Time
+	window       time.Duration
+}
+
+// emitEffectSample is the follow-up half (#918): it re-reads the game's CURRENT signals
+// through the ContextProvider (same per-game source the #917 async path uses), recomputes
+// the SAME fitness functions with the dispatch-time thresholds, computes the per-signal
+// delta, and emits the agent.intervention.effect span(s) + agent_intervention_effect_delta
+// metric. If the partition is gone (game ended/evicted before the window elapsed) it emits
+// a single ABORTED record — clearly marked, no delta, no metric — so the cancellation is
+// visible rather than silent.
+func (l *Loop) emitEffectSample(ctx context.Context, s pendingEffect) {
+	current, ok := l.ctxProvider.Current(l.gameID)
+	windowSeconds := s.window.Seconds()
+
+	// One backdated root span (to dispatch time) parents the per-objective effect spans,
+	// so a Jaeger trace shows the dispatch->follow-up arc, mirroring the #917 apply root.
+	rootCtx, root := l.Tracer.Start(ctx, SpanInterventionEffect,
+		trace.WithTimestamp(s.dispatchedAt),
+		trace.WithSpanKind(trace.SpanKindInternal),
+		trace.WithAttributes(
+			attribute.String(AttrSessionID, l.gameID),
+			attribute.String(AttrGameID, l.gameID),
+			attribute.String(AttrEffectInterventionID, s.id),
+			attribute.String(AttrEffectIntervention, s.intervention),
+			attribute.String(AttrEffectObjective, s.objective),
+			attribute.Float64(AttrEffectWindowSeconds, windowSeconds),
+		),
+	)
+	defer root.End()
+
+	if !ok {
+		// Game ended / partition evicted before the window elapsed (#918 cancellation):
+		// there is no current context to sample, so the effect is unmeasurable. Mark it
+		// aborted on the root and emit nothing further — no fabricated delta, no metric.
+		root.SetAttributes(attribute.Bool(AttrEffectAborted, true))
+		return
+	}
+
+	followUp := EvaluateFitness(current, s.thresholds).Evaluated()
+
+	// Walk the baseline signal vocabulary in a stable order so the spans/metric are
+	// deterministic. Each signal that is still present at follow-up gets a delta; a
+	// signal that disappeared (the objective stopped evaluating) is recorded aborted.
+	for _, key := range sortedKeys(s.baseline) {
+		base := s.baseline[key]
+		fu, present := followUp[key]
+		_, span := l.Tracer.Start(rootCtx, SpanInterventionEffect,
+			trace.WithSpanKind(trace.SpanKindInternal),
+			trace.WithAttributes(
+				attribute.String(AttrEffectInterventionID, s.id),
+				attribute.String(AttrEffectIntervention, s.intervention),
+				attribute.String(AttrEffectObjective, s.objective),
+				attribute.String(AttrEffectSignal, key),
+				attribute.Float64(AttrEffectWindowSeconds, windowSeconds),
+				attribute.Float64(AttrEffectBaseline, base),
+			),
+		)
+		if !present {
+			// The signal was evaluable at dispatch but not at follow-up (the objective's
+			// required signals went missing). We cannot honestly compute a delta, so mark
+			// this signal aborted rather than treating absence as zero.
+			span.SetAttributes(attribute.Bool(AttrEffectAborted, true))
+			span.End()
+			continue
+		}
+		delta := fu - base
+		span.SetAttributes(
+			attribute.Float64(AttrEffectFollowUp, fu),
+			attribute.Float64(AttrEffectDelta, delta),
+		)
+		span.End()
+
+		l.effectDelta.Record(ctx, delta, otelmetric.WithAttributes(
+			attribute.String(AttrEffectIntervention, s.intervention),
+			attribute.String(AttrEffectObjective, s.objective),
+			attribute.String(AttrEffectSignal, key),
+		))
+	}
+}
+
+// sortedKeys returns the map keys sorted, for deterministic span/metric emission order.
+func sortedKeys(m map[string]float64) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// realAfterFunc is the production follow-up scheduler: a time.Timer whose firing is
+// suppressed (and stopped) if root is cancelled first. The returned stop function stops
+// the timer (idempotent), so a shutdown-cancelled sample never leaves a timer running.
+// It is the default when no afterFunc test seam is injected.
+func realAfterFunc(root context.Context) func(d time.Duration, fn func()) func() bool {
+	return func(d time.Duration, fn func()) func() bool {
+		timer := time.NewTimer(d)
+		go func() {
+			select {
+			case <-timer.C:
+				fn()
+			case <-root.Done():
+				// Cancelled before firing: stop the timer and do NOT call fn. The
+				// scheduling goroutine observes root.Done() on its own and returns.
+				timer.Stop()
+			}
+		}()
+		return timer.Stop
+	}
+}

--- a/services/agent/decision/effect_test.go
+++ b/services/agent/decision/effect_test.go
@@ -1,0 +1,389 @@
+package decision
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.uber.org/goleak"
+
+	"github.com/joustmania/agent/flags"
+	"github.com/joustmania/agent/gamecontext"
+)
+
+// effect_test.go drives the #918 intervention-effect MEASUREMENT loop end-to-end with
+// a FAKE context provider and a MANUAL follow-up scheduler — no real sleeps. It covers:
+//   - baseline stamp + sample scheduled at dispatch (the id rides the decision span);
+//   - delta emission after the window (span attributes + the metric);
+//   - the CANCELLATION/eviction case (game gone before the window -> aborted record, no
+//     metric, no leaked goroutine);
+//   - shutdown cancellation mid-window (rootCtx cancelled -> sampler returns, no emit, no
+//     leak), asserted under goleak.
+
+// manualScheduler is the afterFunc test seam: it captures the fn the sampler scheduled
+// so the test can fire the window deterministically (no real timer). stop() is a no-op
+// (no real timer to stop); it must be concurrency-safe because the shutdown-cancel path
+// can call several samplers' stops at once.
+type manualScheduler struct {
+	fn func()
+}
+
+func (m *manualScheduler) after(_ time.Duration, fn func()) func() bool {
+	m.fn = fn
+	return func() bool { return true }
+}
+
+// fire invokes the captured follow-up fn (the window elapsing).
+func (m *manualScheduler) fire() {
+	if m.fn != nil {
+		m.fn()
+	}
+}
+
+// effectLoop builds a Loop wired for effect measurement against a fake provider, with a
+// recording tracer and a manual metric reader. It returns the loop, span recorder,
+// reader, and the manual scheduler driving the follow-up timer.
+func effectLoop(t *testing.T, provider ContextProvider, gameID string) (*Loop, *tracetest.SpanRecorder, *metric.ManualReader, *manualScheduler) {
+	t.Helper()
+	sr := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+
+	reader := metric.NewManualReader()
+	mp := metric.NewMeterProvider(metric.WithReader(reader))
+
+	l := NewLoop(&settableFlags{snap: permissiveEffectSnapshot()}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	l.Tracer = tp.Tracer("test")
+	l.effectDelta = newEffectDeltaHistogram(mp)
+	l.SetGameID(gameID)
+	l.SetContextProvider(provider)
+	l.SetRootContext(context.Background())
+
+	sched := &manualScheduler{}
+	l.afterFunc = sched.after
+	return l, sr, reader, sched
+}
+
+// permissiveEffectSnapshot enables the agent with a permissive allow-list and rate
+// budget so a dispatched decision is not blocked.
+func permissiveEffectSnapshot() flags.Snapshot {
+	return flags.Snapshot{
+		Enabled:              true,
+		Mode:                 flags.DefaultMode,
+		InterventionsAllowed: []string{"grant_shield"},
+		Policy:               flags.Policy{MaxInterventionsPerMinute: 100},
+		Fitness: flags.Fitness{
+			EnduranceMinSessionSeconds:     120,
+			BalancedMaxSkillGap:            0.4,
+			BalancedSpikeSurvivalThreshold: 0.8,
+			AccelerateTargetSessionSeconds: 60,
+		},
+	}
+}
+
+// enduranceBaseline is a fitness.evaluated-shaped baseline for the endurance objective.
+func enduranceBaseline() map[string]float64 {
+	return map[string]float64{
+		"endurance.min_session_seconds": 120,
+		"endurance.session_seconds":     30,
+		"endurance.session_progress":    0.25,
+	}
+}
+
+// durationContext builds an active game context whose only fitness signal is endurance,
+// driven by the session duration, so the follow-up EvaluateFitness produces a comparable
+// endurance.session_progress.
+func durationContext(gameID string, durSeconds float64) gamecontext.GameContext {
+	d := durSeconds
+	return gamecontext.GameContext{
+		SessionID: gameID,
+		GameKind:  "real",
+		Session:   gamecontext.SessionSignals{GameActive: bp(true), DurationSeconds: &d},
+		Players:   map[string]*gamecontext.PlayerSignals{},
+	}
+}
+
+func shieldDecision() Decision {
+	return Decision{Intervention: "grant_shield", ObjectiveServed: ObjectiveEndurance, Reason: "test"}
+}
+
+// ---- baseline stamp + delta emission ----
+
+func TestEffect_DeltaEmittedAfterWindow(t *testing.T) {
+	provider := newFakeContextProvider()
+	const gameID = "game_abc"
+	// At follow-up the session has run to 90s of a 120s target: progress 0.75 vs the
+	// 0.25 baseline -> delta +0.5.
+	provider.set(gameID, durationContext(gameID, 90))
+
+	l, sr, reader, sched := effectLoop(t, provider, gameID)
+
+	id := l.scheduleEffectSample(shieldDecision(), enduranceBaseline(), defaultFit())
+	if id == "" {
+		t.Fatal("scheduleEffectSample returned empty id; expected a scheduled sample")
+	}
+	sched.fire()
+	l.AwaitEffects()
+
+	// Span: find the per-signal effect span carrying the delta.
+	var found bool
+	for _, s := range sr.Ended() {
+		if s.Name() != SpanInterventionEffect {
+			continue
+		}
+		attrs := attrMap(s.Attributes())
+		if attrs[AttrEffectSignal] != "endurance.session_progress" {
+			continue
+		}
+		found = true
+		if got := attrs[AttrEffectInterventionID]; got != id {
+			t.Errorf("effect span intervention id = %q, want %q", got, id)
+		}
+		if got := attrs[AttrEffectBaseline]; got != float64Attr(0.25) {
+			t.Errorf("baseline attr = %v, want 0.25", got)
+		}
+		if got := attrs[AttrEffectFollowUp]; got != float64Attr(0.75) {
+			t.Errorf("follow_up attr = %v, want 0.75", got)
+		}
+		if got := attrs[AttrEffectDelta]; got != float64Attr(0.5) {
+			t.Errorf("delta attr = %v, want 0.5", got)
+		}
+	}
+	if !found {
+		t.Fatal("no agent.intervention.effect span for endurance.session_progress")
+	}
+
+	// Metric: the delta histogram recorded a point for the session_progress signal with
+	// the right delta (a point is recorded per evaluated signal; check the one we assert).
+	delta := readEffectDelta(t, reader, "endurance.session_progress")
+	if delta != 0.5 {
+		t.Errorf("recorded metric delta for session_progress = %v, want 0.5", delta)
+	}
+}
+
+// the decision span carries the effect id when a sample is scheduled at dispatch.
+func TestEffect_DecisionSpanCarriesInterventionID(t *testing.T) {
+	provider := newFakeContextProvider()
+	const gameID = "game_xyz"
+	provider.set(gameID, durationContext(gameID, 60))
+
+	l, sr, _, sched := effectLoop(t, provider, gameID)
+	l.Rules = fakeRules{out: []Decision{shieldDecision()}}
+	// Pre-stamp the cycle's fitness evaluation so OnEvaluate lifts a baseline.
+	l.Rules = &baselineRules{out: []Decision{shieldDecision()}, fitness: enduranceBaseline()}
+
+	l.OnEvaluate(context.Background(), durationContext(gameID, 30), EvalTrigger{Signal: "metrics", T0: time.Now()})
+
+	var decisionSpan sdktrace.ReadOnlySpan
+	for _, s := range sr.Ended() {
+		if s.Name() == SpanDecision {
+			decisionSpan = s
+		}
+	}
+	if decisionSpan == nil {
+		t.Fatal("no agent.decision span emitted")
+	}
+	attrs := attrMap(decisionSpan.Attributes())
+	if attrs[AttrDecisionInterventionID] == nil {
+		t.Fatal("decision span missing decision.intervention_id; effect sample was not scheduled")
+	}
+
+	sched.fire()
+	l.AwaitEffects()
+}
+
+// ---- cancellation: game evicted before the window ----
+
+func TestEffect_AbortedWhenGameEvicted(t *testing.T) {
+	provider := newFakeContextProvider()
+	const gameID = "game_gone"
+	provider.evict(gameID) // partition gone at follow-up time
+
+	l, sr, reader, sched := effectLoop(t, provider, gameID)
+
+	id := l.scheduleEffectSample(shieldDecision(), enduranceBaseline(), defaultFit())
+	if id == "" {
+		t.Fatal("expected a scheduled sample")
+	}
+	sched.fire()
+	l.AwaitEffects()
+
+	var aborted bool
+	for _, s := range sr.Ended() {
+		if s.Name() != SpanInterventionEffect {
+			continue
+		}
+		if attrMap(s.Attributes())[AttrEffectAborted] == true {
+			aborted = true
+		}
+	}
+	if !aborted {
+		t.Fatal("expected an aborted effect record when the game was evicted")
+	}
+	// No metric recorded for an unmeasurable follow-up.
+	if got := readEffectDelta(t, reader, ""); got != 0 {
+		t.Errorf("expected no metric for aborted sample, got sum %v", got)
+	}
+}
+
+// ---- shutdown cancellation mid-window: no emit, no leak ----
+
+func TestEffect_ShutdownCancelsSamplerNoLeak(t *testing.T) {
+	// Ignore the openfeature event-listener goroutine: it is a process-global started by
+	// the flags provider, owned by main()'s deferred shutdown — not the #918 sampler.
+	defer goleak.VerifyNone(t,
+		goleak.IgnoreTopFunction("github.com/open-feature/go-sdk/openfeature.newEventExecutor.(*eventExecutor).startEventListener.func1.1"),
+		goleak.IgnoreTopFunction("github.com/open-feature/go-sdk/openfeature.(*eventExecutor).startEventListener.func1.1"),
+	)
+
+	provider := newFakeContextProvider()
+	const gameID = "game_shutdown"
+	provider.set(gameID, durationContext(gameID, 90))
+
+	sr := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+
+	l := NewLoop(&settableFlags{snap: permissiveEffectSnapshot()}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	l.Tracer = tp.Tracer("test")
+	l.SetGameID(gameID)
+	l.SetContextProvider(provider)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	l.SetRootContext(ctx)
+
+	id := l.scheduleEffectSample(shieldDecision(), enduranceBaseline(), defaultFit())
+	if id == "" {
+		t.Fatal("expected a scheduled sample")
+	}
+
+	// Shut down before the (real, default 20s) window elapses: the sampler must observe
+	// ctx.Done() and return without emitting, and AwaitInflight must join it.
+	cancel()
+	l.AwaitInflight()
+
+	for _, s := range sr.Ended() {
+		if s.Name() == SpanInterventionEffect {
+			t.Fatal("sampler emitted an effect span after shutdown cancellation")
+		}
+	}
+}
+
+// ---- bounded pending set ----
+
+func TestEffect_PendingSetBounded(t *testing.T) {
+	provider := newFakeContextProvider()
+	const gameID = "game_burst"
+	provider.set(gameID, durationContext(gameID, 90))
+
+	l, _, _, _ := effectLoop(t, provider, gameID)
+	// The samplers select on this root; cancel it in cleanup to drain every blocked
+	// goroutine (the manual scheduler never fires them), then join so nothing leaks.
+	ctx, cancel := context.WithCancel(context.Background())
+	l.SetRootContext(ctx)
+	t.Cleanup(func() {
+		cancel()
+		l.AwaitEffects()
+	})
+
+	scheduled := 0
+	for i := 0; i < maxPendingEffects+10; i++ {
+		if l.scheduleEffectSample(shieldDecision(), enduranceBaseline(), defaultFit()) != "" {
+			scheduled++
+		}
+	}
+	if scheduled != maxPendingEffects {
+		t.Errorf("scheduled %d samples, want cap %d", scheduled, maxPendingEffects)
+	}
+}
+
+// ---- no-op paths ----
+
+func TestEffect_NoProviderNoSchedule(t *testing.T) {
+	l := NewLoop(&settableFlags{snap: permissiveEffectSnapshot()}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if id := l.scheduleEffectSample(shieldDecision(), enduranceBaseline(), defaultFit()); id != "" {
+		t.Errorf("expected no schedule without a context provider, got id %q", id)
+	}
+}
+
+func TestEffect_NoBaselineNoSchedule(t *testing.T) {
+	provider := newFakeContextProvider()
+	l, _, _, _ := effectLoop(t, provider, "g")
+	if id := l.scheduleEffectSample(shieldDecision(), nil, defaultFit()); id != "" {
+		t.Errorf("expected no schedule with an empty baseline, got id %q", id)
+	}
+}
+
+// ---- helpers ----
+
+func attrMap(kvs []attribute.KeyValue) map[attribute.Key]interface{} {
+	m := make(map[attribute.Key]interface{}, len(kvs))
+	for _, kv := range kvs {
+		switch kv.Value.Type() {
+		case attribute.STRING:
+			m[kv.Key] = kv.Value.AsString()
+		case attribute.BOOL:
+			m[kv.Key] = kv.Value.AsBool()
+		case attribute.FLOAT64:
+			m[kv.Key] = kv.Value.AsFloat64()
+		default:
+			m[kv.Key] = kv.Value.Emit()
+		}
+	}
+	return m
+}
+
+func float64Attr(v float64) interface{} { return v }
+
+// readEffectDelta sums the recorded agent_intervention_effect_delta histogram points
+// whose signal label matches; pass "" to sum across all signals.
+func readEffectDelta(t *testing.T, reader *metric.ManualReader, signal string) float64 {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("metric collect: %v", err)
+	}
+	var sum float64
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != "agent_intervention_effect_delta" {
+				continue
+			}
+			h, ok := m.Data.(metricdata.Histogram[float64])
+			if !ok {
+				t.Fatalf("metric %s is not a float histogram", m.Name)
+			}
+			for _, dp := range h.DataPoints {
+				if signal != "" {
+					if v, present := dp.Attributes.Value(attribute.Key(AttrEffectSignal)); !present || v.AsString() != signal {
+						continue
+					}
+				}
+				sum += dp.Sum
+			}
+		}
+	}
+	return sum
+}
+
+// baselineRules is a rules engine that returns a fixed decision and reports a fixed
+// fitness evaluation via LastFitness, so OnEvaluate lifts a baseline onto the LayerState.
+type baselineRules struct {
+	out     []Decision
+	fitness map[string]float64
+}
+
+func (r *baselineRules) Evaluate(context.Context, gamecontext.GameContext) []Decision { return r.out }
+
+func (r *baselineRules) LastFitness() FitnessEvaluation {
+	return FitnessEvaluation{Results: map[string]FitnessResult{
+		ObjectiveEndurance: {Objective: ObjectiveEndurance, Evaluated: true, Values: r.fitness},
+	}}
+}

--- a/services/agent/decision/metrics.go
+++ b/services/agent/decision/metrics.go
@@ -38,3 +38,31 @@ func newLLMGatedCounter(mp otelmetric.MeterProvider) otelmetric.Int64Counter {
 func defaultLLMGatedCounter() otelmetric.Int64Counter {
 	return newLLMGatedCounter(otel.GetMeterProvider())
 }
+
+// newEffectDeltaHistogram builds the agent_intervention_effect_delta histogram from
+// the given meter provider (#918). It records the follow_up-baseline change in a
+// game's fitness/objective signal a follow-up window after an intervention was
+// dispatched, so the game-path effect-measurement loop is queryable downstream (the
+// M5 dashboard #791/#792 plots intervention->effect pairs; the #844 retro reads it as
+// per-intervention evidence). The value is a dimensionless 0..1 fitness-progress delta
+// (unit "1"); labels are the intervention type, the served objective, and the dotted
+// fitness signal key. An instrument-creation error yields a no-op histogram so a Loop
+// always has a usable instrument — mirrors newLLMGatedCounter / actions.newWritesCounter.
+func newEffectDeltaHistogram(mp otelmetric.MeterProvider) otelmetric.Float64Histogram {
+	h, err := mp.Meter(decisionMeterName).Float64Histogram(
+		"agent_intervention_effect_delta",
+		otelmetric.WithDescription("Change in a game's fitness/objective signal measured a follow-up window after an intervention was dispatched, labeled by intervention type, objective, and signal (#918)"),
+		otelmetric.WithUnit("1"),
+	)
+	if err != nil {
+		h, _ = metricnoop.NewMeterProvider().Meter(decisionMeterName).Float64Histogram("agent_intervention_effect_delta")
+	}
+	return h
+}
+
+// defaultEffectDeltaHistogram is the no-op fallback histogram a Loop uses until one is
+// injected (NewLoop wires the global meter provider; tests may leave it). It keeps the
+// effect-record path nil-safe without every test having to set a histogram.
+func defaultEffectDeltaHistogram() otelmetric.Float64Histogram {
+	return newEffectDeltaHistogram(otel.GetMeterProvider())
+}

--- a/services/agent/decision/telemetry.go
+++ b/services/agent/decision/telemetry.go
@@ -313,5 +313,62 @@ const (
 	interventionsAllowedFlagKey = "interventions.allowed"
 )
 
+// SpanInterventionEffect is the intervention-effect feedback span (#918): emitted
+// after a follow-up window (default DefaultEffectWindow) once per APPLIED (dispatched)
+// intervention, carrying the BEFORE/AFTER fitness-objective signals for that game and
+// their delta, attributed to the intervention id. It closes the game-path MEASUREMENT
+// loop — the infra path already has fitness->rollback, the game path had nothing
+// (#918). It is MEASUREMENT ONLY: it never reverts the intervention.
+//
+// Because the dispatch cycle's agent.span_received root has long since ended (the
+// follow-up window is seconds later), the effect cannot hang off it — so the sampler
+// opens its OWN root span backdated to dispatch time, parenting an
+// agent.intervention.effect span per evaluated objective, so a Jaeger trace shows the
+// full "dispatched at T0, measured at T0+window, delta=..." story. The metric
+// agent_intervention_effect_delta (see metrics.go) carries the same delta for
+// dashboards/alerts; the M5 dashboard (#791/#792) and the #844 retro consume both.
+const SpanInterventionEffect = "agent.intervention.effect"
+
+// Custom attribute keys of the intervention-effect span (#918). The fitness signal
+// key (e.g. "endurance.session_progress") is the SAME dotted vocabulary the decision
+// span's fitness.evaluated carries, so baseline and follow-up sample identical
+// quantities. baseline/follow_up/delta are the three numeric stamps; aborted marks a
+// follow-up that could not complete (game ended/evicted before the window elapsed).
+const (
+	// AttrEffectInterventionID is the dispatch-unique id tying an effect record to the
+	// intervention that produced it. The decision span carries the same id as
+	// decision.intervention_id, so a Jaeger query joins "what the agent did" to "what
+	// happened next".
+	AttrEffectInterventionID = "intervention.id"
+	// AttrEffectIntervention is the intervention name (decision.action), e.g.
+	// "grant_shield" — a low-cardinality label for grouping effects by type.
+	AttrEffectIntervention = "intervention.type"
+	// AttrEffectObjective is the objective whose fitness this record measures
+	// (endurance/balanced/accelerate) — the objective the intervention served.
+	AttrEffectObjective = "intervention.objective"
+	// AttrEffectSignal is the dotted fitness signal key whose delta this span carries
+	// (e.g. "endurance.session_progress"), from the shared fitness.evaluated vocabulary.
+	AttrEffectSignal = "intervention.signal"
+	// AttrEffectBaseline / AttrEffectFollowUp / AttrEffectDelta are the three numeric
+	// stamps: the signal value at dispatch, at follow-up, and follow_up-baseline.
+	AttrEffectBaseline = "intervention.fitness_baseline"
+	AttrEffectFollowUp = "intervention.fitness_followup"
+	AttrEffectDelta    = "intervention.fitness_delta"
+	// AttrEffectWindowSeconds is the follow-up window length in seconds, so a consumer
+	// knows over what interval the delta was measured.
+	AttrEffectWindowSeconds = "intervention.window_seconds"
+	// AttrEffectAborted is true when the follow-up could NOT be measured because the
+	// game ended or was evicted before the window elapsed (#918 cancellation path): the
+	// record is emitted clearly marked, follow_up/delta are absent, and no metric is
+	// recorded for that objective.
+	AttrEffectAborted = "intervention.effect_aborted"
+)
+
+// AttrDecisionInterventionID stamps the dispatch-unique effect id on the decision
+// span too (#918), so the agent.decision span that dispatched an intervention and the
+// agent.intervention.effect span that measured it carry the SAME id and can be joined
+// in Jaeger. Present only on dispatched (applied) decisions that schedule a follow-up.
+const AttrDecisionInterventionID = "decision.intervention_id"
+
 // instrumentationName scopes the agent's tracer.
 const instrumentationName = "github.com/joustmania/agent"

--- a/services/agent/main.go
+++ b/services/agent/main.go
@@ -67,6 +67,24 @@ func getEnv(key, defaultValue string) string {
 	return defaultValue
 }
 
+// effectWindowFromEnv resolves the intervention-effect follow-up window (#918) from
+// AGENT_EFFECT_WINDOW_SECONDS (a float of seconds). An unset, unparseable, or
+// non-positive value falls back to decision.DefaultEffectWindow so the agent always
+// has a sane window.
+func effectWindowFromEnv() time.Duration {
+	raw := getEnv("AGENT_EFFECT_WINDOW_SECONDS", "")
+	if raw == "" {
+		return decision.DefaultEffectWindow
+	}
+	secs, err := strconv.ParseFloat(raw, 64)
+	if err != nil || secs <= 0 {
+		slog.Warn("AGENT_EFFECT_WINDOW_SECONDS invalid; using default (#918)",
+			"value", raw, "default", decision.DefaultEffectWindow)
+		return decision.DefaultEffectWindow
+	}
+	return time.Duration(secs * float64(time.Second))
+}
+
 // partitionSet turns the Multiplexer's partition id slice into a set for
 // LoopSet.Retain (#845 PR C).
 func partitionSet(ids []string) map[string]struct{} {
@@ -405,6 +423,14 @@ func main() {
 	// game end, and every per-game Loop reads Recent(N) from it on the llm path to
 	// render the prompt's narrative context block (N = llm.context_games, live).
 	sharedContextWindow := gamewindow.NewStore()
+	// Intervention-effect follow-up window (#918): how long after a dispatched
+	// intervention the loop re-samples the game's fitness signals to measure the
+	// effect. Read ONCE at startup from AGENT_EFFECT_WINDOW_SECONDS (a float of
+	// seconds); a non-positive/unparseable/unset value keeps decision.DefaultEffectWindow.
+	effectWindow := effectWindowFromEnv()
+	if effectWindow != decision.DefaultEffectWindow {
+		slog.Info("Intervention-effect follow-up window overridden (#918)", "window", effectWindow)
+	}
 	probeDecisions := strings.EqualFold(getEnv("AGENT_PROBE_DECISIONS", ""), "true")
 	if probeDecisions {
 		slog.Warn("Probe decisions enabled (demo/verification mode)",
@@ -444,6 +470,14 @@ func main() {
 		loop.SetGameID(gameID)
 		loop.SetContextProvider(decision.MuxContextProvider{Mux: mux})
 		loop.SetRootContext(ctx)
+		// Intervention-effect MEASUREMENT window (#918): after a dispatched intervention,
+		// the loop samples THIS game's fitness/objective signals again after this window
+		// and emits the before/after delta (agent.intervention.effect span +
+		// agent_intervention_effect_delta metric), reusing the SetContextProvider source
+		// above to re-read the game's CURRENT signals. The follow-up goroutine is bounded
+		// by SetRootContext so shutdown cancels it cleanly (no leak). Tunable at startup
+		// via AGENT_EFFECT_WINDOW_SECONDS; a non-positive/unset value keeps the default.
+		loop.SetEffectWindow(effectWindow)
 		// Intervention timeline wiring (#945): feed each decision's dispatched/blocked
 		// outcome into the #916 rolling narrative of the SAME game this loop serves.
 		// The closure captures THIS partition's game_id and routes through the


### PR DESCRIPTION
Part of #918. Backend/telemetry half only — the Grafana **dashboard** panel that visualizes intervention → effect pairs is deliberately deferred to M5 (#791/#792). **Measurement only: this does NOT auto-revert a bad intervention** (that game-path control loop is a follow-on).

## The measurement loop it closes

The agent attributes a decision's *reasoning* outbound (objectives / `LayerState` → the `agent.decision` span, #729) but never measured whether the intervention **helped**. The infra path has a closed loop (Bluetooth fitness → rollback, #828); the game path had nothing. This adds the game-path effect-MEASUREMENT layer:

1. **At dispatch** (the applied-decision path in `runDecision`, right after `recordDispatched`) the loop stamps a **baseline** of the game's fitness/objective signals — the same dotted-key quantities the decision span carries as `fitness.evaluated` — tagged with a dispatch-unique intervention id.
2. **After a follow-up window** a per-game sampler re-reads the **same** game's signals (via the same `ContextProvider`/`MuxContextProvider` the #917 async path uses, so per-game isolation #845 holds) and recomputes the **same** fitness functions (`EvaluateFitness`) with the dispatch-time thresholds.
3. It emits an **effect record** attributed to the intervention id (span + metric).

## Emitted shape (the downstream contract for M5 #791/#792 and the #844 retro)

**Span** `agent.intervention.effect` — one backdated root (to dispatch time) per dispatched intervention, parenting one child span per evaluated fitness signal:

| Attribute | Meaning |
|-----------|---------|
| `intervention.id` | dispatch-unique id; also on the `agent.decision` span as `decision.intervention_id` (joins decision → effect in Jaeger) |
| `intervention.type` | intervention name (e.g. `grant_shield`) |
| `intervention.objective` | objective served (endurance/balanced/accelerate) |
| `intervention.signal` | dotted fitness signal key (e.g. `endurance.session_progress`) |
| `intervention.fitness_baseline` / `intervention.fitness_followup` / `intervention.fitness_delta` | the three numeric stamps (`follow_up − baseline`) |
| `intervention.window_seconds` | the follow-up window the delta was measured over |
| `intervention.effect_aborted` | `true` when the follow-up could not be measured (game ended/evicted before the window, or a signal disappeared) |

**Metric** `agent_intervention_effect_delta` — `Float64Histogram`, unit `1` (dimensionless 0..1 progress delta), labels `intervention.type`, `intervention.objective`, `intervention.signal`. No point is recorded for an aborted follow-up.

## Follow-up window

`decision.DefaultEffectWindow = 20s` (in the issue's 15–30s band), overridable at startup via `AGENT_EFFECT_WINDOW_SECONDS` (float seconds; non-positive/unparseable falls back to the default). Wired per-loop in `main.go` via `loop.SetEffectWindow`.

## Cancellation / leak-safety (#923 goleak)

Each follow-up runs in a goroutine tracked on a `WaitGroup` (`effectWG`, joined by `AwaitInflight` at shutdown alongside the #917 inference goroutines) and bounded by the agent **root context** (the same `SetRootContext` the async path uses). It selects on the follow-up timer **and** `rootCtx.Done()`: on shutdown / loop drop it stops the timer and returns **without emitting** (no leaked timer/goroutine). If the partition is gone at follow-up time it emits a clearly-marked **aborted** record rather than fabricating a delta. The in-flight pending set is capped (`maxPendingEffects = 64`) so a burst of dispatches cannot grow unbounded; the baseline is a cheap defensive map copy, so the hot decision path is never blocked.

## Tests (`services/agent/decision/effect_test.go`, all under `-race`)

- baseline stamp + delta emission after the window (span attributes + metric)
- the `decision.intervention_id` riding the `agent.decision` span end-to-end through `OnEvaluate`
- the **cancellation** case: game evicted before the window → aborted record, no metric
- **shutdown** cancellation mid-window → sampler returns, no emit, **no leak** (asserted with `goleak.VerifyNone`)
- bounded pending set + the no-op paths (no provider / no baseline)

## Validation

`go test ./... -race` green · `go vet ./...` clean · `gofmt -l .` empty · `go build ./...` ok. `make lint` (ruff) is Python-only and untouched here; the Go CI gate (`go test -v -race ./...`, `go vet ./...`) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)