### PR TITLE
feat(agent): experiment registry & lifecycle coordinator (#978)

### DIFF
--- a/services/agent/experiment/registry.go
+++ b/services/agent/experiment/registry.go
@@ -1,0 +1,831 @@
+package experiment
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/joustmania/agent/experiment/journal"
+)
+
+// registry.go is the agent-owned experiment COORDINATOR (design §7, #978). It is
+// the experiment-timescale counterpart to the per-game LoopSet/Multiplexer
+// (#845): where those manage one decision loop/store per live game, the Registry
+// manages one entry per live EXPERIMENT. It mints experiment ids, holds each
+// experiment's intent + status, allocates finite shadow capacity across the live
+// set, decides (experiment_id, arm) at spawn, folds concluded games into the
+// journal, drives the verdict + status machine, and tears the experiment down on
+// a terminal status.
+//
+// SOURCE OF TRUTH: the durable journal (#983). The in-memory Registry is a VIEW
+// rebuilt from disk on startup via Rehydrate (the #831 in-memory-loss fix) — the
+// journal's append-only event log + rolling summary are authoritative; the
+// Registry never holds state the journal does not.
+//
+// SEAMS (registry_seams.go): every consequential effect is injected —
+// ShadowSpawner (#976), CohortVerdict (#979), Promoter (#961/#980),
+// TargetingWriter (#977). The Registry owns ONLY the lifecycle logic, so it is
+// unit-testable with recording fakes.
+
+// Status is an experiment's lifecycle status (design §7.2). The set is closed so
+// the journal/dashboards can enumerate every state.
+//
+//	PROPOSED ─▶ RUNNING ─▶ CONCLUDED ─▶ {PROMOTING ─▶ DONE | DISCARDED}
+//	                 │
+//	                 └─▶ ABORTED   (kill-switch / capacity reclaim / error)
+type Status string
+
+const (
+	// StatusProposed — intent recorded; targeting not yet written; no games.
+	StatusProposed Status = "proposed"
+	// StatusRunning — targeting written; the experiment may accrue shadow games.
+	StatusRunning Status = "running"
+	// StatusConcluded — target N reached (or under-powered timeout); verdict computed.
+	StatusConcluded Status = "concluded"
+	// StatusPromoting — a concluded+promote experiment being routed to the Promoter.
+	StatusPromoting Status = "promoting"
+	// StatusDone — terminal: promotion finished; targeting torn down; capacity freed.
+	StatusDone Status = "done"
+	// StatusDiscarded — terminal: concluded without promotion; torn down.
+	StatusDiscarded Status = "discarded"
+	// StatusAborted — terminal: kill-switch / capacity reclaim / error; torn down.
+	StatusAborted Status = "aborted"
+)
+
+// IsTerminal reports whether a status is terminal (the experiment is finished and
+// its capacity + targeting have been released).
+func (s Status) IsTerminal() bool {
+	return s == StatusDone || s == StatusDiscarded || s == StatusAborted
+}
+
+// IsLive reports whether the experiment still occupies a registry slot and may be
+// allocated shadow capacity (PROPOSED/RUNNING — concluded experiments hold their
+// game map for the verdict but are not allocated new capacity).
+func (s Status) IsLive() bool {
+	return s == StatusProposed || s == StatusRunning
+}
+
+// DefaultMaxShadowGames is the fixed cap on concurrent shadow games across ALL
+// live experiments (epic #982 decision 2: a fixed configured cap, not dynamic
+// host-headroom). Override with AGENT_MAX_SHADOW_GAMES. 20 mirrors the issue's
+// suggested default. Real games still preempt shadow at the coordinator (the
+// registry does not fight that — this cap bounds only the registry's own
+// in-flight shadow spawns).
+const DefaultMaxShadowGames = 20
+
+// maxShadowGamesEnv overrides DefaultMaxShadowGames.
+const maxShadowGamesEnv = "AGENT_MAX_SHADOW_GAMES"
+
+// Arm names. The experimental arm resolves the candidate value; the control arm
+// falls through to the existing default (within-experiment baseline). Both are
+// game_kind="shadow" (the hard invariant). These mirror the targeting contract
+// (ArmExperimental in targeting.go) and #975's lib values.
+const (
+	ArmControl = "control"
+)
+
+// DefaultArms is the standard two-arm split (epic #982 decision 5: a
+// within-experiment shadow control arm IS the decision basis, with the recent-real
+// baseline as a sanity cross-check). Round-robin allocation interleaves them.
+func DefaultArms() []string { return []string{ArmExperimental, ArmControl} }
+
+// Intent is the agent's definition of an experiment — the structured hypothesis
+// the registry persists to the journal at PROPOSED. It is the registry-level
+// counterpart to a Proposal (which carries only the flag write): an Intent adds
+// the experiment framing (objective, arms, target N, stop criteria). Minting the
+// experiment_id is the registry's job (Declare), so it is NOT a field here.
+type Intent struct {
+	// Hypothesis is the agent's reasoning: what change + why it might help.
+	Hypothesis string
+	// FlagKey is the game flag under experiment. It is the Proposal's FlagKey.
+	FlagKey string
+	// ExperimentalValue is the candidate value the experimental arm resolves.
+	ExperimentalValue any
+	// Objective is the fitness objective being optimized (e.g. "engagement_balanced").
+	Objective string
+	// Arms are the arm names. Empty ⇒ DefaultArms() (experimental + control).
+	Arms []string
+	// TargetNPerArm is the minimum games per arm before a verdict can be conclusive.
+	// Non-positive ⇒ the verdict seam decides (it stays inconclusive until it does).
+	TargetNPerArm int
+}
+
+// MintExperimentID returns a fresh experiment id in the "exp_<uuid hex[:12]>"
+// shape, mirroring the game_<...> game-id shape (#845). Exported so a caller can
+// pre-mint an id (e.g. to correlate a span) before Declare.
+func MintExperimentID() string {
+	return "exp_" + strings.ReplaceAll(uuid.NewString(), "-", "")[:12]
+}
+
+// MaxShadowGamesFromEnv resolves the fixed shadow-capacity cap from
+// AGENT_MAX_SHADOW_GAMES, falling back to DefaultMaxShadowGames on an unset,
+// empty, or non-positive value (a zero/negative cap would starve every
+// experiment, so it is treated as misconfiguration).
+func MaxShadowGamesFromEnv() int {
+	if v := strings.TrimSpace(os.Getenv(maxShadowGamesEnv)); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return DefaultMaxShadowGames
+}
+
+// entry is the registry's in-memory view of one experiment. It is a cache of the
+// journal: status + the (game_id → arm) map + the round-robin cursor. The journal
+// remains authoritative; on restart Rehydrate rebuilds every entry from disk.
+type entry struct {
+	id      string
+	journal *journal.Journal
+	status  Status
+	flagKey string
+	// arms is the experiment's arm list (from intent), used for round-robin.
+	arms []string
+	// games maps a live (in-flight) shadow game_id → its arm. A game is removed on
+	// conclusion. len(games) is the experiment's current in-flight shadow count.
+	games map[string]string
+	// armCursor indexes arms for round-robin arm assignment within the experiment,
+	// so an experiment fills its arms evenly (experimental, control, experimental…).
+	armCursor int
+}
+
+// inFlight returns the experiment's current count of live (unconcluded) shadow
+// games — the slots it occupies against the global cap.
+func (e *entry) inFlight() int { return len(e.games) }
+
+// Registry is the agent-owned experiment coordinator (design §7). Safe for
+// concurrent use: a single mutex serializes the lifecycle/capacity book-keeping,
+// matching the LoopSet/Multiplexer pattern. The journal handles their own
+// locking; the registry holds at most ONE journal handle per experiment (the
+// single-writer-per-experiment invariant the journal package requires).
+type Registry struct {
+	root    string
+	maxCap  int
+	spawner ShadowSpawner
+	verdict CohortVerdict
+	promo   Promoter
+	target  TargetingWriter
+	clock   func() time.Time
+	log     *slog.Logger
+
+	mu      sync.Mutex
+	entries map[string]*entry
+	// rrCursor is the cross-experiment round-robin cursor for fair capacity
+	// allocation: AllocateAndSpawn rotates the start of the live-experiment scan so
+	// no single experiment is always served first (equal-share, no starvation).
+	rrCursor int
+}
+
+// RegistryConfig configures a Registry. Every seam may be nil — a nil seam
+// degrades to a safe no-op (a nil spawner cannot start a game; a nil verdict
+// leaves the verdict untouched; a nil promoter/target make promotion/teardown
+// recorded no-ops) so a Registry is always safe to construct in a test or before
+// a follow-up wires the real implementation. (Named RegistryConfig to avoid
+// colliding with the M7-7 validation Config in validate.go.)
+type RegistryConfig struct {
+	// Root is the journal experiments root (journal.DirFromEnv() in production; a
+	// t.TempDir in tests). Empty ⇒ journal.DefaultDir.
+	Root string
+	// MaxShadowGames is the fixed concurrent-shadow-game cap. Non-positive ⇒
+	// MaxShadowGamesFromEnv().
+	MaxShadowGames int
+	// Spawner / Verdict / Promoter / Targeting are the injected seams.
+	Spawner   ShadowSpawner
+	Verdict   CohortVerdict
+	Promoter  Promoter
+	Targeting TargetingWriter
+	// Clock is injected so Declare/AppendEvent timestamps are deterministic in
+	// tests. nil ⇒ time.Now (UTC).
+	Clock func() time.Time
+	// Log nil ⇒ slog.Default().
+	Log *slog.Logger
+}
+
+// NewRegistry builds a Registry over the injected seams. It does NOT touch the
+// filesystem or rehydrate — call Rehydrate after construction to rebuild the live
+// set from the journal.
+func NewRegistry(cfg RegistryConfig) *Registry {
+	maxCap := cfg.MaxShadowGames
+	if maxCap <= 0 {
+		maxCap = MaxShadowGamesFromEnv()
+	}
+	clock := cfg.Clock
+	if clock == nil {
+		clock = func() time.Time { return time.Now().UTC() }
+	}
+	log := cfg.Log
+	if log == nil {
+		log = slog.Default()
+	}
+	return &Registry{
+		root:    cfg.Root,
+		maxCap:  maxCap,
+		spawner: cfg.Spawner,
+		verdict: cfg.Verdict,
+		promo:   cfg.Promoter,
+		target:  cfg.Targeting,
+		clock:   clock,
+		log:     log,
+		entries: make(map[string]*entry),
+	}
+}
+
+// Declare defines a new experiment: it mints an experiment_id, persists the
+// immutable intent to the journal (journal.Create), records it as PROPOSED in the
+// registry, and returns the id. It does NOT spawn games or write targeting yet —
+// Start moves the experiment to RUNNING and writes the shadow targeting. Declare
+// fails if the journal already has this id (re-mint collision is astronomically
+// unlikely; a real collision is surfaced, not silently clobbered).
+func (r *Registry) Declare(in Intent) (string, error) {
+	arms := in.Arms
+	if len(arms) == 0 {
+		arms = DefaultArms()
+	}
+	id := MintExperimentID()
+	now := r.clock()
+
+	jrnl, err := journal.Create(r.root, journal.Intent{
+		ExperimentID:      id,
+		CreatedAt:         now,
+		Hypothesis:        in.Hypothesis,
+		FlagKey:           in.FlagKey,
+		ExperimentalValue: in.ExperimentalValue,
+		Objective:         in.Objective,
+		TargetNPerArm:     in.TargetNPerArm,
+		Arms:              arms,
+	})
+	if err != nil {
+		return "", fmt.Errorf("registry: declare experiment: %w", err)
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.entries[id] = &entry{
+		id:      id,
+		journal: jrnl,
+		status:  StatusProposed,
+		flagKey: in.FlagKey,
+		arms:    arms,
+		games:   make(map[string]string),
+	}
+	// Record the PROPOSED transition as a decision event for the audit trail.
+	r.recordDecision(jrnl, StatusProposed, "experiment declared")
+	r.log.Info("experiment.declared", "experiment_id", id, "flag_key", in.FlagKey, "objective", in.Objective)
+	return id, nil
+}
+
+// Start moves a PROPOSED experiment to RUNNING and writes its experiment-scoped
+// shadow targeting via the TargetingWriter (#977). After Start the experiment may
+// be allocated shadow capacity. A no-op (already RUNNING) returns nil. If the
+// targeting write fails the experiment stays PROPOSED (it never accrues games it
+// cannot scope) and the error is returned.
+func (r *Registry) Start(ctx context.Context, id string) error {
+	r.mu.Lock()
+	e := r.entries[id]
+	if e == nil {
+		r.mu.Unlock()
+		return fmt.Errorf("registry: start: unknown experiment %q", id)
+	}
+	if e.status == StatusRunning {
+		r.mu.Unlock()
+		return nil
+	}
+	if e.status != StatusProposed {
+		st := e.status
+		r.mu.Unlock()
+		return fmt.Errorf("registry: start: experiment %q is %s, not proposed", id, st)
+	}
+	intent := e.journal.Intent()
+	r.mu.Unlock()
+
+	if r.target != nil {
+		p := Proposal{
+			FlagKey:           intent.FlagKey,
+			ExperimentID:      id,
+			ExperimentalValue: intent.ExperimentalValue,
+			Rationale:         intent.Hypothesis,
+		}
+		if err := r.target.Apply(ctx, p); err != nil {
+			return fmt.Errorf("registry: start: write targeting for %q: %w", id, err)
+		}
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	// Re-fetch: a concurrent Abort may have removed/terminated it while unlocked.
+	e = r.entries[id]
+	if e == nil || e.status != StatusProposed {
+		return nil
+	}
+	e.status = StatusRunning
+	r.recordDecision(e.journal, StatusRunning, "experiment started")
+	r.log.Info("experiment.started", "experiment_id", id)
+	return nil
+}
+
+// AllocateAndSpawn fills FREE shadow capacity across the live experiments by
+// equal-share / round-robin (epic #982 decision 3), spawning at most one game per
+// experiment per pass until the cap is reached or no live experiment wants
+// another game. It is the registry's capacity scheduler: call it whenever
+// capacity may have freed (a game concluded, an experiment started). It returns
+// the number of games spawned this call.
+//
+// Fairness: the live experiments are scanned starting from a rotating cursor and
+// each gets at most one new game per pass, so K experiments share the cap evenly
+// and none starves. The global cap is the sum of in-flight games across ALL
+// experiments; allocation never exceeds it. Real games preempting shadow at the
+// coordinator is out of scope — this bounds only the registry's own spawns.
+func (r *Registry) AllocateAndSpawn(ctx context.Context) int {
+	if r.spawner == nil {
+		return 0
+	}
+	spawned := 0
+	for {
+		// Each iteration is one round-robin PASS: pick the next live experiment
+		// (from the rotating cursor) that has capacity and spawn ONE game for it.
+		// Re-evaluate capacity each pick so the global cap is never exceeded.
+		id, arm, ok := r.nextAllocation()
+		if !ok {
+			return spawned
+		}
+		gameID, err := r.spawner.Spawn(ctx, id, arm)
+		if err != nil {
+			// The slot was reserved optimistically; release it on failure so a
+			// flaky spawn does not permanently shrink capacity.
+			r.releaseReservation(id, arm)
+			r.log.Warn("experiment.spawn_failed", "experiment_id", id, "arm", arm, "error", err)
+			// Stop this call rather than hot-loop on a failing spawner.
+			return spawned
+		}
+		r.bindGame(id, gameID, arm)
+		spawned++
+	}
+}
+
+// nextAllocation picks the next (experiment_id, arm) to spawn under the global
+// cap, reserving the slot, or reports ok=false when the cap is full or no live
+// experiment exists. It advances both the cross-experiment round-robin cursor
+// (fairness) and the chosen experiment's per-arm cursor (even arm fill). Assumes
+// nothing; takes the lock.
+func (r *Registry) nextAllocation() (id, arm string, ok bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.inFlightLocked() >= r.maxCap {
+		return "", "", false
+	}
+	live := r.liveIDsLocked()
+	if len(live) == 0 {
+		return "", "", false
+	}
+	// Scan starting from the rotating cursor so a different experiment leads each
+	// pass — equal-share over time even when the cap is the binding constraint.
+	start := r.rrCursor % len(live)
+	for i := 0; i < len(live); i++ {
+		cand := live[(start+i)%len(live)]
+		e := r.entries[cand]
+		// Equal-share guard: do not let one experiment hold more than its fair
+		// ceil(cap/K) share while others want games — bound its in-flight count to
+		// the per-experiment share so K experiments converge to an even split.
+		share := r.perExperimentShareLocked(len(live))
+		if e.inFlight() >= share {
+			continue
+		}
+		// Reserve the slot: pick the arm (round-robin within the experiment) and
+		// advance both cursors. The actual bind happens after a successful spawn;
+		// reserve by recording a placeholder so concurrent passes see the slot taken.
+		arm := e.arms[e.armCursor%len(e.arms)]
+		e.armCursor++
+		r.rrCursor = (start + i + 1) % len(live)
+		// Reserve against the cap by pre-incrementing via a placeholder game id; it
+		// is replaced by the real game id in bindGame, or released on spawn failure.
+		placeholder := reservationKey(cand, e.armCursor)
+		e.games[placeholder] = arm
+		return cand, arm, true
+	}
+	return "", "", false
+}
+
+// perExperimentShareLocked is the equal-share ceiling per live experiment:
+// ceil(cap / K). It bounds any one experiment to its fair slice so the cap splits
+// evenly across K live experiments (no starvation). Assumes r.mu is held.
+func (r *Registry) perExperimentShareLocked(k int) int {
+	if k <= 0 {
+		return r.maxCap
+	}
+	return (r.maxCap + k - 1) / k
+}
+
+// reservationKey builds the placeholder game id a reserved-but-not-yet-spawned
+// slot occupies in entry.games. It is distinct from any coordinator game_id
+// (which is "game_<hex>"), so bindGame/releaseReservation can find and replace it.
+func reservationKey(id string, seq int) string {
+	return "__reserved__" + id + "__" + strconv.Itoa(seq)
+}
+
+// bindGame replaces the most-recent reservation for the experiment with the real
+// coordinator game_id, records a game_assigned journal event, and (re)allocation
+// is the caller's concern. Assumes the reservation exists (nextAllocation made it).
+func (r *Registry) bindGame(id, gameID, arm string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	e := r.entries[id]
+	if e == nil {
+		return
+	}
+	// Replace the matching reservation placeholder (an arbitrary one for this arm)
+	// with the real game id. We find ANY reservation for this arm to convert.
+	for k, a := range e.games {
+		if isReservation(k) && a == arm {
+			delete(e.games, k)
+			break
+		}
+	}
+	e.games[gameID] = arm
+	r.appendEvent(e.journal, journal.Event{
+		Kind:   journal.KindGameAssigned,
+		GameID: gameID,
+		Arm:    arm,
+	})
+	r.log.Info("experiment.game_assigned", "experiment_id", id, "game_id", gameID, "arm", arm)
+}
+
+// releaseReservation drops one reservation placeholder for the arm (used when a
+// spawn fails) so a flaky spawn does not permanently consume a capacity slot.
+func (r *Registry) releaseReservation(id, arm string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	e := r.entries[id]
+	if e == nil {
+		return
+	}
+	for k, a := range e.games {
+		if isReservation(k) && a == arm {
+			delete(e.games, k)
+			return
+		}
+	}
+}
+
+// isReservation reports whether a game-map key is a reservation placeholder
+// rather than a real coordinator game_id.
+func isReservation(k string) bool { return strings.HasPrefix(k, "__reserved__") }
+
+// ConcludeGame records that a shadow game ended (design §7.1, §8.1): it appends a
+// game_concluded journal event with the game's fitness sample (folding it into
+// the matching arm's Welford accumulator), then calls the CohortVerdict seam to
+// recompute the interim verdict, records it, and transitions the experiment to
+// CONCLUDED when the verdict warrants (promote/discard, or an under-powered
+// timeout the verdict signals). It looks the game up in the (game_id →
+// experiment_id, arm) map the registry owns. An unknown game_id is ignored (it
+// was not one of ours). On CONCLUDED the experiment is routed to promotion (if the
+// verdict promotes) and torn down. Returns the resulting status.
+func (r *Registry) ConcludeGame(ctx context.Context, gameID string, fitness float64, durationS float64) (Status, error) {
+	r.mu.Lock()
+	id, arm, e := r.findGameLocked(gameID)
+	if e == nil {
+		r.mu.Unlock()
+		return "", nil // not one of ours; ignore.
+	}
+	delete(e.games, gameID)
+	f := fitness
+	r.appendEvent(e.journal, journal.Event{
+		Kind:      journal.KindGameConcluded,
+		GameID:    gameID,
+		Arm:       arm,
+		Fitness:   &f,
+		DurationS: durationS,
+	})
+	jrnl := e.journal
+	r.mu.Unlock()
+
+	// Recompute the interim verdict from the seam (outside the registry lock — the
+	// journal has its own lock). Record it as an interim_verdict event.
+	view := jrnl.CompactView()
+	var verdict journal.Verdict
+	haveVerdict := false
+	if r.verdict != nil {
+		verdict, haveVerdict = r.verdict.Evaluate(view)
+		if haveVerdict {
+			r.appendEvent(jrnl, journal.Event{
+				Kind:    journal.KindInterimVerdict,
+				Verdict: &verdict,
+			})
+		}
+	}
+
+	r.log.Info("experiment.game_concluded",
+		"experiment_id", id, "game_id", gameID, "arm", arm, "fitness", fitness)
+
+	// Decide whether to conclude the experiment. A promote/discard verdict
+	// concludes it; inconclusive keeps it running. (An under-powered timeout is the
+	// verdict seam's call — it returns promote/discard once it is willing to.)
+	if haveVerdict && verdict.Outcome != OutcomeInconclusive {
+		return r.conclude(ctx, id, verdict)
+	}
+	return StatusRunning, nil
+}
+
+// conclude transitions an experiment to CONCLUDED on a final verdict, routes a
+// promote verdict to the Promoter (PROMOTING → DONE), discards otherwise, and
+// tears down the targeting + frees capacity. It is the verdict→terminal path.
+func (r *Registry) conclude(ctx context.Context, id string, verdict journal.Verdict) (Status, error) {
+	r.mu.Lock()
+	e := r.entries[id]
+	if e == nil || e.status.IsTerminal() {
+		r.mu.Unlock()
+		if e != nil {
+			return e.status, nil
+		}
+		return "", nil
+	}
+	e.status = StatusConcluded
+	r.recordDecision(e.journal, StatusConcluded, "target N reached / verdict "+verdict.Outcome)
+	jrnl := e.journal
+	flagKey := e.flagKey
+	r.mu.Unlock()
+
+	r.log.Info("experiment.concluded", "experiment_id", id, "outcome", verdict.Outcome)
+
+	if verdict.Outcome == CohortOutcomePromote {
+		r.promote(ctx, id, jrnl)
+	}
+
+	// Terminal: discard if not promoted/done. Promotion sets DONE; otherwise discard.
+	r.mu.Lock()
+	e = r.entries[id]
+	final := StatusDiscarded
+	if e != nil && e.status == StatusDone {
+		final = StatusDone
+	}
+	r.mu.Unlock()
+
+	r.teardown(ctx, id, flagKey, final, "experiment concluded: "+verdict.Outcome)
+	return final, nil
+}
+
+// promote routes a concluded+promote experiment to the Promoter seam
+// (#961/#980), transitioning PROMOTING → DONE. A nil Promoter or a Promote error
+// is recorded but never blocks teardown — the experiment is concluded either way.
+func (r *Registry) promote(ctx context.Context, id string, jrnl *journal.Journal) {
+	r.mu.Lock()
+	e := r.entries[id]
+	if e == nil {
+		r.mu.Unlock()
+		return
+	}
+	e.status = StatusPromoting
+	r.recordDecision(e.journal, StatusPromoting, "routing to promoter")
+	r.mu.Unlock()
+
+	if r.promo != nil {
+		if err := r.promo.Promote(ctx, jrnl.CompactView()); err != nil {
+			r.log.Warn("experiment.promote_failed", "experiment_id", id, "error", err)
+		}
+	}
+
+	r.mu.Lock()
+	if e := r.entries[id]; e != nil {
+		e.status = StatusDone
+		r.recordDecision(e.journal, StatusDone, "promotion routed")
+	}
+	r.mu.Unlock()
+}
+
+// Abort terminates an experiment (kill-switch / capacity reclaim / error): it
+// records the ABORTED transition, tears down the targeting, and frees capacity.
+// A terminal experiment is a no-op. reason is recorded for the audit trail.
+func (r *Registry) Abort(ctx context.Context, id, reason string) error {
+	r.mu.Lock()
+	e := r.entries[id]
+	if e == nil {
+		r.mu.Unlock()
+		return fmt.Errorf("registry: abort: unknown experiment %q", id)
+	}
+	if e.status.IsTerminal() {
+		r.mu.Unlock()
+		return nil
+	}
+	flagKey := e.flagKey
+	r.mu.Unlock()
+
+	r.teardown(ctx, id, flagKey, StatusAborted, reason)
+	return nil
+}
+
+// AbortAll aborts every live (non-terminal) experiment — the kill-switch path
+// (design §7.2 / §10: auto-stop on agent.json `enabled` false). It is called when
+// the agent is disabled. Returns the ids aborted.
+func (r *Registry) AbortAll(ctx context.Context, reason string) []string {
+	r.mu.Lock()
+	ids := make([]string, 0, len(r.entries))
+	for id, e := range r.entries {
+		if !e.status.IsTerminal() {
+			ids = append(ids, id)
+		}
+	}
+	r.mu.Unlock()
+
+	sort.Strings(ids) // deterministic order (tests + stable logs)
+	for _, id := range ids {
+		_ = r.Abort(ctx, id, reason)
+	}
+	return ids
+}
+
+// teardown is the inverse of Start (design §10): it strips the experiment's
+// shadow targeting branch via the TargetingWriter (#977), records the terminal
+// decision, sets the terminal status, and frees capacity (clearing the in-flight
+// game map so the freed slots are available to other experiments on the next
+// AllocateAndSpawn). Idempotent on a terminal experiment.
+func (r *Registry) teardown(ctx context.Context, id, flagKey string, terminal Status, reason string) {
+	// Strip the targeting OUTSIDE the registry lock (it does file I/O). Stripping a
+	// shadow branch only ever affects shadow games, so it is invariant-safe.
+	if r.target != nil {
+		if err := r.target.Strip(ctx, flagKey, id); err != nil {
+			r.log.Warn("experiment.teardown_strip_failed", "experiment_id", id, "error", err)
+		}
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	e := r.entries[id]
+	if e == nil {
+		return
+	}
+	if e.status.IsTerminal() && e.status == terminal {
+		return
+	}
+	e.status = terminal
+	// Free capacity: drop the in-flight games (reservations + bound games). Their
+	// slots return to the global cap for other experiments.
+	e.games = make(map[string]string)
+	r.appendEvent(e.journal, journal.Event{
+		Kind:   journal.KindOutcome,
+		Status: string(terminal),
+		Note:   reason,
+	})
+	r.log.Info("experiment.torn_down", "experiment_id", id, "status", string(terminal), "reason", reason)
+}
+
+// Rehydrate rebuilds the live registry from the durable journal on startup (the
+// #831 fix, design §7.2): it scans the journal root for experiment dirs, Loads
+// each, and reconstructs an entry from its compact view (status + arms). It does
+// NOT re-load the in-flight game map — a restart loses no DURABLE state (concluded
+// games are folded into the journal summary), and any game that was in-flight at
+// crash time is no longer running, so the registry starts each rehydrated
+// experiment with an empty in-flight set and refills capacity on the next
+// AllocateAndSpawn. Terminal experiments are skipped (their work is done).
+func (r *Registry) Rehydrate(ids []string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, id := range ids {
+		jrnl, err := journal.Load(r.root, id)
+		if err != nil {
+			return fmt.Errorf("registry: rehydrate %q: %w", id, err)
+		}
+		view := jrnl.CompactView()
+		st := Status(view.Status)
+		if st == "" {
+			st = StatusRunning
+		}
+		if st.IsTerminal() {
+			continue // done experiment — nothing to manage.
+		}
+		r.entries[id] = &entry{
+			id:      id,
+			journal: jrnl,
+			status:  st,
+			flagKey: view.Intent.FlagKey,
+			arms:    append([]string(nil), view.Intent.Arms...),
+			games:   make(map[string]string),
+		}
+	}
+	return nil
+}
+
+// --- read accessors (telemetry / tests) ---
+
+// Status returns the current status of an experiment, or ("", false) if unknown.
+func (r *Registry) Status(id string) (Status, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	e := r.entries[id]
+	if e == nil {
+		return "", false
+	}
+	return e.status, true
+}
+
+// InFlight returns the experiment's current in-flight shadow-game count (bound
+// games + reservations), or 0 if unknown.
+func (r *Registry) InFlight(id string) int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if e := r.entries[id]; e != nil {
+		return e.inFlight()
+	}
+	return 0
+}
+
+// TotalInFlight returns the total in-flight shadow games across all experiments —
+// the registry's current draw against the cap.
+func (r *Registry) TotalInFlight() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.inFlightLocked()
+}
+
+// Capacity returns the configured fixed shadow-game cap.
+func (r *Registry) Capacity() int { return r.maxCap }
+
+// Live returns the ids of experiments that may be allocated shadow capacity —
+// i.e. those in RUNNING (targeting written, ready to accrue games), sorted. A
+// PROPOSED experiment occupies a registry slot but is not yet spawnable, so it is
+// not returned here.
+func (r *Registry) Live() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.liveIDsLocked()
+}
+
+// CompactView returns the bounded journal view for an experiment (intent +
+// per-arm aggregates + recent tail) — the read surface the dashboard / LLM
+// consume. ok=false if unknown.
+func (r *Registry) CompactView(id string) (journal.CompactView, bool) {
+	r.mu.Lock()
+	e := r.entries[id]
+	r.mu.Unlock()
+	if e == nil {
+		return journal.CompactView{}, false
+	}
+	return e.journal.CompactView(), true
+}
+
+// --- locked helpers ---
+
+// inFlightLocked sums in-flight games across all experiments. Assumes r.mu held.
+func (r *Registry) inFlightLocked() int {
+	total := 0
+	for _, e := range r.entries {
+		total += e.inFlight()
+	}
+	return total
+}
+
+// liveIDsLocked returns the sorted ids of PROPOSED/RUNNING experiments. Assumes
+// r.mu held. Only RUNNING experiments are spawnable, but PROPOSED ones still
+// occupy a registry slot; nextAllocation filters to RUNNING via the share check
+// implicitly — only RUNNING experiments are returned here for allocation fairness.
+func (r *Registry) liveIDsLocked() []string {
+	ids := make([]string, 0, len(r.entries))
+	for id, e := range r.entries {
+		if e.status == StatusRunning {
+			ids = append(ids, id)
+		}
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+// findGameLocked looks up the experiment + arm owning a coordinator game_id.
+// Assumes r.mu held.
+func (r *Registry) findGameLocked(gameID string) (id, arm string, e *entry) {
+	for eid, ent := range r.entries {
+		if a, ok := ent.games[gameID]; ok {
+			return eid, a, ent
+		}
+	}
+	return "", "", nil
+}
+
+// recordDecision appends a KindDecision status-transition event. Assumes the
+// caller holds r.mu (the journal serializes its own write). Errors are logged,
+// never fatal — the in-memory transition already happened and Rehydrate would
+// re-derive from the prior durable state.
+func (r *Registry) recordDecision(jrnl *journal.Journal, status Status, note string) {
+	r.appendEvent(jrnl, journal.Event{
+		Kind:   journal.KindDecision,
+		Status: string(status),
+		Note:   note,
+	})
+}
+
+// appendEvent stamps the event time from the registry clock (if unset) and
+// appends it to the journal, logging any error. Centralizes the time injection so
+// every registry-emitted event carries a timestamp.
+func (r *Registry) appendEvent(jrnl *journal.Journal, e journal.Event) {
+	if e.At.IsZero() {
+		e.At = r.clock()
+	}
+	if err := jrnl.AppendEvent(e); err != nil {
+		r.log.Warn("experiment.journal_append_failed", "kind", string(e.Kind), "error", err)
+	}
+}

--- a/services/agent/experiment/registry.go
+++ b/services/agent/experiment/registry.go
@@ -184,11 +184,26 @@ type Registry struct {
 }
 
 // RegistryConfig configures a Registry. Every seam may be nil — a nil seam
-// degrades to a safe no-op (a nil spawner cannot start a game; a nil verdict
-// leaves the verdict untouched; a nil promoter/target make promotion/teardown
-// recorded no-ops) so a Registry is always safe to construct in a test or before
-// a follow-up wires the real implementation. (Named RegistryConfig to avoid
-// colliding with the M7-7 validation Config in validate.go.)
+// degrades to a safe but DEGRADED behavior (not merely an inert no-op), so a
+// Registry is always safe to construct in a test or before a follow-up wires the
+// real implementation. Production always injects all four seams. The degraded
+// behaviors are:
+//
+//   - nil Spawner   ⇒ no game is ever started (the no-op stub errors), so the
+//     experiment runs but never accrues shadow games.
+//   - nil Verdict   ⇒ the verdict is never recomputed, so the experiment NEVER
+//     reaches CONCLUDED on its own — it runs until explicitly aborted. (It does
+//     not silently conclude; it simply has no terminal trigger.)
+//   - nil Promoter  ⇒ a concluded+promote experiment is recorded as routed but the
+//     promotion is a no-op; teardown still proceeds (capacity is freed).
+//   - nil Targeting ⇒ Start still transitions the experiment to RUNNING, but with
+//     NO shadow-scoped flag rule written. Its games therefore resolve the flag
+//     DEFAULT (the non-experimental value): a silent, non-experimental no-op
+//     experiment that produces no arm differentiation. Production always injects
+//     #977's writer; a nil writer is a test/degraded shape only.
+//
+// (Named RegistryConfig to avoid colliding with the M7-7 validation Config in
+// validate.go.)
 type RegistryConfig struct {
 	// Root is the journal experiments root (journal.DirFromEnv() in production; a
 	// t.TempDir in tests). Empty ⇒ journal.DefaultDir.
@@ -286,6 +301,12 @@ func (r *Registry) Declare(in Intent) (string, error) {
 // be allocated shadow capacity. A no-op (already RUNNING) returns nil. If the
 // targeting write fails the experiment stays PROPOSED (it never accrues games it
 // cannot scope) and the error is returned.
+//
+// DEGRADED (nil TargetingWriter): Start still transitions the experiment to
+// RUNNING, but no shadow-scoped flag rule is written — its games resolve the flag
+// DEFAULT, making it a silent, non-experimental no-op experiment (no arm
+// differentiation). Production always injects #977's writer; a nil writer is a
+// test/degraded shape only (see RegistryConfig).
 func (r *Registry) Start(ctx context.Context, id string) error {
 	r.mu.Lock()
 	e := r.entries[id]
@@ -507,12 +528,14 @@ func (r *Registry) ConcludeGame(ctx context.Context, gameID string, fitness floa
 	r.mu.Unlock()
 
 	// Recompute the interim verdict from the seam (outside the registry lock — the
-	// journal has its own lock). Record it as an interim_verdict event.
-	view := jrnl.CompactView()
+	// journal has its own lock). The verdict seam consumes the full Summary (raw
+	// per-arm Welford: Count/Mean/M2) so #979 can compute an unbiased / Welch
+	// estimator — CompactView would drop the raw M2. Record it as an interim_verdict
+	// event.
 	var verdict journal.Verdict
 	haveVerdict := false
 	if r.verdict != nil {
-		verdict, haveVerdict = r.verdict.Evaluate(view)
+		verdict, haveVerdict = r.verdict.Evaluate(jrnl.Summary())
 		if haveVerdict {
 			r.appendEvent(jrnl, journal.Event{
 				Kind:    journal.KindInterimVerdict,

--- a/services/agent/experiment/registry_seams.go
+++ b/services/agent/experiment/registry_seams.go
@@ -77,10 +77,15 @@ const (
 // non-parametric later). It returns OutcomeInconclusive until each arm clears the
 // target N AND the difference clears the effect bar.
 type CohortVerdict interface {
-	// Evaluate returns the current verdict for the experiment given its compact
-	// view (intent + per-arm aggregates + recent tail). The bool reports whether a
-	// verdict could be computed at all (false ⇒ leave the prior verdict untouched).
-	Evaluate(view journal.CompactView) (journal.Verdict, bool)
+	// Evaluate returns the current verdict for the experiment given its rolling
+	// Summary — the FULL per-arm Welford state (Count/Mean/raw M2), NOT the
+	// CompactView (which exposes only the derived POPULATION variance and drops the
+	// raw M2). The significance test (#979) needs the raw M2 + count to compute an
+	// unbiased / sample (n-1) variance or a Welch estimator, so the seam consumes
+	// Summary rather than CompactView (see journal.ArmView's downstream note). The
+	// bool reports whether a verdict could be computed at all (false ⇒ leave the
+	// prior verdict untouched).
+	Evaluate(s journal.Summary) (journal.Verdict, bool)
 }
 
 // Promoter routes a CONCLUDED experiment with a promote verdict to the existing

--- a/services/agent/experiment/registry_seams.go
+++ b/services/agent/experiment/registry_seams.go
@@ -1,0 +1,117 @@
+package experiment
+
+import (
+	"context"
+
+	"github.com/joustmania/agent/experiment/journal"
+)
+
+// registry_seams.go defines the INJECTED boundaries of the experiment registry
+// (design §7). The registry owns ONLY the lifecycle + capacity + book-keeping
+// logic; every consequential effect — spawning a shadow game, computing a
+// cohort verdict, promoting a validated experiment, and writing/stripping the
+// shadow-scoped targeting rule — is an interface the registry calls.
+//
+// This mirrors the Gate/Writer/Validator/Promoter split already established in
+// this package: the registry stays unit-testable with recording fakes, and the
+// real implementations are constructed only in main.go (or the relevant
+// follow-up issue). The three forward-looking seams plug in as:
+//
+//   - ShadowSpawner  → #976 (the game-coordinator shadow-spawn RPC). Until then a
+//                      no-op stub is injected and no real game is started.
+//   - CohortVerdict  → #979 (the per-arm Welford aggregation + significance test).
+//                      The registry only stores the verdict it returns.
+//   - Promoter       → #961/#980 (the existing promote.Promoter). The registry
+//                      routes a CONCLUDED+promote outcome to it; it never
+//                      reimplements the promotion safety rail.
+//   - TargetingWriter → #977 (the Gate/Writer). The registry writes the
+//                      experiment-scoped targeting on RUNNING and strips it on
+//                      teardown; it never builds the JSONLogic itself.
+
+// ShadowSpawner starts ONE shadow game bound to (experimentID, arm) and returns
+// the coordinator-assigned game_id. It is the spawn seam (design §5 / §7.1):
+// when capacity allows a new shadow game for an experiment, the registry DECIDES
+// the (experiment_id, arm) ground-truth-at-spawn and hands it to the spawner,
+// which is responsible for setting that experiment_id + arm on the spawned
+// game's OpenFeature evaluation context so the flagd targeting (#977) resolves
+// the right arm.
+//
+// PRODUCTION (#976, not built here): the real implementation calls the
+// game-coordinator shadow-spawn RPC (the M6 headless shadow-game harness),
+// passing experiment_id + arm so the game resolves the experimental variant (or
+// the control fall-through). A control-arm game MUST still be game_kind="shadow"
+// — the hard real-protection invariant (epic #982 decision 7). The no-op stub
+// (NoopShadowSpawner) returns an error so a registry wired without a real spawner
+// never silently believes a game started.
+type ShadowSpawner interface {
+	// Spawn starts a shadow game for the experiment's arm and returns its game_id.
+	// An error means no game was started; the registry records nothing and the
+	// capacity slot is not consumed.
+	Spawn(ctx context.Context, experimentID, arm string) (gameID string, err error)
+}
+
+// Outcome labels mirror the journal Verdict.Outcome strings (and the
+// experiment.Outcome / promote verdicts) without importing them, so the registry
+// can branch on a verdict it stores verbatim. The CohortVerdict seam (#979)
+// supplies one of these.
+const (
+	// OutcomeInconclusive — under-powered (min-N not reached) or no significant
+	// difference yet. The experiment keeps running (or concludes under-powered).
+	OutcomeInconclusive = "inconclusive"
+	// CohortOutcomePromote — the experimental arm cleared the significance + effect
+	// bar; route to the Promoter on conclusion.
+	CohortOutcomePromote = "promote"
+	// CohortOutcomeDiscard — concluded with no promotable improvement; discard.
+	CohortOutcomeDiscard = "discard"
+)
+
+// CohortVerdict computes the current verdict for an experiment from its per-arm
+// running statistics. It is the aggregation seam (design §8): the registry calls
+// it after each game concludes (interim) and on conclusion (final), records the
+// returned journal.Verdict, and transitions status on it. The registry does NOT
+// implement the statistics — #979 does.
+//
+// PRODUCTION (#979, not built here): the real implementation reads the per-arm
+// Welford state from the journal CompactView/Summary and applies the default
+// min-N + effect-size gate (epic #982 decision 1; swappable to Welch /
+// non-parametric later). It returns OutcomeInconclusive until each arm clears the
+// target N AND the difference clears the effect bar.
+type CohortVerdict interface {
+	// Evaluate returns the current verdict for the experiment given its compact
+	// view (intent + per-arm aggregates + recent tail). The bool reports whether a
+	// verdict could be computed at all (false ⇒ leave the prior verdict untouched).
+	Evaluate(view journal.CompactView) (journal.Verdict, bool)
+}
+
+// Promoter routes a CONCLUDED experiment with a promote verdict to the existing
+// promotion flow (#961/#980). The registry injects it as an interface so it never
+// reimplements the promotion safety rail; promote.Promoter (adapted) satisfies it.
+//
+// PRODUCTION (#961/#980, not built here): the real implementation assembles
+// promote.Evidence from the cohort verdict (FitnessBefore = control mean,
+// FitnessAfter = experimental mean, SyntheticGames = N) and calls
+// promote.Promoter.Promote under the live mode/target flags.
+type Promoter interface {
+	// Promote acts on a concluded, promote-verdict experiment. The error is
+	// recorded but never blocks teardown — a failed promotion still releases
+	// capacity (the experiment is concluded either way).
+	Promote(ctx context.Context, view journal.CompactView) error
+}
+
+// TargetingWriter scopes / un-scopes the experiment's shadow targeting branch on
+// the game flagset (#977). The registry calls Apply when an experiment starts
+// RUNNING and Strip on teardown (any terminal status), so the flagd rule tracks
+// the live experiment set. It is an interface so the registry stays free of the
+// game.json write surface; a thin adapter over the Gate/Writer satisfies it.
+//
+// PRODUCTION (#977): Apply runs a Proposal{FlagKey, ExperimentalValue,
+// ExperimentID} through the Gate (which Writes it). Strip removes that
+// experiment's chained-if branch (Writer.stripShadowBranch) — invariant-safe
+// because removing a shadow branch only ever affects shadow games.
+type TargetingWriter interface {
+	// Apply writes the experiment-scoped shadow targeting for the proposal.
+	Apply(ctx context.Context, p Proposal) error
+	// Strip removes the experiment's targeting branch for (flagKey, experimentID).
+	// A missing branch is a no-op (idempotent teardown).
+	Strip(ctx context.Context, flagKey, experimentID string) error
+}

--- a/services/agent/experiment/registry_test.go
+++ b/services/agent/experiment/registry_test.go
@@ -1,0 +1,671 @@
+package experiment
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/joustmania/agent/experiment/journal"
+)
+
+// --- recording fakes for the four registry seams ---
+
+// fakeSpawner records (experimentID, arm) spawn calls and hands back synthetic
+// game ids. It is the ShadowSpawner seam stub the registry drives in tests; the
+// real #976 RPC is not built here.
+type fakeSpawner struct {
+	mu      sync.Mutex
+	calls   []spawnCall
+	failNow bool // when true, Spawn returns an error (slot must be released)
+	seq     int
+}
+
+type spawnCall struct {
+	experimentID string
+	arm          string
+	gameID       string
+}
+
+func (f *fakeSpawner) Spawn(_ context.Context, experimentID, arm string) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.failNow {
+		return "", fmt.Errorf("spawn failed (test)")
+	}
+	f.seq++
+	gameID := fmt.Sprintf("game_%012d", f.seq)
+	f.calls = append(f.calls, spawnCall{experimentID, arm, gameID})
+	return gameID, nil
+}
+
+func (f *fakeSpawner) count() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.calls)
+}
+
+// fakeVerdict returns a fixed verdict, optionally only after a minimum total
+// sample count is reached (so a test can drive inconclusive→conclude).
+type fakeVerdict struct {
+	outcome      string
+	concludeAtN  int  // total games across arms before returning a conclusive verdict
+	alwaysReport bool // if false, returns ok=false until concludeAtN reached
+}
+
+func (f fakeVerdict) Evaluate(view journal.CompactView) (journal.Verdict, bool) {
+	total := 0
+	for _, a := range view.Arms {
+		total += a.Count
+	}
+	if f.concludeAtN > 0 && total < f.concludeAtN {
+		if f.alwaysReport {
+			return journal.Verdict{Outcome: OutcomeInconclusive, Reason: "under-powered"}, true
+		}
+		return journal.Verdict{}, false
+	}
+	return journal.Verdict{Outcome: f.outcome, Significant: f.outcome == CohortOutcomePromote}, true
+}
+
+// fakePromoter records Promote calls.
+type fakePromoter struct {
+	mu     sync.Mutex
+	calls  []string // experiment ids (from the view's intent)
+	retErr error
+}
+
+func (f *fakePromoter) Promote(_ context.Context, view journal.CompactView) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, view.Intent.ExperimentID)
+	return f.retErr
+}
+
+func (f *fakePromoter) count() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.calls)
+}
+
+// fakeTargeting records Apply/Strip calls (the #977 writer seam).
+type fakeTargeting struct {
+	mu       sync.Mutex
+	applied  []string // experiment ids
+	stripped []string // experiment ids
+	applyErr error
+}
+
+func (f *fakeTargeting) Apply(_ context.Context, p Proposal) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.applyErr != nil {
+		return f.applyErr
+	}
+	f.applied = append(f.applied, p.ExperimentID)
+	return nil
+}
+
+func (f *fakeTargeting) Strip(_ context.Context, _ string, experimentID string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.stripped = append(f.stripped, experimentID)
+	return nil
+}
+
+func (f *fakeTargeting) strippedIDs() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.stripped...)
+}
+
+// fixedClock returns deterministic, monotonically-increasing timestamps.
+func fixedClock() func() time.Time {
+	base := time.Date(2026, 6, 13, 10, 0, 0, 0, time.UTC)
+	var n int64
+	var mu sync.Mutex
+	return func() time.Time {
+		mu.Lock()
+		defer mu.Unlock()
+		n++
+		return base.Add(time.Duration(n) * time.Second)
+	}
+}
+
+func newTestRegistry(t *testing.T, cfg RegistryConfig) *Registry {
+	t.Helper()
+	if cfg.Root == "" {
+		cfg.Root = t.TempDir()
+	}
+	if cfg.Clock == nil {
+		cfg.Clock = fixedClock()
+	}
+	return NewRegistry(cfg)
+}
+
+func sampleIntent() Intent {
+	return Intent{
+		Hypothesis:        "raising grace reduces frustration deaths",
+		FlagKey:           "death_grace_period_seconds",
+		ExperimentalValue: 0.5,
+		Objective:         "engagement_balanced",
+		TargetNPerArm:     2,
+	}
+}
+
+// --- tests ---
+
+// Declare → PROPOSED in the registry + intent persisted in the journal.
+func TestDeclarePersistsIntentAndIsProposed(t *testing.T) {
+	root := t.TempDir()
+	r := newTestRegistry(t, RegistryConfig{Root: root})
+
+	id, err := r.Declare(sampleIntent())
+	if err != nil {
+		t.Fatalf("Declare: %v", err)
+	}
+	if id == "" || id[:4] != "exp_" {
+		t.Fatalf("experiment id %q is not exp_<hex>", id)
+	}
+
+	st, ok := r.Status(id)
+	if !ok || st != StatusProposed {
+		t.Fatalf("status = (%v,%v), want (proposed,true)", st, ok)
+	}
+
+	// Intent persisted in the journal: reloadable from disk.
+	jrnl, err := journal.Load(root, id)
+	if err != nil {
+		t.Fatalf("journal.Load: %v", err)
+	}
+	in := jrnl.Intent()
+	if in.FlagKey != "death_grace_period_seconds" || in.ExperimentID != id {
+		t.Fatalf("persisted intent = %+v, want flag/id to match", in)
+	}
+	if got := in.Arms; len(got) != 2 || got[0] != ArmExperimental || got[1] != ArmControl {
+		t.Fatalf("arms = %v, want [experimental control]", got)
+	}
+}
+
+// Capacity: with a cap of N and K experiments, allocation is equal-share /
+// round-robin and never exceeds the cap.
+func TestAllocationEqualShareNeverExceedsCap(t *testing.T) {
+	const cap = 6
+	spawner := &fakeSpawner{}
+	r := newTestRegistry(t, RegistryConfig{
+		MaxShadowGames: cap,
+		Spawner:        spawner,
+		Verdict:        fakeVerdict{concludeAtN: 1000}, // never conclude during this test
+	})
+	ctx := context.Background()
+
+	const k = 3
+	ids := make([]string, k)
+	for i := range ids {
+		id, err := r.Declare(sampleIntent())
+		if err != nil {
+			t.Fatalf("Declare: %v", err)
+		}
+		if err := r.Start(ctx, id); err != nil {
+			t.Fatalf("Start: %v", err)
+		}
+		ids[i] = id
+	}
+
+	got := r.AllocateAndSpawn(ctx)
+	if got != cap {
+		t.Fatalf("spawned %d, want cap %d", got, cap)
+	}
+	if total := r.TotalInFlight(); total != cap {
+		t.Fatalf("total in-flight %d, want %d", total, cap)
+	}
+	if total := r.TotalInFlight(); total > cap {
+		t.Fatalf("exceeded cap: %d > %d", total, cap)
+	}
+	// Equal share: cap 6 over 3 experiments → 2 each.
+	for _, id := range ids {
+		if n := r.InFlight(id); n != 2 {
+			t.Fatalf("experiment %s in-flight %d, want 2 (equal share)", id, n)
+		}
+	}
+	// A second allocate spawns nothing (cap full).
+	if again := r.AllocateAndSpawn(ctx); again != 0 {
+		t.Fatalf("second allocate spawned %d, want 0 (cap full)", again)
+	}
+}
+
+// Arm assignment → game_assigned journal event recorded with the right
+// (experiment_id, arm); the ShadowSpawner seam is called.
+func TestArmAssignmentRecordsJournalEventAndCallsSpawner(t *testing.T) {
+	root := t.TempDir()
+	spawner := &fakeSpawner{}
+	r := newTestRegistry(t, RegistryConfig{
+		Root:           root,
+		MaxShadowGames: 2,
+		Spawner:        spawner,
+		Verdict:        fakeVerdict{concludeAtN: 1000},
+	})
+	ctx := context.Background()
+
+	id, err := r.Declare(sampleIntent())
+	if err != nil {
+		t.Fatalf("Declare: %v", err)
+	}
+	if err := r.Start(ctx, id); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	n := r.AllocateAndSpawn(ctx)
+	if n != 2 {
+		t.Fatalf("spawned %d, want 2", n)
+	}
+	if spawner.count() != 2 {
+		t.Fatalf("spawner called %d times, want 2", spawner.count())
+	}
+
+	// Both arms were assigned (round-robin within the experiment).
+	arms := map[string]bool{}
+	for _, c := range spawner.calls {
+		if c.experimentID != id {
+			t.Fatalf("spawn for %q, want %q", c.experimentID, id)
+		}
+		arms[c.arm] = true
+	}
+	if !arms[ArmExperimental] || !arms[ArmControl] {
+		t.Fatalf("arms assigned = %v, want both experimental + control", arms)
+	}
+
+	// game_assigned events recorded in the journal with the right (game_id, arm).
+	jrnl, err := journal.Load(root, id)
+	if err != nil {
+		t.Fatalf("journal.Load: %v", err)
+	}
+	view := jrnl.CompactView()
+	assigned := map[string]string{}
+	for _, e := range view.RecentTail {
+		if e.Kind == journal.KindGameAssigned {
+			assigned[e.GameID] = e.Arm
+		}
+	}
+	if len(assigned) != 2 {
+		t.Fatalf("game_assigned events = %d, want 2 (tail=%+v)", len(assigned), view.RecentTail)
+	}
+	for _, c := range spawner.calls {
+		if assigned[c.gameID] != c.arm {
+			t.Fatalf("journal arm for %s = %q, want %q", c.gameID, assigned[c.gameID], c.arm)
+		}
+	}
+}
+
+// Game conclusion → game_concluded recorded + CohortVerdict seam called; status
+// transitions on the (stubbed) verdict.
+func TestConcludeGameRecordsAndTransitionsOnVerdict(t *testing.T) {
+	root := t.TempDir()
+	spawner := &fakeSpawner{}
+	promoter := &fakePromoter{}
+	targeting := &fakeTargeting{}
+	r := newTestRegistry(t, RegistryConfig{
+		Root:           root,
+		MaxShadowGames: 4,
+		Spawner:        spawner,
+		// Conclude (promote) once 2 games total have been folded.
+		Verdict:   fakeVerdict{outcome: CohortOutcomePromote, concludeAtN: 2, alwaysReport: true},
+		Promoter:  promoter,
+		Targeting: targeting,
+	})
+	ctx := context.Background()
+
+	id, err := r.Declare(sampleIntent())
+	if err != nil {
+		t.Fatalf("Declare: %v", err)
+	}
+	if err := r.Start(ctx, id); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	n := r.AllocateAndSpawn(ctx)
+	if n == 0 {
+		t.Fatalf("no games spawned")
+	}
+	games := append([]spawnCall(nil), spawner.calls...)
+
+	// First conclusion: still inconclusive (1 < 2) → RUNNING.
+	st, err := r.ConcludeGame(ctx, games[0].gameID, 0.7, 120)
+	if err != nil {
+		t.Fatalf("ConcludeGame: %v", err)
+	}
+	if st != StatusRunning {
+		t.Fatalf("after 1 conclusion status = %v, want running", st)
+	}
+
+	// Second conclusion: verdict promotes → CONCLUDED → PROMOTING → DONE.
+	st, err = r.ConcludeGame(ctx, games[1].gameID, 0.8, 130)
+	if err != nil {
+		t.Fatalf("ConcludeGame: %v", err)
+	}
+	if st != StatusDone {
+		t.Fatalf("after promote verdict status = %v, want done", st)
+	}
+	if promoter.count() != 1 {
+		t.Fatalf("promoter called %d times, want 1", promoter.count())
+	}
+	if got := targeting.strippedIDs(); len(got) != 1 || got[0] != id {
+		t.Fatalf("stripped = %v, want [%s] (teardown)", got, id)
+	}
+
+	// game_concluded events + the verdict are durable in the journal.
+	jrnl, err := journal.Load(root, id)
+	if err != nil {
+		t.Fatalf("journal.Load: %v", err)
+	}
+	view := jrnl.CompactView()
+	concluded := 0
+	for _, e := range view.RecentTail {
+		if e.Kind == journal.KindGameConcluded {
+			concluded++
+			if e.Fitness == nil {
+				t.Fatalf("game_concluded event missing fitness sample")
+			}
+		}
+	}
+	if concluded < 2 {
+		t.Fatalf("game_concluded events in tail = %d, want >= 2", concluded)
+	}
+	// Both arms folded a fitness sample.
+	totalSamples := 0
+	for _, a := range view.Arms {
+		totalSamples += a.Count
+	}
+	if totalSamples != 2 {
+		t.Fatalf("folded samples = %d, want 2", totalSamples)
+	}
+}
+
+// Rehydrate: drop the in-memory registry, rebuild from the journal → same live
+// experiments / status.
+func TestRehydrateRebuildsLiveExperiments(t *testing.T) {
+	root := t.TempDir()
+	clock := fixedClock()
+	ctx := context.Background()
+
+	// First registry: declare + start two experiments, conclude none.
+	r1 := NewRegistry(RegistryConfig{Root: root, MaxShadowGames: 4, Clock: clock})
+	idA, err := r1.Declare(sampleIntent())
+	if err != nil {
+		t.Fatalf("Declare A: %v", err)
+	}
+	idB, err := r1.Declare(sampleIntent())
+	if err != nil {
+		t.Fatalf("Declare B: %v", err)
+	}
+	if err := r1.Start(ctx, idA); err != nil {
+		t.Fatalf("Start A: %v", err)
+	}
+	// Leave B PROPOSED (never started) to prove status round-trips per-experiment.
+
+	// New registry over the SAME journal root: rehydrate from disk.
+	r2 := NewRegistry(RegistryConfig{Root: root, MaxShadowGames: 4, Clock: clock})
+	if err := r2.Rehydrate([]string{idA, idB}); err != nil {
+		t.Fatalf("Rehydrate: %v", err)
+	}
+
+	stA, okA := r2.Status(idA)
+	if !okA || stA != StatusRunning {
+		t.Fatalf("rehydrated A status = (%v,%v), want (running,true)", stA, okA)
+	}
+	stB, okB := r2.Status(idB)
+	if !okB || stB != StatusProposed {
+		t.Fatalf("rehydrated B status = (%v,%v), want (proposed,true)", stB, okB)
+	}
+	// A is live (running) and spawnable; B is proposed (not yet spawnable).
+	live := r2.Live()
+	if len(live) != 1 || live[0] != idA {
+		t.Fatalf("live = %v, want [%s] (only running A)", live, idA)
+	}
+	// Intent survived: flag key matches.
+	view, ok := r2.CompactView(idA)
+	if !ok || view.Intent.FlagKey != "death_grace_period_seconds" {
+		t.Fatalf("rehydrated intent = %+v", view.Intent)
+	}
+}
+
+// Rehydrate is faithful to a concluded experiment: a terminal status is skipped
+// (its work is done, capacity freed).
+func TestRehydrateSkipsTerminalExperiments(t *testing.T) {
+	root := t.TempDir()
+	clock := fixedClock()
+	ctx := context.Background()
+
+	spawner := &fakeSpawner{}
+	r1 := NewRegistry(RegistryConfig{
+		Root:           root,
+		MaxShadowGames: 2,
+		Spawner:        spawner,
+		Verdict:        fakeVerdict{outcome: CohortOutcomeDiscard, concludeAtN: 1, alwaysReport: true},
+		Targeting:      &fakeTargeting{},
+		Clock:          clock,
+	})
+	id, err := r1.Declare(sampleIntent())
+	if err != nil {
+		t.Fatalf("Declare: %v", err)
+	}
+	if err := r1.Start(ctx, id); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	r1.AllocateAndSpawn(ctx)
+	// Conclude a game → discard verdict → DISCARDED (terminal).
+	st, err := r1.ConcludeGame(ctx, spawner.calls[0].gameID, 0.3, 60)
+	if err != nil {
+		t.Fatalf("ConcludeGame: %v", err)
+	}
+	if st != StatusDiscarded {
+		t.Fatalf("status = %v, want discarded", st)
+	}
+
+	r2 := NewRegistry(RegistryConfig{Root: root, MaxShadowGames: 2, Clock: clock})
+	if err := r2.Rehydrate([]string{id}); err != nil {
+		t.Fatalf("Rehydrate: %v", err)
+	}
+	if _, ok := r2.Status(id); ok {
+		t.Fatalf("terminal experiment %s should be skipped on rehydrate", id)
+	}
+}
+
+// Kill-switch → experiments ABORTED, capacity freed, targeting torn down.
+func TestKillSwitchAbortsAllAndFreesCapacity(t *testing.T) {
+	spawner := &fakeSpawner{}
+	targeting := &fakeTargeting{}
+	r := newTestRegistry(t, RegistryConfig{
+		MaxShadowGames: 4,
+		Spawner:        spawner,
+		Verdict:        fakeVerdict{concludeAtN: 1000},
+		Targeting:      targeting,
+	})
+	ctx := context.Background()
+
+	var ids []string
+	for i := 0; i < 2; i++ {
+		id, err := r.Declare(sampleIntent())
+		if err != nil {
+			t.Fatalf("Declare: %v", err)
+		}
+		if err := r.Start(ctx, id); err != nil {
+			t.Fatalf("Start: %v", err)
+		}
+		ids = append(ids, id)
+	}
+	r.AllocateAndSpawn(ctx)
+	if r.TotalInFlight() == 0 {
+		t.Fatalf("expected in-flight games before abort")
+	}
+
+	aborted := r.AbortAll(ctx, "agent disabled (kill-switch)")
+	if len(aborted) != 2 {
+		t.Fatalf("aborted %d, want 2", len(aborted))
+	}
+	for _, id := range ids {
+		st, _ := r.Status(id)
+		if st != StatusAborted {
+			t.Fatalf("experiment %s status = %v, want aborted", id, st)
+		}
+		if n := r.InFlight(id); n != 0 {
+			t.Fatalf("experiment %s in-flight %d after abort, want 0 (capacity freed)", id, n)
+		}
+	}
+	if total := r.TotalInFlight(); total != 0 {
+		t.Fatalf("total in-flight after abort = %d, want 0", total)
+	}
+	// Targeting torn down for every aborted experiment.
+	stripped := map[string]bool{}
+	for _, s := range targeting.strippedIDs() {
+		stripped[s] = true
+	}
+	for _, id := range ids {
+		if !stripped[id] {
+			t.Fatalf("experiment %s targeting not stripped on abort", id)
+		}
+	}
+	// After freeing capacity a new experiment can claim the freed slots.
+	if again := r.AllocateAndSpawn(ctx); again != 0 {
+		t.Fatalf("no live experiments remain; allocate should spawn 0, got %d", again)
+	}
+}
+
+// A failing spawner releases its reserved slot so capacity is not permanently
+// shrunk (no slot leak).
+func TestSpawnFailureReleasesReservation(t *testing.T) {
+	spawner := &fakeSpawner{failNow: true}
+	r := newTestRegistry(t, RegistryConfig{
+		MaxShadowGames: 2,
+		Spawner:        spawner,
+		Verdict:        fakeVerdict{concludeAtN: 1000},
+	})
+	ctx := context.Background()
+	id, err := r.Declare(sampleIntent())
+	if err != nil {
+		t.Fatalf("Declare: %v", err)
+	}
+	if err := r.Start(ctx, id); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if n := r.AllocateAndSpawn(ctx); n != 0 {
+		t.Fatalf("spawned %d on a failing spawner, want 0", n)
+	}
+	if total := r.TotalInFlight(); total != 0 {
+		t.Fatalf("in-flight %d after failed spawn, want 0 (reservation released)", total)
+	}
+}
+
+// Start without a TargetingWriter is fine; with one, Apply is called for the
+// experiment.
+func TestStartWritesTargeting(t *testing.T) {
+	targeting := &fakeTargeting{}
+	r := newTestRegistry(t, RegistryConfig{MaxShadowGames: 2, Targeting: targeting})
+	ctx := context.Background()
+	id, err := r.Declare(sampleIntent())
+	if err != nil {
+		t.Fatalf("Declare: %v", err)
+	}
+	if err := r.Start(ctx, id); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	targeting.mu.Lock()
+	applied := append([]string(nil), targeting.applied...)
+	targeting.mu.Unlock()
+	if len(applied) != 1 || applied[0] != id {
+		t.Fatalf("applied = %v, want [%s]", applied, id)
+	}
+	st, _ := r.Status(id)
+	if st != StatusRunning {
+		t.Fatalf("status = %v, want running", st)
+	}
+}
+
+// A targeting Apply failure keeps the experiment PROPOSED (it never accrues games
+// it cannot scope).
+func TestStartTargetingFailureStaysProposed(t *testing.T) {
+	targeting := &fakeTargeting{applyErr: fmt.Errorf("write failed (test)")}
+	r := newTestRegistry(t, RegistryConfig{MaxShadowGames: 2, Targeting: targeting})
+	ctx := context.Background()
+	id, err := r.Declare(sampleIntent())
+	if err != nil {
+		t.Fatalf("Declare: %v", err)
+	}
+	if err := r.Start(ctx, id); err == nil {
+		t.Fatalf("Start should fail when targeting write fails")
+	}
+	st, _ := r.Status(id)
+	if st != StatusProposed {
+		t.Fatalf("status = %v, want proposed (write failed)", st)
+	}
+}
+
+// Uneven cap: cap 5 over 2 experiments splits as ceil(5/2)=3 ceiling per
+// experiment, total never exceeds 5, round-robin gives 3+2.
+func TestAllocationUnevenCapRoundRobin(t *testing.T) {
+	const cap = 5
+	spawner := &fakeSpawner{}
+	r := newTestRegistry(t, RegistryConfig{
+		MaxShadowGames: cap,
+		Spawner:        spawner,
+		Verdict:        fakeVerdict{concludeAtN: 1000},
+	})
+	ctx := context.Background()
+	var ids []string
+	for i := 0; i < 2; i++ {
+		id, err := r.Declare(sampleIntent())
+		if err != nil {
+			t.Fatalf("Declare: %v", err)
+		}
+		if err := r.Start(ctx, id); err != nil {
+			t.Fatalf("Start: %v", err)
+		}
+		ids = append(ids, id)
+	}
+	if got := r.AllocateAndSpawn(ctx); got != cap {
+		t.Fatalf("spawned %d, want %d", got, cap)
+	}
+	if total := r.TotalInFlight(); total != cap {
+		t.Fatalf("total in-flight %d, want %d (never exceeds cap)", total, cap)
+	}
+	// 3 + 2 split (each bounded by ceil(5/2)=3; round-robin gives the first a head start).
+	a, b := r.InFlight(ids[0]), r.InFlight(ids[1])
+	if a+b != cap || a > 3 || b > 3 {
+		t.Fatalf("split = %d + %d, want sum %d with each <= 3", a, b, cap)
+	}
+}
+
+// Status predicates: terminal + live classification.
+func TestStatusPredicates(t *testing.T) {
+	for _, s := range []Status{StatusDone, StatusDiscarded, StatusAborted} {
+		if !s.IsTerminal() {
+			t.Fatalf("%s should be terminal", s)
+		}
+		if s.IsLive() {
+			t.Fatalf("%s should not be live", s)
+		}
+	}
+	for _, s := range []Status{StatusProposed, StatusRunning} {
+		if s.IsTerminal() {
+			t.Fatalf("%s should not be terminal", s)
+		}
+		if !s.IsLive() {
+			t.Fatalf("%s should be live", s)
+		}
+	}
+}
+
+// MaxShadowGamesFromEnv honors the env override and falls back safely.
+func TestMaxShadowGamesFromEnv(t *testing.T) {
+	t.Setenv(maxShadowGamesEnv, "7")
+	if got := MaxShadowGamesFromEnv(); got != 7 {
+		t.Fatalf("MaxShadowGamesFromEnv = %d, want 7", got)
+	}
+	t.Setenv(maxShadowGamesEnv, "0") // non-positive → default
+	if got := MaxShadowGamesFromEnv(); got != DefaultMaxShadowGames {
+		t.Fatalf("MaxShadowGamesFromEnv(0) = %d, want default %d", got, DefaultMaxShadowGames)
+	}
+	t.Setenv(maxShadowGamesEnv, "garbage")
+	if got := MaxShadowGamesFromEnv(); got != DefaultMaxShadowGames {
+		t.Fatalf("MaxShadowGamesFromEnv(garbage) = %d, want default", got)
+	}
+}

