### PR TITLE
feat(agent): runnable M8 agent dry-run + agent↔flagd flag-dir fix (#999)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,55 @@ up-mock:
 	@echo "  Prometheus: http://localhost/prometheus/"
 	@echo "  Grafana:    http://localhost/grafana/"
 
+# M8 agent shadow-game dry run (#999). Brings up a RUNNABLE experiment cohort
+# loop out-of-the-box: latest images (not the stale release IMAGE_TAG=0.7.0 from
+# .env), mock controllers + full observability (ci flag dir), the agent & the
+# dashboard profiles, the experiment loop enabled, and one seeded experiment.
+# The agent and flagd share the SAME flag dir (services/flagd/ci) so the agent's
+# game.json targeting writes actually reach the running flagd (the #999 dir-
+# mismatch fix lives in docker-compose.dry-run.yml).
+#
+# Gating chain (all must be satisfied for the loop to ACT):
+#   1. AGENT_EXPERIMENTS_ENABLED=true  -> set by docker-compose.dry-run.yml
+#   2. agent.json `enabled` = on       -> MANUAL opt-in, see step below (the
+#      master kill-switch stays fail-closed `off` by default; we do NOT mutate
+#      the committed flag here). Without it the loop self-aborts:
+#      `experiment.torn_down ... reason="kill-switch: agent disabled"`.
+#   3. code_improvement.* promotion gates -> remain default (promotion stays off)
+.PHONY: dry-run
+dry-run:
+	IMAGE_TAG=$(or $(IMAGE_TAG),latest) docker compose \
+		-f docker-compose.yml \
+		-f docker-compose.override.yml \
+		-f docker-compose.ci.yml \
+		-f docker-compose.dry-run.yml \
+		--profile agent --profile dashboard up -d $(if $(BUILD),--build)
+	@echo ""
+	@echo "=========================================="
+	@echo "JoustMania M8 AGENT DRY RUN is running"
+	@echo "=========================================="
+	@echo "  Images:        IMAGE_TAG=$(or $(IMAGE_TAG),latest) (current code, not the .env release pin)"
+	@echo "  Controllers:   mock (flagd ci/ dir, backend=mock)"
+	@echo "  Flag dir:      services/flagd/ci  (shared rw by agent + flagd -> writes are effective)"
+	@echo ""
+	@echo "  Experiment loop gating:"
+	@echo "    [x] AGENT_EXPERIMENTS_ENABLED=true   (set by docker-compose.dry-run.yml)"
+	@echo "    [x] seeded experiment: death_grace_period_seconds = 0.75 (objective=balanced, N=8/arm)"
+	@echo "    [ ] agent kill-switch  -> ENABLE IT (fail-closed off by default):"
+	@echo "        ./scripts/agent-killswitch.sh on   # flips services/flagd/ci/agent.json enabled -> on"
+	@echo "        docker compose -f docker-compose.yml -f docker-compose.ci.yml --profile agent restart agent"
+	@echo "        (or edit services/flagd/ci/agent.json: flags.enabled.defaultVariant = \"on\")"
+	@echo "    [ ] code_improvement.* promotion gates stay OFF (no real-default promotion)"
+	@echo ""
+	@echo "  Observability:"
+	@echo "    Dashboard:  http://localhost/"
+	@echo "    Jaeger:     http://localhost/jaeger/    (agent decision-audit spans)"
+	@echo "    Prometheus: http://localhost/prometheus/"
+	@echo "    Grafana:    http://localhost/grafana/"
+	@echo ""
+	@echo "  Runbook: docs/agent-dry-run-runbook.md"
+	@echo "  Tear down: docker compose -f docker-compose.yml -f docker-compose.override.yml -f docker-compose.ci.yml -f docker-compose.dry-run.yml --profile agent --profile dashboard down"
+
 # ============================================================================
 # Code Quality (using uv directly - fast, no Docker overhead)
 # ============================================================================

--- a/docker-compose.dry-run.yml
+++ b/docker-compose.dry-run.yml
@@ -1,0 +1,62 @@
+# M8 Agent Dry-Run Override (#999)
+#
+# Layered ON TOP of docker-compose.ci.yml so the stack runs with mock
+# controllers (backend=mock from services/flagd/ci/) and the full local
+# observability stack. Use via `make dry-run` (which also pins IMAGE_TAG=latest
+# and activates the `agent` + `dashboard` profiles):
+#
+#   docker compose \
+#     -f docker-compose.yml \
+#     -f docker-compose.override.yml \
+#     -f docker-compose.ci.yml \
+#     -f docker-compose.dry-run.yml \
+#     --profile agent --profile dashboard up -d
+#
+# Why this file exists (the dry-run findings, #999):
+#
+# 1. Agent <-> flagd flag-dir mismatch. In ci-mode, docker-compose.ci.yml
+#    overrides flagd (and menu) to mount ./services/flagd/ci:/etc/flagd, but the
+#    base agent service keeps ./services/flagd:/etc/flagd. So the agent's
+#    experiment-scoped game.json writes (FLAGD_FLAG_DIR=/etc/flagd ->
+#    /etc/flagd/game.json) landed in the BASE file while flagd served the CI one
+#    — the writes never reached the running flagd. Here we !override the agent
+#    volume onto the SAME services/flagd/ci dir flagd and menu serve, so the file
+#    the agent writes IS the file flagd reads (the #959 single-source-of-truth
+#    invariant, extended to the agent under the ci flag dir).
+#
+# 2. Experiment framework opt-in. The base agent env now passes through the
+#    AGENT_EXPERIMENT* vars (default-off); this file turns ON the cohort loop and
+#    seeds ONE experiment so the declare->spawn->conclude->verdict loop has work.
+#    Override values still win, e.g.:
+#      AGENT_EXPERIMENT_SEED_FLAG=move_threshold make dry-run
+#
+# The agent MASTER kill-switch (agent.json `enabled`) still defaults to `off`
+# (fail-closed, unchanged). `make dry-run` prints the one-liner to flip the CI
+# copy on; we do NOT mutate the committed flag here so the default stays safe.
+
+services:
+  agent:
+    profiles:
+      - agent
+    # Resolve the dir mismatch: serve/write the SAME flag dir flagd + menu use
+    # under ci-mode. !override REPLACES the base ./services/flagd:/etc/flagd
+    # mount (compose merges array values by default).
+    volumes: !override
+      - ./services/flagd/ci:/etc/flagd
+    environment:
+      # Master opt-in for the #982/#991 experiment cohort loop.
+      - AGENT_EXPERIMENTS_ENABLED=${AGENT_EXPERIMENTS_ENABLED:-true}
+      # Seed ONE experiment at startup (simplest declaration trigger). The flag
+      # key must EXIST in services/flagd/ci/game.json and the value's JSON kind
+      # must match its existing variants (the Gate's type guard rejects a mistyped
+      # seed). death_grace_period_seconds is a numeric flag (variants 0.0..1.0);
+      # 0.75 is a new shadow-only value. Defaults chosen so a bare `make dry-run`
+      # produces a live experiment; override any via env/.env.
+      - AGENT_EXPERIMENT_SEED_FLAG=${AGENT_EXPERIMENT_SEED_FLAG:-death_grace_period_seconds}
+      - AGENT_EXPERIMENT_SEED_VALUE=${AGENT_EXPERIMENT_SEED_VALUE:-0.75}
+      - AGENT_EXPERIMENT_SEED_OBJECTIVE=${AGENT_EXPERIMENT_SEED_OBJECTIVE:-balanced}
+      - AGENT_EXPERIMENT_SEED_TARGET_N=${AGENT_EXPERIMENT_SEED_TARGET_N:-8}
+      - "AGENT_EXPERIMENT_SEED_HYPOTHESIS=${AGENT_EXPERIMENT_SEED_HYPOTHESIS:-M8 dry-run seed - a longer death grace period balances elimination cadence}"
+      # Faster refill tick than the 30s default so shadow games spin up promptly
+      # during a demo.
+      - AGENT_EXPERIMENT_TICK_SECONDS=${AGENT_EXPERIMENT_TICK_SECONDS:-15}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -656,6 +656,18 @@ services:
       # the remediation_allowed flag (rollout flagd domain, read from rollout.json).
       # After a rollback, re-expansion is suppressed for the cooldown below.
       - AGENT_ROLLOUT_COOLDOWN_SECONDS=${AGENT_ROLLOUT_COOLDOWN_SECONDS:-30}
+      # Experiment cohort loop (#982/#991). Opt-in master switch + the optional
+      # env-seeded single experiment. Declared here (with default-off / empty
+      # defaults) so a host `export` or `.env` value reaches the container — a
+      # plain `up` keeps the framework inert (the M8 dry-run finding, #999). The
+      # promotion path stays gated by the `code_improvement` flags + kill-switch.
+      - AGENT_EXPERIMENTS_ENABLED=${AGENT_EXPERIMENTS_ENABLED:-false}
+      - AGENT_EXPERIMENT_TICK_SECONDS=${AGENT_EXPERIMENT_TICK_SECONDS:-30}
+      - AGENT_EXPERIMENT_SEED_FLAG=${AGENT_EXPERIMENT_SEED_FLAG:-}
+      - AGENT_EXPERIMENT_SEED_VALUE=${AGENT_EXPERIMENT_SEED_VALUE:-}
+      - AGENT_EXPERIMENT_SEED_OBJECTIVE=${AGENT_EXPERIMENT_SEED_OBJECTIVE:-}
+      - AGENT_EXPERIMENT_SEED_TARGET_N=${AGENT_EXPERIMENT_SEED_TARGET_N:-}
+      - AGENT_EXPERIMENT_SEED_HYPOTHESIS=${AGENT_EXPERIMENT_SEED_HYPOTHESIS:-}
       - LOG_LEVEL=${LOG_LEVEL:-info}
       - OTEL_SERVICE_NAME=agent
       - OTEL_SERVICE_NAMESPACE=infrastructure

--- a/docs/agent-dry-run-runbook.md
+++ b/docs/agent-dry-run-runbook.md
@@ -1,0 +1,127 @@
+# M8 Agent Dry-Run Runbook — a runnable experiment cohort loop
+
+This runbook stands up the **M8 experiment cohort loop** (#982/#991) as a live
+dry run: mock controllers, the full local observability stack, the agent
+declaring + spawning shadow games for ONE seeded experiment, all spans flowing
+to Jaeger. It is the operator counterpart to the design in the
+[agent README](../services/agent/README.md) (see *Gating chain* there) and the
+[ACT-path runbook](agent-act-runbook.md) (the live-intervention demo).
+
+The fastest path is:
+
+```bash
+make dry-run
+./scripts/agent-killswitch.sh on    # the loop is inert until you do this
+docker compose -f docker-compose.yml -f docker-compose.ci.yml --profile agent restart agent
+```
+
+`make dry-run` prints the same steps and the observability URLs on completion.
+
+---
+
+## Why a plain `docker compose up` produces a DEAD run
+
+Three defaults silently combine into a loop that never runs (the #999 findings):
+
+| # | Default | Symptom | Fix in the dry-run path |
+|---|---------|---------|-------------------------|
+| 1 | `.env` pins `IMAGE_TAG=0.7.0` (release-please) | A plain `up` runs the last RELEASE images — they predate the experiment framework, so `AGENT_EXPERIMENTS_ENABLED=true` is silently ignored (no `Experiment cohort loop ENABLED` log) | `make dry-run` pins `IMAGE_TAG=latest` (override with `IMAGE_TAG=... make dry-run`, or add `BUILD=1` to build locally) |
+| 2 | Agent master kill-switch `agent.json` `enabled` = `off` (fail-closed) | Loop declares + writes targeting then self-aborts: `experiment.torn_down ... reason="kill-switch: agent disabled"` | **Manual opt-in** — `./scripts/agent-killswitch.sh on` (flips the **ci** flag dir only; production default stays `off`) |
+| 3 | The agent compose env did not declare `AGENT_EXPERIMENTS_ENABLED` / `AGENT_EXPERIMENT_SEED_*` | A host `export` never reached the container (needed a custom override) | These vars are now declared (default-off) on the `agent` service in `docker-compose.yml`; the dry-run override turns them on |
+
+And one **silent-ineffective** trap:
+
+| # | Default | Symptom | Fix |
+|---|---------|---------|-----|
+| 4 | In ci-mode, `flagd`+`menu` mount `services/flagd/ci:/etc/flagd` but the base `agent` keeps `services/flagd:/etc/flagd` | The agent's game.json targeting writes land in the BASE file while flagd serves the CI file — writes happen but never reach flagd; experiment targeting is silently ineffective (a #822-class dir mismatch) | `docker-compose.dry-run.yml` `!override`s the agent volume onto the SAME `services/flagd/ci` dir flagd + menu serve |
+
+---
+
+## The gating chain
+
+For the loop to actually run shadow games **and** (eventually) promote a winning
+value to the real default, three independent gates must be satisfied. They are
+intentionally separate so a dry run can spawn shadows without ever risking a
+real-default change.
+
+1. **Experiments opt-in** — `AGENT_EXPERIMENTS_ENABLED=true`.
+   Constructs the `experiment.Registry` and runs the
+   declare → spawn → conclude → verdict → (gated) promote loop. Default `false`
+   ⇒ no Registry, no shadow spawns, no targeting writes, no promotions.
+   *Set by `docker-compose.dry-run.yml`.*
+
+2. **Agent master kill-switch** — `agent.json` `enabled` flag = `on`.
+   Read live from flagd each cycle. When `off` (the fail-closed default) the
+   loop short-circuits before any work and emits a throttled
+   `kill-switch: agent disabled` span. Hot-reloaded — no restart needed for the
+   flag flip itself, but the agent re-reads it each cycle.
+   *Manual opt-in via `./scripts/agent-killswitch.sh on` — never default-on.*
+
+3. **`code_improvement.*` promotion gates** — separate flags in the agent
+   domain (`code_improvement.mode`, `.target`, `.validation_games`,
+   `.fitness_improvement_threshold`, …). These gate the **real-default
+   promotion** action only. They stay at their defaults in the dry run, so a
+   concluded experiment produces a **verdict** (visible in traces) but does
+   **not** rewrite the real game.json default. Promotion also remains subject
+   to the invariant gate (real-context resolution must be byte-unchanged) and
+   the kill-switch.
+
+A dry run typically exercises gates 1 + 2 only — you watch shadow games run and
+verdicts form, with the real default untouched.
+
+---
+
+## What `make dry-run` brings up
+
+```
+docker compose \
+  -f docker-compose.yml \
+  -f docker-compose.override.yml \
+  -f docker-compose.ci.yml \
+  -f docker-compose.dry-run.yml \
+  --profile agent --profile dashboard up -d
+```
+
+- `IMAGE_TAG=latest` — current code, not the `.env` release pin.
+- `docker-compose.ci.yml` — mock controllers (`backend=mock`), the `agent` /
+  `dashboard` profiles gated behind `--profile`.
+- `docker-compose.dry-run.yml` — `AGENT_EXPERIMENTS_ENABLED=true`, one seeded
+  experiment (`death_grace_period_seconds = 0.75`, objective `balanced`,
+  `N=8`/arm), and the **agent volume `!override`d onto `services/flagd/ci`** so
+  its writes reach flagd.
+- `--profile dashboard` — dashboard + connect-proxy + envoy for the full
+  observability surface at `http://localhost/`.
+
+Seed another flag instead:
+
+```bash
+AGENT_EXPERIMENT_SEED_FLAG=invincibility_seconds \
+AGENT_EXPERIMENT_SEED_VALUE=4.5 \
+make dry-run
+```
+
+The seed flag must **exist in `services/flagd/ci/game.json`** and the value's
+JSON kind must match its variants (the Gate's type guard rejects a mistyped
+seed at the targeting write).
+
+---
+
+## Verifying it is alive
+
+- **Logs**: `docker compose ... logs -f agent` shows `Experiment cohort loop ENABLED`
+  and per-tick `AllocateAndSpawn` activity (not `kill-switch: agent disabled`).
+- **Jaeger** (`http://localhost/jaeger/`, service `agent`): experiment
+  declare/spawn/conclude/verdict spans.
+- **flagd**: `services/flagd/ci/game.json` gains a reserved experiment variant +
+  a `game_kind != "real"` targeting branch for the seeded flag — confirming the
+  agent and flagd share the file.
+
+## Tear down
+
+```bash
+docker compose \
+  -f docker-compose.yml -f docker-compose.override.yml \
+  -f docker-compose.ci.yml -f docker-compose.dry-run.yml \
+  --profile agent --profile dashboard down
+./scripts/agent-killswitch.sh off    # restore the fail-closed default
+```

--- a/scripts/agent-killswitch.sh
+++ b/scripts/agent-killswitch.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Flip the agent MASTER kill-switch (#999 dry-run helper).
+#
+# The agent's `enabled` flag (agent flagd domain) is the master kill-switch and
+# is fail-closed `off` by DEFAULT in BOTH the production flag dir
+# (services/flagd/agent.json) and the ci/dry-run dir (services/flagd/ci/agent.json).
+# With it off the experiment cohort loop declares + writes targeting then aborts:
+#   experiment.torn_down ... reason="kill-switch: agent disabled"
+#
+# This helper toggles the `enabled` defaultVariant in the CI/DRY-RUN flag dir
+# only (the dir `make dry-run` serves). It NEVER touches the production
+# services/flagd/agent.json default — that stays fail-closed by design.
+#
+# Usage:
+#   ./scripts/agent-killswitch.sh on    # enable the agent (dry-run)
+#   ./scripts/agent-killswitch.sh off   # disable it again
+#   ./scripts/agent-killswitch.sh status
+#
+# After flipping, flagd hot-reloads the file; restart the agent so the loop
+# re-reads the existence layer:
+#   docker compose -f docker-compose.yml -f docker-compose.ci.yml --profile agent restart agent
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+FLAG_FILE="${AGENT_FLAG_FILE:-${REPO_ROOT}/services/flagd/ci/agent.json}"
+
+action="${1:-status}"
+
+case "${action}" in
+  on|off)
+    python3 - "${FLAG_FILE}" "${action}" <<'PY'
+import json
+import sys
+
+path, variant = sys.argv[1], sys.argv[2]
+with open(path) as fh:
+    data = json.load(fh)
+
+flag = data["flags"]["enabled"]
+if variant not in flag["variants"]:
+    sys.exit(f"variant {variant!r} not defined in {path}")
+flag["defaultVariant"] = variant
+
+with open(path, "w") as fh:
+    json.dump(data, fh, indent=2)
+    fh.write("\n")
+print(f"agent kill-switch -> {variant}  ({path})")
+PY
+    ;;
+  status)
+    python3 - "${FLAG_FILE}" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+with open(path) as fh:
+    data = json.load(fh)
+print(f"agent kill-switch = {data['flags']['enabled']['defaultVariant']}  ({path})")
+PY
+    ;;
+  *)
+    echo "usage: $0 {on|off|status}" >&2
+    exit 2
+    ;;
+esac

--- a/services/agent/README.md
+++ b/services/agent/README.md
@@ -908,9 +908,38 @@ All configuration is via environment variables:
 | `AGENT_VERDICT_MIN_N` | `8` | #979 min games per arm before a conclusive verdict (else inconclusive) |
 | `AGENT_VERDICT_EFFECT_THRESHOLD` | `0.5` | #979 minimum \|Cohen's d\| for a promote/discard verdict |
 | `AGENT_EXPERIMENT_SEED_FLAG` | _unset_ | When set (and the loop is enabled), declares ONE env-seeded experiment at startup on this game.json flag — the simplest declaration trigger for the demo. Paired with `AGENT_EXPERIMENT_SEED_VALUE` / `_OBJECTIVE` / `_TARGET_N` / `_HYPOTHESIS` |
+| `AGENT_EXPERIMENT_SEED_VALUE` | _unset_ | The seed experiment's experimental value. Parsed as a number when it parses as a float, else bool for `true`/`false`, else the raw string. Its JSON kind must match the flag's existing variants (the Gate's type guard rejects a mistyped seed at the targeting write) |
+| `AGENT_EXPERIMENT_SEED_OBJECTIVE` | `balanced` | The seed experiment's fitness objective (`endurance` / `balanced` / `accelerate` / `chaos`) |
+| `AGENT_EXPERIMENT_SEED_TARGET_N` | _unset_ | Target games per arm for the seed experiment (positive int; falls back to the registry default when unset) |
+| `AGENT_EXPERIMENT_SEED_HYPOTHESIS` | _generated_ | Free-text hypothesis recorded on the seed experiment's intent |
 
 > The Go agent uses the flagd **RPC** resolver (gRPC evaluation port `8013`),
 > not the in-process sync port `8015` that the Python services use.
+
+### Experiment cohort loop dry run (#982/#991/#999)
+
+`make dry-run` brings the cohort loop up **runnable out-of-the-box** — latest
+images, mock controllers, full observability, the loop enabled, and one seeded
+experiment. See the [dry-run runbook](../../docs/agent-dry-run-runbook.md) for
+the operator steps and the silent-failure traps it avoids (stale `IMAGE_TAG`,
+the kill-switch default, and the agent↔flagd flag-dir mismatch under the ci dir).
+
+The loop ACTS only when **three independent gates** are all satisfied — kept
+separate so a dry run can spawn shadow games without ever risking a real-default
+change:
+
+1. **Experiments opt-in** — `AGENT_EXPERIMENTS_ENABLED=true`. Builds the
+   `experiment.Registry` and runs declare → spawn → conclude → verdict →
+   (gated) promote. Default `false` ⇒ no Registry, no shadow spawns, no
+   targeting writes, no promotions.
+2. **Master kill-switch** — `agent.json` `enabled` = `on` (read live each
+   cycle; `off` is the fail-closed default). When `off` the loop short-circuits
+   with a throttled `kill-switch: agent disabled` span. Flip the **dry-run** copy
+   with `./scripts/agent-killswitch.sh on` — production default stays `off`.
+3. **`code_improvement.*` promotion gates** — separate flags that gate the
+   **real-default promotion** action only (still subject to the invariant gate +
+   kill-switch). They stay at defaults in the dry run, so a concluded experiment
+   yields a **verdict** but does **not** rewrite the real game.json default.
 
 ### Probe mode (`AGENT_PROBE_DECISIONS`)
 


### PR DESCRIPTION
## Summary

Makes the M8 experiment cohort loop (#982/#991) **runnable out-of-the-box**. Standing up the first live dry run surfaced three silent defaults that produce a dead run, plus one silently-ineffective flag-dir mismatch (#999). This is all compose / Makefile / flag-config / docs — independent of the agent Go code.

Part of #999.

## The findings (and fixes)

1. **Compose env passthrough** — the `agent` service did not declare `AGENT_EXPERIMENTS_ENABLED` / `AGENT_EXPERIMENT_SEED_*`, so a host `export` never reached the container (needed a custom override). Now declared (default-off / empty) on the `agent` service in `docker-compose.yml`. Default-off behaviour preserved.

2. **Stale `IMAGE_TAG`** — `.env` pins `IMAGE_TAG=0.7.0` (release-please), so a plain `up` runs pre-framework release images. `make dry-run` pins `IMAGE_TAG=latest`.

3. **Kill-switch fail-closed** — `agent.json` `enabled` defaults to `off`, so the loop self-aborts (`kill-switch: agent disabled`). The dry-run path makes enabling explicit via `scripts/agent-killswitch.sh on` (flips the **ci/dry-run** flag dir only — production default stays `off`). The `make dry-run` output and the runbook both spell out the step.

4. **Agent↔flagd dir mismatch** — in ci-mode, `flagd` + `menu` mount `services/flagd/ci:/etc/flagd` but the base `agent` kept `services/flagd:/etc/flagd`, so the agent's `game.json` targeting writes landed in a DIFFERENT file than flagd served (a #822-class mismatch). `docker-compose.dry-run.yml` `!override`s the agent volume onto the SAME `services/flagd/ci` dir.

## What's added

- `docker-compose.dry-run.yml` — agent volume `!override` to shared ci dir + experiment opt-in + one seeded experiment (`death_grace_period_seconds=0.75`; numeric kind matches the flag's variants so the Gate type guard passes).
- `make dry-run` — `IMAGE_TAG=latest`, base + override + ci + dry-run, `--profile agent --profile dashboard`; echoes URLs, the gating chain, and the manual kill-switch step.
- `scripts/agent-killswitch.sh {on|off|status}` — safe JSON flip of the ci-dir kill-switch.
- `docs/agent-dry-run-runbook.md` + agent README — the gating chain (experiments opt-in + master kill-switch + the separate `code_improvement` promotion gates) and the silent-failure traps.

## Validation

- `yaml.safe_load` + duplicate-key check on `docker-compose.yml` and `docker-compose.dry-run.yml` (custom loader for `!override`/`!reset`).
- `docker compose -f ... config` renders for base+override and the full dry-run stack. Rendered config confirms **agent, flagd, and menu all mount `services/flagd/ci` → `/etc/flagd`** (with `FLAGD_FLAG_DIR=/etc/flagd`, the agent writes the exact file flagd serves) and the experiment env + `:latest` image.
- CI unbroken: default CI run (no `--profile`) still excludes agent/dashboard; `docker-compose.ci.yml` untouched.
- `make lint` passes. `bash -n` on the script. `services/flagd/ci/agent.json` left clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)