### PR TITLE
fix(game_coordinator): layer agent sensitivity override on admin baseline (#816)

### DIFF
--- a/services/game_coordinator/difficulty_handlers.py
+++ b/services/game_coordinator/difficulty_handlers.py
@@ -10,9 +10,12 @@ intervention flags against the InterventionManager registry built in PR A:
   resumes the natural schedule from the current state via an explicit revert
   handler (#922 — the manager routes reverts to ``_revert_handlers``, not back to
   the apply-handler, so the override must be cleared there).
-- ``global_sensitivity_override`` — N2: live update of ``game.sensitivity``,
-  consumed next frame by ``_compute_effective_thresholds``; reverting to none
-  (-1) restores the sensitivity the game started with.
+- ``global_sensitivity_override`` — N2: a bounded, temporary override LAYER on
+  top of the admin baseline (never persisted into the baseline — #816 / M9
+  ownership model), consumed next frame by ``_compute_effective_thresholds``;
+  reverting to none (-1) clears the layer so the effective sensitivity returns
+  to the admin's CURRENT baseline (a mid-game admin change wins by invalidating
+  the override).
 - ``player_sensitivity_factor``   — N1: per-serial ``targeting_key`` evaluation
   sets each active player's ``sensitivity_factor`` (clamped 0.5-2.0); serials
   with no targeting match get the neutral default (1.0).
@@ -99,10 +102,14 @@ async def handle_music_tempo_override_revert(ctx: InterventionContext) -> None:
 async def handle_global_sensitivity_override(ctx: InterventionContext) -> None:
     """Apply / clear the agent global-sensitivity override on the live game.
 
-    A value >= 0 sets ``game.sensitivity`` to the matching ``Sensitivity`` index;
-    the change is picked up next frame by ``_compute_effective_thresholds``. A
-    value of -1 (none) restores the sensitivity the game was configured with at
-    start (``game.configured_sensitivity``).
+    The override is a bounded, temporary LAYER on top of the admin baseline; it
+    is never persisted into the baseline (the M9 ownership model — #816). A value
+    >= 0 sets the override to the matching ``Sensitivity`` index, picked up next
+    frame by ``_compute_effective_thresholds``. A value of -1 (none) CLEARS the
+    override so the effective sensitivity returns to the admin's CURRENT baseline
+    (``game.baseline_sensitivity``) — not a stale game-start snapshot. If the
+    admin changed the baseline while the override was active, the override was
+    already invalidated, so this clear is a safe no-op against the new baseline.
     """
     game = ctx.game
     if game is None:
@@ -111,17 +118,15 @@ async def handle_global_sensitivity_override(ctx: InterventionContext) -> None:
 
     idx = int(ctx.value)
     if idx < 0:
-        restored = getattr(game, "configured_sensitivity", game.sensitivity)
-        game.sensitivity = restored
-        logger.info(f"global_sensitivity_override: cleared, restored to {restored.name}")
+        game.clear_sensitivity_override()
         return
 
     try:
-        game.sensitivity = Sensitivity(idx)
+        sensitivity = Sensitivity(idx)
     except ValueError:
         logger.warning(f"global_sensitivity_override: invalid sensitivity index {idx}, ignoring")
         return
-    logger.info(f"global_sensitivity_override: live sensitivity -> {game.sensitivity.name}")
+    game.apply_sensitivity_override(sensitivity)
 
 
 async def handle_player_sensitivity_factor(ctx: InterventionContext, manager: InterventionManager) -> None:

--- a/services/game_coordinator/games/base.py
+++ b/services/game_coordinator/games/base.py
@@ -490,13 +490,28 @@ class BaseGameMode(ABC):
         self.running = False
         self.gameplay_stream = None  # Phase 46: Bidirectional stream for feedback commands
 
-        # Settings - sensitivity is now passed via StartGameConfig
-        # Validate and convert to Sensitivity enum
+        # Settings - sensitivity is now passed via StartGameConfig.
+        #
+        # Sensitivity arbitration (#816, M9 ownership model — epic #814):
+        #   - ``baseline_sensitivity`` is the ADMIN's source of truth (pre-game
+        #     lobby intent). The admin may update it mid-game via
+        #     ``set_baseline_sensitivity`` (which invalidates any active agent
+        #     override — a human baseline change wins).
+        #   - ``sensitivity_override`` is the AGENT's bounded in-game override
+        #     LAYER (``None`` = no override). The agent never persists into the
+        #     baseline; clearing the override returns to the CURRENT baseline,
+        #     not a stale game-start snapshot.
+        #   - ``sensitivity`` (property below) is the EFFECTIVE level read by
+        #     ``_compute_effective_thresholds`` and the metrics/spans: the
+        #     override if active, otherwise the baseline.
+        # Validate and convert to Sensitivity enum.
         if 0 <= sensitivity <= 4:
