### PR TITLE
feat(agent/promote): promote winning experiment arm via the Promoter + teardown (#980)

### DIFF
--- a/services/agent/promote/experiment_seam.go
+++ b/services/agent/promote/experiment_seam.go
@@ -1,0 +1,204 @@
+package promote
+
+// experiment_seam.go is the #980 adapter that lets the experiment REGISTRY
+// (#978) drive the EXISTING #961 Promoter unchanged. It implements the registry's
+// promotion seam (experiment.Promoter: Promote(ctx, journal.CompactView) error)
+// as a thin adapter over *Promoter — it REUSES the env-gated mode/target dispatch
+// and the whole safety rail (NewGitHubClientFromEnv / kill-switch / safe issue+
+// local defaults). It does NOT reimplement promotion, the env gates, or the
+// kill-switch (design §10).
+//
+// IMPORT-CYCLE NOTE (a divergence from the issue's suggested file path): the
+// adapter lives in the `promote` package, NOT in `experiment` as the issue sketched
+// (experiment/promote_seam.go). `promote` already imports `experiment` (promote.go
+// builds promote.Promote from experiment.Proposal/Decision), so an adapter in
+// `experiment` that called into `promote` would form an import cycle. Placing it
+// here keeps the dependency one-directional (promote → experiment) and lets the
+// adapter satisfy experiment.Promoter without any change to the registry seam.
+//
+// WHY THE SEAM SIGNATURE NEED NOT WIDEN: the registry passes a journal.CompactView,
+// which already carries everything the #961 Promoter needs to learn WHICH flag/value
+// to promote and the fitness Evidence:
+//
+//   - the flag identity + candidate value come from CompactView.Intent
+//     (FlagKey, ExperimentalValue, Hypothesis, ExperimentID) — the immutable
+//     experiment intent the journal stores at creation;
+//   - the fitness Evidence comes from the per-arm rolling aggregates
+//     (CompactView.Arms[control].Mean → FitnessBefore, Arms[experimental].Mean →
+//     FitnessAfter, total N across arms → SyntheticGames).
+//
+// So the adapter resolves the experiment's intent straight off the CompactView it
+// is handed; the registry seam stays CompactView-only (no widening, no extra intent
+// reference needed).
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/joustmania/agent/experiment"
+	"github.com/joustmania/agent/experiment/journal"
+)
+
+// ConfigResolver resolves the LIVE promotion Config (mode/target + the agent
+// kill-switch) for one promotion. It is injected so the adapter stays free of an
+// OpenFeature dependency — the SAME "package owns logic, caller owns flagd" split
+// the Promoter, Gate, Writer, and Validator already use. main.go supplies a
+// resolver that reads flags.Promotion(ctx) + the agent `enabled` snapshot; tests
+// supply a fixed Config. A nil resolver yields the SAFE default (issue/local,
+// enabled=false) so the adapter can NEVER reach a real action without an explicit
+// resolver — the safety-rail floor is preserved.
+type ConfigResolver func(ctx context.Context) Config
+
+// ExperimentPromoter adapts the #961 Promoter to the experiment registry's
+// Promoter seam (#978/#980). The registry calls Promote on a CONCLUDED+promote
+// verdict (it never routes a discard/inconclusive here), and this adapter turns the
+// journal.CompactView into the (Proposal, Decision, Config, Evidence) the existing
+// Promoter consumes — then calls it UNCHANGED.
+type ExperimentPromoter struct {
+	// promoter is the existing #961 Promoter. Its env-gated seams (github/git/
+	// realDef) and safety rail are reused verbatim; this adapter only assembles its
+	// inputs.
+	promoter *Promoter
+	// resolveConfig resolves the live mode/target/kill-switch each promotion (never
+	// cached), so flipping code_improvement.mode takes effect on the NEXT promotion.
+	resolveConfig ConfigResolver
+}
+
+// NewExperimentPromoter builds the registry-seam adapter over an existing #961
+// Promoter. p MUST be non-nil (the whole point is to reuse it). resolveConfig may
+// be nil — then every promotion runs under the SAFE default Config (issue/local,
+// disabled), i.e. the adapter degrades to the fail-closed floor rather than
+// fabricating a privileged mode. The returned *ExperimentPromoter satisfies
+// experiment.Promoter and is the concrete value injected into
+// experiment.Registry (cfg.Promoter); the agent main loop wiring is separate.
+func NewExperimentPromoter(p *Promoter, resolveConfig ConfigResolver) *ExperimentPromoter {
+	if resolveConfig == nil {
+		// Fail-closed floor: no resolver ⇒ never autonomous, never github.
+		resolveConfig = func(context.Context) Config {
+			return Config{Mode: ModeIssue, Target: TargetLocal, Enabled: false}
+		}
+	}
+	return &ExperimentPromoter{promoter: p, resolveConfig: resolveConfig}
+}
+
+// Promote implements experiment.Promoter. The registry hands it the concluded
+// experiment's bounded journal view; it builds the #961 Promoter's inputs from the
+// immutable intent + the per-arm rolling aggregates and calls Promote UNCHANGED.
+//
+// Evidence mapping (design §10):
+//
+//	FitnessBefore  = control-arm mean      (CompactView.Arms[ArmControl].Mean)
+//	FitnessAfter   = experimental-arm mean (CompactView.Arms[ArmExperimental].Mean)
+//	FitnessDelta   = after − before
+//	SyntheticGames = total N across all arms (sum of per-arm Count)
+//
+// The flag/value to promote come from the intent: Proposal.FlagKey =
+// Intent.FlagKey, RealDefaultValue (the autonomous candidate) =
+// Intent.ExperimentalValue. The Decision is synthesized as OutcomePromote —
+// the registry routes here ONLY on a promote verdict, so the underlying Promoter's
+// "only a PROMOTE verdict acts" guard passes; a non-promote view (defensive) yields
+// OutcomeDiscard and the Promoter no-ops. A failed promotion is returned as an error
+// (recorded by the registry) but never blocks teardown.
+func (a *ExperimentPromoter) Promote(ctx context.Context, view journal.CompactView) error {
+	if a.promoter == nil {
+		return fmt.Errorf("promote: experiment seam has no underlying promoter")
+	}
+
+	intent := view.Intent
+
+	before := armMean(view, experiment.ArmControl)
+	after := armMean(view, experiment.ArmExperimental)
+	delta := after - before
+	totalN := totalGames(view)
+
+	prop := experiment.Proposal{
+		FlagKey:           intent.FlagKey,
+		ExperimentID:      intent.ExperimentID,
+		ExperimentalValue: intent.ExperimentalValue,
+		Rationale:         intent.Hypothesis,
+	}
+
+	ev := Evidence{
+		FitnessBefore:    before,
+		FitnessAfter:     after,
+		FitnessDelta:     delta,
+		SyntheticGames:   totalN,
+		Reasoning:        intent.Hypothesis,
+		FlagState:        flagState(intent),
+		RealDefaultValue: intent.ExperimentalValue,
+	}
+
+	// The registry only calls Promote on a CONCLUDED+promote verdict; synthesize the
+	// PROMOTE Decision the underlying Promoter's guard expects. A defensive
+	// non-promote view (no verdict, or a verdict that is not "promote") maps to
+	// OutcomeDiscard so the Promoter records a no-op rather than acting — the adapter
+	// only ever ACTS on promote.
+	dec := experiment.Decision{
+		Outcome:       decisionOutcome(view),
+		FitnessBefore: before,
+		FitnessAfter:  after,
+		Games:         totalN,
+	}
+
+	cfg := a.resolveConfig(ctx)
+
+	// Reuse the #961 Promoter UNCHANGED: its env-gated dispatch, safe issue/local
+	// defaults, and kill-switch (cfg.Enabled gates autonomous) apply as-is.
+	res := a.promoter.Promote(ctx, prop, dec, cfg, ev)
+
+	// A discarded outcome with a reason is a RECORDED no-op (e.g. github target not
+	// enabled, or agent disabled) — the safety rail working as designed, NOT a
+	// failure. Surface it as an error so the registry logs it, but it never blocks
+	// teardown (the registry treats a Promote error as non-fatal). A clean applied/
+	// reverted outcome returns nil.
+	if res.Outcome == OutcomeDiscarded && res.Reason != "" {
+		return fmt.Errorf("promote: %s (mode=%s target=%s)", res.Reason, res.Mode, res.Target)
+	}
+	return nil
+}
+
+// armMean returns the rolling mean fitness for an arm, or 0 if the arm has no
+// games yet (a never-played arm reports Count 0 / Mean 0 in the CompactView).
+func armMean(view journal.CompactView, arm string) float64 {
+	if v, ok := view.Arms[arm]; ok {
+		return v.Mean
+	}
+	return 0
+}
+
+// totalGames sums the per-arm game counts — the sample size N behind the verdict
+// (both arms together, per design §10 "SyntheticGames = N").
+func totalGames(view journal.CompactView) int {
+	total := 0
+	for _, v := range view.Arms {
+		total += v.Count
+	}
+	return total
+}
+
+// decisionOutcome maps the journal verdict carried on the view to the Promoter's
+// gate. The registry routes here only on a promote verdict, so this is normally
+// OutcomePromote; anything else is treated as discard (defensive — the Promoter
+// then no-ops rather than acting on a non-promote view).
+func decisionOutcome(view journal.CompactView) experiment.Outcome {
+	if view.Verdict != nil && view.Verdict.Outcome == experiment.CohortOutcomePromote {
+		return experiment.OutcomePromote
+	}
+	return experiment.OutcomeDiscard
+}
+
+// flagState renders a short human-readable snapshot of the experiment's flag
+// context for the issue/PR body (a reviewer sees what was promoted). Best-effort;
+// the Evidence body renderer tolerates an empty value.
+func flagState(intent journal.Intent) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s: experimental=%v", intent.FlagKey, intent.ExperimentalValue)
+	if intent.Objective != "" {
+		fmt.Fprintf(&b, "; objective=%s", intent.Objective)
+	}
+	if intent.ExperimentID != "" {
+		fmt.Fprintf(&b, "; experiment_id=%s", intent.ExperimentID)
+	}
+	return b.String()
+}

