### PR TITLE
fix(agent): bound experiment lifecycle with a termination guard (#1001)

### DIFF
--- a/services/agent/experiment/registry.go
+++ b/services/agent/experiment/registry.go
@@ -100,6 +100,21 @@ const DefaultEffectiveConcurrency = 1
 // value is treated as misconfiguration and falls back to the default.
 const effectiveConcurrencyEnv = "AGENT_SHADOW_EFFECTIVE_CONCURRENCY"
 
+// DefaultMaxGamesPerExperiment is the per-experiment TERMINATION BUDGET (#1001):
+// the absolute upper bound on games a single experiment may accrue before the
+// registry gives up and concludes it INCONCLUSIVE. Without it, an experiment
+// whose verdict can never reach signal (e.g. all-zero fitness ⇒ both arms
+// zero-variance ⇒ undefined effect size ⇒ a permanent "inconclusive" verdict)
+// spawns games forever: the live M8 dry run hit 235 games (target_n=3 exceeded
+// ~70×) and never concluded. 50 is a deliberately small ceiling for cheap
+// headless shadow games; tune via AGENT_EXPERIMENT_MAX_GAMES. A non-positive
+// budget DISABLES this guard (the inconclusive-past-target and
+// degenerate-variance guards below still guarantee termination).
+const DefaultMaxGamesPerExperiment = 50
+
+// maxGamesPerExperimentEnv overrides DefaultMaxGamesPerExperiment.
+const maxGamesPerExperimentEnv = "AGENT_EXPERIMENT_MAX_GAMES"
+
 // Arm names. The experimental arm resolves the candidate value; the control arm
 // falls through to the existing default (within-experiment baseline). Both are
 // game_kind="shadow" (the hard invariant). These mirror the targeting contract
@@ -167,6 +182,22 @@ func EffectiveConcurrencyFromEnv() int {
 	return DefaultEffectiveConcurrency
 }
 
+// MaxGamesPerExperimentFromEnv resolves the per-experiment termination budget
+// (#1001) from AGENT_EXPERIMENT_MAX_GAMES, falling back to
+// DefaultMaxGamesPerExperiment on an unset, empty, or non-numeric value. A 0 or
+// negative value is honored verbatim as "disable the games budget" — unlike the
+// shadow-cap (where a non-positive value is misconfiguration), disabling the
+// games budget is a legitimate choice because the other termination guards still
+// bound the experiment.
+func MaxGamesPerExperimentFromEnv() int {
+	if v := strings.TrimSpace(os.Getenv(maxGamesPerExperimentEnv)); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			return n
+		}
+	}
+	return DefaultMaxGamesPerExperiment
+}
+
 // entry is the registry's in-memory view of one experiment. It is a cache of the
 // journal: status + the (game_id → arm) map + the round-robin cursor. The journal
 // remains authoritative; on restart Rehydrate rebuilds every entry from disk.
