### PR TITLE
feat(agent): durable experiment journal — intent + event log + rolling summary (#983)

### DIFF
--- a/services/agent/experiment/journal/journal.go
+++ b/services/agent/experiment/journal/journal.go
@@ -76,6 +76,12 @@ func newJournal(root string, opts ...Option) *Journal {
 // exists for this experiment_id — the intent is immutable and write-once, so
 // re-creating would risk silently clobbering an in-flight experiment; the caller
 // should Load an existing one instead.
+//
+// Single-writer-per-experiment: a Journal serializes its own writes with a mutex,
+// but that does NOT coordinate across two handles to the SAME experiment dir.
+// Callers MUST hold at most one live Journal per experiment dir at a time (two
+// handles would interleave appends and racily rewrite summary.json). The registry
+// (#978) owns this single-handle invariant.
 func Create(root string, intent Intent, opts ...Option) (*Journal, error) {
 	if intent.ExperimentID == "" {
 		return nil, fmt.Errorf("journal: intent.ExperimentID is required")
@@ -207,7 +213,13 @@ func (j *Journal) writeSummary() error {
 // pre-restart one. This is the #831 in-memory-loss fix: the in-memory state is a
 // VIEW of the durable journal, reconstructed on startup. summary.json on disk is a
 // cache/telemetry view; the log is the source of truth, so Load does NOT trust it
-// and recomputes from events.
+// and recomputes from events. A torn final event line (a partial append left by a
+// crash) is dropped and truncated by the store so Load still reconverges — see
+// store.readEvents; an interior malformed line stays a hard error.
+//
+// Single-writer-per-experiment: like Create, the returned Journal does not
+// coordinate with other handles to the same experiment dir. Callers MUST keep at
+// most one live Journal per experiment dir; the registry (#978) owns this.
 func Load(root string, experimentID string, opts ...Option) (*Journal, error) {
 	j := newJournal(root, opts...)
 
@@ -281,6 +293,12 @@ func (j *Journal) CompactView() CompactView {
 // ArmView is the per-arm aggregate exposed in a CompactView: the derived
 // sufficient statistics (variance already computed from the Welford M2), without
 // the internal M2 the LLM does not need.
+//
+// NOTE for a downstream significance test (#979): Variance here is the POPULATION
+// variance (M2/count) and would BIAS small-N comparisons. An unbiased / Welch
+// estimator MUST instead consume the raw M2 (+ count) from Summary() — see
+// Journal.Summary(), which exposes the full Welford state including M2. CompactView
+// is the bounded LLM/registry view, not the statistics input.
 type ArmView struct {
 	Count    int     `json:"count"`
 	Mean     float64 `json:"mean_fitness"`

--- a/services/agent/experiment/journal/journal.go
+++ b/services/agent/experiment/journal/journal.go
@@ -1,0 +1,339 @@
+package journal
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+// journal.go is the public API (design §9): a small surface mirroring the
+// Proposal/gamesummary style. A Journal is the durable, in-memory-backed handle to
+// ONE experiment: it owns the immutable intent, the append-only event log, and the
+// rolling summary. The in-memory summary is a VIEW; the disk is authoritative.
+//
+// API:
+//   - Create(intent)            → writes intent.json + the initial summary.json.
+//   - AppendEvent(event)        → appends to events.jsonl, folds a game_concluded
+//                                 fitness into the matching arm's Welford
+//                                 accumulator, then atomically rewrites summary.json.
+//   - Load(experimentID)        → rehydrate: rebuild the rolling summary from
+//                                 intent + events on startup (the #831 fix).
+//   - CompactView()             → the bounded {intent, rolling summary, short
+//                                 recent-events tail} the LLM/registry consume.
+
+// DefaultTailSize is the number of most-recent events CompactView returns when the
+// caller does not specify one. Small and fixed so the compact view stays O(1) in N
+// (the bounded-context discipline, §9.2): the prompt carries a short tail, not the
+// whole log.
+const DefaultTailSize = 10
+
+// statusRunning is the initial status stamped on a freshly created experiment.
+const statusRunning = "running"
+
+// Journal is the in-memory handle to one experiment's durable journal. All methods
+// are safe for concurrent use — a single mutex serializes the read-modify-write of
+// the rolling summary and the event-sequence counter, so concurrent AppendEvent
+// calls (e.g. two shadow game-ends, #845) never interleave a fold or reuse a Seq.
+type Journal struct {
+	store *store
+
+	mu      sync.Mutex
+	intent  Intent
+	summary Summary
+	// tail holds the most recent events for the bounded CompactView. It is capped
+	// at maxTail entries (a ring-trimmed slice) so memory stays O(1) in N — the raw
+	// log on disk is the unbounded record; the live tail is a small window.
+	tail    []Event
+	maxTail int
+}
+
+// Option configures a Journal at construction.
+type Option func(*Journal)
+
+// WithTailSize sets how many recent events the journal keeps in memory for
+// CompactView. A non-positive size falls back to DefaultTailSize.
+func WithTailSize(n int) Option {
+	return func(j *Journal) {
+		if n > 0 {
+			j.maxTail = n
+		}
+	}
+}
+
+// newJournal builds an empty Journal bound to root, applying options. The store's
+// directory is created lazily on the first write.
+func newJournal(root string, opts ...Option) *Journal {
+	j := &Journal{store: newStore(root), maxTail: DefaultTailSize}
+	for _, opt := range opts {
+		opt(j)
+	}
+	return j
+}
+
+// Create starts a new experiment: it persists the immutable intent.json and the
+// initial summary.json (status "running", one zeroed Welford accumulator per arm).
+// The returned Journal is the live handle. Create fails if intent.json already
+// exists for this experiment_id — the intent is immutable and write-once, so
+// re-creating would risk silently clobbering an in-flight experiment; the caller
+// should Load an existing one instead.
+func Create(root string, intent Intent, opts ...Option) (*Journal, error) {
+	if intent.ExperimentID == "" {
+		return nil, fmt.Errorf("journal: intent.ExperimentID is required")
+	}
+	if intent.SchemaVersion == 0 {
+		intent.SchemaVersion = SchemaVersion
+	}
+
+	j := newJournal(root, opts...)
+	if _, err := j.store.readIntent(intent.ExperimentID); err == nil {
+		return nil, fmt.Errorf("journal: experiment %q already exists", intent.ExperimentID)
+	}
+
+	j.intent = intent
+	j.summary = Summary{
+		SchemaVersion: SchemaVersion,
+		ExperimentID:  intent.ExperimentID,
+		Status:        statusRunning,
+		UpdatedAt:     intent.CreatedAt,
+		Arms:          make(map[string]*ArmStat, len(intent.Arms)),
+	}
+	for _, arm := range intent.Arms {
+		j.summary.Arms[arm] = &ArmStat{}
+	}
+
+	intentPath := j.store.dir(intent.ExperimentID) + "/" + intentFile
+	if err := writeJSONAtomic(intentPath, j.intent); err != nil {
+		return nil, fmt.Errorf("journal: write intent: %w", err)
+	}
+	if err := j.writeSummary(); err != nil {
+		return nil, fmt.Errorf("journal: write initial summary: %w", err)
+	}
+	return j, nil
+}
+
+// AppendEvent appends one event to the durable log and updates the rolling state.
+// It is the single write path for progression:
+//  1. assign the next monotonic Seq,
+//  2. append the event to events.jsonl (append-only, fsynced),
+//  3. for a game_concluded with a fitness sample, fold it into the matching arm's
+//     Welford accumulator (O(1)),
+//  4. carry a Verdict / Status onto the summary if the event supplies one,
+//  5. atomically rewrite summary.json.
+//
+// The event is durably logged BEFORE the summary is rewritten, so a crash between
+// the two leaves the log ahead of the summary — Load then rebuilds the summary
+// from the log and is correct again. The reverse order could persist a summary
+// counting an event that was never logged. The caller's e.Seq is ignored and
+// overwritten with the journal's counter.
+func (j *Journal) AppendEvent(e Event) error {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+
+	e.Seq = j.summary.EventCount + 1
+
+	path := j.store.dir(j.intent.ExperimentID) + "/" + eventsFile
+	if err := appendEventLine(path, e); err != nil {
+		return fmt.Errorf("journal: append event: %w", err)
+	}
+
+	j.apply(e)
+
+	if err := j.writeSummary(); err != nil {
+		return fmt.Errorf("journal: rewrite summary: %w", err)
+	}
+	return nil
+}
+
+// apply folds one event into the in-memory rolling summary and tail. It is the
+// PURE state transition shared by AppendEvent (live) and Load (replay), so the
+// rehydrated summary is byte-for-byte the same as the one built incrementally —
+// the durability guarantee (§9.3). It assumes j.mu is held.
+func (j *Journal) apply(e Event) {
+	j.summary.EventCount = e.Seq
+	if !e.At.IsZero() {
+		j.summary.UpdatedAt = e.At
+	}
+
+	switch e.Kind {
+	case KindGameConcluded:
+		if e.Fitness != nil {
+			if arm := j.summary.Arms[e.Arm]; arm != nil {
+				arm.Add(*e.Fitness)
+			}
+			// An event for an arm not in Intent.Arms is still recorded in the log
+			// (the complete audit trail) but folds into no accumulator.
+		}
+	case KindInterimVerdict, KindOutcome:
+		if e.Verdict != nil {
+			v := *e.Verdict
+			j.summary.Verdict = &v
+		}
+		if e.Status != "" {
+			j.summary.Status = e.Status
+		}
+	case KindDecision:
+		if e.Status != "" {
+			j.summary.Status = e.Status
+		}
+	}
+
+	j.appendTail(e)
+}
+
+// appendTail adds e to the bounded recent-events tail, trimming the oldest so the
+// tail never exceeds maxTail entries — keeping CompactView O(1) in N.
+func (j *Journal) appendTail(e Event) {
+	j.tail = append(j.tail, e)
+	if len(j.tail) > j.maxTail {
+		// Drop the oldest entries; copy into a fresh slice so the backing array of
+		// the trimmed-off events can be reclaimed (no unbounded growth via reslicing).
+		trimmed := make([]Event, j.maxTail)
+		copy(trimmed, j.tail[len(j.tail)-j.maxTail:])
+		j.tail = trimmed
+	}
+}
+
+// writeSummary atomically rewrites summary.json from the in-memory summary. Assumes
+// j.mu is held.
+func (j *Journal) writeSummary() error {
+	path := j.store.dir(j.intent.ExperimentID) + "/" + summaryFile
+	return writeJSONAtomic(path, j.summary)
+}
+
+// Load (rehydrate) rebuilds a live Journal for an existing experiment from disk:
+// it reads the immutable intent, seeds an empty summary with one Welford
+// accumulator per arm, then replays the append-only event log through the SAME
+// apply transition AppendEvent uses — so the rebuilt rolling summary equals the
+// pre-restart one. This is the #831 in-memory-loss fix: the in-memory state is a
+// VIEW of the durable journal, reconstructed on startup. summary.json on disk is a
+// cache/telemetry view; the log is the source of truth, so Load does NOT trust it
+// and recomputes from events.
+func Load(root string, experimentID string, opts ...Option) (*Journal, error) {
+	j := newJournal(root, opts...)
+
+	intent, err := j.store.readIntent(experimentID)
+	if err != nil {
+		return nil, fmt.Errorf("journal: load intent: %w", err)
+	}
+	j.intent = intent
+
+	j.summary = Summary{
+		SchemaVersion: SchemaVersion,
+		ExperimentID:  intent.ExperimentID,
+		Status:        statusRunning,
+		UpdatedAt:     intent.CreatedAt,
+		Arms:          make(map[string]*ArmStat, len(intent.Arms)),
+	}
+	for _, arm := range intent.Arms {
+		j.summary.Arms[arm] = &ArmStat{}
+	}
+
+	events, err := j.store.readEvents(experimentID)
+	if err != nil {
+		return nil, fmt.Errorf("journal: load events: %w", err)
+	}
+	for _, e := range events {
+		j.apply(e)
+	}
+	return j, nil
+}
+
+// CompactView is the bounded read accessor the LLM and the live registry consume
+// (design §9.2). It returns the immutable intent, a COPY of the rolling summary
+// (per-arm count/mean/variance + current verdict), and a short tail of the most
+// recent events — NEVER the full game-by-game log. Its size is O(arms + tailSize),
+// constant in N, so a prompt built from it stays roughly the same size whether the
+// experiment has seen 5 games or 500. The returned values are copies, safe for the
+// caller to read without holding the journal lock.
+func (j *Journal) CompactView() CompactView {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+
+	armsCopy := make(map[string]ArmView, len(j.summary.Arms))
+	for name, stat := range j.summary.Arms {
+		armsCopy[name] = ArmView{
+			Count:    stat.Count,
+			Mean:     stat.Mean,
+			Variance: stat.Variance(),
+		}
+	}
+
+	var verdict *Verdict
+	if j.summary.Verdict != nil {
+		v := *j.summary.Verdict
+		verdict = &v
+	}
+
+	tail := make([]Event, len(j.tail))
+	copy(tail, j.tail)
+
+	return CompactView{
+		Intent:     j.intent,
+		Status:     j.summary.Status,
+		UpdatedAt:  j.summary.UpdatedAt,
+		EventCount: j.summary.EventCount,
+		Arms:       armsCopy,
+		Verdict:    verdict,
+		RecentTail: tail,
+	}
+}
+
+// ArmView is the per-arm aggregate exposed in a CompactView: the derived
+// sufficient statistics (variance already computed from the Welford M2), without
+// the internal M2 the LLM does not need.
+type ArmView struct {
+	Count    int     `json:"count"`
+	Mean     float64 `json:"mean_fitness"`
+	Variance float64 `json:"variance"`
+}
+
+// CompactView is the bounded snapshot fed to the LLM / registry (§9.2). Its size is
+// O(arms + len(RecentTail)) — independent of how many games the experiment has run.
+type CompactView struct {
+	// Intent is the immutable goal.
+	Intent Intent `json:"intent"`
+	// Status is the experiment's lifecycle status.
+	Status string `json:"status"`
+	// UpdatedAt is the timestamp of the last folded event.
+	UpdatedAt time.Time `json:"updated_at"`
+	// EventCount is how many events have been logged (the full-log size, for context
+	// — the log itself is NOT included).
+	EventCount int `json:"event_count"`
+	// Arms is the per-arm rolling aggregates.
+	Arms map[string]ArmView `json:"arms"`
+	// Verdict is the current rolling verdict, or nil.
+	Verdict *Verdict `json:"verdict,omitempty"`
+	// RecentTail is the short bounded tail of most-recent events (oldest-first).
+	RecentTail []Event `json:"recent_tail"`
+}
+
+// Intent returns a copy of the experiment's immutable intent.
+func (j *Journal) Intent() Intent {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	return j.intent
+}
+
+// Summary returns a deep copy of the current rolling summary (the full per-arm
+// Welford state, including M2). The map and arm pointers are copied so the caller
+// cannot mutate the journal's live state.
+func (j *Journal) Summary() Summary {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	return j.copySummaryLocked()
+}
+
+// copySummaryLocked deep-copies the rolling summary. Assumes j.mu is held.
+func (j *Journal) copySummaryLocked() Summary {
+	out := j.summary
+	out.Arms = make(map[string]*ArmStat, len(j.summary.Arms))
+	for name, stat := range j.summary.Arms {
+		s := *stat
+		out.Arms[name] = &s
+	}
+	if j.summary.Verdict != nil {
+		v := *j.summary.Verdict
+		out.Verdict = &v
+	}
+	return out
+}

--- a/services/agent/experiment/journal/journal_test.go
+++ b/services/agent/experiment/journal/journal_test.go
@@ -1,0 +1,477 @@
+package journal
+
+import (
+	"bufio"
+	"encoding/json"
+	"math"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func testIntent() Intent {
+	return Intent{
+		ExperimentID:      "exp_a1b2c3d4e5f6",
+		CreatedAt:         time.Date(2026, 6, 13, 10, 0, 0, 0, time.UTC),
+		Hypothesis:        "Raising death_grace_period reduces frustration deaths.",
+		FlagKey:           "death_grace_period_seconds",
+		ExperimentalValue: 0.5,
+		Objective:         "engagement_balanced",
+		TargetNPerArm:     20,
+		Arms:              []string{"experimental", "control"},
+	}
+}
+
+func fitnessEvent(arm string, fitness float64, at time.Time) Event {
+	f := fitness
+	return Event{
+		At:      at,
+		Kind:    KindGameConcluded,
+		GameID:  "game_" + arm,
+		Arm:     arm,
+		Fitness: &f,
+	}
+}
+
+func TestCreate_WritesIntentAndInitialSummary(t *testing.T) {
+	dir := t.TempDir()
+	j, err := Create(dir, testIntent())
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	expDir := filepath.Join(dir, "exp_a1b2c3d4e5f6")
+	for _, name := range []string{intentFile, summaryFile} {
+		if _, err := os.Stat(filepath.Join(expDir, name)); err != nil {
+			t.Errorf("expected %s on disk: %v", name, err)
+		}
+	}
+	// events.jsonl must NOT exist yet — no events appended.
+	if _, err := os.Stat(filepath.Join(expDir, eventsFile)); !os.IsNotExist(err) {
+		t.Errorf("events.jsonl should not exist before any append, got err=%v", err)
+	}
+
+	sum := j.Summary()
+	if sum.Status != statusRunning {
+		t.Errorf("initial status = %q, want %q", sum.Status, statusRunning)
+	}
+	if len(sum.Arms) != 2 || sum.Arms["experimental"].Count != 0 || sum.Arms["control"].Count != 0 {
+		t.Errorf("arms not seeded zeroed: %+v", sum.Arms)
+	}
+}
+
+func TestCreate_RejectsDuplicate(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := Create(dir, testIntent()); err != nil {
+		t.Fatalf("first Create: %v", err)
+	}
+	if _, err := Create(dir, testIntent()); err == nil {
+		t.Fatal("second Create should fail (intent is write-once)")
+	}
+}
+
+func TestCreate_RequiresExperimentID(t *testing.T) {
+	in := testIntent()
+	in.ExperimentID = ""
+	if _, err := Create(t.TempDir(), in); err == nil {
+		t.Fatal("Create with empty ExperimentID should fail")
+	}
+}
+
+// TestAppendEvent_WelfordFold: per-arm fitness samples fold into the rolling
+// summary's Welford accumulator and match a direct computation.
+func TestAppendEvent_WelfordFold(t *testing.T) {
+	dir := t.TempDir()
+	j, err := Create(dir, testIntent())
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	exp := []float64{0.71, 0.83, 0.69, 0.77}
+	ctrl := []float64{0.66, 0.59, 0.61}
+	base := testIntent().CreatedAt
+	for i, f := range exp {
+		if err := j.AppendEvent(fitnessEvent("experimental", f, base.Add(time.Duration(i)*time.Minute))); err != nil {
+			t.Fatalf("append exp: %v", err)
+		}
+	}
+	for i, f := range ctrl {
+		if err := j.AppendEvent(fitnessEvent("control", f, base.Add(time.Duration(i)*time.Minute))); err != nil {
+			t.Fatalf("append ctrl: %v", err)
+		}
+	}
+
+	sum := j.Summary()
+	for arm, samples := range map[string][]float64{"experimental": exp, "control": ctrl} {
+		wantN, wantMean, wantVar := directStats(samples)
+		got := sum.Arms[arm]
+		if got.Count != wantN {
+			t.Errorf("%s count = %d, want %d", arm, got.Count, wantN)
+		}
+		if math.Abs(got.Mean-wantMean) > 1e-9 {
+			t.Errorf("%s mean = %v, want %v", arm, got.Mean, wantMean)
+		}
+		if math.Abs(got.Variance()-wantVar) > 1e-9 {
+			t.Errorf("%s variance = %v, want %v", arm, got.Variance(), wantVar)
+		}
+	}
+	if sum.EventCount != len(exp)+len(ctrl) {
+		t.Errorf("EventCount = %d, want %d", sum.EventCount, len(exp)+len(ctrl))
+	}
+}
+
+// TestAppendEvent_AppendOnly: events.jsonl grows by exactly one line per event,
+// in order, and earlier lines are never rewritten.
+func TestAppendEvent_AppendOnly(t *testing.T) {
+	dir := t.TempDir()
+	j, err := Create(dir, testIntent())
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	eventsPath := filepath.Join(dir, "exp_a1b2c3d4e5f6", eventsFile)
+
+	var firstLine string
+	base := testIntent().CreatedAt
+	for i := 1; i <= 5; i++ {
+		if err := j.AppendEvent(fitnessEvent("experimental", float64(i)/10, base.Add(time.Duration(i)*time.Minute))); err != nil {
+			t.Fatalf("append %d: %v", i, err)
+		}
+		lines := readLines(t, eventsPath)
+		if len(lines) != i {
+			t.Fatalf("after %d appends, file has %d lines", i, len(lines))
+		}
+		// Sequence numbers are monotonic 1..i in file order.
+		for k, ln := range lines {
+			var e Event
+			if err := json.Unmarshal([]byte(ln), &e); err != nil {
+				t.Fatalf("line %d not valid JSON: %v", k, err)
+			}
+			if e.Seq != k+1 {
+				t.Errorf("line %d has Seq %d, want %d", k, e.Seq, k+1)
+			}
+		}
+		if i == 1 {
+			firstLine = lines[0]
+		} else if lines[0] != firstLine {
+			t.Errorf("first line was rewritten: %q != %q", lines[0], firstLine)
+		}
+	}
+}
+
+// TestRehydrate_SurvivesRestart: write intent + events, drop the in-memory state,
+// Load from disk, and the rebuilt rolling summary equals the pre-drop one.
+func TestRehydrate_SurvivesRestart(t *testing.T) {
+	dir := t.TempDir()
+	j, err := Create(dir, testIntent())
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	base := testIntent().CreatedAt
+	samples := []struct {
+		arm string
+		f   float64
+	}{
+		{"experimental", 0.71}, {"control", 0.66}, {"experimental", 0.83},
+		{"control", 0.59}, {"experimental", 0.69}, {"control", 0.61},
+	}
+	for i, s := range samples {
+		if err := j.AppendEvent(fitnessEvent(s.arm, s.f, base.Add(time.Duration(i)*time.Minute))); err != nil {
+			t.Fatalf("append: %v", err)
+		}
+	}
+	// A verdict + status transition, to prove non-fitness events rehydrate too.
+	if err := j.AppendEvent(Event{
+		At:      base.Add(time.Hour),
+		Kind:    KindInterimVerdict,
+		Verdict: &Verdict{Outcome: "inconclusive", Delta: 0.043, Significant: false, Reason: "n_per_arm < target (20)"},
+	}); err != nil {
+		t.Fatalf("append verdict: %v", err)
+	}
+
+	before := j.Summary()
+
+	// Drop the in-memory handle entirely; rebuild only from disk.
+	reloaded, err := Load(dir, "exp_a1b2c3d4e5f6")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	after := reloaded.Summary()
+
+	if !summariesEqual(before, after) {
+		t.Errorf("rehydrated summary differs from pre-drop:\nbefore=%+v\nafter =%+v", before, after)
+	}
+	// Spot-check a derived statistic and the verdict carried across the restart.
+	if after.Arms["experimental"].Count != 3 || after.Verdict == nil || after.Verdict.Outcome != "inconclusive" {
+		t.Errorf("rehydrated state wrong: arms=%+v verdict=%+v", after.Arms, after.Verdict)
+	}
+}
+
+// TestRehydrate_RecomputesFromLogNotSummaryCache: the event log is the source of
+// truth. A corrupted summary.json on disk must NOT influence Load — the rebuilt
+// summary comes purely from intent + events.
+func TestRehydrate_RecomputesFromLogNotSummaryCache(t *testing.T) {
+	dir := t.TempDir()
+	j, err := Create(dir, testIntent())
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	base := testIntent().CreatedAt
+	if err := j.AppendEvent(fitnessEvent("experimental", 0.9, base)); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	want := j.Summary()
+
+	// Corrupt summary.json with bogus stats; Load must ignore it.
+	summaryPath := filepath.Join(dir, "exp_a1b2c3d4e5f6", summaryFile)
+	if err := os.WriteFile(summaryPath, []byte(`{"experiment_id":"exp_a1b2c3d4e5f6","arms":{"experimental":{"count":999,"mean":-5,"m2":12345}}}`), 0o644); err != nil {
+		t.Fatalf("corrupt summary: %v", err)
+	}
+
+	reloaded, err := Load(dir, "exp_a1b2c3d4e5f6")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	got := reloaded.Summary()
+	if got.Arms["experimental"].Count != want.Arms["experimental"].Count ||
+		math.Abs(got.Arms["experimental"].Mean-want.Arms["experimental"].Mean) > 1e-9 {
+		t.Errorf("Load trusted the corrupt summary cache: got %+v want %+v",
+			got.Arms["experimental"], want.Arms["experimental"])
+	}
+}
+
+// TestAtomicWrite_NoPartialFiles: after writes, no .tmp leftovers remain and
+// summary.json / intent.json are complete, parseable JSON.
+func TestAtomicWrite_NoPartialFiles(t *testing.T) {
+	dir := t.TempDir()
+	j, err := Create(dir, testIntent())
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := j.AppendEvent(fitnessEvent("experimental", 0.5, testIntent().CreatedAt)); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+
+	expDir := filepath.Join(dir, "exp_a1b2c3d4e5f6")
+	entries, err := os.ReadDir(expDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".tmp") {
+			t.Errorf("temp leftover present: %s", e.Name())
+		}
+	}
+	// Both rewritten files round-trip as JSON (never half-written).
+	for _, name := range []string{intentFile, summaryFile} {
+		data, err := os.ReadFile(filepath.Join(expDir, name))
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		var v map[string]any
+		if err := json.Unmarshal(data, &v); err != nil {
+			t.Errorf("%s is not complete JSON: %v", name, err)
+		}
+	}
+}
+
+// TestCompactView_BoundedInN: the compact view's size stays constant as N grows —
+// arms count is fixed and the recent tail is capped, regardless of total events.
+func TestCompactView_BoundedInN(t *testing.T) {
+	dir := t.TempDir()
+	j, err := Create(dir, testIntent(), WithTailSize(5))
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	base := testIntent().CreatedAt
+	sizeAt := func() (int, int) {
+		v := j.CompactView()
+		return len(v.Arms), len(v.RecentTail)
+	}
+
+	for i := 1; i <= 200; i++ {
+		arm := "experimental"
+		if i%2 == 0 {
+			arm = "control"
+		}
+		if err := j.AppendEvent(fitnessEvent(arm, float64(i%10)/10, base.Add(time.Duration(i)*time.Second))); err != nil {
+			t.Fatalf("append %d: %v", i, err)
+		}
+		if i == 10 || i == 100 || i == 200 {
+			arms, tail := sizeAt()
+			if arms != 2 {
+				t.Errorf("at N=%d, arms=%d, want 2 (O(1))", i, arms)
+			}
+			if tail != 5 {
+				t.Errorf("at N=%d, tail=%d, want capped at 5 (O(1))", i, tail)
+			}
+		}
+	}
+
+	// The full event count is still reported (for context) without carrying the log.
+	v := j.CompactView()
+	if v.EventCount != 200 {
+		t.Errorf("EventCount = %d, want 200", v.EventCount)
+	}
+	// Tail is oldest-first and holds the LAST 5 events.
+	if v.RecentTail[len(v.RecentTail)-1].Seq != 200 {
+		t.Errorf("tail does not end at the newest event: last seq %d", v.RecentTail[len(v.RecentTail)-1].Seq)
+	}
+	if v.RecentTail[0].Seq != 196 {
+		t.Errorf("tail does not start at seq 196: got %d", v.RecentTail[0].Seq)
+	}
+}
+
+func TestCompactView_RehydratedTailIsBounded(t *testing.T) {
+	dir := t.TempDir()
+	j, err := Create(dir, testIntent(), WithTailSize(3))
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	base := testIntent().CreatedAt
+	for i := 1; i <= 50; i++ {
+		if err := j.AppendEvent(fitnessEvent("experimental", 0.5, base.Add(time.Duration(i)*time.Second))); err != nil {
+			t.Fatalf("append: %v", err)
+		}
+	}
+	reloaded, err := Load(dir, "exp_a1b2c3d4e5f6", WithTailSize(3))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got := len(reloaded.CompactView().RecentTail); got != 3 {
+		t.Errorf("rehydrated tail = %d, want capped at 3", got)
+	}
+}
+
+// TestAppendEvent_UnknownArmLoggedButNotFolded: an event for an arm not in the
+// intent is still recorded in the log (complete audit trail) but folds into no
+// accumulator.
+func TestAppendEvent_UnknownArmLoggedButNotFolded(t *testing.T) {
+	dir := t.TempDir()
+	j, err := Create(dir, testIntent())
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := j.AppendEvent(fitnessEvent("bogus", 0.9, testIntent().CreatedAt)); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	sum := j.Summary()
+	if _, ok := sum.Arms["bogus"]; ok {
+		t.Error("unknown arm should not appear in summary arms")
+	}
+	if sum.EventCount != 1 {
+		t.Errorf("event should still be logged: EventCount=%d", sum.EventCount)
+	}
+}
+
+// TestAppendEvent_ConcurrentSafe: concurrent appends never reuse a Seq nor lose a
+// fold; the final count equals the number of appends. Run with -race.
+func TestAppendEvent_ConcurrentSafe(t *testing.T) {
+	dir := t.TempDir()
+	j, err := Create(dir, testIntent())
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	const n = 50
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			_ = j.AppendEvent(fitnessEvent("experimental", 1.0, time.Now()))
+		}()
+	}
+	wg.Wait()
+
+	sum := j.Summary()
+	if sum.EventCount != n {
+		t.Errorf("EventCount = %d, want %d", sum.EventCount, n)
+	}
+	if sum.Arms["experimental"].Count != n {
+		t.Errorf("fold count = %d, want %d", sum.Arms["experimental"].Count, n)
+	}
+	// Seq numbers in the log are a contiguous 1..n permutation (none lost/dup).
+	lines := readLines(t, filepath.Join(dir, "exp_a1b2c3d4e5f6", eventsFile))
+	seen := make(map[int]bool, n)
+	for _, ln := range lines {
+		var e Event
+		if err := json.Unmarshal([]byte(ln), &e); err != nil {
+			t.Fatalf("bad line: %v", err)
+		}
+		if seen[e.Seq] {
+			t.Errorf("duplicate Seq %d", e.Seq)
+		}
+		seen[e.Seq] = true
+	}
+	for s := 1; s <= n; s++ {
+		if !seen[s] {
+			t.Errorf("missing Seq %d", s)
+		}
+	}
+}
+
+func TestLoad_MissingExperiment(t *testing.T) {
+	if _, err := Load(t.TempDir(), "exp_nope"); err == nil {
+		t.Fatal("Load of a non-existent experiment should fail")
+	}
+}
+
+func TestDirFromEnv(t *testing.T) {
+	t.Setenv(experimentDirEnv, "")
+	if DirFromEnv() != DefaultDir {
+		t.Errorf("empty env should yield DefaultDir, got %q", DirFromEnv())
+	}
+	t.Setenv(experimentDirEnv, "/custom/experiments")
+	if DirFromEnv() != "/custom/experiments" {
+		t.Errorf("env override not honored, got %q", DirFromEnv())
+	}
+}
+
+// --- test helpers ---
+
+func readLines(t *testing.T, path string) []string {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open %s: %v", path, err)
+	}
+	defer func() { _ = f.Close() }()
+	var lines []string
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		if strings.TrimSpace(sc.Text()) != "" {
+			lines = append(lines, sc.Text())
+		}
+	}
+	if err := sc.Err(); err != nil {
+		t.Fatalf("scan %s: %v", path, err)
+	}
+	return lines
+}
+
+// summariesEqual compares two rolling summaries for the fields a rehydrate must
+// preserve: status, event count, per-arm Welford state, and verdict.
+func summariesEqual(a, b Summary) bool {
+	if a.Status != b.Status || a.EventCount != b.EventCount || len(a.Arms) != len(b.Arms) {
+		return false
+	}
+	for name, sa := range a.Arms {
+		sb, ok := b.Arms[name]
+		if !ok || sa.Count != sb.Count ||
+			math.Abs(sa.Mean-sb.Mean) > 1e-12 || math.Abs(sa.M2-sb.M2) > 1e-12 {
+			return false
+		}
+	}
+	switch {
+	case a.Verdict == nil && b.Verdict == nil:
+		return true
+	case a.Verdict == nil || b.Verdict == nil:
+		return false
+	default:
+		return *a.Verdict == *b.Verdict
+	}
+}

--- a/services/agent/experiment/journal/journal_test.go
+++ b/services/agent/experiment/journal/journal_test.go
@@ -420,6 +420,111 @@ func TestLoad_MissingExperiment(t *testing.T) {
 	}
 }
 
+// TestRehydrate_TornTrailingLineDropped: a crash mid-append can leave a partial
+// final line in events.jsonl (O_APPEND has no cross-crash atomicity). Load must
+// DROP that torn tail and reconverge from the valid prefix — the dropped event was
+// never acknowledged to the caller, so the rehydrated summary must equal one built
+// from only the valid events. A subsequent AppendEvent must then continue with the
+// correct next Seq, and the journal must remain loadable afterwards.
+func TestRehydrate_TornTrailingLineDropped(t *testing.T) {
+	dir := t.TempDir()
+	j, err := Create(dir, testIntent())
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	base := testIntent().CreatedAt
+	valid := []struct {
+		arm string
+		f   float64
+	}{
+		{"experimental", 0.71}, {"control", 0.66}, {"experimental", 0.83},
+	}
+	for i, s := range valid {
+		if err := j.AppendEvent(fitnessEvent(s.arm, s.f, base.Add(time.Duration(i)*time.Minute))); err != nil {
+			t.Fatalf("append: %v", err)
+		}
+	}
+	// Summary built from ONLY the valid events — the expected reconverged state.
+	want := j.Summary()
+
+	// Simulate a torn final line: a partial/truncated JSON event with no trailing
+	// newline, exactly what a crash mid-write of event N+1 leaves behind.
+	eventsPath := filepath.Join(dir, "exp_a1b2c3d4e5f6", eventsFile)
+	// No trailing newline — a real torn tail ends mid-write.
+	tornLine := `{"seq":4,"kind":"game_concluded","arm":"experimental","fitn`
+	appendRawNoNewline(t, eventsPath, tornLine)
+
+	reloaded, err := Load(dir, "exp_a1b2c3d4e5f6")
+	if err != nil {
+		t.Fatalf("Load must reconverge from a torn tail, got error: %v", err)
+	}
+	got := reloaded.Summary()
+	if !summariesEqual(want, got) {
+		t.Errorf("rehydrated summary differs from valid-only:\nwant=%+v\ngot =%+v", want, got)
+	}
+	if got.EventCount != len(valid) {
+		t.Errorf("EventCount = %d, want %d (torn tail must not count)", got.EventCount, len(valid))
+	}
+
+	// The torn bytes must be truncated so the file holds only the valid lines.
+	if lines := readLines(t, eventsPath); len(lines) != len(valid) {
+		t.Errorf("after Load, events.jsonl has %d lines, want %d (torn tail not truncated)", len(lines), len(valid))
+	}
+
+	// A subsequent append must continue at the correct next Seq...
+	if err := reloaded.AppendEvent(fitnessEvent("control", 0.59, base.Add(time.Hour))); err != nil {
+		t.Fatalf("append after recovery: %v", err)
+	}
+	if got := reloaded.Summary().EventCount; got != len(valid)+1 {
+		t.Errorf("EventCount after recovery append = %d, want %d", got, len(valid)+1)
+	}
+	lastLine := readLines(t, eventsPath)
+	var last Event
+	if err := json.Unmarshal([]byte(lastLine[len(lastLine)-1]), &last); err != nil {
+		t.Fatalf("last line not valid JSON: %v", err)
+	}
+	if last.Seq != len(valid)+1 {
+		t.Errorf("recovered append Seq = %d, want %d", last.Seq, len(valid)+1)
+	}
+
+	// ...and the journal must remain loadable (the recovered tail is NOT now an
+	// interior torn line that would hard-error the NEXT Load).
+	if _, err := Load(dir, "exp_a1b2c3d4e5f6"); err != nil {
+		t.Errorf("journal not loadable after recovery + append: %v", err)
+	}
+}
+
+// TestRehydrate_InteriorCorruptionHardErrors: a malformed line that is NOT the last
+// line cannot be a torn tail (a later event was durably committed after it). That
+// signals a genuine lost/corrupted write, so Load must HARD-ERROR rather than
+// silently skip it.
+func TestRehydrate_InteriorCorruptionHardErrors(t *testing.T) {
+	dir := t.TempDir()
+	j, err := Create(dir, testIntent())
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	base := testIntent().CreatedAt
+	if err := j.AppendEvent(fitnessEvent("experimental", 0.71, base)); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+
+	// Corrupt an INTERIOR line: a garbage line followed by a valid trailing line.
+	eventsPath := filepath.Join(dir, "exp_a1b2c3d4e5f6", eventsFile)
+	appendRaw(t, eventsPath, "{not valid json") // interior (a valid line follows)
+	good := fitnessEvent("control", 0.66, base.Add(time.Minute))
+	good.Seq = 3
+	line, err := json.Marshal(good)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	appendRaw(t, eventsPath, string(line))
+
+	if _, err := Load(dir, "exp_a1b2c3d4e5f6"); err == nil {
+		t.Fatal("Load must hard-error on an interior malformed line, got nil")
+	}
+}
+
 func TestDirFromEnv(t *testing.T) {
 	t.Setenv(experimentDirEnv, "")
 	if DirFromEnv() != DefaultDir {
@@ -432,6 +537,34 @@ func TestDirFromEnv(t *testing.T) {
 }
 
 // --- test helpers ---
+
+// appendRaw appends a raw line (plus newline) directly to an events log, bypassing
+// the journal — used to inject torn or corrupt lines a crash would leave behind.
+func appendRaw(t *testing.T, path, line string) {
+	t.Helper()
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Fatalf("open %s for raw append: %v", path, err)
+	}
+	defer func() { _ = f.Close() }()
+	if _, err := f.WriteString(line + "\n"); err != nil {
+		t.Fatalf("raw append to %s: %v", path, err)
+	}
+}
+
+// appendRawNoNewline appends a raw line WITHOUT a trailing newline — a faithful
+// torn tail left mid-write by a crash.
+func appendRawNoNewline(t *testing.T, path, line string) {
+	t.Helper()
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Fatalf("open %s for raw append: %v", path, err)
+	}
+	defer func() { _ = f.Close() }()
+	if _, err := f.WriteString(line); err != nil {
+		t.Fatalf("raw append to %s: %v", path, err)
+	}
+}
 
 func readLines(t *testing.T, path string) []string {
 	t.Helper()

--- a/services/agent/experiment/journal/record.go
+++ b/services/agent/experiment/journal/record.go
@@ -1,0 +1,173 @@
+// Package journal is the agent's durable experiment journal (#983, epic #982):
+// the THIRD state class in the M7 model. Distinct from services/flagd/agent.json
+// (`:ro` governance the agent only reads) and services/flagd/game.json (the
+// control plane the agent writes), the journal is the agent's OWN working memory
+// — the agent both writes and reads it, and nothing else governs it (design §9).
+//
+// An experiment is a long-lived, evolving entity. This package defines HOW its
+// goal + progression + outcome are stored WITHOUT unbounded context growth, in a
+// three-part record per experiment (design §9.1):
+//
+//	(a) INTENT — immutable. Written once at creation: the hypothesis + full
+//	    experiment config. Never rewritten. On disk: intent.json.
+//	(b) EVENT LOG — append-only. One JSON object per material event, in order,
+//	    never rewritten. The audit trail and the ONLY place raw per-game fitness
+//	    samples are retained. On disk: events.jsonl.
+//	(c) ROLLING SUMMARY — rewritten atomically each conclusion. Per-arm
+//	    count/mean/variance via Welford (§8.2) plus the current verdict. O(1) size
+//	    in N. The compact view the live registry and the LLM read. On disk:
+//	    summary.json.
+//
+// Bounded-LLM-context discipline (§9.2, load-bearing): a caller building an LLM
+// prompt reads CompactView — intent + the rolling per-arm aggregates + a SHORT
+// recent tail — never the full game-by-game log, so prompt size stays roughly
+// constant as N grows from 1 to hundreds of games.
+//
+// Durability (§9.3): the journal is authoritative on a local mounted volume and
+// survives agent restart — the live in-memory state is a VIEW rebuilt from disk
+// via Load (the #831 in-memory-loss fix). Telemetry is a view, never the source
+// of truth. Persistence reuses the proven gamesummary pattern (atomic temp +
+// fsync + rename, env-overridable dir).
+//
+// Scope (this issue): STORAGE + STATE machinery ONLY. It does NOT wire into the
+// registry (#978), the aggregator (#979), or emit telemetry (#981); those consume
+// this package later. Decisions baked in (epic #982, 2026-06-13): journal backend
+// is JSONL + JSON (NOT SQLite); statistics are per-arm Welford running stats.
+package journal
+
+import "time"
+
+// SchemaVersion is bumped when the on-disk intent.json / summary.json shape
+// changes in a way a reader must notice. Carried on both records so the registry
+// (#978) and offline tooling can branch on it rather than guess. Mirrors
+// gamesummary.SchemaVersion.
+const SchemaVersion = 1
+
+// Intent is the immutable goal of an experiment (design §9.4a, intent.json).
+// Written exactly once by Create and never rewritten — the audit record of WHAT
+// the agent tried and WHY. Field names are stable wire contract.
+type Intent struct {
+	// SchemaVersion is SchemaVersion at write time.
+	SchemaVersion int `json:"schema_version"`
+	// ExperimentID is the stable id, e.g. "exp_a1b2c3d4e5f6". It is the journal
+	// directory name (sanitized) and the join key for every event and the summary.
+	ExperimentID string `json:"experiment_id"`
+	// CreatedAt is when the experiment was proposed (injected, never read off a
+	// clock here, so Create is deterministic for tests).
+	CreatedAt time.Time `json:"created_at"`
+	// Hypothesis is the agent's reasoning: what change + why it might help.
+	Hypothesis string `json:"hypothesis"`
+	// FlagKey is the game flag under experiment (e.g. "death_grace_period_seconds").
+	FlagKey string `json:"flag_key"`
+	// ExperimentalValue is the candidate value the experimental arm resolves. Any
+	// JSON scalar/object; stored verbatim for the audit trail and later attribution.
+	ExperimentalValue any `json:"experimental_value"`
+	// Objective is the fitness objective being optimized (e.g. "engagement_balanced").
+	Objective string `json:"objective"`
+	// TargetNPerArm is the minimum games per arm before a verdict can be conclusive.
+	TargetNPerArm int `json:"target_n_per_arm"`
+	// Arms are the arm names, e.g. ["experimental", "control"]. The summary keeps
+	// one Welford accumulator per arm; an event for an unknown arm is recorded in
+	// the log but folds into no accumulator (the log stays the complete audit trail).
+	Arms []string `json:"arms"`
+}
+
+// EventKind enumerates the material events in the append-only log (design §9.1b).
+// The set is closed so offline replay / dashboards can enumerate every kind.
+type EventKind string
+
+const (
+	// KindGameAssigned — a shadow game was bound to an arm (spawn binding, §5).
+	KindGameAssigned EventKind = "game_assigned"
+	// KindGameConcluded — a game finished and carries its fitness sample. This is
+	// the ONLY event that folds into an arm's Welford accumulator.
+	KindGameConcluded EventKind = "game_concluded"
+	// KindInterimVerdict — the rolling verdict recorded after a conclusion.
+	KindInterimVerdict EventKind = "interim_verdict"
+	// KindDecision — a status transition (continue/stop/promote).
+	KindDecision EventKind = "decision"
+	// KindOutcome — the terminal result (promoted/rejected/inconclusive).
+	KindOutcome EventKind = "outcome"
+)
+
+// Event is one entry in the append-only log (design §9.4b, one JSON object per
+// line in events.jsonl). It is a UNION across event kinds: Seq/At/Kind are always
+// set; the remaining fields are populated per kind (omitempty keeps each line
+// minimal and the kind self-describing). Never rewritten once appended.
+type Event struct {
+	// Seq is the 1-based monotonic sequence number assigned by the journal. It is
+	// the append order and the count of events; a gap would signal a lost write.
+	Seq int `json:"seq"`
+	// At is the event timestamp (injected by the caller, not read off a clock here).
+	At time.Time `json:"at"`
+	// Kind is the event kind (see EventKind).
+	Kind EventKind `json:"kind"`
+
+	// GameID is the game this event concerns (game_assigned / game_concluded). "" otherwise.
+	GameID string `json:"game_id,omitempty"`
+	// Arm is the arm the game belongs to (game_assigned / game_concluded). "" otherwise.
+	Arm string `json:"arm,omitempty"`
+	// Fitness is the game's fitness sample (game_concluded only). Folded into the
+	// arm's Welford accumulator. A pointer so a genuine 0.0 sample is distinct from
+	// "no fitness on this event kind" and is preserved across a rehydrate.
+	Fitness *float64 `json:"fitness,omitempty"`
+	// DurationS is the game's wall-clock duration in seconds (game_concluded),
+	// retained for the audit trail; not folded into statistics.
+	DurationS float64 `json:"duration_s,omitempty"`
+
+	// Verdict is the rolling verdict carried on an interim_verdict or outcome event.
+	Verdict *Verdict `json:"verdict,omitempty"`
+	// Status is the new status on a decision event (e.g. "running", "concluded").
+	Status string `json:"status,omitempty"`
+	// Note is a short free-text annotation for any event (optional audit context).
+	Note string `json:"note,omitempty"`
+}
+
+// ArmStat is the per-arm rolling sufficient statistics (design §9.4c). It embeds
+// the Welford accumulator so count/mean/M2 persist exactly across a rehydrate.
+type ArmStat struct {
+	// Welford carries count, mean, and M2 (variance is derived).
+	Welford
+}
+
+// Verdict is the current comparison verdict carried on the rolling summary and on
+// interim_verdict/outcome events. This package does NOT compute significance — the
+// aggregator (#979) supplies the verdict; the journal only stores it (it stays the
+// agent's working memory, not the statistics engine). Fields mirror design §9.4c.
+type Verdict struct {
+	// Outcome is the verdict label ("inconclusive" / "promote" / "discard"), kept a
+	// plain string so the journal does not depend on the experiment package's
+	// Outcome enum and can store labels it does not interpret.
+	Outcome string `json:"outcome"`
+	// Delta is experimental mean minus control mean (or whatever the aggregator
+	// computes); informational here.
+	Delta float64 `json:"delta"`
+	// Significant is whether the verdict cleared the significance bar.
+	Significant bool `json:"significant"`
+	// Reason is a short human-readable explanation (e.g. "n_per_arm < target (20)").
+	Reason string `json:"reason,omitempty"`
+}
+
+// Summary is the rolling sufficient-statistics snapshot (design §9.4c,
+// summary.json). Rewritten atomically by the journal after each conclusion. O(1)
+// size in N: one ArmStat per arm regardless of how many games each arm has seen.
+type Summary struct {
+	// SchemaVersion is SchemaVersion at write time.
+	SchemaVersion int `json:"schema_version"`
+	// ExperimentID joins the summary to its intent and events.
+	ExperimentID string `json:"experiment_id"`
+	// Status is the experiment lifecycle status ("running", "concluded", ...). It is
+	// set from decision/outcome events; defaults to "running" at Create.
+	Status string `json:"status"`
+	// UpdatedAt is the timestamp of the most recent fold (the At of the last event,
+	// so the summary's freshness tracks the log without reading a clock).
+	UpdatedAt time.Time `json:"updated_at"`
+	// EventCount is the number of events folded so far (the last Seq). Lets a reader
+	// verify the summary is in sync with events.jsonl after a rehydrate.
+	EventCount int `json:"event_count"`
+	// Arms is the per-arm rolling statistics, keyed by arm name. Seeded with every
+	// arm from Intent.Arms at Create so a never-played arm reports count 0.
+	Arms map[string]*ArmStat `json:"arms"`
+	// Verdict is the current rolling verdict, or nil before any has been recorded.
+	Verdict *Verdict `json:"verdict,omitempty"`
+}

--- a/services/agent/experiment/journal/store.go
+++ b/services/agent/experiment/journal/store.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -170,9 +171,22 @@ func (s *store) readIntent(experimentID string) (Intent, error) {
 }
 
 // readEvents loads events.jsonl in order. A missing file yields an empty slice
-// (an experiment created but with no events yet is valid). A malformed line is a
-// hard error — the log is the source of truth and silently skipping a line would
-// corrupt the rehydrated statistics.
+// (an experiment created but with no events yet is valid).
+//
+// Torn-tail recovery (design §9.3 durability): appendEventLine commits each event
+// with O_APPEND → single write → fsync, and POSIX gives an append NO cross-crash
+// atomicity. A crash mid-write of event N+1 — after event N was durably fsynced
+// AND acknowledged to the caller — can leave a partial final line. That last event
+// was never acknowledged, so dropping it is correct: the summary (rewritten only
+// AFTER the append returns) never counted it, and Load must still reconverge.
+// So a malformed LAST non-empty line is DROPPED with a warning, and the torn bytes
+// are TRUNCATED off the file so the next AppendEvent does not turn the partial line
+// into an interior line (which would then hard-error on the NEXT Load).
+//
+// A malformed INTERIOR (non-last) line stays a HARD error: an event followed by a
+// later durably-committed event cannot itself be a torn tail — it signals a genuine
+// lost/corrupted write, and silently skipping it would corrupt the rehydrated
+// statistics (consistent with the Seq-gap reasoning).
 func (s *store) readEvents(experimentID string) ([]Event, error) {
 	path := filepath.Join(s.dir(experimentID), eventsFile)
 	f, err := os.Open(path)
@@ -189,21 +203,60 @@ func (s *store) readEvents(experimentID string) ([]Event, error) {
 	// Allow long lines (a large experimental_value is not on events, but a Note
 	// could be sizable); 1 MiB ceiling is generous for a single event line.
 	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	// We must distinguish "malformed interior line" (hard error) from "malformed
+	// final line" (torn tail → drop). bufio.Scanner cannot look ahead, so when a
+	// line fails to unmarshal we DEFER the decision: stash it and keep scanning. If
+	// nothing more follows, it was the tail; if another non-empty line follows, the
+	// stashed one was interior and we hard-error.
 	lineNo := 0
+	// offset tracks the byte position of the END of the last successfully parsed
+	// line, so a torn tail can be truncated back to that point.
+	var validBytes int64
+	var pendingBad bool      // a malformed line is awaiting the tail/interior verdict
+	var pendingBadLineNo int // its 1-based line number, for the error/log message
 	for scanner.Scan() {
 		lineNo++
 		raw := scanner.Bytes()
+		// +1 for the newline bufio strips. The final line may have no trailing
+		// newline (exactly the torn-tail case), but that line is either dropped
+		// (no truncation past validBytes) or — if valid — the file already ends
+		// there, so validBytes is never used to truncate beyond EOF.
+		lineLen := int64(len(raw)) + 1
+
 		if len(strings.TrimSpace(string(raw))) == 0 {
+			validBytes += lineLen
 			continue
+		}
+		// A non-empty line follows a previously stashed bad line → that bad line was
+		// interior, not a torn tail. Hard error.
+		if pendingBad {
+			return nil, fmt.Errorf("decode event line %d for %q: malformed interior line (a later event follows it)", pendingBadLineNo, experimentID)
 		}
 		var e Event
 		if err := json.Unmarshal(raw, &e); err != nil {
-			return nil, fmt.Errorf("decode event line %d for %q: %w", lineNo, experimentID, err)
+			// Could be a torn final line — defer the verdict until we know whether
+			// another line follows.
+			pendingBad = true
+			pendingBadLineNo = lineNo
+			continue
 		}
 		events = append(events, e)
+		validBytes += lineLen
 	}
 	if err := scanner.Err(); err != nil {
 		return nil, fmt.Errorf("scan events log for %q: %w", experimentID, err)
+	}
+
+	// A still-pending bad line at EOF is the torn tail: drop it and truncate the
+	// partial bytes so the recovered journal stays loadable and the next append
+	// continues cleanly after the last VALID event.
+	if pendingBad {
+		log.Printf("journal: dropping torn final line %d of events log for %q (partial write from a crash); reconverging from %d prior event(s)", pendingBadLineNo, experimentID, len(events))
+		_ = f.Close() // release the read handle before truncating
+		if err := os.Truncate(path, validBytes); err != nil {
+			return nil, fmt.Errorf("truncate torn tail of events log for %q: %w", experimentID, err)
+		}
 	}
 	return events, nil
 }

--- a/services/agent/experiment/journal/store.go
+++ b/services/agent/experiment/journal/store.go
@@ -1,0 +1,209 @@
+package journal
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// store.go is the on-disk layout + persistence primitives (design §9.3). It
+// reuses the proven gamesummary.Writer pattern (writer.go:24, :82-129): one
+// directory per experiment under a fixed root, atomic temp+fsync+rename for the
+// rewritten files so a reader NEVER observes a half-written intent.json or
+// summary.json. The append-only events.jsonl is opened O_APPEND and fsynced per
+// append — it is never rewritten, so it needs no rename dance.
+
+// DefaultDir is the in-container experiments root. Override with
+// AGENT_EXPERIMENT_DIR. Mirrors gamesummary.DefaultDir / AGENT_GAME_SUMMARY_DIR.
+const DefaultDir = "/var/lib/joustmania/agent/experiments"
+
+// experimentDirEnv is the env var that overrides DefaultDir.
+const experimentDirEnv = "AGENT_EXPERIMENT_DIR"
+
+const (
+	intentFile  = "intent.json"
+	eventsFile  = "events.jsonl"
+	summaryFile = "summary.json"
+)
+
+// safeDirChars matches any rune NOT allowed in an experiment directory name.
+// experiment_ids are "exp_<hex>" (already safe), but the id is treated defensively
+// as an external label: anything outside [A-Za-z0-9._-] becomes '_' so the id can
+// never escape the experiments root (path traversal) or produce an unwritable name.
+// Mirrors gamesummary.safeFilenameChars.
+var safeDirChars = regexp.MustCompile(`[^A-Za-z0-9._-]`)
+
+// safeDirName sanitizes an experiment_id into a filesystem-safe directory name. An
+// empty or all-unsafe id collapses to "unknown" so a write never targets the root
+// itself or escapes it.
+func safeDirName(experimentID string) string {
+	name := safeDirChars.ReplaceAllString(experimentID, "_")
+	name = strings.Trim(name, ".")
+	if name == "" {
+		return "unknown"
+	}
+	return name
+}
+
+// DirFromEnv resolves the experiments root from AGENT_EXPERIMENT_DIR, falling back
+// to DefaultDir — the single env-override seam, mirroring gamesummary.DirFromEnv.
+func DirFromEnv() string {
+	if d := strings.TrimSpace(os.Getenv(experimentDirEnv)); d != "" {
+		return d
+	}
+	return DefaultDir
+}
+
+// store binds a root experiments directory. It holds no per-experiment state and
+// resolves each experiment's sub-directory from its (sanitized) id.
+type store struct {
+	root string
+}
+
+// newStore builds a store rooted at root. An empty root uses DefaultDir. The
+// directory is created lazily on first write (not here) so construction never
+// touches the filesystem and a test can point it at a t.TempDir().
+func newStore(root string) *store {
+	if root == "" {
+		root = DefaultDir
+	}
+	return &store{root: root}
+}
+
+// dir returns the per-experiment directory path.
+func (s *store) dir(experimentID string) string {
+	return filepath.Join(s.root, safeDirName(experimentID))
+}
+
+// writeJSONAtomic marshals v as indented JSON and persists it to path via a
+// temp+fsync+rename in the SAME directory — so a concurrent reader observes only
+// the complete file (gamesummary.Writer.Write, writer.go:82-129). Used for the two
+// rewritten files (intent.json, summary.json).
+func writeJSONAtomic(path string, v any) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("create experiment dir %q: %w", dir, err)
+	}
+
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal %q: %w", path, err)
+	}
+	data = append(data, '\n')
+
+	// Unique temp name in the destination dir so concurrent writes / retries never
+	// share a temp file, and the rename stays within one filesystem.
+	tmp, err := os.CreateTemp(dir, "."+filepath.Base(path)+"-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temp file for %q: %w", path, err)
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }()
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write temp file for %q: %w", path, err)
+	}
+	// fsync before rename so the bytes are durable before the directory entry
+	// flips — a crash can never leave the destination pointing at empty data.
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("sync temp file for %q: %w", path, err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp file for %q: %w", path, err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return fmt.Errorf("rename temp file to %q: %w", path, err)
+	}
+	return nil
+}
+
+// appendEventLine appends one JSON-encoded event as a single line to events.jsonl.
+// The file is opened O_APPEND|O_CREATE and fsynced after the write, so the line is
+// durable and ordered; the file is NEVER rewritten or truncated (the append-only
+// audit-trail guarantee, design §9.1b). The event is marshaled WITHOUT indentation
+// so it occupies exactly one line — the JSONL contract.
+func appendEventLine(path string, e Event) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create experiment dir for events: %w", err)
+	}
+	line, err := json.Marshal(e)
+	if err != nil {
+		return fmt.Errorf("marshal event seq %d: %w", e.Seq, err)
+	}
+	line = append(line, '\n')
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("open events log %q: %w", path, err)
+	}
+	if _, err := f.Write(line); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("append event to %q: %w", path, err)
+	}
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("sync events log %q: %w", path, err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("close events log %q: %w", path, err)
+	}
+	return nil
+}
+
+// readIntent loads and decodes intent.json for an experiment.
+func (s *store) readIntent(experimentID string) (Intent, error) {
+	var in Intent
+	data, err := os.ReadFile(filepath.Join(s.dir(experimentID), intentFile))
+	if err != nil {
+		return in, fmt.Errorf("read intent for %q: %w", experimentID, err)
+	}
+	if err := json.Unmarshal(data, &in); err != nil {
+		return in, fmt.Errorf("decode intent for %q: %w", experimentID, err)
+	}
+	return in, nil
+}
+
+// readEvents loads events.jsonl in order. A missing file yields an empty slice
+// (an experiment created but with no events yet is valid). A malformed line is a
+// hard error — the log is the source of truth and silently skipping a line would
+// corrupt the rehydrated statistics.
+func (s *store) readEvents(experimentID string) ([]Event, error) {
+	path := filepath.Join(s.dir(experimentID), eventsFile)
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("open events log for %q: %w", experimentID, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	var events []Event
+	scanner := bufio.NewScanner(f)
+	// Allow long lines (a large experimental_value is not on events, but a Note
+	// could be sizable); 1 MiB ceiling is generous for a single event line.
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	lineNo := 0
+	for scanner.Scan() {
+		lineNo++
+		raw := scanner.Bytes()
+		if len(strings.TrimSpace(string(raw))) == 0 {
+			continue
+		}
+		var e Event
+		if err := json.Unmarshal(raw, &e); err != nil {
+			return nil, fmt.Errorf("decode event line %d for %q: %w", lineNo, experimentID, err)
+		}
+		events = append(events, e)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scan events log for %q: %w", experimentID, err)
+	}
+	return events, nil
+}

--- a/services/agent/experiment/journal/welford.go
+++ b/services/agent/experiment/journal/welford.go
@@ -1,0 +1,54 @@
+package journal
+
+import "math"
+
+// welford.go implements Welford's online algorithm for running count / mean /
+// variance (design §8.2). It is the journal's sufficient-statistics engine: per
+// arm we keep only (count, mean, M2), updated O(1) per game-end, so the live
+// aggregate is constant-size in N — the raw per-game fitness samples live ONLY in
+// the append-only event log on disk (design §9c). This is the load-bearing
+// property behind the bounded-LLM-context discipline (§9.2): 50 games and 500
+// games fold into the same three numbers.
+
+// Welford accumulates a stream of fitness samples into running statistics. The
+// zero value is a valid empty accumulator (count 0). It is NOT safe for
+// concurrent mutation; the Journal serializes Append behind its own lock.
+type Welford struct {
+	// Count is the number of samples folded in so far.
+	Count int `json:"count"`
+	// Mean is the running mean of the samples (0 when Count == 0).
+	Mean float64 `json:"mean"`
+	// M2 is the running sum of squared deviations from the mean — Welford's
+	// aggregate. Variance is derived from it (see Variance); it is persisted so a
+	// rehydrate restores the accumulator exactly without replaying arithmetic that
+	// could drift.
+	M2 float64 `json:"m2"`
+}
+
+// Add folds one sample into the accumulator using Welford's recurrence. O(1) in
+// time and memory regardless of how many samples have been added.
+func (w *Welford) Add(sample float64) {
+	w.Count++
+	delta := sample - w.Mean
+	w.Mean += delta / float64(w.Count)
+	delta2 := sample - w.Mean
+	w.M2 += delta * delta2
+}
+
+// Variance returns the population variance (M2 / count). It returns 0 for an
+// empty accumulator (no samples) and for a single sample (no spread). Population
+// rather than sample variance is used because the arm aggregate describes the
+// games actually observed, not an inference about a larger population; the
+// significance test (#979) reads count/mean/variance and applies its own
+// correction if it wants the sample (n-1) form.
+func (w *Welford) Variance() float64 {
+	if w.Count == 0 {
+		return 0
+	}
+	return w.M2 / float64(w.Count)
+}
+
+// StdDev returns the population standard deviation (sqrt of Variance).
+func (w *Welford) StdDev() float64 {
+	return math.Sqrt(w.Variance())
+}

--- a/services/agent/experiment/journal/welford_test.go
+++ b/services/agent/experiment/journal/welford_test.go
@@ -1,0 +1,74 @@
+package journal
+
+import (
+	"math"
+	"testing"
+)
+
+// directStats computes count, mean, and population variance directly (two-pass) so
+// the Welford accumulator can be checked against an independent implementation.
+func directStats(samples []float64) (int, float64, float64) {
+	n := len(samples)
+	if n == 0 {
+		return 0, 0, 0
+	}
+	var sum float64
+	for _, s := range samples {
+		sum += s
+	}
+	mean := sum / float64(n)
+	var ss float64
+	for _, s := range samples {
+		d := s - mean
+		ss += d * d
+	}
+	return n, mean, ss / float64(n)
+}
+
+func TestWelford_MatchesDirectComputation(t *testing.T) {
+	cases := [][]float64{
+		{0.71, 0.66, 0.83, 0.59, 0.74, 0.61, 0.69, 0.77},
+		{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+		{0.5, 0.5, 0.5, 0.5},          // zero variance
+		{42.0},                        // single sample
+		{-1.5, 2.25, -3.75, 0.0, 8.1}, // mixed signs incl. a genuine 0.0
+	}
+	for i, samples := range cases {
+		var w Welford
+		for _, s := range samples {
+			w.Add(s)
+		}
+		wantN, wantMean, wantVar := directStats(samples)
+		if w.Count != wantN {
+			t.Errorf("case %d: count = %d, want %d", i, w.Count, wantN)
+		}
+		if math.Abs(w.Mean-wantMean) > 1e-9 {
+			t.Errorf("case %d: mean = %v, want %v", i, w.Mean, wantMean)
+		}
+		if math.Abs(w.Variance()-wantVar) > 1e-9 {
+			t.Errorf("case %d: variance = %v, want %v", i, w.Variance(), wantVar)
+		}
+	}
+}
+
+func TestWelford_EmptyAndSingle(t *testing.T) {
+	var w Welford
+	if w.Count != 0 || w.Mean != 0 || w.Variance() != 0 || w.StdDev() != 0 {
+		t.Errorf("empty accumulator should be all-zero, got %+v var=%v", w, w.Variance())
+	}
+	w.Add(3.0)
+	if w.Count != 1 || w.Mean != 3.0 || w.Variance() != 0 {
+		t.Errorf("single sample: count=%d mean=%v var=%v, want 1/3/0", w.Count, w.Mean, w.Variance())
+	}
+}
+
+func TestWelford_StdDev(t *testing.T) {
+	var w Welford
+	for _, s := range []float64{2, 4, 4, 4, 5, 5, 7, 9} {
+		w.Add(s)
+	}
+	// Known population stats for this textbook set: mean 5, variance 4, stddev 2.
+	if math.Abs(w.Mean-5) > 1e-9 || math.Abs(w.Variance()-4) > 1e-9 || math.Abs(w.StdDev()-2) > 1e-9 {
+		t.Errorf("mean=%v var=%v std=%v, want 5/4/2", w.Mean, w.Variance(), w.StdDev())
+	}
+}


### PR DESCRIPTION
Part of #982 — durable experiment journal.

Phase 3 (state) of the agent experiment/cohort framework. Adds a self-contained `services/agent/experiment/journal/` package implementing the three-part experiment record from design §9 (`docs/design/agent-experiment-cohorts.md`).

## Three-part record (design §9.1)
- **(a) INTENT — immutable** (`intent.json`): experiment_id, hypothesis, flag_key, experimental_value, objective, target_n_per_arm, arms. Written once at `Create`; never rewritten.
- **(b) EVENT LOG — append-only** (`events.jsonl`, one JSON object per line): `game_assigned`, `game_concluded` (+fitness sample), `interim_verdict`, `decision`, `outcome`. The audit trail and the **only** place raw per-game fitness samples are retained. Never rewritten — O_APPEND + fsync per line.
- **(c) ROLLING SUMMARY — rewritten atomically** (`summary.json`): per-arm `count`/`mean`/`variance` via **Welford** (online, O(1) in N) + the current verdict.

## API
- `Create(root, intent)` → writes `intent.json` + initial `summary.json`.
- `AppendEvent(event)` → appends to `events.jsonl`, folds a `game_concluded` fitness into the matching arm's Welford accumulator, atomically rewrites `summary.json`.
- `Load(root, experimentID)` → **rehydrate**: rebuild the rolling summary from intent + events on startup. The in-memory state is a VIEW of the durable journal (the **#831** in-memory-loss fix); the event log is the source of truth (a corrupt `summary.json` cache is ignored).
- `CompactView()` → the bounded `{intent, rolling summary, short recent-events tail}` the LLM/registry consume — **never** the full log, so prompt size stays ~constant as N grows (§9.2).

## Persistence (design §9.3)
Reuses the proven `gamesummary` pattern: atomic temp + fsync + rename for the rewritten files. Env-overridable dir `AGENT_EXPERIMENT_DIR` (default `/var/lib/joustmania/agent/experiments`), one directory per experiment.

## Scope
Storage + state machinery only — does NOT wire into the registry (#978), aggregator (#979), or telemetry (#981); those consume this package later. Journal backend = **JSONL + JSON** per the epic decision (not SQLite).

## Tests
Welford-vs-direct correctness, append-only ordering/immutability, rehydrate restart-survival (incl. ignoring a corrupt summary cache), atomic no-partial writes, O(1) bounded view, concurrent-append safety. `go test ./... -race`, `go vet ./...`, `gofmt -l .` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)