-            self.sensitivity = Sensitivity(sensitivity)
+            self._baseline_sensitivity = Sensitivity(sensitivity)
         else:
             logger.warning(f"Sensitivity {sensitivity} out of range, using MEDIUM")
-            self.sensitivity = Sensitivity.MEDIUM
+            self._baseline_sensitivity = Sensitivity.MEDIUM
+        # No agent override at game start; effective == baseline.
+        self._sensitivity_override: Sensitivity | None = None
 
         # #766 F1: death/warning threshold tables promoted to the ``game.thresholds``
         # object flag. Read ONCE here (init-frozen by design — no live re-evaluation);
@@ -556,9 +571,12 @@ class BaseGameMode(ABC):
         # None = no override; the natural schedule runs. Set/cleared by the
         # music_tempo_override intervention handler; consumed in _check_music_speed.
         self.tempo_override: float | None = None
-        # Configured sensitivity captured at game start so a reverted
-        # global_sensitivity_override (#730 PR C) restores the original level.
-        self.configured_sensitivity = self.sensitivity
+        # Backwards-compatible alias kept for any external reader (#730 PR C).
+        # The reverted global_sensitivity_override now restores the CURRENT admin
+        # baseline (#816), so this is no longer the restore target — but the
+        # game-start snapshot is still useful telemetry, so expose it as a
+        # property mirroring the baseline at construction time.
+        self._configured_sensitivity = self._baseline_sensitivity
         self.dead_count = 0  # Track deaths for tempo timing
         # Elimination ordering for game_player_elimination_order metric (#730).
         # Incremented on each kill; the value at kill time is the player's order
@@ -580,6 +598,76 @@ class BaseGameMode(ABC):
         self.countdown_music_volume = _read_volume_flag("audio_volume.countdown_music", COUNTDOWN_MUSIC_VOLUME)
 
         logger.info(f"{self.get_game_name()} game initialized: {self.game_id}")
+
+    # ========================================================================
+    # Sensitivity arbitration (#816, M9 ownership model — epic #814)
+    # ========================================================================
+    # ``sensitivity`` is the EFFECTIVE level: the agent override if one is
+    # active, otherwise the admin baseline. Every reader (the per-frame
+    # ``_compute_effective_thresholds``, the game_sensitivity metric, span
+    # attributes) sees the effective value with no change. Writers are split by
+    # owner: the admin owns ``baseline_sensitivity`` (assigning ``sensitivity``
+    # is the admin path and routes here); the agent owns the override layer via
+    # ``apply_sensitivity_override`` / ``clear_sensitivity_override`` and never
+    # touches the baseline.
+
+    @property
+    def sensitivity(self) -> Sensitivity:
+        """Effective sensitivity: agent override if active, else admin baseline."""
+        if self._sensitivity_override is not None:
+            return self._sensitivity_override
+        return self._baseline_sensitivity
+
+    @sensitivity.setter
+    def sensitivity(self, value: Sensitivity) -> None:
+        """Admin path: set the baseline (clears any active agent override).
+
+        Assigning ``game.sensitivity`` is treated as a HUMAN baseline change
+        (the lobby/admin surface and existing test fixtures do this). Per the
+        ownership model a human baseline change invalidates the agent's active
+        override, so this delegates to :meth:`set_baseline_sensitivity`.
+        """
+        self.set_baseline_sensitivity(value)
+
+    @property
+    def baseline_sensitivity(self) -> Sensitivity:
+        """The admin's source-of-truth sensitivity (pre-game lobby intent)."""
+        return self._baseline_sensitivity
+
+    @property
+    def sensitivity_override(self) -> Sensitivity | None:
+        """The agent's active override layer, or ``None`` if no override."""
+        return self._sensitivity_override
+
+    @property
+    def configured_sensitivity(self) -> Sensitivity:
+        """Game-start sensitivity snapshot (telemetry only; not the restore target)."""
+        return self._configured_sensitivity
+
+    def set_baseline_sensitivity(self, value: Sensitivity) -> None:
+        """Update the admin baseline; invalidate any active agent override (#816).
+
+        A human baseline change wins: the agent's in-game override is dropped so
+        a later override clear cannot clobber fresh admin intent, and the
+        effective sensitivity reflects the new baseline immediately.
+        """
+        had_override = self._sensitivity_override is not None
+        self._baseline_sensitivity = value
+        self._sensitivity_override = None
+        if had_override:
+            logger.info(f"sensitivity: admin baseline -> {value.name}; active agent override invalidated")
+        else:
+            logger.info(f"sensitivity: admin baseline -> {value.name}")
+
+    def apply_sensitivity_override(self, value: Sensitivity) -> None:
+        """Agent path: set the temporary override layer on top of the baseline."""
+        self._sensitivity_override = value
+        logger.info(f"sensitivity: agent override -> {value.name} (baseline {self._baseline_sensitivity.name})")
+
+    def clear_sensitivity_override(self) -> None:
+        """Agent path: drop the override; effective returns to the CURRENT baseline."""
+        self._sensitivity_override = None
+        logger.info(f"sensitivity: agent override cleared, restored to baseline {self._baseline_sensitivity.name}")
 
     # ========================================================================
     # Abstract Methods - Subclasses MUST implement these