--- a/services/agent/promote/experiment_seam_test.go
+++ b/services/agent/promote/experiment_seam_test.go
@@ -1,0 +1,199 @@
+package promote
+
+// experiment_seam_test.go covers the #980 registry-seam adapter
+// (ExperimentPromoter): it builds the #961 Promoter's inputs from a
+// journal.CompactView and reuses the existing env-gated dispatch + safety rail
+// UNCHANGED. The fakes/helpers (recordingGitHub, recordingRealDefault,
+// promoterWithRecorder, discardLogger) are the in-package recorders from
+// promote_test.go.
+
+import (
+	"context"
+	"testing"
+
+	"go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"github.com/joustmania/agent/experiment"
+	"github.com/joustmania/agent/experiment/journal"
+)
+
+// ExperimentPromoter must satisfy the registry's promotion seam (experiment.Promoter).
+var _ experiment.Promoter = (*ExperimentPromoter)(nil)
+
+// promoteView builds a CONCLUDED+promote CompactView: control mean 0.40 over 6
+// games, experimental mean 0.70 over 8 games (total N = 14), promote verdict.
+func promoteView() journal.CompactView {
+	return journal.CompactView{
+		Intent: journal.Intent{
+			ExperimentID:      "exp_abc123",
+			FlagKey:           "death_grace_period_ms",
+			ExperimentalValue: 500,
+			Hypothesis:        "longer grace reduces early eliminations",
+			Objective:         "engagement_balanced",
+			Arms:              []string{experiment.ArmExperimental, experiment.ArmControl},
+		},
+		Status: "concluded",
+		Arms: map[string]journal.ArmView{
+			experiment.ArmControl:      {Count: 6, Mean: 0.40},
+			experiment.ArmExperimental: {Count: 8, Mean: 0.70},
+		},
+		Verdict: &journal.Verdict{Outcome: experiment.CohortOutcomePromote, Delta: 0.30, Significant: true},
+	}
+}
+
+// fixedConfig returns a ConfigResolver that always yields cfg (no flagd).
+func fixedConfig(cfg Config) ConfigResolver {
+	return func(context.Context) Config { return cfg }
+}
+
+// adapterWithRecorder wires an ExperimentPromoter over a Promoter that uses the
+// given seams + a span recorder, with the supplied live Config.
+func adapterWithRecorder(t *testing.T, gh GitHubClient, git GitClient, realDef RealDefaultWriter, cfg Config) (*ExperimentPromoter, *tracetest.SpanRecorder) {
+	t.Helper()
+	rec := tracetest.NewSpanRecorder()
+	tp := trace.NewTracerProvider(trace.WithSpanProcessor(rec))
+	p := NewPromoter(gh, git, realDef, nil, nil, testRepo(), tp.Tracer("test"), discardLogger())
+	return NewExperimentPromoter(p, fixedConfig(cfg)), rec
+}
+
+// TestExperimentSeamEvidenceMapping: a promote view builds Evidence with control
+// mean→Before, experimental mean→After, delta, and N=total across arms, and the
+// underlying #961 Promoter is invoked with the right flag/value. mode=pr local
+// exercises a clean APPLIED outcome (a local commit) so the adapter returns nil.
+func TestExperimentSeamEvidenceMapping(t *testing.T) {
+	gh := &recordingGitHub{}
+	git := &recordingGit{sha: "deadbeef"}
+	a, rec := adapterWithRecorder(t, gh, git, nil, Config{Mode: ModePR, Target: TargetLocal, Enabled: false})
+
+	if err := a.Promote(context.Background(), promoteView()); err != nil {
+		t.Fatalf("Promote returned error on clean local PR: %v", err)
+	}
+
+	// The #961 Promoter ran and stamped the fitness Evidence on its span.
+	span := spanByName(t, rec, SpanPromote)
+	if got := float64Attr(span, AttrFitnessBefore); got != 0.40 {
+		t.Errorf("FitnessBefore: want control mean 0.40, got %v", got)
+	}
+	if got := float64Attr(span, AttrFitnessAfter); got != 0.70 {
+		t.Errorf("FitnessAfter: want experimental mean 0.70, got %v", got)
+	}
+	if got := float64Attr(span, AttrFitnessDelta); got < 0.2999 || got > 0.3001 {
+		t.Errorf("FitnessDelta: want 0.30, got %v", got)
+	}
+	if got := stringAttr(span, AttrFlagKey); got != "death_grace_period_ms" {
+		t.Errorf("flag key: want death_grace_period_ms, got %q", got)
+	}
+
+	// A local PR commits the change; the recorder proves the right flag/value flowed
+	// through into the #961 Promoter's body (N=14 sample size).
+	if len(git.commits) == 0 {
+		t.Fatalf("expected a local commit (mode=pr, target=local)")
+	}
+}
+
+// TestExperimentSeamGitHubGatedNoOp: with the real github path NOT enabled (the
+// default — main.go passes inert no-op clients), a github-target promotion degrades
+// to a RECORDED no-op. The adapter does NOT bypass the #961 gates: it surfaces the
+// recorded reason as a (non-fatal) error and touches nothing real.
+func TestExperimentSeamGitHubGatedNoOp(t *testing.T) {
+	// gh/git nil ⇒ NewPromoter installs the inert recording no-ops (the default,
+	// fail-closed floor). realDef nil ⇒ no real-default writer wired.
+	a, rec := adapterWithRecorder(t, nil, nil, nil, Config{Mode: ModeIssue, Target: TargetGitHub, Enabled: false})
+
+	err := a.Promote(context.Background(), promoteView())
+	if err == nil {
+		t.Fatalf("expected a recorded no-op error when github target is not enabled")
+	}
+
+	span := spanByName(t, rec, SpanPromote)
+	if got := stringAttr(span, AttrOutcome); got != string(OutcomeDiscarded) {
+		t.Errorf("outcome: want discarded (no-op), got %q", got)
+	}
+	if stringAttr(span, AttrReason) == "" {
+		t.Errorf("expected a non-empty reason proving the safety rail degraded the github path")
+	}
+}
+
+// TestExperimentSeamAutonomousDisabledNoOp: autonomous mode while the agent is
+// DISABLED must never mutate the real default — the kill-switch (Config.Enabled) is
+// the #961 Promoter's, reused. The recordingRealDefault must record ZERO writes.
+func TestExperimentSeamAutonomousDisabledNoOp(t *testing.T) {
+	realDef := &recordingRealDefault{}
+	a, rec := adapterWithRecorder(t, nil, nil, realDef, Config{Mode: ModeAutonomous, Target: TargetLocal, Enabled: false})
+
+	err := a.Promote(context.Background(), promoteView())
+	if err == nil {
+		t.Fatalf("expected a recorded no-op error when autonomous is requested while disabled")
+	}
+	if len(realDef.calls) != 0 {
+		t.Errorf("kill-switch breached: real default written %d time(s) while disabled", len(realDef.calls))
+	}
+	span := spanByName(t, rec, SpanPromote)
+	if got := stringAttr(span, AttrOutcome); got != string(OutcomeDiscarded) {
+		t.Errorf("outcome: want discarded (kill-switch no-op), got %q", got)
+	}
+}
+
+// TestExperimentSeamNilResolverSafeDefault: with NO resolver, every promotion runs
+// under the SAFE default Config (issue/local, disabled) — the adapter never
+// fabricates a privileged mode. A github real path is unreachable (default
+// target=local, mode=issue), so a local issue mode no-ops cleanly without touching
+// the real default.
+func TestExperimentSeamNilResolverSafeDefault(t *testing.T) {
+	realDef := &recordingRealDefault{}
+	rec := tracetest.NewSpanRecorder()
+	tp := trace.NewTracerProvider(trace.WithSpanProcessor(rec))
+	// nil git/github ⇒ inert no-ops; nil resolver ⇒ safe default issue/local/disabled.
+	p := NewPromoter(nil, nil, realDef, nil, nil, testRepo(), tp.Tracer("test"), discardLogger())
+	a := NewExperimentPromoter(p, nil)
+
+	_ = a.Promote(context.Background(), promoteView())
+
+	span := spanByName(t, rec, SpanPromote)
+	if got := stringAttr(span, AttrGate); got != string(ModeIssue) {
+		t.Errorf("nil resolver should default to issue mode, got %q", got)
+	}
+	if got := stringAttr(span, AttrTarget); got != string(TargetLocal) {
+		t.Errorf("nil resolver should default to local target, got %q", got)
+	}
+	if len(realDef.calls) != 0 {
+		t.Errorf("safe default must not write the real default; got %d write(s)", len(realDef.calls))
+	}
+}
+
+// TestExperimentSeamNonPromoteVerdictNoOp: the adapter only ACTS on a promote
+// verdict. A view whose verdict is NOT promote (defensive — the registry should
+// never route it here) synthesizes an OutcomeDiscard Decision, so the #961
+// Promoter's "only PROMOTE acts" guard no-ops and nothing real is touched.
+func TestExperimentSeamNonPromoteVerdictNoOp(t *testing.T) {
+	realDef := &recordingRealDefault{}
+	a, rec := adapterWithRecorder(t, nil, nil, realDef, Config{Mode: ModeAutonomous, Target: TargetLocal, Enabled: true})
+
+	view := promoteView()
+	view.Verdict = &journal.Verdict{Outcome: experiment.CohortOutcomeDiscard}
+
+	_ = a.Promote(context.Background(), view)
+
+	if len(realDef.calls) != 0 {
+		t.Errorf("non-promote verdict must not promote: real default written %d time(s)", len(realDef.calls))
+	}
+	span := spanByName(t, rec, SpanPromote)
+	if got := stringAttr(span, AttrOutcome); got != string(OutcomeDiscarded) {
+		t.Errorf("non-promote verdict: want discarded, got %q", got)
+	}
+	if got := stringAttr(span, AttrReason); got == "" {
+		t.Errorf("expected a reason explaining the non-promote no-op")
+	}
+}
+
+// float64Attr reads a float64 span attribute by key (helper local to this file;
+// stringAttr lives in promote_test.go).
+func float64Attr(s trace.ReadOnlySpan, key string) float64 {
+	for _, a := range s.Attributes() {
+		if string(a.Key) == key {
+			return a.Value.AsFloat64()
+		}
+	}
+	return 0
+}


