### PR TITLE
feat(agent): cohort fitness aggregation & arm-comparison verdict (#979)

### DIFF
--- a/services/agent/experiment/verdict.go
+++ b/services/agent/experiment/verdict.go
@@ -1,0 +1,257 @@
+package experiment
+
+import (
+	"fmt"
+	"math"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/joustmania/agent/experiment/journal"
+)
+
+// verdict.go implements the CohortVerdict seam (design §8.3, epic #982 decision
+// 1): the per-arm aggregation + arm-comparison that turns a journal.Summary's raw
+// Welford state into a promote / discard / inconclusive verdict. It is the
+// extension of the M7-7 single-run FitnessMeasurer (validate.go) from "one batch →
+// one number" to "a cohort → per-arm aggregates → a verdict".
+//
+// DEFAULT RULE (decision 1): a min-N + effect-size gate. Both arms must clear a
+// configured minimum count AND the standardized effect size between the
+// experimental and control arms must clear a configured threshold; otherwise the
+// verdict is INCONCLUSIVE (under-powered or within noise). This is the
+// conservative fallback the maintainer chose over a Welch t-test — it never
+// promotes on a thin sample, so an under-powered cohort yields inconclusive, never
+// a false positive (#979 acceptance).
+//
+// SWAPPABLE (design §8.3): the comparison itself is a CohortStat strategy. The
+// default is effectSizeGate (Cohen's d); a Welch t-test or a non-parametric test
+// can replace it later WITHOUT touching the CohortVerdict seam — the registry only
+// ever sees journal.Verdict.
+//
+// CONTROL ARM is the PRIMARY decision basis (decision 5): the within-experiment
+// shadow control arm is differenced against the experimental arm here. The
+// recent-real baseline (the M7-7 validate.Baseline seam) is a SECONDARY sanity
+// anchor; it is NOT wired through this seam because CohortVerdict.Evaluate is
+// handed only a Summary (no ctx / Proposal to call Baseline.Fitness against) — see
+// the wiring note at the bottom of this file. Shipping the within-experiment
+// comparison (the primary basis) and deferring the baseline cross-check is the
+// path the issue authorizes.
+
+// Default gate thresholds. Tuned conservative: a verdict needs a non-trivial
+// sample per arm and a medium standardized effect before it commits.
+const (
+	// DefaultMinNPerArm is the minimum Count each arm must reach before a
+	// conclusive verdict. Below this for either arm ⇒ INCONCLUSIVE regardless of
+	// the observed delta (under-powered). 8 is a deliberately small floor for
+	// cheap headless shadow games; tune via AGENT_VERDICT_MIN_N.
+	DefaultMinNPerArm = 8
+
+	// DefaultEffectThreshold is the minimum |Cohen's d| (standardized mean
+	// difference) for a promote/discard verdict. 0.5 ≈ Cohen's "medium" effect.
+	// Below this magnitude (with N met) the arms are within-noise ⇒ INCONCLUSIVE.
+	// Tune via AGENT_VERDICT_EFFECT_THRESHOLD.
+	DefaultEffectThreshold = 0.5
+)
+
+const (
+	minNEnv   = "AGENT_VERDICT_MIN_N"
+	effectEnv = "AGENT_VERDICT_EFFECT_THRESHOLD"
+)
+
+// CohortStat is the swappable arm-comparison strategy (design §8.3). Given the two
+// arms' raw running statistics it returns a standardized effect size (experimental
+// relative to control: positive = experimental better, negative = worse) and
+// whether that effect could be computed at all (false ⇒ variance undefined /
+// degenerate, treat as no signal). The default effectSizeGate implements Cohen's
+// d; a Welch / non-parametric statistic can satisfy the same interface later.
+type CohortStat interface {
+	// Effect returns the standardized effect of experimental vs control and a bool
+	// reporting whether it is defined. The caller (CohortVerdict) still applies the
+	// min-N gate; this strategy only quantifies the difference.
+	Effect(experimental, control journal.Welford) (effect float64, ok bool)
+}
+
+// effectSizeGate is the default CohortStat: Cohen's d, the difference of means in
+// units of the pooled standard deviation. It uses the UNBIASED sample variance
+// M2/(Count−1) per arm — this is exactly why the seam is handed the raw Summary
+// (with raw M2/Count) rather than the CompactView (which exposes only the derived
+// POPULATION variance M2/Count). Population variance would under-state spread at
+// small N and inflate the effect size toward a premature verdict; the sample
+// (n−1) form is the conservative, correct choice here.
+type effectSizeGate struct{}
+
+// Effect computes Cohen's d = (mean_exp − mean_control) / pooledSD, using the
+// pooled UNBIASED sample variance. It returns ok=false when either arm has fewer
+// than 2 samples (sample variance undefined) or the pooled SD is zero (no spread —
+// the standardized effect is undefined / infinite, which the min-N gate handles
+// separately so we never divide by zero).
+func (effectSizeGate) Effect(experimental, control journal.Welford) (float64, bool) {
+	if experimental.Count < 2 || control.Count < 2 {
+		return 0, false
+	}
+	// Unbiased sample variance M2/(n−1) per arm — NOT the population M2/n.
+	varExp := experimental.M2 / float64(experimental.Count-1)
+	varCtl := control.M2 / float64(control.Count-1)
+
+	// Pooled standard deviation (the standard two-sample pooled estimator).
+	dfExp := float64(experimental.Count - 1)
+	dfCtl := float64(control.Count - 1)
+	pooledVar := (dfExp*varExp + dfCtl*varCtl) / (dfExp + dfCtl)
+	pooledSD := math.Sqrt(pooledVar)
+	if pooledSD == 0 {
+		return 0, false
+	}
+	return (experimental.Mean - control.Mean) / pooledSD, true
+}
+
+// Verdict is the default CohortVerdict implementation (the min-N + effect-size
+// gate). It is constructed via NewVerdict / NewVerdictFromEnv and injected into the
+// registry as the CohortVerdict seam. Higher fitness is better (the convention the
+// FitnessMeasurer and decision loop already use), so a positive effect means the
+// experimental arm beat control.
+type Verdict struct {
+	// minN is the minimum Count both arms must reach for a conclusive verdict.
+	minN int
+	// effectThreshold is the minimum |effect| for a promote/discard verdict.
+	effectThreshold float64
+	// stat is the swappable comparison strategy (default effectSizeGate).
+	stat CohortStat
+}
+
+// NewVerdict builds a Verdict with explicit thresholds. A non-positive minN falls
+// back to DefaultMinNPerArm; a non-positive effectThreshold falls back to
+// DefaultEffectThreshold. A nil stat falls back to the default Cohen's d gate.
+func NewVerdict(minN int, effectThreshold float64, stat CohortStat) *Verdict {
+	if minN <= 0 {
+		minN = DefaultMinNPerArm
+	}
+	if effectThreshold <= 0 {
+		effectThreshold = DefaultEffectThreshold
+	}
+	if stat == nil {
+		stat = effectSizeGate{}
+	}
+	return &Verdict{minN: minN, effectThreshold: effectThreshold, stat: stat}
+}
+
+// NewVerdictFromEnv builds a Verdict from AGENT_VERDICT_MIN_N /
+// AGENT_VERDICT_EFFECT_THRESHOLD, falling back to the defaults on an unset, empty,
+// or invalid value. The default Cohen's d strategy is used.
+func NewVerdictFromEnv() *Verdict {
+	minN := DefaultMinNPerArm
+	if v := strings.TrimSpace(os.Getenv(minNEnv)); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			minN = n
+		}
+	}
+	threshold := DefaultEffectThreshold
+	if v := strings.TrimSpace(os.Getenv(effectEnv)); v != "" {
+		if f, err := strconv.ParseFloat(v, 64); err == nil && f > 0 {
+			threshold = f
+		}
+	}
+	return NewVerdict(minN, threshold, effectSizeGate{})
+}
+
+// Evaluate computes the current verdict for an experiment from its rolling
+// Summary (the CohortVerdict seam contract, design §8.3).
+//
+// It reads the canonical experimental and control arms (ArmExperimental /
+// ArmControl) and applies the min-N + effect-size gate:
+//
+//   - Either arm Count < minN ⇒ INCONCLUSIVE (under-powered). Recorded so the
+//     registry keeps the experiment RUNNING; never a promote/discard on a thin
+//     sample.
+//   - Both arms ≥ minN AND effect ≥ +threshold ⇒ PROMOTE (experimental clearly
+//     better). Significant.
+//   - Both arms ≥ minN AND effect ≤ −threshold ⇒ DISCARD (experimental clearly
+//     worse). Significant.
+//   - Otherwise (N met but |effect| < threshold, or effect undefined) ⇒
+//     INCONCLUSIVE (within noise). Recorded, keeps running.
+//
+// The bool reports whether a verdict could be computed at all. It is true whenever
+// both canonical arms are present in the Summary (even when the verdict is
+// under-powered INCONCLUSIVE — that IS a meaningful interim verdict the registry
+// records). It is false only when the Summary lacks the canonical arms entirely,
+// so the registry leaves any prior verdict untouched rather than overwriting it
+// with a vacuous one.
+func (v *Verdict) Evaluate(s journal.Summary) (journal.Verdict, bool) {
+	expStat, expOK := s.Arms[ArmExperimental]
+	ctlStat, ctlOK := s.Arms[ArmControl]
+	if !expOK || !ctlOK || expStat == nil || ctlStat == nil {
+		// The canonical two-arm shape is absent — nothing to compare; do not
+		// clobber any prior verdict.
+		return journal.Verdict{}, false
+	}
+
+	exp := expStat.Welford
+	ctl := ctlStat.Welford
+	delta := exp.Mean - ctl.Mean
+
+	// Min-N gate FIRST: an under-powered cohort is inconclusive regardless of the
+	// observed delta or effect (the #979 acceptance: never a false positive).
+	if exp.Count < v.minN || ctl.Count < v.minN {
+		return journal.Verdict{
+			Outcome:     OutcomeInconclusive,
+			Delta:       delta,
+			Significant: false,
+			Reason: fmt.Sprintf("under-powered: n_experimental=%d n_control=%d < min_n=%d",
+				exp.Count, ctl.Count, v.minN),
+		}, true
+	}
+
+	// Effect-size gate: compute the standardized effect via the swappable strategy.
+	effect, ok := v.stat.Effect(exp, ctl)
+	if !ok {
+		// Variance undefined / degenerate (e.g. zero-spread arms) — N is met but we
+		// cannot standardize the difference, so treat it as no signal.
+		return journal.Verdict{
+			Outcome:     OutcomeInconclusive,
+			Delta:       delta,
+			Significant: false,
+			Reason:      "effect size undefined (degenerate variance)",
+		}, true
+	}
+
+	switch {
+	case effect >= v.effectThreshold:
+		return journal.Verdict{
+			Outcome:     CohortOutcomePromote,
+			Delta:       delta,
+			Significant: true,
+			Reason: fmt.Sprintf("experimental better: effect=%.3f >= threshold=%.2f (n=%d/%d)",
+				effect, v.effectThreshold, exp.Count, ctl.Count),
+		}, true
+	case effect <= -v.effectThreshold:
+		return journal.Verdict{
+			Outcome:     CohortOutcomeDiscard,
+			Delta:       delta,
+			Significant: true,
+			Reason: fmt.Sprintf("experimental worse: effect=%.3f <= -threshold=%.2f (n=%d/%d)",
+				effect, v.effectThreshold, exp.Count, ctl.Count),
+		}, true
+	default:
+		return journal.Verdict{
+			Outcome:     OutcomeInconclusive,
+			Delta:       delta,
+			Significant: false,
+			Reason: fmt.Sprintf("within noise: |effect|=%.3f < threshold=%.2f (n=%d/%d)",
+				math.Abs(effect), v.effectThreshold, exp.Count, ctl.Count),
+		}, true
+	}
+}
+
+// Wiring note (recent-real baseline, design §8.3 secondary anchor — DEFERRED):
+//
+// The within-experiment control arm is the PRIMARY decision basis and is fully
+// implemented above. The recent-real baseline (validate.Baseline.Fitness) is the
+// design's SECONDARY sanity cross-check. It is NOT wired here because the
+// CohortVerdict seam (registry_seams.go) deliberately passes only a
+// journal.Summary — there is no ctx / Proposal in Evaluate's signature to call
+// Baseline.Fitness(ctx, p) against, and the registry's ConcludeGame call site does
+// not thread one through. Plumbing it would mean widening the seam (and the
+// registry call sites), which is out of scope for this issue. Follow-up: either
+// fold a recent-real baseline sample into a third pseudo-arm on the Summary at
+// game-end, or annotate the Verdict.Reason with a baseline cross-check after the
+// registry gains access to Baseline. Tracked as a follow-up on epic #982.