--- a/services/game_coordinator/tests/test_sensitivity_arbitration.py
+++ b/services/game_coordinator/tests/test_sensitivity_arbitration.py
@@ -1,0 +1,232 @@
+"""
+Sensitivity arbitration tests (#816, epic #814 / M9 ownership model).
+
+These exercise the admin-baseline vs. agent-override arbitration for global
+sensitivity. The ratified ownership model (epic #814):
+
+- Human owns PRE-GAME intent: the lobby baseline sensitivity.
+- Agent owns bounded IN-GAME deltas: ``global_sensitivity_override`` is a
+  temporary override layer applied ON TOP of the baseline.
+- Agent NEVER persists into game.json (it mutates only the live override layer).
+- A human baseline change INVALIDATES any active agent override for that
+  parameter, so the agent's override never clobbers fresh admin intent.
+
+Concretely the game exposes:
+- ``baseline_sensitivity``  — admin source of truth (game-start value, updatable
+  mid-game via the admin setter, which invalidates the override).
+- ``sensitivity_override``  — the agent override layer (``None`` = no override).
+- ``sensitivity``           — read-only EFFECTIVE level = override if active else
+  baseline; what ``_compute_effective_thresholds`` and metrics read.
+
+The first class below is the characterization suite (current public behavior
+that must be preserved). The later classes are the new edge cases the fix adds.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+test_dir = Path(__file__).parent
+service_dir = test_dir.parent
+project_root = service_dir.parent.parent
+sys.path.insert(0, str(project_root))
+sys.path.insert(0, str(test_dir))
+
+from conftest import MockControllerManagerService, async_noop  # noqa: E402
+
+from lib.types import Sensitivity  # noqa: E402
+from services.game_coordinator.difficulty_handlers import (  # noqa: E402
+    handle_global_sensitivity_override,
+)
+from services.game_coordinator.games.base import Player  # noqa: E402
+from services.game_coordinator.games.ffa import FFAGame  # noqa: E402
+from services.game_coordinator.interventions import (  # noqa: E402
+    INTERVENTION_SPECS,
+    InterventionContext,
+)
+
+
+def make_game(sensitivity=2, num_players=2):
+    mock_cm = MockControllerManagerService(num_controllers=num_players)
+    game = FFAGame(
+        controller_manager_client=mock_cm,
+        event_publisher=async_noop,
+        audio_client=AsyncMock(),
+        game_id="test_sensitivity_arbitration",
+        sensitivity=sensitivity,
+    )
+    for i in range(num_players):
+        s = f"p{i + 1}"
+        game.players[s] = Player(serial=s, alive=True, color=(255, 0, 0))
+    return game
+
+
+def _spec(flag_key):
+    return next(s for s in INTERVENTION_SPECS if s.flag_key == flag_key)
+
+
+def make_ctx(value, game):
+    return InterventionContext(
+        spec=_spec("global_sensitivity_override"),
+        value=value,
+        payload="",
+        target_serial=None,
+        game=game,
+        objective="balanced",
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Characterization: behavior that must be preserved across the fix.
+# --------------------------------------------------------------------------- #
+class TestCharacterizationPreserved:
+    def test_effective_sensitivity_equals_baseline_with_no_override(self):
+        game = make_game(sensitivity=1)
+        assert game.sensitivity == Sensitivity.SLOW
+
+    @pytest.mark.asyncio
+    async def test_agent_override_changes_effective_sensitivity(self):
+        game = make_game(sensitivity=0)
+        await handle_global_sensitivity_override(make_ctx(4, game))
+        assert game.sensitivity == Sensitivity.ULTRA_FAST
+
+    @pytest.mark.asyncio
+    async def test_override_clear_returns_to_baseline(self):
+        game = make_game(sensitivity=1)  # SLOW baseline
+        await handle_global_sensitivity_override(make_ctx(3, game))
+        assert game.sensitivity == Sensitivity.FAST
+        await handle_global_sensitivity_override(make_ctx(-1, game))
+        assert game.sensitivity == Sensitivity.SLOW
+
+    @pytest.mark.asyncio
+    async def test_invalid_index_ignored(self):
+        game = make_game(sensitivity=2)
+        await handle_global_sensitivity_override(make_ctx(99, game))
+        assert game.sensitivity == Sensitivity.MEDIUM
+
+    @pytest.mark.asyncio
+    async def test_no_live_game_is_noop(self):
+        await handle_global_sensitivity_override(make_ctx(3, None))  # no raise
+
+    @pytest.mark.asyncio
+    async def test_override_changes_effective_thresholds(self):
+        game = make_game(sensitivity=0)
+        player = game.players["p1"]
+        _, death_before = game._compute_effective_thresholds(player)
+        await handle_global_sensitivity_override(make_ctx(4, game))
+        _, death_after = game._compute_effective_thresholds(player)
+        assert death_after != death_before
+
+    def test_admin_setter_via_sensitivity_attribute_sets_effective(self):
+        """Legacy/admin path: assigning game.sensitivity sets the effective level.
+
+        Existing fixtures and the lobby path assign ``game.sensitivity = X``; that
+        must keep setting the effective sensitivity (it sets the baseline).
+        """
+        game = make_game(sensitivity=2)
+        game.sensitivity = Sensitivity.ULTRA_FAST
+        assert game.sensitivity == Sensitivity.ULTRA_FAST
+
+
+# --------------------------------------------------------------------------- #
+# Agent never persists into game.json (the writers only touch live state).
+# --------------------------------------------------------------------------- #
+class TestAgentDoesNotPersist:
+    @pytest.mark.asyncio
+    async def test_override_does_not_mutate_baseline(self):
+        game = make_game(sensitivity=2)  # MEDIUM baseline
+        await handle_global_sensitivity_override(make_ctx(4, game))
+        # Effective is the override, but the admin baseline is untouched.
+        assert game.sensitivity == Sensitivity.ULTRA_FAST
+        assert game.baseline_sensitivity == Sensitivity.MEDIUM
+
+    @pytest.mark.asyncio
+    async def test_override_clear_leaves_baseline_intact(self):
+        game = make_game(sensitivity=2)
+        await handle_global_sensitivity_override(make_ctx(0, game))
+        await handle_global_sensitivity_override(make_ctx(-1, game))
+        assert game.baseline_sensitivity == Sensitivity.MEDIUM
+        assert game.sensitivity_override is None
+
+
+# --------------------------------------------------------------------------- #
+# Restore semantics: clear restores the CURRENT baseline, not a game-start snap.
+# --------------------------------------------------------------------------- #
+class TestRestoreToCurrentBaseline:
+    @pytest.mark.asyncio
+    async def test_clear_with_no_admin_change_restores_baseline(self):
+        game = make_game(sensitivity=2)
+        await handle_global_sensitivity_override(make_ctx(4, game))
+        await handle_global_sensitivity_override(make_ctx(-1, game))
+        assert game.sensitivity == Sensitivity.MEDIUM
+
+
+# --------------------------------------------------------------------------- #
+# Admin baseline change INVALIDATES an active agent override.
+# --------------------------------------------------------------------------- #
+class TestAdminBaselineChangeInvalidatesOverride:
+    @pytest.mark.asyncio
+    async def test_admin_change_during_active_override_takes_effect(self):
+        game = make_game(sensitivity=2)
+        await handle_global_sensitivity_override(make_ctx(4, game))
+        assert game.sensitivity == Sensitivity.ULTRA_FAST
+
+        # Admin changes the baseline mid-game -> override invalidated, admin wins.
+        game.set_baseline_sensitivity(Sensitivity.SLOW)
+        assert game.sensitivity == Sensitivity.SLOW
+        assert game.sensitivity_override is None
+
+    @pytest.mark.asyncio
+    async def test_admin_setter_attribute_also_invalidates_override(self):
+        game = make_game(sensitivity=2)
+        await handle_global_sensitivity_override(make_ctx(4, game))
+        game.sensitivity = Sensitivity.SLOW  # admin via attribute
+        assert game.sensitivity == Sensitivity.SLOW
+        assert game.sensitivity_override is None
+
+    @pytest.mark.asyncio
+    async def test_clear_after_admin_change_restores_new_baseline(self):
+        """After admin changes baseline, a stale override clear must NOT clobber
+        the new admin intent with the old game-start value."""
+        game = make_game(sensitivity=2)  # game-start MEDIUM
+        await handle_global_sensitivity_override(make_ctx(0, game))  # agent -> ULTRA_SLOW
+        game.set_baseline_sensitivity(Sensitivity.FAST)  # admin mid-game change
+        # Override already invalidated; a late clear is a no-op on the baseline.
+        await handle_global_sensitivity_override(make_ctx(-1, game))
+        assert game.sensitivity == Sensitivity.FAST
+
+    @pytest.mark.asyncio
+    async def test_new_override_after_admin_change_layers_on_new_baseline(self):
+        game = make_game(sensitivity=2)
+        await handle_global_sensitivity_override(make_ctx(0, game))
+        game.set_baseline_sensitivity(Sensitivity.SLOW)
+        # Agent issues a fresh override against the new baseline.
+        await handle_global_sensitivity_override(make_ctx(3, game))
+        assert game.sensitivity == Sensitivity.FAST
+        await handle_global_sensitivity_override(make_ctx(-1, game))
+        assert game.sensitivity == Sensitivity.SLOW  # the NEW baseline
+
+
+# --------------------------------------------------------------------------- #
+# Multiple sequential overrides without an intervening clear.
+# --------------------------------------------------------------------------- #
+class TestMultipleOverrides:
+    @pytest.mark.asyncio
+    async def test_second_override_replaces_first(self):
+        game = make_game(sensitivity=2)
+        await handle_global_sensitivity_override(make_ctx(0, game))
+        assert game.sensitivity == Sensitivity.ULTRA_SLOW
+        await handle_global_sensitivity_override(make_ctx(4, game))
+        assert game.sensitivity == Sensitivity.ULTRA_FAST
+        # Clearing returns to the untouched baseline, not the first override.
+        await handle_global_sensitivity_override(make_ctx(-1, game))
+        assert game.sensitivity == Sensitivity.MEDIUM
+
+    @pytest.mark.asyncio
+    async def test_no_admin_change_baseline_constant_across_overrides(self):
+        game = make_game(sensitivity=3)
+        for idx in (0, 1, 4, 2):
+            await handle_global_sensitivity_override(make_ctx(idx, game))
+            assert game.baseline_sensitivity == Sensitivity.FAST


### PR DESCRIPTION
Part of #816 (epic #814, milestone M9). Implements the ownership model documented in #820 (PR #996).

## Problem
The agent's `global_sensitivity_override` mutated the single `game.sensitivity` field mid-game. On clear it "restored" the **game-start snapshot** (`configured_sensitivity`), not the admin's current baseline — so a late override clear could clobber a newer admin intent. Meanwhile admin mid-game changes silently no-op. Asymmetric and lossy.

## Fix
Split the conflated `sensitivity` field on the game object into an owner-aware, layered model:
- `baseline_sensitivity` — admin source of truth (pre-game lobby intent)
- `sensitivity_override` — the agent's temporary override layer (`None` = none)
- `sensitivity` — now a **read-only property**: `override if override is not None else baseline`. All existing readers (`_compute_effective_thresholds`, the `game_sensitivity` metric, span attrs) are unchanged.

Writers split by owner:
- **Admin** (`game.sensitivity = X` / `set_baseline_sensitivity`) sets the baseline **and invalidates any active agent override** — human baseline change wins (per the ratified model).
- **Agent** (`apply_sensitivity_override` / `clear_sensitivity_override`) never persists into the baseline (game.json untouched); clear returns to the **current** baseline, not the game-start snapshot.
- `configured_sensitivity` retained as a read-only property for game-start telemetry only — no longer the restore target.

## Arbitration choice
Override is an absolute-index layer (0–4) with invalidate-on-admin-touch, rather than an additive delta — because the agent flag's wire value is an absolute index + `-1` sentinel; treating it as a delta would need an out-of-scope flag-schema/agent change. Invalidate-on-touch already yields the symmetric, admin-wins composition. (Noted for the #820 doc.)

## Tests
- New `tests/test_sensitivity_arbitration.py`: **16 tests** (override apply/clear, admin change during active override, invalidation, clear-restores-current-baseline).
- Characterization-first: 9 passed unchanged against old code (simple paths preserved), 7 new-model tests failed on old / pass on new. Pre-existing `test_revert_restores_configured_sensitivity` still passes unmodified.
- Full game_coordinator suite: **969 passed, 0 failed**. `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)