### PR DESCRIPTION
Part of #982 — promotion via Promoter + teardown.

Phase 5 of the agent experiment/cohort framework: close the loop from a cohort verdict to a gated promotion. Implements the experiment registry's `Promoter` seam (#978) as a thin adapter over the **existing** env-gated #961 Promoter (design §10), reusing its safety rail unchanged.

## What

New `promote.ExperimentPromoter` satisfies `experiment.Promoter` (`Promote(ctx, journal.CompactView) error`). On a CONCLUDED+promote verdict the registry routes here; the adapter assembles the #961 Promoter's inputs straight off the journal `CompactView` and calls `Promote(...)` unchanged.

**Evidence mapping (§10):**
| Evidence field | Source |
|---|---|
| `FitnessBefore` | control-arm mean (`Arms[ArmControl].Mean`) |
| `FitnessAfter` | experimental-arm mean (`Arms[ArmExperimental].Mean`) |
| `FitnessDelta` | after − before |
| `SyntheticGames` | total N across all arms (Σ per-arm `Count`) |

**Flag/value to promote:** taken from the immutable intent carried on the view (`Intent.FlagKey`, `Intent.ExperimentalValue` → `Proposal` + `Evidence.RealDefaultValue`). The seam signature did **not** need widening — `CompactView.Intent` already carries the flag identity + candidate value.