--- a/services/agent/experiment/registry_test.go
+++ b/services/agent/experiment/registry_test.go
@@ -54,9 +54,9 @@ type fakeVerdict struct {
 	alwaysReport bool // if false, returns ok=false until concludeAtN reached
 }
 
-func (f fakeVerdict) Evaluate(view journal.CompactView) (journal.Verdict, bool) {
+func (f fakeVerdict) Evaluate(s journal.Summary) (journal.Verdict, bool) {
 	total := 0
-	for _, a := range view.Arms {
+	for _, a := range s.Arms {
 		total += a.Count
 	}
 	if f.concludeAtN > 0 && total < f.concludeAtN {
@@ -667,5 +667,182 @@ func TestMaxShadowGamesFromEnv(t *testing.T) {
 	t.Setenv(maxShadowGamesEnv, "garbage")
 	if got := MaxShadowGamesFromEnv(); got != DefaultMaxShadowGames {
 		t.Fatalf("MaxShadowGamesFromEnv(garbage) = %d, want default", got)
+	}
+}
+
+// Concurrency: many goroutines hammering AllocateAndSpawn (optionally racing
+// ConcludeGame) must NEVER exceed the cap, must invoke the spawner exactly cap
+// times when no slot is freed, and must leak no reservation. The cap is race-safe
+// by design (the slot is reserved under r.mu in nextAllocation before the
+// unlocked Spawn); this test locks that invariant in so a future change cannot
+// silently break it. Run under -race.
+func TestConcurrentAllocateNeverExceedsCap(t *testing.T) {
+	const cap = 8
+	spawner := &fakeSpawner{}
+	r := newTestRegistry(t, RegistryConfig{
+		MaxShadowGames: cap,
+		Spawner:        spawner,
+		Verdict:        fakeVerdict{concludeAtN: 1_000_000}, // never conclude
+	})
+	ctx := context.Background()
+
+	// A handful of live experiments to share the cap across.
+	const k = 4
+	for i := 0; i < k; i++ {
+		id, err := r.Declare(sampleIntent())
+		if err != nil {
+			t.Fatalf("Declare: %v", err)
+		}
+		if err := r.Start(ctx, id); err != nil {
+			t.Fatalf("Start: %v", err)
+		}
+	}
+
+	// N goroutines each call AllocateAndSpawn repeatedly. While they run, a
+	// watchdog goroutine continuously asserts the cap is never observed exceeded.
+	const goroutines = 16
+	const callsPer = 50
+	var maxObserved int64
+	stop := make(chan struct{})
+	var wgWatch sync.WaitGroup
+	wgWatch.Add(1)
+	go func() {
+		defer wgWatch.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				if n := int64(r.TotalInFlight()); n > maxObserved {
+					maxObserved = n
+				}
+			}
+		}
+	}()
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for g := 0; g < goroutines; g++ {
+		go func() {
+			defer wg.Done()
+			for c := 0; c < callsPer; c++ {
+				r.AllocateAndSpawn(ctx)
+			}
+		}()
+	}
+	wg.Wait()
+	close(stop)
+	wgWatch.Wait()
+
+	// Invariant 1: the cap was never exceeded (live observation by the watchdog).
+	if maxObserved > cap {
+		t.Fatalf("observed in-flight %d exceeded cap %d during concurrent allocate", maxObserved, cap)
+	}
+	// Invariant 2: settled exactly at the cap (no slot was freed, so it fills full).
+	if total := r.TotalInFlight(); total != cap {
+		t.Fatalf("settled total in-flight %d, want exactly cap %d", total, cap)
+	}
+	// Invariant 3: the spawner was invoked EXACTLY cap times — no over-spawn from a
+	// lost reservation, no under-spawn from a leaked one.
+	if got := spawner.count(); got != cap {
+		t.Fatalf("spawner invoked %d times, want exactly cap %d (no over/under-spawn)", got, cap)
+	}
+}
+
+// Concurrency: AllocateAndSpawn racing ConcludeGame frees and refills slots
+// without ever exceeding the cap and without leaking reservations. After the
+// dust settles, in-flight + concluded accounts for every spawn (no orphaned
+// reservation placeholder lingering against the cap). Run under -race.
+func TestConcurrentAllocateAndConcludeNoLeak(t *testing.T) {
+	const cap = 8
+	spawner := &fakeSpawner{}
+	r := newTestRegistry(t, RegistryConfig{
+		MaxShadowGames: cap,
+		Spawner:        spawner,
+		Verdict:        fakeVerdict{concludeAtN: 1_000_000}, // never conclude the experiment itself
+	})
+	ctx := context.Background()
+
+	const k = 4
+	for i := 0; i < k; i++ {
+		id, err := r.Declare(sampleIntent())
+		if err != nil {
+			t.Fatalf("Declare: %v", err)
+		}
+		if err := r.Start(ctx, id); err != nil {
+			t.Fatalf("Start: %v", err)
+		}
+	}
+
+	var maxObserved int64
+	stop := make(chan struct{})
+	var wgWatch sync.WaitGroup
+	wgWatch.Add(1)
+	go func() {
+		defer wgWatch.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				if n := int64(r.TotalInFlight()); n > maxObserved {
+					maxObserved = n
+				}
+			}
+		}
+	}()
+
+	// Allocators keep filling capacity.
+	const allocators = 12
+	var wg sync.WaitGroup
+	wg.Add(allocators)
+	for g := 0; g < allocators; g++ {
+		go func() {
+			defer wg.Done()
+			for c := 0; c < 100; c++ {
+				r.AllocateAndSpawn(ctx)
+			}
+		}()
+	}
+
+	// Concluders drain bound games as they appear, freeing slots to refill.
+	const concluders = 6
+	wg.Add(concluders)
+	for g := 0; g < concluders; g++ {
+		go func() {
+			defer wg.Done()
+			for c := 0; c < 100; c++ {
+				// Grab a snapshot of bound (real) game ids and conclude one.
+				spawner.mu.Lock()
+				var gid string
+				if len(spawner.calls) > 0 {
+					gid = spawner.calls[len(spawner.calls)-1].gameID
+				}
+				spawner.mu.Unlock()
+				if gid == "" {
+					continue
+				}
+				// A double-conclude of the same gid is a harmless no-op (unknown id).
+				if _, err := r.ConcludeGame(ctx, gid, 0.5, 60); err != nil {
+					t.Errorf("ConcludeGame: %v", err)
+					return
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(stop)
+	wgWatch.Wait()
+
+	// The cap was never exceeded despite the alloc/conclude race.
+	if maxObserved > cap {
+		t.Fatalf("observed in-flight %d exceeded cap %d under concurrent alloc/conclude", maxObserved, cap)
+	}
+	// No reservation leak: a final settling allocate refills to exactly the cap.
+	// (A leaked reservation would permanently shrink capacity below cap.)
+	r.AllocateAndSpawn(ctx)
+	if total := r.TotalInFlight(); total != cap {
+		t.Fatalf("after settling allocate, in-flight %d != cap %d (reservation leak?)", total, cap)
 	}
 }


### PR DESCRIPTION
Part of #982 — experiment registry & lifecycle (phase 3, design §7).

The agent-owned experiment **coordinator/registry**: the experiment-timescale counterpart to the per-game LoopSet/Multiplexer (#845). It defines experiments, allocates finite shadow capacity across them, decides `(experiment_id, arm)` at spawn, folds concluded games into the durable journal (#983), drives the verdict + status machine, and tears each experiment down on a terminal status.

## What's here
- `experiment/registry.go` — the `Registry` coordinator + `Status` machine + capacity scheduler.
- `experiment/registry_seams.go` — the four injected interfaces.
- `experiment/registry_test.go` — lifecycle, capacity, arm-assignment, conclusion, rehydrate, kill-switch (recording fakes for every seam).

## Status machine (§7.2)
```
PROPOSED ─▶ RUNNING ─▶ CONCLUDED ─▶ {PROMOTING ─▶ DONE | DISCARDED}
                 │
                 └─▶ ABORTED   (kill-switch / capacity reclaim / error)
```
Every transition is recorded as a journal `decision`/`outcome` event.

## Capacity & allocation (epic decisions 2 + 3)
- **Fixed** cap from `AGENT_MAX_SHADOW_GAMES` (default 20).
- Split **equal-share / round-robin** across live experiments (`ceil(cap/K)` ceiling per experiment, rotating cursor). Never exceeds the cap; no starvation. Two-arm split (experimental + control; decision 5) filled round-robin within each experiment. Real games preempting shadow at the coordinator is out of scope — this bounds only the registry's own spawns.

## Seams (defined + called; internals NOT built here)
| Seam | Plugs in | This PR |
|------|----------|---------|
| `ShadowSpawner` | #976 game-coordinator shadow-spawn RPC | interface + call site; no-op stub safe default |
| `CohortVerdict` | #979 per-arm Welford + min-N/effect-size gate | interface + interim/final call site; records `interim_verdict` |
| `Promoter` | #961/#980 promote flow | interface; CONCLUDED+promote routes to it |
| `TargetingWriter` | #977 Gate/Writer | Apply on RUNNING, Strip on teardown |

All injected; a nil seam degrades to a safe no-op.

## Journal integration + rehydrate (#983, #831)
The in-memory registry is a **view** of the journal: `Declare` → `journal.Create` (intent persisted), game assign/conclude/verdict/transition all append journal events, and `Rehydrate` rebuilds the live set from `journal.Load` on startup (terminal experiments skipped). Proven by `TestRehydrateRebuildsLiveExperiments` / `TestRehydrateSkipsTerminalExperiments`.

## Validation
`go test ./... -race` ✓ · `go vet ./...` ✓ · `gofmt -l` clean · `go mod tidy` no-op (google/uuid already a dep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)