### PR TITLE
fix(agent): recover real game duration so shadow games conclude with non-zero fitness (#997)

### DIFF
--- a/services/agent/experiment_fitness_test.go
+++ b/services/agent/experiment_fitness_test.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/joustmania/agent/decision"
+	"github.com/joustmania/agent/gamecontext"
+)
+
+// TestDefaultGameFitness_DurationlessEnduranceFoldsZero pins the #994 contract that
+// the worst-case 0 is hit ONLY for a genuinely signal-less game: an endurance game
+// whose GameContext carries no duration AND no timeline to recover one folds 0.
+func TestDefaultGameFitness_DurationlessEnduranceFoldsZero(t *testing.T) {
+	gc := gamecontext.GameContext{
+		SessionID:    "game_abc123",
+		ExperimentID: "exp_1",
+		Arm:          "experimental",
+		// No Session.DurationSeconds, no Timeline → nothing to recover.
+	}
+	gc = withEffectiveDuration(gc)
+	if gc.Session.DurationSeconds != nil {
+		t.Fatalf("expected DurationSeconds to stay nil for a signal-less game, got %v", *gc.Session.DurationSeconds)
+	}
+	if fit := defaultGameFitness(gc, decision.ObjectiveEndurance); fit != 0 {
+		t.Fatalf("signal-less endurance game must fold worst-case 0, got %v", fit)
+	}
+}
+
+// TestWithEffectiveDuration_RecoversFromTimeline is the #997 root-cause fix: when the
+// coordinator's end-only game_duration_seconds gauge has not arrived (DurationSeconds
+// nil) but the partition's start→end phase timeline is present, the real elapsed game
+// time is recovered onto the context.
+func TestWithEffectiveDuration_RecoversFromTimeline(t *testing.T) {
+	start := time.Unix(1_000, 0)
+	gc := gamecontext.GameContext{
+		SessionID: "game_abc123",
+		Timeline: []gamecontext.TimelineEvent{
+			{At: start, Kind: gamecontext.EventPhase, Detail: "start"},
+			{At: start.Add(45 * time.Second), Kind: gamecontext.EventPhase, Detail: "end"},
+		},
+	}
+	got := withEffectiveDuration(gc)
+	if got.Session.DurationSeconds == nil {
+		t.Fatal("expected DurationSeconds to be recovered from the timeline, got nil")
+	}
+	if *got.Session.DurationSeconds != 45 {
+		t.Fatalf("recovered duration = %v, want 45", *got.Session.DurationSeconds)
+	}
+}
+
+// TestWithEffectiveDuration_GaugeIsAuthoritative ensures the recovery never clobbers a
+// real game_duration_seconds gauge when it IS present (the gauge wins).
+func TestWithEffectiveDuration_GaugeIsAuthoritative(t *testing.T) {
+	gauge := 120.0
+	start := time.Unix(1_000, 0)
+	gc := gamecontext.GameContext{
+		Session: gamecontext.SessionSignals{DurationSeconds: &gauge},
+		Timeline: []gamecontext.TimelineEvent{
+			{At: start, Kind: gamecontext.EventPhase, Detail: "start"},
+			{At: start.Add(45 * time.Second), Kind: gamecontext.EventPhase, Detail: "end"},
+		},
+	}
+	got := withEffectiveDuration(gc)
+	if got.Session.DurationSeconds == nil || *got.Session.DurationSeconds != 120 {
+		t.Fatalf("gauge must remain authoritative, got %v", got.Session.DurationSeconds)
+	}
+}
+
+// TestWithEffectiveDuration_NoBracketsNoRecovery ensures a timeline missing a phase
+// bracket (or with a non-positive span) recovers nothing, preserving the
+// signal-less-folds-zero contract.
+func TestWithEffectiveDuration_NoBracketsNoRecovery(t *testing.T) {
+	start := time.Unix(1_000, 0)
+	cases := []struct {
+		name     string
+		timeline []gamecontext.TimelineEvent
+	}{
+		{"start only", []gamecontext.TimelineEvent{
+			{At: start, Kind: gamecontext.EventPhase, Detail: "start"},
+		}},
+		{"end only", []gamecontext.TimelineEvent{
+			{At: start, Kind: gamecontext.EventPhase, Detail: "end"},
+		}},
+		{"non-positive span", []gamecontext.TimelineEvent{
+			{At: start.Add(10 * time.Second), Kind: gamecontext.EventPhase, Detail: "start"},
+			{At: start, Kind: gamecontext.EventPhase, Detail: "end"},
+		}},
+		{"empty", nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gc := gamecontext.GameContext{Timeline: tc.timeline}
+			got := withEffectiveDuration(gc)
+			if got.Session.DurationSeconds != nil {
+				t.Fatalf("expected no recovery, got %v", *got.Session.DurationSeconds)
+			}
+		})
+	}
+}
+
+// TestOnGameEnd_DrivenShadowGameYieldsNonZeroFitness is the headline #997 acceptance:
+// a shadow game driven to a natural end (no end-only duration gauge observed, but a
+// start→end phase timeline present, exactly as the Store hands OnGameEnd) concludes
+// with a MEANINGFUL, objective-relevant endurance fitness in (0,1] — not the
+// worst-case 0 that made every concluded game inert in the M8 dry run.
+func TestOnGameEnd_DrivenShadowGameYieldsNonZeroFitness(t *testing.T) {
+	// A 60s game against the default 120s endurance target → progress 0.5.
+	start := time.Unix(1_000, 0)
+	gc := gamecontext.GameContext{
+		SessionID:    "game_driven_1",
+		GameKind:     "shadow",
+		ExperimentID: "exp_endurance",
+		Arm:          "experimental",
+		Timeline: []gamecontext.TimelineEvent{
+			{At: start, Kind: gamecontext.EventPhase, Detail: "start"},
+			{At: start.Add(60 * time.Second), Kind: gamecontext.EventPhase, Detail: "end"},
+		},
+	}
+
+	loop := &experimentLoop{
+		registry: nil, // not exercised: we score fitness directly via the same path onGameEnd uses
+		log:      testLogger(),
+		fitness:  defaultGameFitness,
+	}
+
+	// Mirror onGameEnd's signal-recovery + scoring without the registry side effects.
+	scored := withEffectiveDuration(gc)
+	fit := loop.fitness(scored, decision.ObjectiveEndurance)
+	if fit <= 0 {
+		t.Fatalf("driven shadow game must yield non-zero endurance fitness, got %v", fit)
+	}
+	if fit != 0.5 {
+		t.Fatalf("60s/120s endurance progress = %v, want 0.5", fit)
+	}
+}