## Safety rail reused, NOT bypassed
- The env-gated mode/target dispatch, the safe `issue`/`local` defaults, and the kill-switch (`Config.Enabled` gates autonomous) are the #961 Promoter's — the adapter only assembles inputs.
- Live `Config` is resolved via an injected `ConfigResolver` (caller owns flagd, same split as Gate/Writer/Validator). A **nil** resolver falls back to the safe default (`issue`/`local`, disabled) — the adapter can never fabricate a privileged mode.

## Teardown
Already handled by the registry on terminal status (strips the experiment's shadow targeting branch via the `TargetingWriter.Strip` seam #978 + frees capacity). Nothing promotion-specific to add (§10).

## Placement note (divergence from issue sketch)
The issue suggested `experiment/promote_seam.go`. That would create an import cycle (`promote` already imports `experiment`). The adapter lives in the **promote** package instead, keeping the dependency one-directional. Documented in the file header.

## Tests
- Evidence mapping: control→Before, exp→After, delta, N=total; #961 Promoter invoked with the right flag/value.
- github target with the real path OFF → recorded no-op (safety rail degrades, surfaced as a non-fatal error).
- autonomous-while-disabled → ZERO real-default writes (kill-switch reused).
- nil resolver → safe `issue`/`local` default, no real-default write.
- non-promote verdict → no-op (adapter only acts on promote).

`go test ./... -race`, `go vet ./...`, `gofmt -l .`, `make lint` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)