### PR TITLE
feat(menu): rationalize admin controller surface to human essentials (#815)

### DIFF
--- a/docs/OWNERSHIP_MODEL.md
+++ b/docs/OWNERSHIP_MODEL.md
@@ -75,6 +75,35 @@ no-ops** for that game — the game already captured its value.
 | `werewolf.reveal_time_seconds` | Human | `game.json` | Frozen at init | Agent has no override; human-only. |
 | `force_all_start` | Human | `game.json` | **Live** (read at start by menu, not frozen into a game) | Human-only; the one admin flag with no freeze. |
 
+### 3.1 Controller-cycled admin surface (issue [#815](https://github.com/WatchMeJoustMyFlags/JoustMania/issues/815))
+
+The eight flags above are all human-owned, but they are **not** all worth cycling
+blind on a controller (MOVE to select an option, SELECT/START to nudge its value,
+with only an LED pulse + voice line as feedback). Deep per-mode knobs that are
+frozen at start and rarely changed at party time are awkward and error-prone on
+that surface, so #815 trimmed the **controller-cycled** list to the human
+essentials. **Every flag still exists in `game.json` and stays settable via the
+dashboard, the file, or flagd directly** — only the controller-cycle UI shrinks.
+
+| Flag | Decision | Rationale |
+|---|---|---|
+| `sensitivity` | **KEEP cycled** | Baseline calibration the admin tunes by feel; the primary human knob. |
+| `num_teams` | **KEEP cycled** | Structural pre-game choice; quick to set on the controller. |
+| `force_all_start` | **KEEP cycled** | Live-evaluated at force start (`admin.py` `handle_force_start`); human-essential. |
+| `random_assignment` | **MOVE → flag-only** | Folds into game-mode selection; dashboard/file/flagd only. |
+| `nonstop.time_limit_seconds` | **MOVE → flag-only** | Per-mode knob, frozen at start; dashboard/file/flagd only. |
+| `invincibility_seconds` | **MOVE → flag-only** | Per-mode knob overlapping agent `shield_seconds` (§4.2); dashboard/file/flagd only. |
+| `fight_club.min_rounds` | **MOVE → flag-only** | Per-mode knob, rarely changed at party time; dashboard/file/flagd only. |
+| `werewolf.reveal_time_seconds` | **MOVE → flag-only** | Per-mode knob, frozen at start; dashboard/file/flagd only. |
+
+The moved flags keep their definitions in
+[`services/flagd/game.json`](../services/flagd/game.json) and are still read at
+game start by [`services/menu/servicer.py`](../services/menu/servicer.py)
+`_build_game_config` (`random_assignment`, `nonstop.time_limit_seconds`,
+`invincibility_seconds`, `fight_club.min_rounds`, `werewolf.reveal_time_seconds`).
+The controller cycle is defined by `option_names` / `option_colors` in
+[`services/menu/handlers/admin.py`](../services/menu/handlers/admin.py).
+
 The agent's live intervention surface (all `interventions.json`, all bounded):
 
 | Parameter | Shape | Runtime target | Composition |

--- a/docs/controller-guide.md
+++ b/docs/controller-guide.md
@@ -42,9 +42,16 @@ Access advanced settings by pressing **all 4 front buttons simultaneously** (X +
 
 | Button | Function | Feedback |
 |--------|----------|----------|
-| **MOVE** | Cycle through options (num_teams / force_all_start) | Shows option color (1s) |
+| **MOVE** | Cycle through options (sensitivity / num_teams / force_all_start) | Shows option color (1s) |
 | **Select** | Increase current option value | Flashes based on value + voice |
 | **Start** | Decrease current option value | Flashes based on value + voice |
+
+> **Note (issue #815):** The controller-cycled option list is limited to the
+> three human essentials above. The per-mode tunables `random_assignment`,
+> `nonstop.time_limit_seconds`, `invincibility_seconds`, `fight_club.min_rounds`,
+> and `werewolf.reveal_time_seconds` are **no longer cycled on the controller** —
+> they still exist as `game.json` flags and are set via the dashboard, the file,
+> or flagd. See [Ownership Model §3.1](OWNERSHIP_MODEL.md#31-controller-cycled-admin-surface-issue-815).
 
 **Quick Access Functions:**
 

--- a/services/menu/README.md
+++ b/services/menu/README.md
@@ -300,13 +300,22 @@ Enter admin mode by pressing all 4 face buttons (Cross + Circle + Square + Trian
 
 | Button | Action |
 |--------|--------|
-| Move | Cycle through settings (num_teams, force_all_start) |
-| Trigger | Increase current setting value |
-| Cross | Decrease current setting value |
+| Move | Cycle through settings (sensitivity, num_teams, force_all_start) |
+| Select | Increase current setting value |
+| Start | Decrease current setting value |
+| Cross | Cycle game mode |
 | Circle | Cycle sensitivity (Slow/Medium/Fast) |
 | Triangle | Show battery levels on all controllers |
 | Square | Toggle instruction display |
+| Trigger | Hold 3s = force start game |
 | PS | Exit admin mode |
+
+> **Controller-cycled surface (issue #815):** Only `sensitivity`, `num_teams`,
+> and `force_all_start` are cycled via Move. The per-mode tunables
+> `random_assignment`, `nonstop.time_limit_seconds`, `invincibility_seconds`,
+> `fight_club.min_rounds`, and `werewolf.reveal_time_seconds` remain `game.json`
+> flags set via dashboard/file/flagd — they are no longer cycled on the
+> controller. See [Ownership Model §3.1](../../docs/OWNERSHIP_MODEL.md#31-controller-cycled-admin-surface-issue-815).
 
 ### Timeout
 

--- a/services/menu/handlers/admin.py
+++ b/services/menu/handlers/admin.py
@@ -9,7 +9,7 @@ Button mappings in admin mode:
 - Circle: Cycle sensitivity (unchanged)
 - Square: Toggle instructions (unchanged)
 - Triangle: Show battery (unchanged)
-- Move: Cycle between options (num_teams / force_all_start)
+- Move: Cycle between options (sensitivity / num_teams / force_all_start)
 - Trigger: Hold 3s = Force start game (LED dims during hold)
 - Select: Increase current option value
 - Start: Decrease current option value
@@ -96,26 +96,24 @@ class AdminModeHandler:
         self.session_span_context = None
 
         # Admin option navigation
-        # Options cycle through all game settings configurable via admin mode
+        # The controller-cycled surface is intentionally limited to the human
+        # essentials (issue #815): a baseline calibration knob (sensitivity), a
+        # structural pre-game choice (num_teams), and a live force-start toggle
+        # (force_all_start). The remaining per-mode tunables
+        # (random_assignment, nonstop.time_limit_seconds, invincibility_seconds,
+        # fight_club.min_rounds, werewolf.reveal_time_seconds) still EXIST as
+        # game.json flags and stay settable via dashboard/file/flagd — they are
+        # simply no longer cycled blind on the controller. See
+        # docs/OWNERSHIP_MODEL.md §3 for the per-flag keep/move decision.
         self.current_option = 0
         self.option_names = [
             "sensitivity",  # 0-4 (Ultra Slow to Ultra Fast)
             "num_teams",  # 2-6 teams (for Teams, RandomTeams, Traitor)
-            "random_assignment",  # True/False for Teams mode
-            "nonstop.time_limit_seconds",  # 0=unlimited, 60-300 seconds
-            "invincibility_seconds",  # 2.0-8.0 seconds (Tournament, FightClub)
-            "fight_club.min_rounds",  # 5-20 rounds
-            "werewolf.reveal_time_seconds",  # 20.0-60.0 seconds
-            "force_all_start",  # True/False
+            "force_all_start",  # True/False (live-evaluated at force start)
         ]
         self.option_colors = [
             Colors.Blue,  # sensitivity
             Colors.Turquoise,  # num_teams
-            Colors.Magenta,  # random_assignment
-            Colors.Yellow,  # nonstop.time_limit_seconds
-            Colors.Green,  # invincibility_seconds
-            Colors.Orange,  # fight_club.min_rounds
-            Colors.Purple,  # werewolf.reveal_time_seconds
             Colors.Orange,  # force_all_start
         ]
 
@@ -919,7 +917,7 @@ class AdminModeHandler:
         """
         Cycle through admin options.
 
-        Options: num_teams -> force_all_start -> num_teams
+        Options: sensitivity -> num_teams -> force_all_start -> sensitivity
 
         Args:
             serial: Controller serial number

--- a/services/menu/tests/test_admin_handler.py
+++ b/services/menu/tests/test_admin_handler.py
@@ -102,18 +102,30 @@ class TestAdminOptionNavigation:
     """Tests for admin option navigation."""
 
     def test_option_names_defined(self, handler):
-        """All expected options should be defined."""
+        """Controller-cycled surface is the 3 human essentials (issue #815).
+
+        The 5 per-mode tunables (random_assignment, nonstop.time_limit_seconds,
+        invincibility_seconds, fight_club.min_rounds, werewolf.reveal_time_seconds)
+        are intentionally NOT cycled on the controller anymore — they remain
+        settable via their game.json flags (dashboard/file/flagd).
+        """
         expected = [
             "sensitivity",
             "num_teams",
+            "force_all_start",
+        ]
+        assert handler.option_names == expected
+
+    def test_moved_options_not_cycled(self, handler):
+        """The 5 moved-to-flag-only options must NOT be in the controller cycle."""
+        moved = {
             "random_assignment",
             "nonstop.time_limit_seconds",
             "invincibility_seconds",
             "fight_club.min_rounds",
             "werewolf.reveal_time_seconds",
-            "force_all_start",
-        ]
-        assert handler.option_names == expected
+        }
+        assert moved.isdisjoint(handler.option_names)
 
     def test_option_colors_match_names(self, handler):
         """Each option should have a corresponding color."""
@@ -137,6 +149,27 @@ class TestAdminOptionNavigation:
         handler.current_option = len(handler.option_names) - 1
         await handler.handle_cycle_option("test_serial")
         assert handler.current_option == 0
+
+    @pytest.mark.asyncio
+    async def test_cycle_option_full_loop(self, handler):
+        """A full MOVE-cycle should visit each of the 3 options in order and wrap.
+
+        sensitivity (0) -> num_teams (1) -> force_all_start (2) -> sensitivity (0).
+        Guards against off-by-one / modulo bugs with the reduced list length.
+        """
+        handler.current_option = 0
+        expected_sequence = ["num_teams", "force_all_start", "sensitivity"]
+        for expected_name in expected_sequence:
+            await handler.handle_cycle_option("test_serial")
+            assert handler.option_names[handler.current_option] == expected_name
+
+    @pytest.mark.asyncio
+    async def test_cycle_option_index_always_in_bounds(self, handler):
+        """current_option must stay a valid index across many cycles."""
+        handler.current_option = 0
+        for _ in range(10):
+            await handler.handle_cycle_option("test_serial")
+            assert 0 <= handler.current_option < len(handler.option_names)
 
 
 class TestIncreaseValueSensitivity:
@@ -179,82 +212,13 @@ class TestIncreaseValueBoolean:
     """Tests for boolean settings increase (toggle) via FlagConfigWriter."""
 
     @pytest.mark.asyncio
-    async def test_random_assignment_cycles_forward(self, handler, mock_state_manager):
-        """random_assignment toggle should call cycle_variant with forward=True."""
-        handler.current_option = 2  # random_assignment
-
-        await handler.handle_increase_value("test_serial")
-
-        mock_state_manager.game_settings_writer.cycle_variant.assert_called_once_with("random_assignment", forward=True)
-
-    @pytest.mark.asyncio
     async def test_force_all_start_cycles_forward(self, handler, mock_state_manager):
         """force_all_start toggle should call cycle_variant with forward=True."""
-        handler.current_option = 7  # force_all_start
+        handler.current_option = 2  # force_all_start (index 2 in reduced surface)
 
         await handler.handle_increase_value("test_serial")
 
         mock_state_manager.game_settings_writer.cycle_variant.assert_called_once_with("force_all_start", forward=True)
-
-
-class TestIncreaseValueNonstopTimeLimit:
-    """Tests for nonstop_time_limit increase via FlagConfigWriter."""
-
-    @pytest.mark.asyncio
-    async def test_nonstop_time_limit_cycles_forward(self, handler, mock_state_manager):
-        """nonstop_time_limit should call cycle_variant with forward=True."""
-        handler.current_option = 3  # nonstop_time_limit
-
-        await handler.handle_increase_value("test_serial")
-
-        mock_state_manager.game_settings_writer.cycle_variant.assert_called_once_with(
-            "nonstop.time_limit_seconds", forward=True
-        )
-
-
-class TestIncreaseValueInvincibility:
-    """Tests for invincibility increase via FlagConfigWriter."""
-
-    @pytest.mark.asyncio
-    async def test_invincibility_cycles_forward(self, handler, mock_state_manager):
-        """invincibility should call cycle_variant with forward=True."""
-        handler.current_option = 4  # invincibility
-
-        await handler.handle_increase_value("test_serial")
-
-        mock_state_manager.game_settings_writer.cycle_variant.assert_called_once_with(
-            "invincibility_seconds", forward=True
-        )
-
-
-class TestIncreaseValueFightClubMinRounds:
-    """Tests for fight_club_min_rounds increase via FlagConfigWriter."""
-
-    @pytest.mark.asyncio
-    async def test_fight_club_min_rounds_cycles_forward(self, handler, mock_state_manager):
-        """fight_club_min_rounds should call cycle_variant with forward=True."""
-        handler.current_option = 5  # fight_club_min_rounds
-
-        await handler.handle_increase_value("test_serial")
-
-        mock_state_manager.game_settings_writer.cycle_variant.assert_called_once_with(
-            "fight_club.min_rounds", forward=True
-        )
-
-
-class TestIncreaseValueWerewolfRevealTime:
-    """Tests for werewolf_reveal_time increase via FlagConfigWriter."""
-
-    @pytest.mark.asyncio
-    async def test_werewolf_reveal_time_cycles_forward(self, handler, mock_state_manager):
-        """werewolf_reveal_time should call cycle_variant with forward=True."""
-        handler.current_option = 6  # werewolf_reveal_time
-
-        await handler.handle_increase_value("test_serial")
-
-        mock_state_manager.game_settings_writer.cycle_variant.assert_called_once_with(
-            "werewolf.reveal_time_seconds", forward=True
-        )
 
 
 class TestDecreaseValueSensitivity:
@@ -283,19 +247,17 @@ class TestDecreaseValueNumTeams:
         mock_state_manager.game_settings_writer.cycle_variant.assert_called_once_with("num_teams", forward=False)
 
 
-class TestDecreaseValueInvincibility:
-    """Tests for invincibility decrease via FlagConfigWriter."""
+class TestDecreaseValueForceAllStart:
+    """Tests for force_all_start decrease via FlagConfigWriter."""
 
     @pytest.mark.asyncio
-    async def test_invincibility_cycles_backward(self, handler, mock_state_manager):
-        """invincibility decrease should call cycle_variant with forward=False."""
-        handler.current_option = 4  # invincibility
+    async def test_force_all_start_cycles_backward(self, handler, mock_state_manager):
+        """force_all_start decrease should call cycle_variant with forward=False."""
+        handler.current_option = 2  # force_all_start (index 2 in reduced surface)
 
         await handler.handle_decrease_value("test_serial")
 
-        mock_state_manager.game_settings_writer.cycle_variant.assert_called_once_with(
-            "invincibility_seconds", forward=False
-        )
+        mock_state_manager.game_settings_writer.cycle_variant.assert_called_once_with("force_all_start", forward=False)
 
 
 class TestShowValueFeedback:


### PR DESCRIPTION
Part of #815 (epic #814, milestone M9). Builds on the merged ownership model (#820).

## Decision (ratified with maintainer)
The MOVE-cycled admin option list shrinks from **8 → 3**. "Move to flag-only" means the flag still exists and stays settable via dashboard/file/flagd — it's just no longer cycled blind on a PS Move controller.

| Option | Decision |
|---|---|
| `sensitivity` | **KEEP** cycled (baseline intent) |
| `num_teams` | **KEEP** cycled (pre-game structural) |
| `force_all_start` | **KEEP** cycled (live-evaluated at force start) |
| `random_assignment` | move → flag-only |
| `nonstop.time_limit_seconds` | move → flag-only |
| `invincibility_seconds` | move → flag-only (overlaps agent shield, composed in #817) |
| `fight_club.min_rounds` | move → flag-only |
| `werewolf.reveal_time_seconds` | move → flag-only |

Separate (non-cycle) controls untouched: game-mode cycle (Cross), battery (Triangle), instructions (Square), force-start trigger-hold.

## Changes
- `admin.py`: trimmed `option_names`/`option_colors` to the 3 survivors; cycling uses `% len(option_names)` so it's length-agnostic (no off-by-one); the only positional dependency (`force_all_start` index 7 → 2) fixed.
- The 5 moved flags remain **defined** (`services/flagd/game.json`) and **read** at game start (`servicer.py:_build_game_config`, lines 834/848/855/863/868) — removing them from the cycle has zero effect on resolution. `_variant_to_value`/`_show_value_feedback` branches left intact (harmless, documents ranges).
- Docs: `OWNERSHIP_MODEL.md` §3.1 records the per-flag keep/move rationale for all 8; notes added to `controller-guide.md` and `menu/README.md` (also corrected stale button mappings there).

## Tests
- `test_admin_handler.py`: **122 passed** (removed 6 moved-option cycle tests, added 4 boundary/disjoint tests).
- Full menu suite: **356 passed**. `make lint` clean.

## AC
- ✅ Explicit keep/move decision recorded for each of the 8 options
- ✅ `option_names`/`option_colors` reduced; unit tests updated
- ✅ Moved options remain settable via flagd flags, documented where

🤖 Generated with [Claude Code](https://claude.com/claude-code)