@@ -212,6 +243,19 @@ type Registry struct {
 	clock        func() time.Time
 	log          *slog.Logger
 
+	// maxGames is the per-experiment termination budget (#1001): the registry gives
+	// up and concludes an experiment INCONCLUSIVE once it has accrued this many
+	// concluded games. <= 0 disables the games-budget guard (the other guards still
+	// guarantee termination).
+	maxGames int
+	// minN is the verdict min-N-per-arm gate, mirrored here ONLY for two
+	// registry-side concerns: reconciling a too-small Intent.TargetNPerArm up to it
+	// (so target_n < min-N cannot cause a perpetual under-powered loop), and the
+	// "inconclusive past target N" termination guard. It is read from the same
+	// AGENT_VERDICT_MIN_N the verdict reads, so the two stay coherent without
+	// widening the CohortVerdict seam.
+	minN int
+
 	mu      sync.Mutex
 	entries map[string]*entry
 	// rrCursor is the cross-experiment round-robin cursor for fair capacity
@@ -254,6 +298,19 @@ type RegistryConfig struct {
 	// produces doomed "Game already in progress" rejections. Non-positive ⇒
 	// EffectiveConcurrencyFromEnv() (default 1). It is clamped to <= MaxShadowGames.
 	EffectiveConcurrency int
+	// MaxGamesPerExperiment is the per-experiment termination budget (#1001): the
+	// upper bound on concluded games before the registry gives up and concludes the
+	// experiment INCONCLUSIVE. Zero ⇒ MaxGamesPerExperimentFromEnv() (the default
+	// path). A NEGATIVE value explicitly DISABLES the games budget; the
+	// inconclusive-past-target and degenerate-variance guards still terminate the
+	// experiment, so it can never loop forever even with the budget off.
+	MaxGamesPerExperiment int
+	// VerdictMinN is the verdict's min-N-per-arm gate, mirrored into the registry
+	// for target_n reconciliation and the inconclusive-past-target guard. Zero ⇒
+	// MinNFromEnv() (the same AGENT_VERDICT_MIN_N the verdict reads). Negative ⇒
+	// disabled (no min-N reconciliation; the inconclusive-past-target guard then
+	// keys off target_n alone).
+	VerdictMinN int
 	// Spawner / Verdict / Promoter / Targeting are the injected seams.
 	Spawner   ShadowSpawner
 	Verdict   CohortVerdict
@@ -284,6 +341,30 @@ func NewRegistry(cfg RegistryConfig) *Registry {
 	if effectiveCap > maxCap {
 		effectiveCap = maxCap
 	}
+	// Termination budget (#1001): zero means "read the env default"; a negative
+	// config value is an explicit disable, normalized to 0 (the guard treats <= 0 as
+	// off).
+	maxGames := cfg.MaxGamesPerExperiment
+	switch {
+	case maxGames == 0:
+		maxGames = MaxGamesPerExperimentFromEnv()
+	case maxGames < 0:
+		maxGames = 0
+	}
+	// The env default may itself be non-positive (operator disabled it); normalize.
+	if maxGames < 0 {
+		maxGames = 0
+	}
+	// Min-N mirror (#1001): zero means "read the env default"; negative disables
+	// min-N reconciliation (normalized to 0, so the inconclusive-past-target guard
+	// then keys off target_n alone).
+	minN := cfg.VerdictMinN
+	switch {
+	case minN == 0:
+		minN = MinNFromEnv()
+	case minN < 0:
+		minN = 0
+	}
 	clock := cfg.Clock
 	if clock == nil {
 		clock = func() time.Time { return time.Now().UTC() }
@@ -296,6 +377,8 @@ func NewRegistry(cfg RegistryConfig) *Registry {
 		root:         cfg.Root,
 		maxCap:       maxCap,
 		effectiveCap: effectiveCap,
+		maxGames:     maxGames,
+		minN:         minN,
 		spawner:      cfg.Spawner,
 		verdict:      cfg.Verdict,
 		promo:        cfg.Promoter,
@@ -320,6 +403,21 @@ func (r *Registry) Declare(in Intent) (string, error) {
 	id := MintExperimentID()
 	now := r.clock()
 
+	// Reconcile target_n vs the verdict min-N (#1001). A target_n below the verdict
+	// min-N can NEVER satisfy the verdict's conclusive gate, so the experiment would
+	// be under-powered forever. Raise it to the min-N floor (the persisted intent
+	// records the effective value). This is the coherent semantic chosen for the
+	// issue: the lifecycle's "target reached" point is at least the verdict's min-N,
+	// so reaching target and reaching a conclusive-eligible sample coincide.
+	targetN := in.TargetNPerArm
+	if r.minN > 0 && targetN < r.minN {
+		if targetN > 0 {
+			r.log.Info("experiment.target_n_reconciled",
+				"experiment_id", id, "requested_target_n", targetN, "min_n", r.minN)
+		}
+		targetN = r.minN
+	}
+
 	jrnl, err := journal.Create(r.root, journal.Intent{
 		ExperimentID:      id,
 		CreatedAt:         now,
@@ -327,7 +425,7 @@ func (r *Registry) Declare(in Intent) (string, error) {
 		FlagKey:           in.FlagKey,
 		ExperimentalValue: in.ExperimentalValue,
 		Objective:         in.Objective,
-		TargetNPerArm:     in.TargetNPerArm,
+		TargetNPerArm:     targetN,
 		Arms:              arms,
 	})
 	if err != nil {
@@ -624,7 +722,99 @@ func (r *Registry) ConcludeGame(ctx context.Context, gameID string, fitness floa
 	if haveVerdict && verdict.Outcome != OutcomeInconclusive {
 		return r.conclude(ctx, id, verdict)
 	}
+
+	// TERMINATION GUARD (#1001): the verdict is inconclusive (or absent). Without a
+	// bound, an experiment that can never reach signal — e.g. all-zero fitness ⇒
+	// both arms zero-variance ⇒ undefined effect size ⇒ permanent "inconclusive" —
+	// spawns games forever. If any give-up condition holds, conclude+teardown the
+	// experiment as a FINAL inconclusive instead of leaving it RUNNING.
+	if reason, giveUp := r.shouldGiveUp(jrnl.Summary(), jrnl.Intent().TargetNPerArm); giveUp {
+		final := journal.Verdict{
+			Outcome:     OutcomeInconclusive,
+			Significant: false,
+			Reason:      reason,
+		}
+		if haveVerdict {
+			final.Delta = verdict.Delta
+		}
+		r.log.Info("experiment.terminated_inconclusive",
+			"experiment_id", id, "reason", reason)
+		return r.conclude(ctx, id, final)
+	}
+
 	return StatusRunning, nil
+}
+
+// shouldGiveUp implements the #1001 termination guard: it decides whether an
+// experiment that is still inconclusive must be concluded INCONCLUSIVE (rather
+// than left RUNNING forever). It returns a human-readable reason and true when
+// ANY of the give-up conditions holds:
+//
+//	(a) GAMES BUDGET — total concluded games across arms has reached r.maxGames
+//	    (AGENT_EXPERIMENT_MAX_GAMES; the absolute ceiling, the primary backstop).
+//	(b) INCONCLUSIVE PAST TARGET — every arm has reached the effective target N
+//	    (max(target_n, min-N)), so the cohort is fully powered yet the verdict is
+//	    still inconclusive: more games will not change a within-noise result.
+//	(c) DEGENERATE VARIANCE — every arm is past target N AND has zero variance
+//	    (all-equal fitness, the #997 all-zero case): the effect size is undefined
+//	    and re-evaluating forever cannot help.
+//
+// The guard reads only the rolling Summary (per-arm Welford count/M2) plus the
+// persisted intent's target_n (passed in by the caller), so it is O(arms) and
+// needs no extra book-keeping.
+func (r *Registry) shouldGiveUp(s journal.Summary, targetN int) (string, bool) {
+	// Total concluded games across all arms (reservations are not in the Summary).
+	total := 0
+	for _, a := range s.Arms {
+		if a != nil {
+			total += a.Count
+		}
+	}
+
+	// (a) Absolute games budget. <= 0 disables this guard.
+	if r.maxGames > 0 && total >= r.maxGames {
+		return fmt.Sprintf("games budget exhausted: %d games >= max=%d, still inconclusive",
+			total, r.maxGames), true
+	}
+
+	// Effective target N: the larger of the persisted target_n and the verdict
+	// min-N. (Declare already reconciles target_n up to min-N, so they normally
+	// coincide; this max is a belt-and-braces floor for rehydrated/legacy intents.)
+	target := targetN
+	if r.minN > target {
+		target = r.minN
+	}
+
+	// Both (b) and (c) require every arm to have reached the effective target N.
+	// Until then the cohort is genuinely under-powered and keeps running (bounded by
+	// the games budget above). A non-positive target makes these guards inert (the
+	// budget alone bounds the experiment).
+	if target <= 0 {
+		return "", false
+	}
+	allReachedTarget := len(s.Arms) > 0
+	allDegenerate := true
+	for _, a := range s.Arms {
+		if a == nil || a.Count < target {
+			allReachedTarget = false
+			break
+		}
+		if a.M2 != 0 {
+			allDegenerate = false
+		}
+	}
+	if !allReachedTarget {
+		return "", false
+	}
+
+	// (c) Degenerate variance past target N — checked first for a precise reason.
+	if allDegenerate {
+		return fmt.Sprintf("degenerate variance past target N=%d on all arms (zero spread); effect size undefined",
+			target), true
+	}
+
+	// (b) Inconclusive past target N — fully powered but still within noise.
+	return fmt.Sprintf("inconclusive past target N=%d on all arms; no significant effect", target), true
 }
 
 // conclude transitions an experiment to CONCLUDED on a final verdict, routes a
@@ -661,7 +851,11 @@ func (r *Registry) conclude(ctx context.Context, id string, verdict journal.Verd
 	}
 	r.mu.Unlock()
 
-	r.teardown(ctx, id, flagKey, final, "experiment concluded: "+verdict.Outcome)
+	note := "experiment concluded: " + verdict.Outcome
+	if verdict.Reason != "" {
+		note += " (" + verdict.Reason + ")"
+	}
+	r.teardown(ctx, id, flagKey, final, note)
 	return final, nil
 }
 

--- a/services/agent/experiment/registry_test.go
+++ b/services/agent/experiment/registry_test.go
@@ -868,3 +868,217 @@ func TestConcurrentAllocateAndConcludeNoLeak(t *testing.T) {
 		t.Fatalf("after settling allocate, in-flight %d != cap %d (reservation leak?)", total, cap)
 	}
 }
+
+// --- #1001 termination guard tests ---
+
+// alwaysInconclusive is a CohortVerdict that NEVER concludes: it always returns
+// an inconclusive verdict (as the real verdict does for all-zero / within-noise /
+// degenerate cohorts). It isolates the registry's termination guard from the
+// verdict so a test proves the registry itself bounds the experiment.
+type alwaysInconclusive struct{}
+
+func (alwaysInconclusive) Evaluate(_ journal.Summary) (journal.Verdict, bool) {
+	return journal.Verdict{Outcome: OutcomeInconclusive, Reason: "always inconclusive (test)"}, true
+}
+
+// drainToTerminal repeatedly refills shadow capacity and concludes every spawned
+// game with the same fitness, until the experiment reaches a terminal status or
+// safetyMax games have been concluded (a safety net so a REGRESSED guard fails
+// the test instead of looping forever). It returns the terminal status and the
+// number of games concluded. The spawner is the source of truth for the spawned
+// game ids (robust regardless of journal tail size).
+func drainToTerminal(t *testing.T, r *Registry, spawner *fakeSpawner, id string, fitness float64, safetyMax int) (Status, int) {
+	t.Helper()
+	ctx := context.Background()
+	done := map[string]bool{}
+	concluded := 0
+	for concluded < safetyMax {
+		r.AllocateAndSpawn(ctx)
+
+		// Conclude every spawned-but-not-yet-concluded game for this experiment.
+		spawner.mu.Lock()
+		pending := make([]string, 0, len(spawner.calls))
+		for _, c := range spawner.calls {
+			if c.experimentID == id && !done[c.gameID] {
+				pending = append(pending, c.gameID)
+			}
+		}
+		spawner.mu.Unlock()
+
+		if len(pending) == 0 {
+			st, _ := r.Status(id)
+			t.Fatalf("no games to conclude but experiment still %s (stuck)", st)
+		}
+
+		for _, gid := range pending {
+			st, err := r.ConcludeGame(ctx, gid, fitness, 60)
+			if err != nil {
+				t.Fatalf("ConcludeGame(%s): %v", gid, err)
+			}
+			done[gid] = true
+			concluded++
+			if st.IsTerminal() {
+				return st, concluded
+			}
+		}
+	}
+	st, _ := r.Status(id)
+	return st, concluded
+}
+
+// (a) GAMES BUDGET: with a verdict that never concludes, the experiment MUST stop
+// at the configured max-games budget instead of spawning forever. This is the
+// direct #1001 regression: the dry run hit 235 games with no bound.
+func TestTerminationGamesBudget(t *testing.T) {
+	root := t.TempDir()
+	spawner := &fakeSpawner{}
+	targeting := &fakeTargeting{}
+	r := newTestRegistry(t, RegistryConfig{
+		Root:                  root,
+		MaxShadowGames:        2,
+		MaxGamesPerExperiment: 6,   // small budget for the test
+		VerdictMinN:           100, // huge so the inconclusive-past-target guard never fires
+		Spawner:               spawner,
+		Verdict:               alwaysInconclusive{},
+		Targeting:             targeting,
+	})
+	ctx := context.Background()
+
+	id, err := r.Declare(sampleIntent())
+	if err != nil {
+		t.Fatalf("Declare: %v", err)
+	}
+	if err := r.Start(ctx, id); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	st, concluded := drainToTerminal(t, r, spawner, id, 0.5, 50)
+	if !st.IsTerminal() {
+		t.Fatalf("experiment did not terminate (status=%s, concluded=%d)", st, concluded)
+	}
+	if st != StatusDiscarded {
+		t.Fatalf("terminal status = %s, want discarded (inconclusive teardown)", st)
+	}
+	// It must have stopped near the budget, not run unbounded.
+	if concluded > 6+2 { // budget + one in-flight capacity pass of slack
+		t.Fatalf("concluded %d games, want ~6 (budget); guard did not bound the experiment", concluded)
+	}
+	if got := targeting.strippedIDs(); len(got) != 1 || got[0] != id {
+		t.Fatalf("stripped = %v, want [%s] (teardown freed targeting)", got, id)
+	}
+}
+
+// (c) DEGENERATE VARIANCE / all-zero fitness: using the REAL verdict, all games
+// score fitness=0 ⇒ both arms zero-variance ⇒ undefined effect ⇒ permanent
+// inconclusive. The experiment MUST terminate via the degenerate-variance guard
+// once both arms pass target N — not loop forever (the exact #997/#1001 case).
+func TestTerminationAllZeroFitnessDegenerate(t *testing.T) {
+	root := t.TempDir()
+	spawner := &fakeSpawner{}
+	targeting := &fakeTargeting{}
+	r := newTestRegistry(t, RegistryConfig{
+		Root:                  root,
+		MaxShadowGames:        2,
+		MaxGamesPerExperiment: 1000, // do NOT let the budget be what stops it
+		VerdictMinN:           3,
+		Spawner:               spawner,
+		Verdict:               NewVerdict(3, 0.5, nil), // the real min-N + Cohen's d gate
+		Targeting:             targeting,
+	})
+	ctx := context.Background()
+
+	in := sampleIntent()
+	in.TargetNPerArm = 3
+	id, err := r.Declare(in)
+	if err != nil {
+		t.Fatalf("Declare: %v", err)
+	}
+	if err := r.Start(ctx, id); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	st, concluded := drainToTerminal(t, r, spawner, id, 0.0, 100)
+	if !st.IsTerminal() {
+		t.Fatalf("all-zero experiment did not terminate (status=%s, concluded=%d)", st, concluded)
+	}
+	if st != StatusDiscarded {
+		t.Fatalf("terminal status = %s, want discarded", st)
+	}
+	// Should stop shortly after both arms reach target N=3 (≈6 games), nowhere near
+	// the 1000 budget.
+	if concluded > 12 {
+		t.Fatalf("concluded %d games, want ~6 (degenerate guard at target N)", concluded)
+	}
+}
+
+// (target_n < min-N) must NOT cause an infinite under-powered loop. Declare
+// reconciles target_n up to min-N, and the guard then concludes once both arms
+// reach that floor. Uses the real verdict with constant non-zero fitness (still
+// inconclusive because zero within-arm variance).
+func TestTerminationTargetBelowMinNDoesNotLoop(t *testing.T) {
+	root := t.TempDir()
+	spawner := &fakeSpawner{}
+	targeting := &fakeTargeting{}
+	r := newTestRegistry(t, RegistryConfig{
+		Root:                  root,
+		MaxShadowGames:        2,
+		MaxGamesPerExperiment: 1000, // budget must not be the stopper
+		VerdictMinN:           8,    // min-N well above target_n
+		Spawner:               spawner,
+		Verdict:               NewVerdict(8, 0.5, nil),
+		Targeting:             targeting,
+	})
+	ctx := context.Background()
+
+	in := sampleIntent()
+	in.TargetNPerArm = 2 // < min-N=8: would loop forever without reconciliation
+	id, err := r.Declare(in)
+	if err != nil {
+		t.Fatalf("Declare: %v", err)
+	}
+
+	// Declare must have reconciled the persisted target_n up to min-N.
+	jrnl, err := journal.Load(root, id)
+	if err != nil {
+		t.Fatalf("journal.Load: %v", err)
+	}
+	if got := jrnl.Intent().TargetNPerArm; got != 8 {
+		t.Fatalf("persisted target_n = %d, want 8 (reconciled up to min-N)", got)
+	}
+
+	if err := r.Start(ctx, id); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	st, concluded := drainToTerminal(t, r, spawner, id, 0.42, 200)
+	if !st.IsTerminal() {
+		t.Fatalf("target_n<min-N experiment did not terminate (status=%s, concluded=%d)", st, concluded)
+	}
+	// Terminates around both arms reaching N=8 (≈16 games), not unbounded.
+	if concluded > 24 {
+		t.Fatalf("concluded %d games, want ~16 (reconciled target N=8)", concluded)
+	}
+}
+
+// Config/env semantics: MaxGamesPerExperimentFromEnv honors an explicit disable,
+// and NewRegistry's zero/negative handling matches the documented rule.
+func TestMaxGamesPerExperimentConfig(t *testing.T) {
+	t.Setenv(maxGamesPerExperimentEnv, "")
+	if got := MaxGamesPerExperimentFromEnv(); got != DefaultMaxGamesPerExperiment {
+		t.Fatalf("unset env = %d, want default %d", got, DefaultMaxGamesPerExperiment)
+	}
+	t.Setenv(maxGamesPerExperimentEnv, "0")
+	if got := MaxGamesPerExperimentFromEnv(); got != 0 {
+		t.Fatalf("env=0 = %d, want 0 (disabled)", got)
+	}
+	t.Setenv(maxGamesPerExperimentEnv, "garbage")
+	if got := MaxGamesPerExperimentFromEnv(); got != DefaultMaxGamesPerExperiment {
+		t.Fatalf("env=garbage = %d, want default", got)
+	}
+
+	// A negative config value disables the budget (registry maxGames clamps to 0).
+	r := NewRegistry(RegistryConfig{Root: t.TempDir(), MaxGamesPerExperiment: -1})
+	if r.maxGames != 0 {
+		t.Fatalf("negative config maxGames = %d, want 0 (disabled)", r.maxGames)
+	}
+}

--- a/services/agent/experiment/verdict.go
+++ b/services/agent/experiment/verdict.go
@@ -135,16 +135,26 @@ func NewVerdict(minN int, effectThreshold float64, stat CohortStat) *Verdict {
 	return &Verdict{minN: minN, effectThreshold: effectThreshold, stat: stat}
 }
 
+// MinNFromEnv resolves the verdict min-N-per-arm gate from AGENT_VERDICT_MIN_N,
+// falling back to DefaultMinNPerArm on an unset, empty, non-numeric, or
+// non-positive value. It is exported so the registry can mirror the SAME min-N
+// the verdict uses (for target_n reconciliation and the inconclusive-past-target
+// termination guard, #1001) without duplicating the parse or widening the
+// CohortVerdict seam.
+func MinNFromEnv() int {
+	if v := strings.TrimSpace(os.Getenv(minNEnv)); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return DefaultMinNPerArm
+}
+
 // NewVerdictFromEnv builds a Verdict from AGENT_VERDICT_MIN_N /
 // AGENT_VERDICT_EFFECT_THRESHOLD, falling back to the defaults on an unset, empty,
 // or invalid value. The default Cohen's d strategy is used.
 func NewVerdictFromEnv() *Verdict {
-	minN := DefaultMinNPerArm
-	if v := strings.TrimSpace(os.Getenv(minNEnv)); v != "" {
-		if n, err := strconv.Atoi(v); err == nil && n > 0 {
-			minN = n
-		}
-	}
+	minN := MinNFromEnv()
 	threshold := DefaultEffectThreshold
 	if v := strings.TrimSpace(os.Getenv(effectEnv)); v != "" {
 		if f, err := strconv.ParseFloat(v, 64); err == nil && f > 0 {


### PR DESCRIPTION
## Problem

Part of #1001. An experiment whose verdict can never reach signal ran **forever**. In the M8 dry run all games scored `fitness=0`, so both arms had zero variance, Cohen's d was undefined, and the verdict stayed permanently `inconclusive ("degenerate variance")`. The registry treated INCONCLUSIVE as "keep running" with **no upper bound**, so it spawned **235 games** (`target_n=3` exceeded ~70×) and never concluded — churning games, spans, and journal events with zero useful output.

## Fix

A **termination guard** in the registry conclude/lifecycle path (`ConcludeGame`/`shouldGiveUp`), so every experiment reaches a terminal state in bounded games. After an inconclusive (or absent) verdict the experiment is concluded + torn down as a FINAL inconclusive (→ `discarded`) when **ANY** of:

- **(a) games budget** — total concluded games ≥ `AGENT_EXPERIMENT_MAX_GAMES` (default **50**; non-positive disables this guard). The absolute backstop.
- **(b) inconclusive past target** — every arm reached the effective target N and the verdict is still inconclusive (within-noise; more games won't change it).
- **(c) degenerate variance** — every arm is past target N with zero variance (the all-zero / all-equal fitness case, the exact #997/#1001 scenario) → effect size undefined.

### target_n ↔ min-N reconciliation

`AGENT_EXPERIMENT_SEED_TARGET_N` (3 in the dry run) below the verdict `min-N` (`AGENT_VERDICT_MIN_N`, default 8) guarantees a perpetual under-powered/inconclusive loop. **Chosen semantic:** `Declare` raises `Intent.TargetNPerArm` up to the verdict min-N, so the lifecycle's "target reached" point coincides with the verdict's conclusive-eligible sample. The effective target N the guard uses is `max(target_n, min-N)`. The reconciled value is persisted in the journal intent.

Config is env-driven (`AGENT_EXPERIMENT_MAX_GAMES`, `AGENT_VERDICT_MIN_N`); the production `NewRegistry` call is left at defaults, so the guard is active out of the box. `verdict.MinNFromEnv` is exported so the registry mirrors the same min-N without widening the `CohortVerdict` seam.

## Tests

- `TestTerminationGamesBudget` — a never-concluding verdict terminates at the games budget (the direct 235-games regression).
- `TestTerminationAllZeroFitnessDegenerate` — all-zero fitness, **real verdict** → degenerate guard terminates near target N (not the 1000 budget).
- `TestTerminationTargetBelowMinNDoesNotLoop` — `target_n=2 < min-N=8` is reconciled to 8 at Declare and terminates instead of looping.
- `TestMaxGamesPerExperimentConfig` — env/disable semantics.

Full agent suite green under `go test ./... -race`; `go vet ./...` and `gofmt -l .` clean.

## Overlap note

Kept strictly to the conclude/lifecycle methods + verdict, per the parallel-work guidance: #998 owns the spawn/allocate path, #997 owns the fitness fold. This branch is off `origin/main` and does not touch either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)