--- a/services/agent/experiment/verdict_test.go
+++ b/services/agent/experiment/verdict_test.go
@@ -1,0 +1,297 @@
+package experiment
+
+import (
+	"math"
+	"testing"
+
+	"github.com/joustmania/agent/experiment/journal"
+)
+
+// armFrom builds an ArmStat by folding the given samples through the real Welford
+// recurrence, so Count/Mean/M2 are exactly what the journal would persist. Building
+// the Summary from raw samples (rather than hand-setting M2) keeps the tests honest
+// about what the verdict actually reads.
+func armFrom(samples ...float64) *journal.ArmStat {
+	var st journal.ArmStat
+	for _, s := range samples {
+		st.Add(s)
+	}
+	return &st
+}
+
+// summaryWith assembles a journal.Summary with the canonical experimental/control
+// arms from the given samples.
+func summaryWith(exp, ctl *journal.ArmStat) journal.Summary {
+	return journal.Summary{
+		ExperimentID: "exp_test",
+		Status:       "running",
+		Arms: map[string]*journal.ArmStat{
+			ArmExperimental: exp,
+			ArmControl:      ctl,
+		},
+	}
+}
+
+// repeat returns a slice of n copies of v, plus a small spread so variance is
+// non-zero (otherwise pooled SD is 0 and Cohen's d is undefined). The spread is
+// symmetric so the mean is exactly v.
+func spread(n int, mean, halfWidth float64) []float64 {
+	out := make([]float64, 0, n)
+	for i := 0; i < n; i++ {
+		if i%2 == 0 {
+			out = append(out, mean+halfWidth)
+		} else {
+			out = append(out, mean-halfWidth)
+		}
+	}
+	return out
+}
+
+func TestVerdict_UnderPowered_Inconclusive(t *testing.T) {
+	v := NewVerdict(8, 0.5, nil)
+	// Experimental arm has only 3 samples (< min-N 8) but a HUGE delta vs control.
+	// Must still be INCONCLUSIVE — under-powered, never a false-positive promote.
+	exp := armFrom(spread(3, 100.0, 1.0)...)
+	ctl := armFrom(spread(20, 0.0, 1.0)...)
+
+	got, ok := v.Evaluate(summaryWith(exp, ctl))
+	if !ok {
+		t.Fatalf("expected ok=true (both arms present), got false")
+	}
+	if got.Outcome != OutcomeInconclusive {
+		t.Fatalf("under-powered verdict = %q, want %q", got.Outcome, OutcomeInconclusive)
+	}
+	if got.Significant {
+		t.Fatalf("under-powered verdict should not be significant")
+	}
+}
+
+func TestVerdict_ClearWin_Promote(t *testing.T) {
+	v := NewVerdict(8, 0.5, nil)
+	// Both arms meet N; experimental mean far above control with tight spread →
+	// large positive Cohen's d → PROMOTE.
+	exp := armFrom(spread(10, 0.80, 0.02)...)
+	ctl := armFrom(spread(10, 0.50, 0.02)...)
+
+	got, ok := v.Evaluate(summaryWith(exp, ctl))
+	if !ok {
+		t.Fatalf("expected ok=true")
+	}
+	if got.Outcome != CohortOutcomePromote {
+		t.Fatalf("clear-win verdict = %q (reason %q), want %q", got.Outcome, got.Reason, CohortOutcomePromote)
+	}
+	if !got.Significant {
+		t.Fatalf("clear-win verdict should be significant")
+	}
+	if got.Delta <= 0 {
+		t.Fatalf("clear-win delta = %v, want positive", got.Delta)
+	}
+}
+
+func TestVerdict_ClearLoss_Discard(t *testing.T) {
+	v := NewVerdict(8, 0.5, nil)
+	// Experimental far BELOW control → large negative effect → DISCARD.
+	exp := armFrom(spread(10, 0.30, 0.02)...)
+	ctl := armFrom(spread(10, 0.70, 0.02)...)
+
+	got, ok := v.Evaluate(summaryWith(exp, ctl))
+	if !ok {
+		t.Fatalf("expected ok=true")
+	}
+	if got.Outcome != CohortOutcomeDiscard {
+		t.Fatalf("clear-loss verdict = %q (reason %q), want %q", got.Outcome, got.Reason, CohortOutcomeDiscard)
+	}
+	if !got.Significant {
+		t.Fatalf("clear-loss verdict should be significant")
+	}
+	if got.Delta >= 0 {
+		t.Fatalf("clear-loss delta = %v, want negative", got.Delta)
+	}
+}
+
+func TestVerdict_Borderline_Inconclusive(t *testing.T) {
+	v := NewVerdict(8, 0.5, nil)
+	// N met, but the means differ only slightly relative to the spread → small
+	// |Cohen's d| below the 0.5 threshold → INCONCLUSIVE (within noise).
+	exp := armFrom(spread(12, 0.55, 0.20)...)
+	ctl := armFrom(spread(12, 0.50, 0.20)...)
+
+	got, ok := v.Evaluate(summaryWith(exp, ctl))
+	if !ok {
+		t.Fatalf("expected ok=true")
+	}
+	if got.Outcome != OutcomeInconclusive {
+		t.Fatalf("borderline verdict = %q (reason %q), want %q", got.Outcome, got.Reason, OutcomeInconclusive)
+	}
+	if got.Significant {
+		t.Fatalf("borderline verdict should not be significant")
+	}
+}
+
+func TestVerdict_MissingArm_NoVerdict(t *testing.T) {
+	v := NewVerdict(8, 0.5, nil)
+	// Only the experimental arm present — cannot compare; bool must be false so the
+	// registry leaves any prior verdict untouched.
+	s := journal.Summary{
+		ExperimentID: "exp_test",
+		Arms:         map[string]*journal.ArmStat{ArmExperimental: armFrom(spread(10, 0.8, 0.02)...)},
+	}
+	if _, ok := v.Evaluate(s); ok {
+		t.Fatalf("missing control arm should yield ok=false")
+	}
+}
+
+func TestVerdict_NilArmStat_NoVerdict(t *testing.T) {
+	v := NewVerdict(8, 0.5, nil)
+	s := journal.Summary{
+		Arms: map[string]*journal.ArmStat{
+			ArmExperimental: armFrom(spread(10, 0.8, 0.02)...),
+			ArmControl:      nil,
+		},
+	}
+	if _, ok := v.Evaluate(s); ok {
+		t.Fatalf("nil control ArmStat should yield ok=false")
+	}
+}
+
+func TestVerdict_EmptyAndSingleSample_Inconclusive(t *testing.T) {
+	v := NewVerdict(8, 0.5, nil)
+
+	// Count 0 / Count 1 arms: must not panic and must be INCONCLUSIVE (under-powered
+	// AND variance undefined). Both still need ok=true so the interim verdict is
+	// recorded.
+	cases := []struct {
+		name     string
+		exp, ctl *journal.ArmStat
+	}{
+		{"both empty", armFrom(), armFrom()},
+		{"exp single, ctl empty", armFrom(0.9), armFrom()},
+		{"both single", armFrom(0.9), armFrom(0.1)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := v.Evaluate(summaryWith(tc.exp, tc.ctl))
+			if !ok {
+				t.Fatalf("expected ok=true (arms present)")
+			}
+			if got.Outcome != OutcomeInconclusive {
+				t.Fatalf("verdict = %q, want %q", got.Outcome, OutcomeInconclusive)
+			}
+		})
+	}
+}
+
+func TestVerdict_ZeroVariance_Inconclusive(t *testing.T) {
+	v := NewVerdict(2, 0.5, nil)
+	// Both arms meet (lowered) min-N but every sample is identical → pooled SD 0 →
+	// effect undefined → INCONCLUSIVE, no panic / no divide-by-zero.
+	exp := armFrom(0.5, 0.5, 0.5, 0.5)
+	ctl := armFrom(0.5, 0.5, 0.5, 0.5)
+
+	got, ok := v.Evaluate(summaryWith(exp, ctl))
+	if !ok {
+		t.Fatalf("expected ok=true")
+	}
+	if got.Outcome != OutcomeInconclusive {
+		t.Fatalf("zero-variance verdict = %q (reason %q), want %q", got.Outcome, got.Reason, OutcomeInconclusive)
+	}
+}
+
+// TestVerdict_UsesUnbiasedVariance constructs a case where the population variance
+// (M2/n) clears the effect threshold but the UNBIASED sample variance (M2/(n−1))
+// does not — proving the gate uses the sample (n−1) estimator, not population.
+//
+// With small N the unbiased variance is larger (divides by n−1 < n), so the pooled
+// SD is larger and Cohen's d is SMALLER. We pick a delta that lands ABOVE 0.5 under
+// population variance but BELOW 0.5 under sample variance → the correct (unbiased)
+// implementation returns INCONCLUSIVE; a population-variance bug would return
+// PROMOTE.
+func TestVerdict_UsesUnbiasedVariance(t *testing.T) {
+	v := NewVerdict(2, 0.5, nil)
+
+	// n=4 per arm. Spread halfWidth h gives M2 = 4*h^2 (4 deviations of ±h).
+	// population var = M2/4 = h^2 ;  sample var = M2/3 = (4/3)h^2.
+	// Pick h and delta so d_pop >= 0.5 > d_sample.
+	const h = 0.10
+	// population pooled SD = h = 0.10 ;  sample pooled SD = sqrt(4/3)*h ≈ 0.1155.
+	// delta = 0.054: d_pop = 0.54 (>=0.5 → promote);  d_sample ≈ 0.467 (<0.5 → inconclusive).
+	exp := armFrom(spread(4, 0.554, h)...)
+	ctl := armFrom(spread(4, 0.500, h)...)
+
+	// Sanity: confirm the population-variance effect WOULD have promoted, so the
+	// test is actually discriminating between the two estimators.
+	popVarExp := exp.M2 / float64(exp.Count)
+	popVarCtl := ctl.M2 / float64(ctl.Count)
+	popPooled := math.Sqrt((popVarExp + popVarCtl) / 2)
+	dPop := (exp.Mean - ctl.Mean) / popPooled
+	if dPop < 0.5 {
+		t.Fatalf("test misconfigured: population-variance d=%.4f should be >= 0.5", dPop)
+	}
+
+	got, ok := v.Evaluate(summaryWith(exp, ctl))
+	if !ok {
+		t.Fatalf("expected ok=true")
+	}
+	if got.Outcome != OutcomeInconclusive {
+		t.Fatalf("unbiased-variance verdict = %q (population d=%.4f), want %q — "+
+			"the gate must use sample (n-1) variance, not population", got.Outcome, dPop, OutcomeInconclusive)
+	}
+}
+
+func TestVerdict_DefaultsOnNonPositiveConfig(t *testing.T) {
+	v := NewVerdict(0, -1, nil)
+	if v.minN != DefaultMinNPerArm {
+		t.Fatalf("minN = %d, want default %d", v.minN, DefaultMinNPerArm)
+	}
+	if v.effectThreshold != DefaultEffectThreshold {
+		t.Fatalf("effectThreshold = %v, want default %v", v.effectThreshold, DefaultEffectThreshold)
+	}
+	if v.stat == nil {
+		t.Fatalf("nil stat should fall back to the default gate")
+	}
+}
+
+func TestVerdictFromEnv(t *testing.T) {
+	t.Setenv(minNEnv, "5")
+	t.Setenv(effectEnv, "0.8")
+	v := NewVerdictFromEnv()
+	if v.minN != 5 {
+		t.Fatalf("env minN = %d, want 5", v.minN)
+	}
+	if v.effectThreshold != 0.8 {
+		t.Fatalf("env effectThreshold = %v, want 0.8", v.effectThreshold)
+	}
+
+	// Invalid / empty values fall back to defaults.
+	t.Setenv(minNEnv, "not-a-number")
+	t.Setenv(effectEnv, "")
+	v2 := NewVerdictFromEnv()
+	if v2.minN != DefaultMinNPerArm || v2.effectThreshold != DefaultEffectThreshold {
+		t.Fatalf("invalid env should fall back to defaults, got minN=%d threshold=%v", v2.minN, v2.effectThreshold)
+	}
+}
+
+// TestVerdict_SwappableStrategy verifies a custom CohortStat replaces the gate
+// without touching the seam — the design's swappability requirement (§8.3).
+func TestVerdict_SwappableStrategy(t *testing.T) {
+	// A stub strategy that always reports a large positive effect, ignoring the
+	// actual stats — stands in for a future Welch / non-parametric test.
+	v := NewVerdict(2, 0.5, constantStat{effect: 5.0, ok: true})
+	exp := armFrom(0.5, 0.5, 0.5) // identical samples — default gate would be inconclusive
+	ctl := armFrom(0.5, 0.5, 0.5)
+
+	got, ok := v.Evaluate(summaryWith(exp, ctl))
+	if !ok {
+		t.Fatalf("expected ok=true")
+	}
+	if got.Outcome != CohortOutcomePromote {
+		t.Fatalf("custom strategy verdict = %q, want %q (strategy not honored)", got.Outcome, CohortOutcomePromote)
+	}
+}
+
+type constantStat struct {
+	effect float64
+	ok     bool
+}
+
+func (c constantStat) Effect(_, _ journal.Welford) (float64, bool) { return c.effect, c.ok }