--- a/services/agent/experiment_loop.go
+++ b/services/agent/experiment_loop.go
@@ -278,6 +278,15 @@ func (e *experimentLoop) onGameEnd(gc gamecontext.GameContext) {
 	if cv, ok := e.registry.CompactView(gc.ExperimentID); ok {
 		objective = cv.Intent.Objective
 	}
+	// The coordinator emits game_duration_seconds ONLY at game end (one gauge set in
+	// the session teardown), so for an agent-spawned shadow game it routinely loses
+	// the race against the game_active=0 datapoint that fires THIS hook — leaving
+	// gc.Session.DurationSeconds nil at conclusion. That nil made every
+	// duration-based objective (endurance/accelerate) skip its fitness function and
+	// fold the worst-case 0 (#997). Recover the real elapsed time from the partition's
+	// own start→end phase timeline so a concluded shadow game carries a meaningful,
+	// objective-relevant duration even when the end-only gauge has not arrived.
+	gc = withEffectiveDuration(gc)
 	fitness := e.fitness(gc, objective)
 	duration := 0.0
 	if gc.Session.DurationSeconds != nil {
@@ -312,6 +321,61 @@ func defaultGameFitness(gc gamecontext.GameContext, objective string) float64 {
 		return r.Progress
 	}
 	return 0
+}
+
+// withEffectiveDuration returns gc with Session.DurationSeconds populated from the
+// partition's start→end phase timeline when the coordinator's end-only
+// game_duration_seconds gauge has not yet been observed (DurationSeconds == nil).
+// It is a no-op when the gauge IS present (the gauge is authoritative) or when the
+// timeline lacks a start/end pair to bracket (no signal to recover — a genuinely
+// signal-less game still folds the worst-case 0, the #994 contract).
+//
+// This is the honest #997 fix: the recovered value is the real wall-clock game
+// duration the agent's own Store stamped on the session phase events
+// (SetGameActive start/end), NOT a fabricated number — so duration-based
+// objectives (endurance/accelerate) get the signal they need at conclusion.
+func withEffectiveDuration(gc gamecontext.GameContext) gamecontext.GameContext {
+	if gc.Session.DurationSeconds != nil {
+		return gc
+	}
+	dur, ok := timelinePhaseDuration(gc.Timeline)
+	if !ok {
+		return gc
+	}
+	gc.Session.DurationSeconds = &dur
+	return gc
+}
+
+// timelinePhaseDuration derives the elapsed game time from a partition's rolling
+// narrative: the seconds between the session's "start" phase event and its "end"
+// phase event. It returns false when either bracket is missing or the span is
+// non-positive (nothing trustworthy to recover). The end snapshot the Store hands
+// OnGameEnd is taken right AFTER appending the "end" phase (store.go SetGameActive),
+// so both brackets are present on a normally concluded game.
+func timelinePhaseDuration(timeline []gamecontext.TimelineEvent) (float64, bool) {
+	var start, end time.Time
+	var haveStart, haveEnd bool
+	for _, ev := range timeline {
+		if ev.Kind != gamecontext.EventPhase {
+			continue
+		}
+		switch ev.Detail {
+		case "start":
+			start = ev.At
+			haveStart = true
+		case "end":
+			end = ev.At
+			haveEnd = true
+		}
+	}
+	if !haveStart || !haveEnd {
+		return 0, false
+	}
+	d := end.Sub(start).Seconds()
+	if d <= 0 {
+		return 0, false
+	}
+	return d, true
 }
 
 // experimentTick resolves the AllocateAndSpawn cadence from


### PR DESCRIPTION
## Summary
Fixes the M8 dry-run BLOCKER (#997): every concluded agent-spawned shadow game reported `fitness=0` (236/236), so experiments never reached a verdict — the cohort loop was structurally working but functionally inert.

## Root cause (confirmed: both (a) and (b), with the structural cause being end-only duration)
The coordinator emits `game_duration_seconds` **only once, at game end** (a single gauge set in `game_session.py` session teardown) — despite the agent treating it as a live signal. For an agent-spawned shadow game this gauge routinely loses the race against the `game_active=0` datapoint that fires the agent's `OnGameEnd` hook, so `gc.Session.DurationSeconds` is **nil at conclusion** (`agent.evaluate ... duration=0`).

With no duration signal, the endurance/accelerate fitness functions **skip** (they only run when a session duration is present), and `defaultGameFitness` folds the worst-case `0` (the default the #994 review flagged). The synthetic driver also ends games in seconds (cause a), which compounds it, but the literal `fitness=0` came from the missing duration signal (cause b).

> Note: `game_current_mode` carries no `game_id` label, so it lands in the fallback partition (hence `game_mode=""` in the eval context). That is a real symptom but **not** the fitness blocker for endurance/accelerate, which need duration, not mode.

## Fix
In `experiment_loop.onGameEnd`, recover the **real elapsed game time** from the partition's own `start`→`end` phase timeline (stamped by the Store on `SetGameActive`) when the end-only gauge has not arrived (`withEffectiveDuration` / `timelinePhaseDuration`):
- The coordinator gauge stays **authoritative** when present.
- A genuinely signal-less game (no `start`/`end` timeline brackets, or a non-positive span) still folds the worst-case `0` — the #994 contract is preserved.
- The recovered value is the agent's own wall-clock duration, **not a fabricated number**, so duration-based objectives (endurance/accelerate) get the signal they need.

The synthetic driver is intentionally left as-is: padding game length would distort the very signal the env-seeded `death_grace_period_seconds` experiment measures (the grace effect manifests as a real duration difference between arms).

## Tests (`services/agent/experiment_fitness_test.go`)
- A driven shadow game (60s vs default 120s endurance target) concludes with endurance fitness `0.5` — non-zero and objective-relevant.
- The gauge remains authoritative when present.
- Recovery is a no-op (folds `0`) for genuinely signal-less games (missing brackets, non-positive span, empty).

## Validation
- `go test ./... -race` ✅
- `go vet ./...` ✅
- `gofmt -l .` clean ✅
- `make lint` (ruff) ✅

Part of epic #982. Related: #979 (verdict), #991 (assembly), #994 (default-fitness review).

File-overlap note: changes are confined to `experiment_loop.go` (onGameEnd fold) + a new test file — no edits to `experiment/registry.go` conclude/allocate, avoiding conflicts with #1001/#998.

🤖 Generated with [Claude Code](https://claude.com/claude-code)