### PR TITLE
Experiment-scoped flag targeting for concurrent cohorts (#977)

### DIFF
--- a/services/agent/experiment/experiment_test.go
+++ b/services/agent/experiment/experiment_test.go
@@ -307,7 +307,7 @@ func TestResolveFlag_UnknownOperatorFailsClosed(t *testing.T) {
 func TestCheckVariantsAndDefault_DetectsDefaultChange(t *testing.T) {
 	before := mustFlag(t, `{"variants":{"a":1,"b":2},"defaultVariant":"a"}`)
 	after := mustFlag(t, `{"variants":{"a":1,"b":2,"agent_experiment":9},"defaultVariant":"b"}`)
-	if rej := checkVariantsAndDefault(before, after); rej == nil || rej.Reason != ReasonDefaultChanged {
+	if rej := checkVariantsAndDefault(before, after, ExperimentVariant); rej == nil || rej.Reason != ReasonDefaultChanged {
 		t.Fatalf("expected default_variant_changed, got %v", rej)
 	}
 }
@@ -315,7 +315,7 @@ func TestCheckVariantsAndDefault_DetectsDefaultChange(t *testing.T) {
 func TestCheckVariantsAndDefault_DetectsExistingVariantMutation(t *testing.T) {
 	before := mustFlag(t, `{"variants":{"a":1,"b":2},"defaultVariant":"a"}`)
 	after := mustFlag(t, `{"variants":{"a":1,"b":99,"agent_experiment":9},"defaultVariant":"a"}`)
-	if rej := checkVariantsAndDefault(before, after); rej == nil || rej.Reason != ReasonExistingVariantChanged {
+	if rej := checkVariantsAndDefault(before, after, ExperimentVariant); rej == nil || rej.Reason != ReasonExistingVariantChanged {
 		t.Fatalf("expected existing_variant_changed, got %v", rej)
 	}
 }

--- a/services/agent/experiment/gate.go
+++ b/services/agent/experiment/gate.go
@@ -147,7 +147,8 @@ func (g *Gate) Review(ctx context.Context, p Proposal) error {
 	span.SetAttributes(attribute.Bool(AttrBlocked, false))
 	g.log.Info("code_improvement.proposed",
 		"flag_key", p.FlagKey,
-		"variant", ExperimentVariant)
+		"experiment_id", p.ExperimentID,
+		"variant", experimentVariantName(p.ExperimentID))
 	return nil
 }
 
@@ -207,7 +208,7 @@ func (g *Gate) validate(p Proposal) *RejectError {
 		return &RejectError{Reason: ReasonWriteSimulationError, Detail: err.Error()}
 	}
 
-	if rej := checkVariantsAndDefault(beforeFlag, afterFlag); rej != nil {
+	if rej := checkVariantsAndDefault(beforeFlag, afterFlag, experimentVariantName(p.ExperimentID)); rej != nil {
 		return rej
 	}
 	if rej := checkTargetingShadowScoped(afterFlag); rej != nil {
@@ -220,9 +221,11 @@ func (g *Gate) validate(p Proposal) *RejectError {
 }
 
 // checkVariantsAndDefault enforces: defaultVariant byte-unchanged; every
-// pre-existing variant byte-unchanged; the ONLY added variant is the reserved
-// experimental one.
-func checkVariantsAndDefault(before, after *flagObj) *RejectError {
+// pre-existing variant byte-unchanged (including OTHER experiments' variants);
+// the ONLY added/overwritten variant is THIS proposal's reserved experiment
+// variant (writtenVariant). With K experiments on one flag, each carries its own
+// agent_experiment__<id> variant; a single write may replace only its own.
+func checkVariantsAndDefault(before, after *flagObj, writtenVariant string) *RejectError {
 	bDV, _ := before.raw("defaultVariant")
 	aDV, _ := after.raw("defaultVariant")
 	if !jsonEqual(bDV, aDV) {
@@ -237,13 +240,13 @@ func checkVariantsAndDefault(before, after *flagObj) *RejectError {
 	if _, err := after.get("variants", &aVars); err != nil {
 		return &RejectError{Reason: ReasonWriteSimulationError, Detail: err.Error()}
 	}
-	// Every pre-existing GAME-AUTHORED variant must survive byte-for-byte. The
-	// reserved experimental variant is exempt: it is never resolved by a real
-	// context (the shadow targeting guarantees that), so overwriting it on
-	// re-experimentation is safe and keeps re-runs idempotent (one variant, not
-	// an accumulating set).
+	// Every pre-existing variant must survive byte-for-byte — game-authored AND
+	// other experiments' agent_experiment__<id> variants. The ONLY exemption is
+	// the variant THIS proposal writes (writtenVariant): it is never resolved by a
+	// real context (its shadow branch guarantees that), so overwriting it on
+	// re-experimentation is safe and keeps re-runs idempotent (replace, not stack).
 	for name, bv := range bVars {
-		if name == ExperimentVariant {
+		if name == writtenVariant {
 			continue
 		}
 		av, ok := aVars[name]
@@ -254,12 +257,13 @@ func checkVariantsAndDefault(before, after *flagObj) *RejectError {
 			return &RejectError{Reason: ReasonExistingVariantChanged, Detail: "changed variant " + name}
 		}
 	}
-	// Any newly added variant must be exactly the reserved experimental one.
+	// Any newly added variant must be exactly THIS proposal's reserved experiment
+	// variant. (Other experiments' variants are pre-existing, handled above.)
 	for name := range aVars {
 		if _, existed := bVars[name]; existed {
 			continue
 		}
-		if name != ExperimentVariant {
+		if name != writtenVariant {
 			return &RejectError{Reason: ReasonTargetingNotShadowScoped, Detail: "unexpected new variant " + name}
 		}
 	}
@@ -335,10 +339,15 @@ func checkTypeCompatible(flag *flagObj, experimental any) *RejectError {
 	return nil
 }
 
-// checkTargetingShadowScoped enforces that the resulting targeting is exactly a
-// shadow-scoped wrapper: top-level {"if":[shadowCond, experimentVariant, else]}.
-// This is the structural proof that the experimental variant is unreachable for
-// a real context (the condition is game_kind != "real").
+// checkTargetingShadowScoped enforces that the resulting targeting is a CHAIN of
+// shadow-scoped wrappers: each link is {"if":[shadowCond, <its experiment
+// variant>, <next link>]} where shadowCond is either the legacy game_kind!=real
+// condition (selecting the unscoped agent_experiment variant) or an experiment-
+// scoped experiment_id==id AND arm==experimental condition (selecting
+// agent_experiment__id). The chain bottoms out in a TERMINAL else that mentions
+// NO experiment variant — that is the real / control / other-game path, and it
+// is what a real context resolves. This is the structural proof, now across ALL
+// branches, that no experiment variant is reachable for a real context.
 func checkTargetingShadowScoped(after *flagObj) *RejectError {
 	t, ok := after.raw("targeting")
 	if !ok {
@@ -346,38 +355,65 @@ func checkTargetingShadowScoped(after *flagObj) *RejectError {
 		// one — but applyProposal always writes one, so absence is a bug.
 		return &RejectError{Reason: ReasonTargetingNotShadowScoped, Detail: "missing targeting"}
 	}
-	var obj map[string]json.RawMessage
-	if err := json.Unmarshal(t, &obj); err != nil || len(obj) != 1 {
-		return &RejectError{Reason: ReasonTargetingNotShadowScoped, Detail: "targeting not a single-key if"}
-	}
-	ifRaw, ok := obj["if"]
-	if !ok {
-		return &RejectError{Reason: ReasonTargetingNotShadowScoped, Detail: "targeting top-level op is not if"}
-	}
-	var arms []json.RawMessage
-	if err := json.Unmarshal(ifRaw, &arms); err != nil || len(arms) != 3 {
-		return &RejectError{Reason: ReasonTargetingNotShadowScoped, Detail: "if is not [cond, then, else]"}
-	}
-	if !isShadowCondition(arms[0]) {
-		return &RejectError{Reason: ReasonTargetingNotShadowScoped, Detail: "condition is not game_kind != real"}
-	}
-	if !isExperimentVariant(arms[1]) {
-		return &RejectError{Reason: ReasonTargetingNotShadowScoped, Detail: "then-branch is not the experimental variant"}
-	}
-	// The else branch (real path) may be anything that does NOT itself select the
-	// experimental variant — guard against an else that leaks the variant to real.
-	if elseSelectsExperiment(arms[2]) {
-		return &RejectError{Reason: ReasonTargetingNotShadowScoped, Detail: "else-branch can select the experimental variant"}
-	}
-	return nil
+	return walkShadowChain(t)
 }
 
-// elseSelectsExperiment reports whether the real-path else branch could resolve
-// to the experimental variant (a literal string, or any nested rule that
-// mentions it). A conservative substring check on the raw bytes: the reserved
-// variant name must never appear in the real branch.
-func elseSelectsExperiment(elseBranch json.RawMessage) bool {
-	return strings.Contains(string(elseBranch), `"`+ExperimentVariant+`"`)
+// walkShadowChain validates one link of the targeting chain and recurses into
+// its else. A node that is NOT a single-key if is the terminal else: it must not
+// mention any experiment variant (or it could leak one to the real/control
+// path). A node that IS an if must be a recognised shadow link (cond + matching
+// experiment variant) before we descend; an if we don't recognise as ours is
+// treated as a terminal else and held to the same no-experiment-variant rule.
+func walkShadowChain(node json.RawMessage) *RejectError {
+	arms, ok := decodeIfArms(node)
+	if !ok {
+		// Terminal else (real/control path): may be anything that does NOT itself
+		// select an experiment variant.
+		if mentionsExperimentVariant(node) {
+			return &RejectError{Reason: ReasonTargetingNotShadowScoped, Detail: "else-branch can select an experiment variant"}
+		}
+		return nil
+	}
+
+	cond, then, elseBranch := arms[0], arms[1], arms[2]
+
+	// Identify which experiment this link is scoped to and confirm its then-branch
+	// selects exactly that experiment's variant. Legacy (game_kind!=real) link
+	// selects the unscoped ExperimentVariant; an experiment-scoped link selects
+	// agent_experiment__<id>.
+	var wantVariant string
+	switch {
+	case isShadowCondition(cond):
+		wantVariant = ExperimentVariant
+	default:
+		id, ok := experimentIDFromCondition(cond)
+		if !ok {
+			// An if we don't recognise as a shadow link. It could be a game-authored
+			// targeting (e.g. game_mode==Werewolf). It is part of the real/control
+			// path, so it must not select any experiment variant — treat as terminal.
+			if mentionsExperimentVariant(node) {
+				return &RejectError{Reason: ReasonTargetingNotShadowScoped, Detail: "unrecognised if-condition reaches an experiment variant"}
+			}
+			return nil
+		}
+		wantVariant = experimentVariantName(id)
+	}
+
+	if !variantNameIs(then, wantVariant) {
+		return &RejectError{Reason: ReasonTargetingNotShadowScoped, Detail: "then-branch is not this link's experiment variant"}
+	}
+	// The then-branch is a bare variant string; descend the chain via the else.
+	return walkShadowChain(elseBranch)
+}
+
+// mentionsExperimentVariant reports whether raw references ANY reserved
+// experiment variant name as a JSON string — the legacy agent_experiment or any
+// scoped agent_experiment__<id>. A conservative substring check on the raw bytes:
+// no experiment variant may appear in a terminal (real/control) branch. Because
+// the scoped names are prefixed by the legacy name, a single substring test on
+// the prefix catches both.
+func mentionsExperimentVariant(raw json.RawMessage) bool {
+	return strings.Contains(string(raw), `"`+ExperimentVariant)
 }
 
 // checkRealResolutionUnchanged is the belt-and-suspenders EVAL: resolve the flag

--- a/services/agent/experiment/proposal.go
+++ b/services/agent/experiment/proposal.go
@@ -44,6 +44,16 @@ type Proposal struct {
 	// parameterized surface").
 	FlagKey string
 
+	// ExperimentID scopes this proposal to one experiment so K concurrent
+	// experiments coexist on the same flag without clobbering (#977). Empty = the
+	// LEGACY unscoped binary rule (game_kind != "real" selects the single reserved
+	// agent_experiment variant) — byte-identical to the pre-#977 writer. Non-empty
+	// = an experiment-scoped rule: experiment_id == ExperimentID AND arm ==
+	// "experimental" selects a per-experiment agent_experiment__<id> variant;
+	// control + real + every OTHER experiment fall through to the existing default.
+	// The id is opaque to the Writer/Gate; the spawn step (#978) owns allocation.
+	ExperimentID string
+
 	// ExperimentalValue is the value shadow games should resolve for FlagKey. It
 	// is added as a new variant; its JSON kind MUST match the flag's existing
 	// variants (the game-side reader expects a consistent type). The Gate enforces

--- a/services/agent/experiment/targeting.go
+++ b/services/agent/experiment/targeting.go
@@ -3,6 +3,7 @@ package experiment
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 )
 
 // Shared constants for the shadow-scoping contract. These are the single source
@@ -26,32 +27,85 @@ const (
 	// protected, and real games always set game_kind="real".
 	GameKindReal = "real"
 
-	// ExperimentVariant is the single variant name the Writer adds/overwrites
-	// with the experimental value. One reserved name keeps re-experimentation on
-	// the same flag idempotent (overwrite, not accumulate) and makes the Gate's
-	// "only this variant is new" check trivial. It is namespaced so it can never
-	// collide with a game-authored variant.
+	// ExperimentIDVar is the evaluation-context key carrying the experiment a
+	// game belongs to. It is a CROSS-SERVICE CONTRACT: #975 sets this same key on
+	// the game-side OpenFeature context (mirroring game_kind). A real game has NO
+	// experiment_id (the API-level default omits it), so every experiment
+	// condition is false for real → existing default. Must match #975's lib value.
+	ExperimentIDVar = "experiment_id"
+
+	// ArmVar is the evaluation-context key carrying which arm of an experiment a
+	// game is in: "experimental" (resolve the override) or "control" (fall
+	// through to the existing default). Cross-service contract with #975.
+	ArmVar = "arm"
+
+	// ArmExperimental is the arm value that resolves the experimental variant. The
+	// control arm is NOT a distinct value the targeting matches — a control game
+	// simply is NOT ArmExperimental, so the `and` is false and it falls through to
+	// the existing else (same trick as the game_kind != real fall-through).
+	// Cross-service contract with #975.
+	ArmExperimental = "experimental"
+
+	// ExperimentVariant is the LEGACY single reserved variant name used by the
+	// binary (experiment-unscoped) shadow rule when a Proposal carries no
+	// ExperimentID. Experiment-scoped proposals use experimentVariantName(id) =
+	// ExperimentVariant + "__" + id so K experiments on one flag never collide.
+	// It is namespaced so it can never collide with a game-authored variant.
 	ExperimentVariant = "agent_experiment"
+
+	// experimentVariantSep separates the ExperimentVariant prefix from the
+	// experiment id in a scoped variant name (agent_experiment__exp_X).
+	experimentVariantSep = "__"
 )
 
-// buildShadowTargeting constructs the flagd JSONLogic targeting block that
-// selects ExperimentVariant for shadow games (game_kind != "real") and falls
-// through to whatever real games resolved before (existingTargeting, or null →
-// defaultVariant) for real games.
+// experimentVariantName returns the reserved variant name for an experiment-
+// scoped proposal: "agent_experiment__<experiment_id>". An empty id yields the
+// legacy unscoped ExperimentVariant so the pre-experiment rule round-trips
+// byte-for-byte (regression contract).
+func experimentVariantName(experimentID string) string {
+	if experimentID == "" {
+		return ExperimentVariant
+	}
+	return ExperimentVariant + experimentVariantSep + experimentID
+}
+
+// isAnyExperimentVariant reports whether name is a reserved experiment variant —
+// the legacy ExperimentVariant or any scoped agent_experiment__<id>. The Gate
+// uses this to recognise every agent-owned variant (immutable across re-runs)
+// and to forbid any OTHER newly added variant.
+func isAnyExperimentVariant(name string) bool {
+	return name == ExperimentVariant || strings.HasPrefix(name, ExperimentVariant+experimentVariantSep)
+}
+
+// buildShadowTargeting constructs the flagd JSONLogic targeting block for a
+// proposal, wrapping any pre-existing targeting (existingTargeting, or null) as
+// the else branch.
 //
-// Shape (matches the flagd targeting precedent in game.json, e.g. the
-// `sensitivity` flag's {"if":[cond, "fast", null]}):
+// Unscoped (experimentID == ""), the binary shadow rule — byte-identical to the
+// pre-#977 writer so the regression round-trips exactly:
 //
 //	{"if": [ {"!=": [{"var":"game_kind"}, "real"]}, "agent_experiment", <else> ]}
 //
-// where <else> is the flag's PRE-EXISTING targeting block verbatim (so a flag
-// that already targets game_mode keeps doing so for real games), or null when
-// the flag had no targeting (→ flagd falls through to defaultVariant).
+// Experiment-scoped (experimentID == "exp_X"):
 //
-// This is shadow-scoped BY CONSTRUCTION: for a `real` context the "!=" condition
-// is false, so flagd evaluates <else> — byte-identical to the pre-write
-// resolution. That is the structural half of the Gate's invariant.
-func buildShadowTargeting(existingTargeting json.RawMessage) (json.RawMessage, error) {
+//	{"if": [
+//	  {"and": [ {"==": [{"var":"experiment_id"}, "exp_X"]},
+//	            {"==": [{"var":"arm"}, "experimental"]} ]},
+//	  "agent_experiment__exp_X",
+//	  <else>
+//	]}
+//
+// In both cases <else> is the flag's PRE-EXISTING targeting verbatim (so a flag
+// that already targets game_mode, OR carries another experiment's branch, keeps
+// doing so), or null when the flag had no targeting. K experiments on the SAME
+// flag therefore nest as chained ifs: this experiment's branch is outermost, the
+// previous targeting (its own chain) is the else.
+//
+// Shadow/experiment-scoped BY CONSTRUCTION: a real context has no experiment_id
+// (and game_kind="real"), so every condition is false → flagd evaluates <else>,
+// byte-identical to the pre-write real resolution. That is the structural half
+// of the Gate's invariant, and it now holds across ALL chained branches.
+func buildShadowTargeting(experimentID string, existingTargeting json.RawMessage) (json.RawMessage, error) {
 	var elseBranch json.RawMessage
 	if len(existingTargeting) > 0 {
 		elseBranch = existingTargeting
@@ -59,23 +113,18 @@ func buildShadowTargeting(existingTargeting json.RawMessage) (json.RawMessage, e
 		elseBranch = json.RawMessage("null")
 	}
 
-	cond := map[string]any{
-		"!=": []any{
-			map[string]any{"var": GameKindVar},
-			GameKindReal,
-		},
-	}
-	condRaw, err := json.Marshal(cond)
+	condRaw, err := json.Marshal(shadowCondition(experimentID))
 	if err != nil {
 		return nil, fmt.Errorf("marshal shadow condition: %w", err)
 	}
-	thenRaw, err := json.Marshal(ExperimentVariant)
+	thenRaw, err := json.Marshal(experimentVariantName(experimentID))
 	if err != nil {
 		return nil, fmt.Errorf("marshal shadow variant: %w", err)
 	}
 
-	// Assemble {"if": [cond, then, else]} from raw parts so the pre-existing
-	// targeting (else) round-trips byte-for-byte.
+	// Assemble {"if": [cond, then, else]} from raw parts so the else (any
+	// pre-existing targeting, including other experiments' branches) round-trips
+	// byte-for-byte.
 	var buf []byte
 	buf = append(buf, []byte(`{"if":[`)...)
 	buf = append(buf, condRaw...)
@@ -85,6 +134,96 @@ func buildShadowTargeting(existingTargeting json.RawMessage) (json.RawMessage, e
 	buf = append(buf, elseBranch...)
 	buf = append(buf, []byte(`]}`)...)
 	return json.RawMessage(buf), nil
+}
+
+// shadowCondition returns the JSONLogic condition that selects the experimental
+// variant for a proposal. Unscoped: game_kind != real. Scoped: experiment_id ==
+// id AND arm == experimental.
+func shadowCondition(experimentID string) map[string]any {
+	if experimentID == "" {
+		return map[string]any{
+			"!=": []any{
+				map[string]any{"var": GameKindVar},
+				GameKindReal,
+			},
+		}
+	}
+	return map[string]any{
+		"and": []any{
+			map[string]any{"==": []any{map[string]any{"var": ExperimentIDVar}, experimentID}},
+			map[string]any{"==": []any{map[string]any{"var": ArmVar}, ArmExperimental}},
+		},
+	}
+}
+
+// isShadowCondition reports whether raw is the LEGACY unscoped shadow condition
+// {"!=":[{"var":"game_kind"},"real"]}.
+func isShadowCondition(raw json.RawMessage) bool {
+	want, err := json.Marshal(shadowCondition(""))
+	if err != nil {
+		return false
+	}
+	return jsonEqual(raw, want)
+}
+
+// experimentIDFromCondition returns (id, true) when raw is an experiment-scoped
+// condition {"and":[{"==":[{"var":"experiment_id"}, id]}, {"==":[{"var":"arm"},
+// "experimental"]}]}, extracting the experiment id. Otherwise ("", false). The
+// arm clause must be exactly == experimental so the control arm cannot match.
+func experimentIDFromCondition(raw json.RawMessage) (string, bool) {
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err != nil || len(obj) != 1 {
+		return "", false
+	}
+	andRaw, ok := obj["and"]
+	if !ok {
+		return "", false
+	}
+	var clauses []json.RawMessage
+	if err := json.Unmarshal(andRaw, &clauses); err != nil || len(clauses) != 2 {
+		return "", false
+	}
+	id, ok := equalsVarLiteral(clauses[0], ExperimentIDVar)
+	if !ok {
+		return "", false
+	}
+	arm, ok := equalsVarLiteral(clauses[1], ArmVar)
+	if !ok || arm != ArmExperimental {
+		return "", false
+	}
+	if id == "" {
+		return "", false
+	}
+	return id, true
+}
+
+// equalsVarLiteral parses {"==":[{"var": wantVar}, "<literal>"]} and returns the
+// string literal if the var matches wantVar. Returns ("", false) on any other
+// shape (non-string literal, wrong var, wrong op).
+func equalsVarLiteral(raw json.RawMessage, wantVar string) (string, bool) {
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err != nil || len(obj) != 1 {
+		return "", false
+	}
+	eqRaw, ok := obj["=="]
+	if !ok {
+		return "", false
+	}
+	var operands []json.RawMessage
+	if err := json.Unmarshal(eqRaw, &operands); err != nil || len(operands) != 2 {
+		return "", false
+	}
+	var v struct {
+		Var string `json:"var"`
+	}
+	if err := json.Unmarshal(operands[0], &v); err != nil || v.Var != wantVar {
+		return "", false
+	}
+	var lit string
+	if err := json.Unmarshal(operands[1], &lit); err != nil {
+		return "", false
+	}
+	return lit, true
 }
 
 // jsonEqual reports whether two raw JSON values are semantically equal

--- a/services/agent/experiment/targeting_experiment_test.go
+++ b/services/agent/experiment/targeting_experiment_test.go
@@ -1,0 +1,349 @@
+package experiment
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+
+	jsonlogic "github.com/diegoholiveira/jsonlogic/v3"
+)
+
+// resolveExperiment resolves a flag for a full experiment eval-context
+// (game_kind/experiment_id/arm) using the SAME jsonlogic engine flagd uses — an
+// independent re-implementation of resolution in the test, so it does not just
+// trust resolveFlag. ctx keys absent from a real game (no experiment_id) model a
+// real game by construction.
+func resolveExperiment(t *testing.T, path, flagKey string, ctx map[string]any) (string, any) {
+	t.Helper()
+	flagRaw := readFlagRaw(t, path, flagKey)
+	var flag struct {
+		Variants       map[string]any  `json:"variants"`
+		DefaultVariant string          `json:"defaultVariant"`
+		Targeting      json.RawMessage `json:"targeting"`
+	}
+	if err := json.Unmarshal(flagRaw, &flag); err != nil {
+		t.Fatalf("decode flag: %v", err)
+	}
+	variant := flag.DefaultVariant
+	if len(flag.Targeting) > 0 {
+		data, _ := json.Marshal(ctx)
+		var out bytes.Buffer
+		if err := jsonlogic.Apply(bytes.NewReader(flag.Targeting), bytes.NewReader(data), &out); err != nil {
+			t.Fatalf("jsonlogic apply: %v", err)
+		}
+		var sel any
+		_ = json.Unmarshal(out.Bytes(), &sel)
+		if name, ok := sel.(string); ok {
+			if _, known := flag.Variants[name]; known {
+				variant = name
+			}
+		}
+	}
+	return variant, flag.Variants[variant]
+}
+
+// realCtx / experimentalCtx / controlCtx build the three eval contexts a game
+// presents. A real game omits experiment_id entirely (API-level default).
+func realCtx() map[string]any { return map[string]any{GameKindVar: GameKindReal} }
+func experimentalCtx(id string) map[string]any {
+	return map[string]any{GameKindVar: GameKindShadowForTest, ExperimentIDVar: id, ArmVar: ArmExperimental}
+}
+func controlCtx(id string) map[string]any {
+	return map[string]any{GameKindVar: GameKindShadowForTest, ExperimentIDVar: id, ArmVar: "control"}
+}
+
+// GameKindShadowForTest mirrors the shadow game_kind value (#975 GAME_KIND_SHADOW
+// = "shadow"). Experiment targeting does NOT key on it; it is set only so the
+// eval contexts look like real shadow games.
+const GameKindShadowForTest = "shadow"
+
+// ---- Single experiment ------------------------------------------------------
+
+// A single experiment-scoped proposal: the experimental arm resolves V; the
+// control arm AND a real game both resolve the pre-experiment default.
+func TestReview_SingleExperimentScoped(t *testing.T) {
+	g, path, _ := gateWithRecorder(t)
+	const flagKey = "invincibility_seconds"
+	const expID = "exp_alpha"
+
+	beforeVar, beforeVal := resolveExperiment(t, path, flagKey, realCtx())
+
+	if err := g.Review(context.Background(), Proposal{
+		FlagKey:           flagKey,
+		ExperimentID:      expID,
+		ExperimentalValue: 6.0,
+		Rationale:         "longer invincibility for cohort alpha",
+	}); err != nil {
+		t.Fatalf("experiment proposal rejected: %v", err)
+	}
+
+	// Experimental arm resolves the experiment-scoped variant + value.
+	expVar, expVal := resolveExperiment(t, path, flagKey, experimentalCtx(expID))
+	if want := experimentVariantName(expID); expVar != want {
+		t.Fatalf("experimental arm variant = %q, want %q", expVar, want)
+	}
+	if expVal != 6.0 {
+		t.Fatalf("experimental arm value = %v, want 6.0", expVal)
+	}
+
+	// Control arm falls through to the pre-experiment default (no separate control
+	// variant — control IS the else branch).
+	ctlVar, ctlVal := resolveExperiment(t, path, flagKey, controlCtx(expID))
+	if ctlVar != beforeVar || ctlVal != beforeVal {
+		t.Fatalf("control arm drifted: before %s=%v, control %s=%v", beforeVar, beforeVal, ctlVar, ctlVal)
+	}
+
+	// Real game (no experiment_id) — THE INVARIANT.
+	realVar, realVal := resolveExperiment(t, path, flagKey, realCtx())
+	if realVar != beforeVar || realVal != beforeVal {
+		t.Fatalf("real resolution changed: before %s=%v, after %s=%v", beforeVar, beforeVal, realVar, realVal)
+	}
+}
+
+// ---- Two experiments on the SAME flag: non-bleed ---------------------------
+
+// The headline #977 test: two concurrent experiments on one flag coexist as
+// chained ifs. Each experiment's experimental arm resolves ONLY its own value;
+// the other experiment's games (both arms) and real games are unaffected. Mirrors
+// the fail-safe style of lib/tests/test_feature_flags.py (real-by-default + each
+// scope isolated).
+func TestReview_TwoExperimentsSameFlagNonBleed(t *testing.T) {
+	g, path, _ := gateWithRecorder(t)
+	const flagKey = "invincibility_seconds"
+	const expA, expB = "exp_alpha", "exp_beta"
+
+	_, realValBefore := resolveExperiment(t, path, flagKey, realCtx())
+
+	if err := g.Review(context.Background(), Proposal{
+		FlagKey: flagKey, ExperimentID: expA, ExperimentalValue: 6.0,
+	}); err != nil {
+		t.Fatalf("experiment A rejected: %v", err)
+	}
+	if err := g.Review(context.Background(), Proposal{
+		FlagKey: flagKey, ExperimentID: expB, ExperimentalValue: 8.0,
+	}); err != nil {
+		t.Fatalf("experiment B rejected: %v", err)
+	}
+
+	// A's experimental arm resolves ONLY A's value.
+	if v, val := resolveExperiment(t, path, flagKey, experimentalCtx(expA)); v != experimentVariantName(expA) || val != 6.0 {
+		t.Fatalf("A experimental = %s/%v, want %s/6.0", v, val, experimentVariantName(expA))
+	}
+	// B's experimental arm resolves ONLY B's value (A did NOT clobber it; B's
+	// write did NOT bleed into A).
+	if v, val := resolveExperiment(t, path, flagKey, experimentalCtx(expB)); v != experimentVariantName(expB) || val != 8.0 {
+		t.Fatalf("B experimental = %s/%v, want %s/8.0", v, val, experimentVariantName(expB))
+	}
+
+	// Each control arm and BOTH real games resolve the original default — unbled.
+	for name, ctx := range map[string]map[string]any{
+		"A control": controlCtx(expA),
+		"B control": controlCtx(expB),
+		"real":      realCtx(),
+		// A game in experiment A's experimental arm must NOT pick up B's value and
+		// vice versa — covered above; here ensure an unrelated experiment id falls
+		// through too.
+		"other experiment": experimentalCtx("exp_gamma"),
+	} {
+		if _, val := resolveExperiment(t, path, flagKey, ctx); val != realValBefore {
+			t.Fatalf("%s bled: resolved %v, want original default %v", name, val, realValBefore)
+		}
+	}
+
+	// Both experiment variants exist; the two original game variants survive.
+	flag := readFlagRaw(t, path, flagKey)
+	var f struct {
+		Variants map[string]json.RawMessage `json:"variants"`
+	}
+	_ = json.Unmarshal(flag, &f)
+	for _, want := range []string{experimentVariantName(expA), experimentVariantName(expB), "4s", "6s"} {
+		if _, ok := f.Variants[want]; !ok {
+			t.Fatalf("variant %q missing after two experiments", want)
+		}
+	}
+}
+
+// Re-running the SAME experiment id is idempotent (replace its value) and does
+// NOT disturb the OTHER experiment chained on the same flag.
+func TestReview_ReExperimentSameIDPreservesOther(t *testing.T) {
+	g, path, _ := gateWithRecorder(t)
+	const flagKey = "invincibility_seconds"
+	const expA, expB = "exp_alpha", "exp_beta"
+
+	for _, p := range []Proposal{
+		{FlagKey: flagKey, ExperimentID: expA, ExperimentalValue: 6.0},
+		{FlagKey: flagKey, ExperimentID: expB, ExperimentalValue: 8.0},
+		{FlagKey: flagKey, ExperimentID: expA, ExperimentalValue: 7.0}, // re-run A
+	} {
+		if err := g.Review(context.Background(), p); err != nil {
+			t.Fatalf("review %+v: %v", p, err)
+		}
+	}
+
+	if _, val := resolveExperiment(t, path, flagKey, experimentalCtx(expA)); val != 7.0 {
+		t.Fatalf("A after re-run = %v, want 7.0 (latest)", val)
+	}
+	if _, val := resolveExperiment(t, path, flagKey, experimentalCtx(expB)); val != 8.0 {
+		t.Fatalf("B after A re-run = %v, want 8.0 (undisturbed)", val)
+	}
+	// Exactly one variant per experiment (no accumulation).
+	flag := readFlagRaw(t, path, flagKey)
+	var f struct {
+		Variants map[string]json.RawMessage `json:"variants"`
+	}
+	_ = json.Unmarshal(flag, &f)
+	count := 0
+	for name := range f.Variants {
+		if isAnyExperimentVariant(name) {
+			count++
+		}
+	}
+	if count != 2 {
+		t.Fatalf("expected 2 experiment variants (A,B), got %d", count)
+	}
+}
+
+// Two experiments on DIFFERENT flags are fully independent (K independent rules).
+func TestReview_TwoExperimentsDifferentFlags(t *testing.T) {
+	g, path, _ := gateWithRecorder(t)
+
+	_, numBefore := resolveExperiment(t, path, "num_teams", realCtx())
+
+	if err := g.Review(context.Background(), Proposal{
+		FlagKey: "invincibility_seconds", ExperimentID: "exp_a", ExperimentalValue: 6.0,
+	}); err != nil {
+		t.Fatalf("A: %v", err)
+	}
+	if err := g.Review(context.Background(), Proposal{
+		FlagKey: "num_teams", ExperimentID: "exp_b", ExperimentalValue: 4,
+	}); err != nil {
+		t.Fatalf("B: %v", err)
+	}
+
+	if _, val := resolveExperiment(t, path, "num_teams", realCtx()); val != numBefore {
+		t.Fatalf("num_teams real drifted: %v want %v", val, numBefore)
+	}
+	if _, val := resolveExperiment(t, path, "num_teams", experimentalCtx("exp_b")); val != float64(4) {
+		t.Fatalf("num_teams exp_b experimental = %v, want 4", val)
+	}
+}
+
+// ---- Gate verifies the invariant across ALL branches -----------------------
+
+// A hand-built after-state with TWO experiment branches whose TERMINAL else
+// leaks an experiment variant to the real/control path must be rejected by
+// checkTargetingShadowScoped (the chain walk reaches all branches).
+func TestCheckTargeting_ChainTerminalElseLeak(t *testing.T) {
+	after := mustFlag(t, `{
+		"variants":{"a":1,"agent_experiment__x":9,"agent_experiment__y":7},
+		"defaultVariant":"a",
+		"targeting":{"if":[
+			{"and":[{"==":[{"var":"experiment_id"},"x"]},{"==":[{"var":"arm"},"experimental"]}]},
+			"agent_experiment__x",
+			{"if":[
+				{"and":[{"==":[{"var":"experiment_id"},"y"]},{"==":[{"var":"arm"},"experimental"]}]},
+				"agent_experiment__y",
+				"agent_experiment__x"
+			]}
+		]}
+	}`)
+	if rej := checkTargetingShadowScoped(after); rej == nil || rej.Reason != ReasonTargetingNotShadowScoped {
+		t.Fatalf("expected targeting_not_shadow_scoped for terminal-else leak, got %v", rej)
+	}
+}
+
+// A chain whose branch then-arm selects the WRONG experiment's variant (a
+// mismatched cond/variant pairing) is rejected.
+func TestCheckTargeting_ChainBranchVariantMismatch(t *testing.T) {
+	after := mustFlag(t, `{
+		"variants":{"a":1,"agent_experiment__x":9,"agent_experiment__y":7},
+		"defaultVariant":"a",
+		"targeting":{"if":[
+			{"and":[{"==":[{"var":"experiment_id"},"x"]},{"==":[{"var":"arm"},"experimental"]}]},
+			"agent_experiment__y",
+			null
+		]}
+	}`)
+	if rej := checkTargetingShadowScoped(after); rej == nil || rej.Reason != ReasonTargetingNotShadowScoped {
+		t.Fatalf("expected targeting_not_shadow_scoped for branch/variant mismatch, got %v", rej)
+	}
+}
+
+// A well-formed two-experiment chain (the exact shape applyProposal builds) is
+// ACCEPTED by the chain walk.
+func TestCheckTargeting_ValidChainAccepted(t *testing.T) {
+	after := mustFlag(t, `{
+		"variants":{"a":1,"agent_experiment__x":9,"agent_experiment__y":7},
+		"defaultVariant":"a",
+		"targeting":{"if":[
+			{"and":[{"==":[{"var":"experiment_id"},"y"]},{"==":[{"var":"arm"},"experimental"]}]},
+			"agent_experiment__y",
+			{"if":[
+				{"and":[{"==":[{"var":"experiment_id"},"x"]},{"==":[{"var":"arm"},"experimental"]}]},
+				"agent_experiment__x",
+				null
+			]}
+		]}
+	}`)
+	if rej := checkTargetingShadowScoped(after); rej != nil {
+		t.Fatalf("valid two-experiment chain rejected: %v", rej)
+	}
+}
+
+// The real-resolution eval over the full chain catches a proposal that would
+// change real resolution: a chain whose terminal else flips real to b.
+func TestCheckRealResolution_ChainAcrossBranches(t *testing.T) {
+	before := mustFlag(t, `{"variants":{"a":1,"b":2},"defaultVariant":"a"}`)
+	after := mustFlag(t, `{"variants":{"a":1,"b":2,"agent_experiment__x":9},"defaultVariant":"a",
+		"targeting":{"if":[
+			{"and":[{"==":[{"var":"experiment_id"},"x"]},{"==":[{"var":"arm"},"experimental"]}]},
+			"agent_experiment__x",
+			{"if":[{"==":[{"var":"game_kind"},"real"]},"b","a"]}
+		]}}`)
+	if rej := checkRealResolutionUnchanged(before, after); rej == nil || rej.Reason != ReasonRealResolutionChanged {
+		t.Fatalf("expected real_resolution_changed across chain, got %v", rej)
+	}
+}
+
+// ---- Regression: empty ExperimentID round-trips the legacy rule byte-for-byte
+// (the pre-#977 binary game_kind!=real rule). -------------------------------
+
+func TestBuildShadowTargeting_LegacyByteForByte(t *testing.T) {
+	got, err := buildShadowTargeting("", json.RawMessage("null"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	const want = `{"if":[{"!=":[{"var":"game_kind"},"real"]},"agent_experiment",null]}`
+	if string(got) != want {
+		t.Fatalf("legacy targeting drifted:\n got %s\nwant %s", got, want)
+	}
+}
+
+// experimentVariantName / experimentIDFromCondition round-trip.
+func TestExperimentVariantNameRoundTrip(t *testing.T) {
+	if experimentVariantName("") != ExperimentVariant {
+		t.Fatalf("empty id should yield legacy variant")
+	}
+	if got := experimentVariantName("exp_42"); got != "agent_experiment__exp_42" {
+		t.Fatalf("scoped variant = %q", got)
+	}
+	cond, _ := json.Marshal(shadowCondition("exp_42"))
+	id, ok := experimentIDFromCondition(cond)
+	if !ok || id != "exp_42" {
+		t.Fatalf("condition decode = %q,%v", id, ok)
+	}
+	// The legacy condition is not an experiment condition.
+	legacy, _ := json.Marshal(shadowCondition(""))
+	if _, ok := experimentIDFromCondition(legacy); ok {
+		t.Fatalf("legacy condition mis-decoded as experiment")
+	}
+	// A control-arm condition must NOT decode (arm != experimental).
+	ctlCond, _ := json.Marshal(map[string]any{"and": []any{
+		map[string]any{"==": []any{map[string]any{"var": ExperimentIDVar}, "exp_42"}},
+		map[string]any{"==": []any{map[string]any{"var": ArmVar}, "control"}},
+	}})
+	if _, ok := experimentIDFromCondition(ctlCond); ok {
+		t.Fatalf("control-arm condition mis-decoded as experimental")
+	}
+}

--- a/services/agent/experiment/writer.go
+++ b/services/agent/experiment/writer.go
@@ -115,18 +115,21 @@ func applyProposal(doc *document, p Proposal) error {
 	if err != nil {
 		return fmt.Errorf("marshal experimental value for %q: %w", p.FlagKey, err)
 	}
-	variants[ExperimentVariant] = valRaw
+	variants[experimentVariantName(p.ExperimentID)] = valRaw
 	if err := f.set("variants", variants); err != nil {
 		return err
 	}
 
-	// Compose the shadow branch over any pre-existing targeting so real games
-	// keep their prior behaviour. We read the targeting that was present BEFORE
-	// we touched it; on re-experimentation the prior block already starts with
-	// our shadow branch, so we strip it first to avoid nesting it indefinitely.
+	// Compose THIS proposal's branch over the pre-existing targeting so real games
+	// (and OTHER experiments' games) keep their prior behaviour. We read the
+	// targeting present BEFORE we touched it and strip only the branch matching
+	// THIS proposal's experiment id — so re-experimenting the same id is idempotent
+	// (replace, don't stack) while DIFFERENT experiments accumulate as a chain of
+	// ifs (each keyed on its own experiment_id). The remaining chain becomes the
+	// else of the freshly-built outermost branch.
 	existing, _ := f.raw("targeting")
-	existing = stripShadowBranch(existing)
-	targeting, err := buildShadowTargeting(existing)
+	existing = stripShadowBranch(p.ExperimentID, existing)
+	targeting, err := buildShadowTargeting(p.ExperimentID, existing)
 	if err != nil {
 		return err
 	}
@@ -135,54 +138,99 @@ func applyProposal(doc *document, p Proposal) error {
 	return doc.putFlag(p.FlagKey, f)
 }
 
-// stripShadowBranch returns the ELSE branch of a targeting block previously
-// produced by buildShadowTargeting, or the block unchanged if it is not one of
-// ours. This makes re-experimenting on the same flag idempotent: we re-wrap the
-// original (pre-experiment) targeting instead of stacking shadow branches.
-func stripShadowBranch(targeting json.RawMessage) json.RawMessage {
+// stripShadowBranch removes the chained-if branch produced by a PRIOR write for
+// experimentID, returning the targeting with only that branch elided (its else
+// spliced in where it sat). Other experiments' branches and the original
+// (pre-experiment) targeting are preserved verbatim. A targeting that is not one
+// of ours, or carries no branch for experimentID, is returned unchanged. This
+// keeps re-experimenting one id idempotent (replace, not stack) without
+// disturbing the K-1 other experiments on the same flag.
+func stripShadowBranch(experimentID string, targeting json.RawMessage) json.RawMessage {
 	if len(targeting) == 0 {
 		return nil
 	}
+	arms, ok := decodeIfArms(targeting)
+	if !ok {
+		return targeting // not a {"if":[cond,then,else]} — not ours, leave it.
+	}
+	// Is THIS the branch for experimentID? cond must match the proposal's shadow
+	// condition AND then must select that proposal's variant.
+	if conditionMatchesExperiment(arms[0], experimentID) && variantNameIs(arms[1], experimentVariantName(experimentID)) {
+		// Drop this branch: its else becomes the result (recursing in case a stale
+		// duplicate of the same id was somehow chained deeper — defensive).
+		stripped := stripShadowBranch(experimentID, arms[2])
+		if len(stripped) == 0 || string(stripped) == "null" {
+			return nil
+		}
+		return stripped
+	}
+	// A different experiment's (or the legacy) branch: keep it, recurse into the
+	// else so a deeper branch for experimentID is still found and removed.
+	newElse := stripShadowBranch(experimentID, arms[2])
+	if jsonEqual(orNull(newElse), orNull(arms[2])) {
+		return targeting // nothing changed below — return original bytes verbatim.
+	}
+	return rebuildIf(arms[0], arms[1], orNull(newElse))
+}
+
+// decodeIfArms returns the three arms of a single-key {"if":[cond,then,else]}
+// block, or (nil,false) if raw is not exactly that shape.
+func decodeIfArms(raw json.RawMessage) ([]json.RawMessage, bool) {
 	var obj map[string]json.RawMessage
-	if err := json.Unmarshal(targeting, &obj); err != nil {
-		return targeting
+	if err := json.Unmarshal(raw, &obj); err != nil || len(obj) != 1 {
+		return nil, false
 	}
 	ifRaw, ok := obj["if"]
-	if !ok || len(obj) != 1 {
-		return targeting
+	if !ok {
+		return nil, false
 	}
 	var arms []json.RawMessage
 	if err := json.Unmarshal(ifRaw, &arms); err != nil || len(arms) != 3 {
-		return targeting
+		return nil, false
 	}
-	// Confirm arm[0] is our shadow condition and arm[1] selects our variant.
-	if !isShadowCondition(arms[0]) || !isExperimentVariant(arms[1]) {
-		return targeting
-	}
-	if string(arms[2]) == "null" {
-		return nil
-	}
-	return arms[2]
+	return arms, true
 }
 
-// isShadowCondition reports whether raw is exactly {"!=":[{"var":"game_kind"},"real"]}.
-func isShadowCondition(raw json.RawMessage) bool {
-	want, err := json.Marshal(map[string]any{
-		"!=": []any{map[string]any{"var": GameKindVar}, GameKindReal},
-	})
-	if err != nil {
-		return false
+// conditionMatchesExperiment reports whether cond is the shadow condition for
+// experimentID — the legacy game_kind!=real condition when id is empty, or the
+// experiment_id==id AND arm==experimental condition otherwise.
+func conditionMatchesExperiment(cond json.RawMessage, experimentID string) bool {
+	if experimentID == "" {
+		return isShadowCondition(cond)
 	}
-	return jsonEqual(raw, want)
+	got, ok := experimentIDFromCondition(cond)
+	return ok && got == experimentID
 }
 
-// isExperimentVariant reports whether raw is the JSON string ExperimentVariant.
-func isExperimentVariant(raw json.RawMessage) bool {
+// variantNameIs reports whether raw is the JSON string equal to want.
+func variantNameIs(raw json.RawMessage, want string) bool {
 	var s string
 	if err := json.Unmarshal(raw, &s); err != nil {
 		return false
 	}
-	return s == ExperimentVariant
+	return s == want
+}
+
+// rebuildIf reassembles {"if":[cond,then,else]} from raw arms, preserving each
+// arm's bytes (so untouched sibling branches round-trip).
+func rebuildIf(cond, then, elseBranch json.RawMessage) json.RawMessage {
+	var buf []byte
+	buf = append(buf, []byte(`{"if":[`)...)
+	buf = append(buf, cond...)
+	buf = append(buf, ',')
+	buf = append(buf, then...)
+	buf = append(buf, ',')
+	buf = append(buf, elseBranch...)
+	buf = append(buf, []byte(`]}`)...)
+	return json.RawMessage(buf)
+}
+
+// orNull returns raw, or the JSON literal null when raw is empty.
+func orNull(raw json.RawMessage) json.RawMessage {
+	if len(raw) == 0 {
+		return json.RawMessage("null")
+	}
+	return raw
 }
 
 // writeInPlace overwrites the file at the same path WITHOUT temp+rename. Rename


### PR DESCRIPTION
Part of #982 — experiment-scoped targeting.

Phase 2 of the agent experiment/cohort framework (#977). Extends the experiment Writer/Gate (`services/agent/experiment/`) from the binary `game_kind != "real"` shadow rule to **experiment-keyed JSONLogic**, so K concurrent experiments coexist on a flag without clobbering. Implements design §6 of `docs/design/agent-experiment-cohorts.md`.

## Rule shape

`Proposal` gains `ExperimentID`. Empty keeps the legacy unscoped rule **byte-for-byte** (regression contract). Non-empty emits:

```jsonc
{"if": [
  {"and": [ {"==": [{"var":"experiment_id"}, "exp_X"]},
            {"==": [{"var":"arm"}, "experimental"]} ]},
  "agent_experiment__exp_X",
  <existing-else>
]}
```

- **Control = the else-branch.** A control game (`arm=control`) makes the `and` false → falls through to the existing default. No separate control variant.
- **Real-by-default preserved.** A real game has no `experiment_id` → every condition false → existing default.

## K experiments on the same flag

Chained `if`s: each experiment's branch is the next's else, keyed on its own `experiment_id`, with per-experiment variant names `agent_experiment__<id>` (replacing the single `ExperimentVariant`). `stripShadowBranch` removes only the **re-run experiment's own** branch (walking the chain), so the other K−1 are untouched; re-runs replace, not stack. K experiments on K different flags are K independent rules.

## Gate checks all branches

- `checkVariantsAndDefault` now protects **other experiments'** variants too — only the variant this proposal writes may change.
- `checkTargetingShadowScoped` walks the whole chain: each link must select exactly its own experiment variant; the terminal else (real/control/other-game path) must mention no experiment variant.
- The belt-and-suspenders real-context eval (`checkRealResolutionUnchanged`) is unchanged and now backstops every branch (real has no `experiment_id`).

Cross-service contract constants added: `ExperimentIDVar="experiment_id"`, `ArmVar="arm"`, `ArmExperimental="experimental"` (match #975).

## Tests

`go test ./... -race`, `go vet ./...`, `gofmt -l .`, `make lint` all clean. New cases: legacy byte-for-byte round-trip; single-experiment arms; **two-experiment same-flag non-bleed** (each experimental arm resolves only its own value, control/real/other unaffected); re-run preserves sibling; different-flags independence; Gate chain rejections (terminal-else leak, branch/variant mismatch, real-resolution change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)