### PR DESCRIPTION
Part of #982 — cohort aggregation & verdict.

Implements the `CohortVerdict` seam the experiment registry (#978) calls on each game conclusion (interim) and on conclusion (final). This is the extension of the M7-7 single-run `FitnessMeasurer` from *one batch → one number* to *a cohort → per-arm aggregates → a verdict* (design §8.3).

## What

`services/agent/experiment/verdict.go` — `experiment.Verdict` implements `CohortVerdict.Evaluate(journal.Summary) (journal.Verdict, bool)`:

- Reads the canonical `ArmExperimental` / `ArmControl` arm stats (raw Welford `Count`/`Mean`/`M2`) off the `Summary`.
- **Default rule (epic #982 decision 1): min-N + effect-size gate.** Both arms must clear a configured `min-N` **and** the standardized effect size (Cohen's d) must clear a configured threshold:
  - either arm `Count < minN` → **INCONCLUSIVE** (under-powered) regardless of delta — never a false-positive promote (the #979 acceptance);
  - both arms ≥ minN and `effect ≥ +threshold` → **PROMOTE**;
  - both arms ≥ minN and `effect ≤ -threshold` → **DISCARD**;
  - otherwise (within noise, or effect undefined) → **INCONCLUSIVE**.
- **Unbiased variance:** Cohen's d uses the pooled **sample** variance `M2/(Count-1)` per arm — *not* population `M2/Count`. This is exactly why the seam is handed the raw `Summary` rather than the `CompactView` (which exposes only the derived population variance). A dedicated test (`TestVerdict_UsesUnbiasedVariance`) is constructed so population variance would PROMOTE but the unbiased estimator returns INCONCLUSIVE — it fails if the population form is ever used.
- **Edge guards:** `Count < 2` (sample variance undefined) and zero pooled SD (no spread) → no panic, no divide-by-zero, → inconclusive.
- **Swappable:** the comparison is a `CohortStat` strategy (default `effectSizeGate`); a Welch t-test / non-parametric test can replace it later without touching the seam.
- **Configurable:** `NewVerdict(minN, effectThreshold, stat)` + `NewVerdictFromEnv()` (`AGENT_VERDICT_MIN_N`, `AGENT_VERDICT_EFFECT_THRESHOLD`), conservative defaults (min-N 8, |d| 0.5).

## Control arm vs recent-real baseline (decision 5)

The within-experiment shadow **control arm is the primary decision basis** and is fully implemented. The **recent-real baseline** (the M7-7 `validate.Baseline` seam) is the design's *secondary* sanity cross-check — **deferred**: `CohortVerdict.Evaluate` is handed only a `journal.Summary` (no `ctx`/`Proposal` to call `Baseline.Fitness` against, and the registry's `ConcludeGame` call site does not thread one through). Plumbing it would widen the seam, which is out of scope here. A wiring note in `verdict.go` records the follow-up. This is the path the issue authorizes.

## Wiring

`experiment.Verdict` is the concrete `CohortVerdict` to inject via `RegistryConfig.Verdict`. The registry call site is unchanged — it records the returned `journal.Verdict` and concludes the experiment when `Outcome != OutcomeInconclusive`. Final assembly (main loop) is deliberately **not** rewired here.

## Tests

`services/agent/experiment/verdict_test.go` — under-powered → inconclusive (even with huge delta); clear win → promote; clear loss → discard; borderline → inconclusive; Count 0/1 and zero-variance edge cases (no panic); unbiased-vs-population discriminating test; env config; swappable-strategy test. `go test ./... -race`, `go vet ./...`, `gofmt -l .` all clean; `make lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)