### PR TITLE
fix(agent): unblock shadow-game lifecycle — under-populated start + game_error slot leak (#1013 #1014)

### DIFF
--- a/services/agent/experiment/journal/record.go
+++ b/services/agent/experiment/journal/record.go
@@ -82,6 +82,13 @@ const (
 	// KindGameConcluded — a game finished and carries its fitness sample. This is
 	// the ONLY event that folds into an arm's Welford accumulator.
 	KindGameConcluded EventKind = "game_concluded"
+	// KindGameReleased — a shadow game ended WITHOUT a usable fitness sample
+	// (game_error / timeout / abort) so its in-flight slot was freed WITHOUT
+	// folding a sample (#1014). It is a NON-COUNTING release: it never touches an
+	// arm's Welford accumulator, so a transient game failure cannot pollute the
+	// cohort with a fabricated 0-fitness sample. It is recorded purely for the
+	// audit trail (why a bound game vanished without a conclusion).
+	KindGameReleased EventKind = "game_released"
 	// KindInterimVerdict — the rolling verdict recorded after a conclusion.
 	KindInterimVerdict EventKind = "interim_verdict"
 	// KindDecision — a status transition (continue/stop/promote).

--- a/services/agent/experiment/registry.go
+++ b/services/agent/experiment/registry.go
@@ -262,6 +262,18 @@ type Registry struct {
 	// allocation: AllocateAndSpawn rotates the start of the live-experiment scan so
 	// no single experiment is always served first (equal-share, no starvation).
 	rrCursor int
+	// releaseTombstones records game_ids whose terminal callback (ReleaseGame) fired
+	// BEFORE the registry bound the game_id into e.games — the bind-vs-fast-terminal
+	// race (#1014). A game that hits a terminal outcome the instant it starts (e.g.
+	// game_error at admission) fires its TerminalCallback while only the reservation
+	// placeholder is in e.games, so findGameLocked cannot match it and ReleaseGame
+	// would no-op, then bindGame would record the game_id permanently and leak the
+	// slot forever. To close the race, ReleaseGame for an unfound game_id leaves a
+	// tombstone here; bindGame checks it and, on a hit, drops the reservation WITHOUT
+	// binding (freeing the slot, non-counting) and consumes the tombstone. The map is
+	// only ever populated for the brief window between spawn and bind, so it stays
+	// O(in-flight) at worst.
+	releaseTombstones map[string]string // game_id → release reason
 }
 
 // RegistryConfig configures a Registry. Every seam may be nil — a nil seam
@@ -374,18 +386,19 @@ func NewRegistry(cfg RegistryConfig) *Registry {
 		log = slog.Default()
 	}
 	return &Registry{
-		root:         cfg.Root,
-		maxCap:       maxCap,
-		effectiveCap: effectiveCap,
-		maxGames:     maxGames,
-		minN:         minN,
-		spawner:      cfg.Spawner,
-		verdict:      cfg.Verdict,
-		promo:        cfg.Promoter,
-		target:       cfg.Targeting,
-		clock:        clock,
-		log:          log,
-		entries:      make(map[string]*entry),
+		root:              cfg.Root,
+		maxCap:            maxCap,
+		effectiveCap:      effectiveCap,
+		maxGames:          maxGames,
+		minN:              minN,
+		spawner:           cfg.Spawner,
+		verdict:           cfg.Verdict,
+		promo:             cfg.Promoter,
+		target:            cfg.Targeting,
+		clock:             clock,
+		log:               log,
+		entries:           make(map[string]*entry),
+		releaseTombstones: make(map[string]string),
 	}
 }
 
@@ -551,8 +564,12 @@ func (r *Registry) AllocateAndSpawn(ctx context.Context) int {
 			// Stop this call rather than hot-loop on a failing spawner.
 			return spawned
 		}
-		r.bindGame(id, gameID, arm)
-		spawned++
+		if r.bindGame(id, gameID, arm) {
+			spawned++
+		}
+		// If bindGame did NOT bind (the #1014 bind-vs-fast-terminal race freed the
+		// reservation instead), the slot is back in the cap; the loop's next
+		// nextAllocation will refill it, so no special handling is needed here.
 	}
 }
 
@@ -623,21 +640,50 @@ func reservationKey(id string, seq int) string {
 // bindGame replaces the most-recent reservation for the experiment with the real
 // coordinator game_id, records a game_assigned journal event, and (re)allocation
 // is the caller's concern. Assumes the reservation exists (nextAllocation made it).
-func (r *Registry) bindGame(id, gameID, arm string) {
+//
+// BIND-VS-FAST-TERMINAL RACE (#1014): a game can hit a terminal outcome — and fire
+// its TerminalCallback → ReleaseGame(gameID) — BEFORE this bind runs (the drive
+// goroutine starts inside Spawn, before Spawn returns the game_id). When that
+// happens ReleaseGame cannot find the not-yet-bound game_id, so it leaves a
+// tombstone instead. bindGame detects that tombstone and, rather than recording the
+// game_id permanently (which would leak the slot forever — the terminal callback
+// already fired and will never fire again), it drops the reservation WITHOUT binding
+// and records a non-counting release. The slot returns to the cap immediately.
+//
+// It returns true when it bound the game_id (a live in-flight game), false when it
+// freed the reservation without binding (the race lost, or the experiment vanished)
+// — the caller counts only genuinely-started games.
+func (r *Registry) bindGame(id, gameID, arm string) bool {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	e := r.entries[id]
 	if e == nil {
-		return
+		// Experiment vanished (torn down) between spawn and bind: nothing to bind, and
+		// teardown already cleared the reservation. Drop any tombstone so it cannot
+		// outlive the experiment.
+		delete(r.releaseTombstones, gameID)
+		return false
 	}
+
+	// If the game already terminated before we could bind it, do NOT record the
+	// game_id — free the reservation slot instead and consume the tombstone.
+	if reason, tombstoned := r.releaseTombstones[gameID]; tombstoned {
+		delete(r.releaseTombstones, gameID)
+		r.dropOneReservationLocked(e, arm)
+		r.appendEvent(e.journal, journal.Event{
+			Kind:   journal.KindGameReleased,
+			GameID: gameID,
+			Arm:    arm,
+			Note:   reason,
+		})
+		r.log.Warn("experiment.game_released_before_bind (#1014)",
+			"experiment_id", id, "game_id", gameID, "arm", arm, "reason", reason)
+		return false
+	}
+
 	// Replace the matching reservation placeholder (an arbitrary one for this arm)
 	// with the real game id. We find ANY reservation for this arm to convert.
-	for k, a := range e.games {
-		if isReservation(k) && a == arm {
-			delete(e.games, k)
-			break
-		}
-	}
+	r.dropOneReservationLocked(e, arm)
 	e.games[gameID] = arm
 	r.appendEvent(e.journal, journal.Event{
 		Kind:   journal.KindGameAssigned,
@@ -645,6 +691,20 @@ func (r *Registry) bindGame(id, gameID, arm string) {
 		Arm:    arm,
 	})
 	r.log.Info("experiment.game_assigned", "experiment_id", id, "game_id", gameID, "arm", arm)
+	return true
+}
+
+// dropOneReservationLocked deletes one reservation placeholder for the arm from the
+// experiment's game map (an arbitrary one — they are interchangeable for the same
+// arm). It is the shared helper for bindGame (convert/free a reservation) and
+// releaseReservation (free on spawn failure). Assumes r.mu is held.
+func (r *Registry) dropOneReservationLocked(e *entry, arm string) {
+	for k, a := range e.games {
+		if isReservation(k) && a == arm {
+			delete(e.games, k)
+			return
+		}
+	}
 }
 
 // releaseReservation drops one reservation placeholder for the arm (used when a
@@ -656,12 +716,7 @@ func (r *Registry) releaseReservation(id, arm string) {
 	if e == nil {
 		return
 	}
-	for k, a := range e.games {
-		if isReservation(k) && a == arm {
-			delete(e.games, k)
-			return
-		}
-	}
+	r.dropOneReservationLocked(e, arm)
 }
 
 // isReservation reports whether a game-map key is a reservation placeholder
@@ -685,6 +740,10 @@ func (r *Registry) ConcludeGame(ctx context.Context, gameID string, fitness floa
 		return "", nil // not one of ours; ignore.
 	}
 	delete(e.games, gameID)
+	// Drop any release tombstone for this id: a bound game that concludes normally
+	// can never have one (bindGame consumes it before binding), but clear it
+	// defensively so an out-of-order unfound-release cannot linger.
+	delete(r.releaseTombstones, gameID)
 	f := fitness
 	r.appendEvent(e.journal, journal.Event{
 		Kind:      journal.KindGameConcluded,
@@ -764,10 +823,25 @@ func (r *Registry) ReleaseGame(gameID, reason string) bool {
 	r.mu.Lock()
 	id, arm, e := r.findGameLocked(gameID)
 	if e == nil {
+		// The game_id is not (yet) bound. This is EITHER the bind-vs-fast-terminal
+		// race (#1014) — the terminal callback fired before AllocateAndSpawn bound the
+		// real game_id, so the reservation placeholder is still in e.games — OR a
+		// genuinely unknown id (already concluded/released, or not one of ours). We
+		// cannot tell the two apart here, so leave a tombstone: a pending bindGame for
+		// this id will detect it and free its reservation WITHOUT recording the id
+		// (closing the leak); a never-bound id's tombstone is swept on the owning
+		// experiment's teardown (and is harmless until then — it holds no slot).
+		if _, dup := r.releaseTombstones[gameID]; !dup {
+			r.releaseTombstones[gameID] = reason
+		}
 		r.mu.Unlock()
-		return false // already concluded/released, or not one of ours.
+		return false // no bound slot freed (the bind, if any, frees it).
 	}
 	delete(e.games, gameID)
+	// A tombstone can never coexist with a bound game (bindGame consumes it before
+	// binding), but drop defensively so a prior unfound-release for a since-rebound id
+	// cannot linger.
+	delete(r.releaseTombstones, gameID)
 	r.appendEvent(e.journal, journal.Event{
 		Kind:   journal.KindGameReleased,
 		GameID: gameID,

--- a/services/agent/experiment/registry.go
+++ b/services/agent/experiment/registry.go
@@ -269,11 +269,25 @@ type Registry struct {
 	// placeholder is in e.games, so findGameLocked cannot match it and ReleaseGame
 	// would no-op, then bindGame would record the game_id permanently and leak the
 	// slot forever. To close the race, ReleaseGame for an unfound game_id leaves a
-	// tombstone here; bindGame checks it and, on a hit, drops the reservation WITHOUT
-	// binding (freeing the slot, non-counting) and consumes the tombstone. The map is
-	// only ever populated for the brief window between spawn and bind, so it stays
-	// O(in-flight) at worst.
+	// tombstone here ONLY WHILE A SPAWN IS IN FLIGHT (spawnsInFlight > 0); bindGame
+	// checks it and, on a hit, drops the reservation WITHOUT binding (freeing the
+	// slot, non-counting) and consumes the tombstone.
+	//
+	// BOUNDEDNESS: a tombstone is only meaningful for a bind that is still coming, and
+	// a bind can only be pending while a spawn is in flight. So we (1) refuse to record
+	// a tombstone when spawnsInFlight == 0 (an unfound ReleaseGame then is provably a
+	// stale/duplicate call — already concluded or already released — not the race), and
+	// (2) clear the whole map whenever spawnsInFlight returns to 0 (no bind can be
+	// pending, so any survivor is a proven orphan). The map is therefore bounded by the
+	// number of CONCURRENT in-flight spawns — genuinely O(in-flight) — and is empty
+	// whenever the registry is quiescent. This is what makes the conclude-then-release
+	// and double-release orderings (which would otherwise leave an un-consumable
+	// tombstone) self-cleaning.
 	releaseTombstones map[string]string // game_id → release reason
+	// spawnsInFlight counts spawns currently between nextAllocation's reservation and
+	// bindGame (the only window in which a real game_id can be reported-terminal before
+	// it is bound). It gates and bounds releaseTombstones (see above).
+	spawnsInFlight int
 }
 
 // RegistryConfig configures a Registry. Every seam may be nil — a nil seam
@@ -615,6 +629,10 @@ func (r *Registry) nextAllocation() (id, arm string, ok bool) {
 		// is replaced by the real game id in bindGame, or released on spawn failure.
 		placeholder := reservationKey(cand, e.armCursor)
 		e.games[placeholder] = arm
+		// A spawn is now in flight (reserved, not yet bound). It is the only window in
+		// which a real game_id can be reported-terminal before bind, so this gates and
+		// bounds the tombstone map. Decremented in bindGame / releaseReservation.
+		r.spawnsInFlight++
 		return cand, arm, true
 	}
 	return "", "", false
@@ -656,6 +674,9 @@ func reservationKey(id string, seq int) string {
 func (r *Registry) bindGame(id, gameID, arm string) bool {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	// The spawn that produced this game_id has resolved (whichever branch we take
+	// below). Account for it so the tombstone map stays bounded and self-cleaning.
+	defer r.spawnResolvedLocked()
 	e := r.entries[id]
 	if e == nil {
 		// Experiment vanished (torn down) between spawn and bind: nothing to bind, and
@@ -712,11 +733,32 @@ func (r *Registry) dropOneReservationLocked(e *entry, arm string) {
 func (r *Registry) releaseReservation(id, arm string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	// The spawn resolved (with an error); account for it whether or not the
+	// experiment still exists, so spawnsInFlight cannot drift positive and pin the
+	// tombstone map open.
+	defer r.spawnResolvedLocked()
 	e := r.entries[id]
 	if e == nil {
 		return
 	}
 	r.dropOneReservationLocked(e, arm)
+}
+
+// spawnResolvedLocked records that one in-flight spawn has resolved (bound, freed,
+// or failed). When the count returns to zero NO bind can be pending, so any tombstone
+// still in the map is a proven orphan (a stale conclude-then-release or double-release
+// that no bindGame will ever consume) and is swept — keeping releaseTombstones bounded
+// by concurrent in-flight spawns and empty whenever the registry is quiescent. Assumes
+// r.mu is held.
+func (r *Registry) spawnResolvedLocked() {
+	if r.spawnsInFlight > 0 {
+		r.spawnsInFlight--
+	}
+	if r.spawnsInFlight == 0 && len(r.releaseTombstones) > 0 {
+		for k := range r.releaseTombstones {
+			delete(r.releaseTombstones, k)
+		}
+	}
 }
 
 // isReservation reports whether a game-map key is a reservation placeholder
@@ -817,22 +859,28 @@ func (r *Registry) ConcludeGame(ctx context.Context, gameID string, fitness floa
 // telemetry-driven ConcludeGame path never fires for it.
 //
 // It is IDEMPOTENT and SAFE to call alongside ConcludeGame: an unknown game_id
-// (already concluded/released, or not one of ours) is ignored. Returns whether a
-// slot was actually freed.
+// (already concluded/released, or not one of ours) is ignored — and never records a
+// lingering tombstone unless a bind is genuinely pending (spawnsInFlight > 0), so the
+// conclude-then-release and double-release orderings leave no orphan. Returns whether
+// a slot was actually freed.
 func (r *Registry) ReleaseGame(gameID, reason string) bool {
 	r.mu.Lock()
 	id, arm, e := r.findGameLocked(gameID)
 	if e == nil {
-		// The game_id is not (yet) bound. This is EITHER the bind-vs-fast-terminal
-		// race (#1014) — the terminal callback fired before AllocateAndSpawn bound the
-		// real game_id, so the reservation placeholder is still in e.games — OR a
-		// genuinely unknown id (already concluded/released, or not one of ours). We
-		// cannot tell the two apart here, so leave a tombstone: a pending bindGame for
-		// this id will detect it and free its reservation WITHOUT recording the id
-		// (closing the leak); a never-bound id's tombstone is swept on the owning
-		// experiment's teardown (and is harmless until then — it holds no slot).
-		if _, dup := r.releaseTombstones[gameID]; !dup {
-			r.releaseTombstones[gameID] = reason
+		// The game_id is not bound. This is EITHER the bind-vs-fast-terminal race
+		// (#1014) — the terminal callback fired before AllocateAndSpawn could bind the
+		// real game_id, so only the reservation placeholder is in e.games — OR a
+		// genuinely stale call (already concluded/released, or not one of ours). We tell
+		// them apart by spawnsInFlight: the race can ONLY happen while a spawn is in
+		// flight (a bind is still coming). So tombstone ONLY then; bindGame will detect
+		// it and free the reservation WITHOUT recording the id (closing the leak), and
+		// spawnResolvedLocked sweeps any survivor when the last spawn resolves. When NO
+		// spawn is in flight an unfound release is provably stale — recording a tombstone
+		// would just leak an entry no bind will ever consume, so we skip it.
+		if r.spawnsInFlight > 0 {
+			if _, dup := r.releaseTombstones[gameID]; !dup {
+				r.releaseTombstones[gameID] = reason
+			}
 		}
 		r.mu.Unlock()
 		return false // no bound slot freed (the bind, if any, frees it).

--- a/services/agent/experiment/registry.go
+++ b/services/agent/experiment/registry.go
@@ -745,6 +745,42 @@ func (r *Registry) ConcludeGame(ctx context.Context, gameID string, fitness floa
 	return StatusRunning, nil
 }
 
+// ReleaseGame frees the in-flight slot held by a shadow game that ended WITHOUT
+// producing a usable fitness sample (#1014): a game that terminated in
+// game_error, was force-ended on timeout, or was aborted. Unlike ConcludeGame it
+// does NOT fold a fitness sample, recompute the verdict, or advance the
+// termination budget — a transient game failure must not pollute the cohort with
+// a fabricated 0-fitness sample (epic #982: fitness is observed, never assumed).
+// It simply drops the (game_id → arm) binding so the slot returns to the cap,
+// records a non-counting release event for the audit trail, and lets the next
+// AllocateAndSpawn refill it. This is the BACKSTOP that guarantees the
+// effective_concurrency=1 loop can never deadlock on an errored game even if the
+// telemetry-driven ConcludeGame path never fires for it.
+//
+// It is IDEMPOTENT and SAFE to call alongside ConcludeGame: an unknown game_id
+// (already concluded/released, or not one of ours) is ignored. Returns whether a
+// slot was actually freed.
+func (r *Registry) ReleaseGame(gameID, reason string) bool {
+	r.mu.Lock()
+	id, arm, e := r.findGameLocked(gameID)
+	if e == nil {
+		r.mu.Unlock()
+		return false // already concluded/released, or not one of ours.
+	}
+	delete(e.games, gameID)
+	r.appendEvent(e.journal, journal.Event{
+		Kind:   journal.KindGameReleased,
+		GameID: gameID,
+		Arm:    arm,
+		Note:   reason,
+	})
+	r.mu.Unlock()
+
+	r.log.Info("experiment.game_released",
+		"experiment_id", id, "game_id", gameID, "arm", arm, "reason", reason)
+	return true
+}
+
 // shouldGiveUp implements the #1001 termination guard: it decides whether an
 // experiment that is still inconclusive must be concluded INCONCLUSIVE (rather
 // than left RUNNING forever). It returns a human-readable reason and true when

--- a/services/agent/experiment/registry_test.go
+++ b/services/agent/experiment/registry_test.go
@@ -1205,3 +1205,119 @@ func TestBindAfterTeardownDropsTombstone(t *testing.T) {
 		t.Fatalf("tombstone not dropped on missing-experiment bind: %d left", leftover)
 	}
 }
+
+// tombstoneCount returns the registry's current tombstone-map size (test-only).
+func tombstoneCount(r *Registry) int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.releaseTombstones)
+}
+
+// TestConcludeThenReleaseLeavesNoOrphanTombstone is the bounded-map regression for
+// the conclude-then-release ordering: ReleaseGame is documented as safe to call
+// alongside ConcludeGame. If telemetry concludes a (bound) game first and the drive
+// goroutine's terminal callback then calls ReleaseGame on the same id, the unfound
+// release must NOT leave an un-consumable tombstone — because no spawn is in flight,
+// it is provably a stale call and must be skipped. Before the spawnsInFlight gate
+// this leaked one map entry per occurrence forever.
+func TestConcludeThenReleaseLeavesNoOrphanTombstone(t *testing.T) {
+	spawner := &fakeSpawner{}
+	r := newTestRegistry(t, RegistryConfig{
+		MaxShadowGames: 2,
+		Spawner:        spawner,
+		Verdict:        fakeVerdict{concludeAtN: 1000},
+	})
+	ctx := context.Background()
+	id, err := r.Declare(sampleIntent())
+	if err != nil {
+		t.Fatalf("Declare: %v", err)
+	}
+	if err := r.Start(ctx, id); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if n := r.AllocateAndSpawn(ctx); n != 2 {
+		t.Fatalf("spawned %d, want 2", n)
+	}
+	gid := spawner.calls[0].gameID
+
+	// Telemetry concludes the bound game first.
+	if _, err := r.ConcludeGame(ctx, gid, 0.5, 30); err != nil {
+		t.Fatalf("ConcludeGame: %v", err)
+	}
+	// The drive goroutine's terminal callback now races in on the SAME id (no spawn
+	// is in flight — both spawns already bound). It must be a no-op with no tombstone.
+	if freed := r.ReleaseGame(gid, "late terminal callback"); freed {
+		t.Fatalf("ReleaseGame freed an already-concluded game, want false")
+	}
+	if n := tombstoneCount(r); n != 0 {
+		t.Fatalf("orphan tombstone leaked on conclude-then-release: %d, want 0", n)
+	}
+}
+
+// TestDoubleReleaseLeavesNoOrphanTombstone is the bounded-map regression for the
+// double-release ordering: the first ReleaseGame frees the bound slot; a second
+// ReleaseGame on the same id (no spawn in flight) must be an idempotent no-op that
+// leaves no tombstone.
+func TestDoubleReleaseLeavesNoOrphanTombstone(t *testing.T) {
+	spawner := &fakeSpawner{}
+	r := newTestRegistry(t, RegistryConfig{
+		MaxShadowGames: 2,
+		Spawner:        spawner,
+		Verdict:        fakeVerdict{concludeAtN: 1000},
+	})
+	ctx := context.Background()
+	id, err := r.Declare(sampleIntent())
+	if err != nil {
+		t.Fatalf("Declare: %v", err)
+	}
+	if err := r.Start(ctx, id); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if n := r.AllocateAndSpawn(ctx); n != 2 {
+		t.Fatalf("spawned %d, want 2", n)
+	}
+	gid := spawner.calls[0].gameID
+
+	if freed := r.ReleaseGame(gid, "error"); !freed {
+		t.Fatalf("first ReleaseGame should free the bound slot")
+	}
+	if freed := r.ReleaseGame(gid, "error again"); freed {
+		t.Fatalf("second ReleaseGame on the same id should be a no-op")
+	}
+	if n := tombstoneCount(r); n != 0 {
+		t.Fatalf("orphan tombstone leaked on double-release: %d, want 0", n)
+	}
+}
+
+// TestQuiescentRegistryHasNoTombstones is the bounded-map invariant: after a full
+// spawn/bind/conclude cycle with no spawn in flight, the tombstone map is empty (the
+// map is O(concurrent in-flight spawns) and quiescent-empty, never accumulating).
+func TestQuiescentRegistryHasNoTombstones(t *testing.T) {
+	spawner := &fakeSpawner{}
+	r := newTestRegistry(t, RegistryConfig{
+		MaxShadowGames: 2,
+		Spawner:        spawner,
+		Verdict:        fakeVerdict{concludeAtN: 1000},
+	})
+	ctx := context.Background()
+	id, _ := r.Declare(sampleIntent())
+	if err := r.Start(ctx, id); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	r.AllocateAndSpawn(ctx)
+	for _, c := range spawner.calls {
+		if _, err := r.ConcludeGame(ctx, c.gameID, 0.5, 30); err != nil {
+			t.Fatalf("ConcludeGame: %v", err)
+		}
+	}
+	r.mu.Lock()
+	inFlightSpawns := r.spawnsInFlight
+	tombs := len(r.releaseTombstones)
+	r.mu.Unlock()
+	if inFlightSpawns != 0 {
+		t.Fatalf("spawnsInFlight = %d after a full cycle, want 0", inFlightSpawns)
+	}
+	if tombs != 0 {
+		t.Fatalf("releaseTombstones = %d on a quiescent registry, want 0", tombs)
+	}
+}

--- a/services/agent/experiment/registry_test.go
+++ b/services/agent/experiment/registry_test.go
@@ -1082,3 +1082,126 @@ func TestMaxGamesPerExperimentConfig(t *testing.T) {
 		t.Fatalf("negative config maxGames = %d, want 0 (disabled)", r.maxGames)
 	}
 }
+
+// fastTerminalSpawner reproduces the bind-vs-fast-terminal race (#1014): inside
+// Spawn — i.e. BEFORE Spawn returns and the registry can call bindGame — it fires
+// the terminal callback by calling ReleaseGame(gameID) on the registry, exactly as
+// a game that errors at admission would (its drive goroutine fires onTerminal →
+// ReleaseGame the instant it starts). The real gamerunner spawns its drive
+// goroutine inside StartExperimentGame before returning the id, so this ordering is
+// real, not contrived; the default fakeSpawner binds synchronously and never
+// exercises it.
+type fastTerminalSpawner struct {
+	mu  sync.Mutex
+	reg *Registry // set after construction so Spawn can call back into the registry
+	seq int
+}
+
+func (f *fastTerminalSpawner) Spawn(_ context.Context, _, _ string) (string, error) {
+	f.mu.Lock()
+	f.seq++
+	seq := f.seq
+	gameID := fmt.Sprintf("game_%012d", seq)
+	reg := f.reg
+	f.mu.Unlock()
+	// Only the FIRST game races a pre-bind terminal; otherwise the always-release
+	// would make AllocateAndSpawn refill-and-release in a tight loop (the slot keeps
+	// freeing). One pre-bind terminal is enough to exercise the race; subsequent
+	// spawns bind normally so the pass terminates.
+	if seq == 1 {
+		// Terminal callback fires BEFORE Spawn returns ⇒ before AllocateAndSpawn binds.
+		reg.ReleaseGame(gameID, "game_error at admission (test)")
+	}
+	return gameID, nil
+}
+
+// TestBindVsFastTerminalDoesNotLeakSlot is the #1014 regression: a game that
+// terminates (error) BEFORE the registry binds its game_id must NOT leak the
+// in-flight slot. Before the fix, ReleaseGame no-op'd on the not-yet-bound id and
+// bindGame then recorded the id permanently, pinning the slot forever and
+// deadlocking the effective_concurrency=1 loop. The fix tombstones the early
+// release and frees the reservation at bind time, so a SUBSEQUENT AllocateAndSpawn
+// succeeds.
+func TestBindVsFastTerminalDoesNotLeakSlot(t *testing.T) {
+	spawner := &fastTerminalSpawner{}
+	r := newTestRegistry(t, RegistryConfig{
+		MaxShadowGames:       1,
+		EffectiveConcurrency: 1, // the exact deadlock-prone shape (#1014 target case)
+		Spawner:              spawner,
+		Verdict:              fakeVerdict{concludeAtN: 1000},
+	})
+	spawner.mu.Lock()
+	spawner.reg = r
+	spawner.mu.Unlock()
+
+	ctx := context.Background()
+	id, err := r.Declare(sampleIntent())
+	if err != nil {
+		t.Fatalf("Declare: %v", err)
+	}
+	if err := r.Start(ctx, id); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// One pass: the FIRST spawned game terminates before bind, freeing its slot; the
+	// pass then refills it with a healthy game (seq>=2 binds normally). Before the
+	// fix the first game's id was bound permanently — TotalInFlight would have
+	// settled at 1 holding a DEAD game, and no further game could ever start. With
+	// the fix the lone slot holds the healthy second game, proving the dead game's
+	// slot was reclaimed.
+	r.AllocateAndSpawn(ctx)
+	if total := r.TotalInFlight(); total != 1 {
+		t.Fatalf("in-flight %d, want 1 (the dead game's slot reclaimed + refilled)", total)
+	}
+
+	// The slot must hold the SECOND (healthy) game, not the first (released) one.
+	r.mu.Lock()
+	_, _, e := r.findGameLocked("game_000000000001")
+	firstStillBound := e != nil
+	_, _, e2 := r.findGameLocked("game_000000000002")
+	secondBound := e2 != nil
+	leftoverTombstones := len(r.releaseTombstones)
+	r.mu.Unlock()
+	if firstStillBound {
+		t.Fatalf("released game_000000000001 is still bound — the #1014 slot leak")
+	}
+	if !secondBound {
+		t.Fatalf("healthy game_000000000002 not bound — the freed slot was not reused")
+	}
+	// No tombstone may linger after bind consumed it (bounded-map invariant).
+	if leftoverTombstones != 0 {
+		t.Fatalf("releaseTombstones has %d leftover entries, want 0", leftoverTombstones)
+	}
+
+	// Conclude the healthy game and confirm the slot frees for a brand-new spawn —
+	// end-to-end proof the loop is not deadlocked.
+	if _, err := r.ConcludeGame(ctx, "game_000000000002", 0.5, 10); err != nil {
+		t.Fatalf("ConcludeGame: %v", err)
+	}
+	if total := r.TotalInFlight(); total != 0 {
+		t.Fatalf("in-flight %d after concluding the healthy game, want 0", total)
+	}
+	if n := r.AllocateAndSpawn(ctx); n != 1 {
+		t.Fatalf("post-conclude spawned %d, want 1 (loop not deadlocked)", n)
+	}
+}
+
+// TestBindAfterTeardownDropsTombstone covers the bindGame e==nil branch: if the
+// experiment is torn down between the early release and the bind, bindGame must not
+// resurrect a tombstone (it has no entry to free) — the map must end empty.
+func TestBindAfterTeardownDropsTombstone(t *testing.T) {
+	r := newTestRegistry(t, RegistryConfig{MaxShadowGames: 1, EffectiveConcurrency: 1})
+	// Seed a tombstone for an id whose experiment does not exist, then bind it.
+	r.mu.Lock()
+	r.releaseTombstones["game_zzz"] = "stale (test)"
+	r.mu.Unlock()
+	if bound := r.bindGame("exp_missing", "game_zzz", ArmControl); bound {
+		t.Fatalf("bindGame on a missing experiment returned bound=true, want false")
+	}
+	r.mu.Lock()
+	leftover := len(r.releaseTombstones)
+	r.mu.Unlock()
+	if leftover != 0 {
+		t.Fatalf("tombstone not dropped on missing-experiment bind: %d left", leftover)
+	}
+}

--- a/services/agent/experiment/release_game_test.go
+++ b/services/agent/experiment/release_game_test.go
@@ -1,0 +1,148 @@
+package experiment
+
+import (
+	"context"
+	"testing"
+
+	"github.com/joustmania/agent/experiment/journal"
+)
+
+// TestReleaseGameFreesSlotWithoutFoldingSample covers the #1014 backstop: a game
+// that ended WITHOUT a usable fitness sample (game_error / force-end) is released
+// via ReleaseGame, which must free the in-flight slot WITHOUT folding a fitness
+// sample into the arm (so a transient failure cannot pollute the cohort).
+func TestReleaseGameFreesSlotWithoutFoldingSample(t *testing.T) {
+	spawner := &fakeSpawner{}
+	r := newTestRegistry(t, RegistryConfig{
+		MaxShadowGames:       2,
+		EffectiveConcurrency: 2,
+		Spawner:              spawner,
+		Verdict:              fakeVerdict{concludeAtN: 1000},
+	})
+	ctx := context.Background()
+	id, err := r.Declare(sampleIntent())
+	if err != nil {
+		t.Fatalf("Declare: %v", err)
+	}
+	if err := r.Start(ctx, id); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if n := r.AllocateAndSpawn(ctx); n == 0 {
+		t.Fatal("expected at least one spawn")
+	}
+	if r.TotalInFlight() == 0 {
+		t.Fatal("expected in-flight games after spawn")
+	}
+
+	// The spawner recorded the bound game ids; release the first one as a failure.
+	gameID := spawner.calls[0].gameID
+	beforeInFlight := r.TotalInFlight()
+	if !r.ReleaseGame(gameID, "game ended without usable fitness sample: error") {
+		t.Fatal("ReleaseGame returned false for a bound game")
+	}
+	if got := r.TotalInFlight(); got != beforeInFlight-1 {
+		t.Fatalf("in-flight = %d after release, want %d", got, beforeInFlight-1)
+	}
+
+	// No fitness sample was folded: every arm's count stays 0.
+	cv, _ := r.CompactView(id)
+	for arm, a := range cv.Arms {
+		if a.Count != 0 {
+			t.Fatalf("arm %q count = %d after release, want 0 (release must not fold a sample)", arm, a.Count)
+		}
+	}
+
+	// A game_released audit event is recorded; no game_concluded.
+	var released, concluded int
+	for _, ev := range cv.RecentTail {
+		switch ev.Kind {
+		case journal.KindGameReleased:
+			released++
+		case journal.KindGameConcluded:
+			concluded++
+		}
+	}
+	if released != 1 {
+		t.Fatalf("game_released events = %d, want 1", released)
+	}
+	if concluded != 0 {
+		t.Fatalf("game_concluded events = %d, want 0 (release is non-counting)", concluded)
+	}
+}
+
+// TestReleaseGameIsIdempotent confirms ReleaseGame is safe to call alongside the
+// telemetry-driven ConcludeGame path: a second release (or a release after
+// conclude) for an unknown/already-handled game_id is a no-op returning false.
+func TestReleaseGameIsIdempotent(t *testing.T) {
+	spawner := &fakeSpawner{}
+	r := newTestRegistry(t, RegistryConfig{
+		MaxShadowGames: 1, EffectiveConcurrency: 1,
+		Spawner: spawner, Verdict: fakeVerdict{concludeAtN: 1000},
+	})
+	ctx := context.Background()
+	id, _ := r.Declare(sampleIntent())
+	_ = r.Start(ctx, id)
+	r.AllocateAndSpawn(ctx)
+	gameID := spawner.calls[0].gameID
+
+	if !r.ReleaseGame(gameID, "first") {
+		t.Fatal("first ReleaseGame should free the slot")
+	}
+	if r.ReleaseGame(gameID, "second") {
+		t.Fatal("second ReleaseGame for the same game must be a no-op (false)")
+	}
+	if r.ReleaseGame("game_never_existed", "x") {
+		t.Fatal("ReleaseGame for an unknown game must return false")
+	}
+}
+
+// TestErroredGameDoesNotDeadlockAtConcurrencyOne is the #1014 regression: at
+// EffectiveConcurrency=1 the coordinator runs one game at a time, so a single
+// errored game that leaks its in-flight slot deadlocks the loop forever. Releasing
+// the errored game must free the only slot so the NEXT AllocateAndSpawn spawns
+// again (the loop keeps progressing).
+func TestErroredGameDoesNotDeadlockAtConcurrencyOne(t *testing.T) {
+	spawner := &fakeSpawner{}
+	r := newTestRegistry(t, RegistryConfig{
+		MaxShadowGames:       4, // capacity bookkeeping allows more...
+		EffectiveConcurrency: 1, // ...but only ONE in-flight at a time (#998).
+		Spawner:              spawner,
+		Verdict:              fakeVerdict{concludeAtN: 1000}, // never concludes on its own.
+	})
+	ctx := context.Background()
+	id, _ := r.Declare(sampleIntent())
+	if err := r.Start(ctx, id); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// First tick: exactly one game spawns (the effective cap is 1).
+	if n := r.AllocateAndSpawn(ctx); n != 1 {
+		t.Fatalf("first allocate spawned %d, want 1 (effective cap)", n)
+	}
+	if r.TotalInFlight() != 1 {
+		t.Fatalf("in-flight = %d, want 1", r.TotalInFlight())
+	}
+
+	// While that game is in-flight the loop is FULL: another tick spawns nothing.
+	if n := r.AllocateAndSpawn(ctx); n != 0 {
+		t.Fatalf("allocate while full spawned %d, want 0", n)
+	}
+
+	// The game errors. WITHOUT the #1014 fix the slot leaks and the loop is stuck
+	// at in_flight=1 forever. ReleaseGame frees the slot.
+	gameID := spawner.calls[0].gameID
+	if !r.ReleaseGame(gameID, "game ended without usable fitness sample: error") {
+		t.Fatal("ReleaseGame did not free the errored game's slot")
+	}
+	if r.TotalInFlight() != 0 {
+		t.Fatalf("in-flight = %d after release, want 0 (slot freed, no deadlock)", r.TotalInFlight())
+	}
+
+	// The loop continues: the next tick spawns the next game (no deadlock).
+	if n := r.AllocateAndSpawn(ctx); n != 1 {
+		t.Fatalf("allocate after release spawned %d, want 1 (loop progresses)", n)
+	}
+	if spawner.count() != 2 {
+		t.Fatalf("total spawns = %d, want 2 (the errored slot was reused)", spawner.count())
+	}
+}

--- a/services/agent/experiment_loop.go
+++ b/services/agent/experiment_loop.go
@@ -141,7 +141,7 @@ func buildExperimentLoop(
 		Log:       logger,
 	})
 
-	return &experimentLoop{
+	loop := &experimentLoop{
 		registry: registry,
 		spawner:  spawner,
 		flags:    flagsClient,
@@ -150,6 +150,12 @@ func buildExperimentLoop(
 		seed:     seedIntentFromEnv(),
 		fitness:  defaultGameFitness,
 	}
+	// Wire the #1014 terminal-outcome backstop: each spawned game signals its
+	// terminal outcome here, and a non-concluding game releases its in-flight slot
+	// directly (independent of the telemetry game_active=0 path), so the
+	// effective_concurrency=1 loop can never deadlock on an errored game.
+	spawner.SetTerminalCallback(loop.onGameTerminal)
+	return loop
 }
 
 // promotionConfigResolver builds the #980 ConfigResolver from the live agent
@@ -300,6 +306,32 @@ func (e *experimentLoop) onGameEnd(gc gamecontext.GameContext) {
 	}
 	if status == experiment.StatusRunning {
 		// A freed in-flight slot; refill it (respecting the kill-switch).
+		e.allocateIfEnabled(context.Background())
+	}
+}
+
+// onGameTerminal is the #1014 terminal-outcome backstop, invoked by a spawned
+// game's drive goroutine the instant the game ends. For a game that ended WITHOUT
+// a usable fitness sample — game_error or force-end (timeout) — it RELEASES the
+// in-flight slot directly via the registry (a NON-COUNTING release: no fitness
+// sample, no budget increment), so the effective_concurrency=1 loop can never
+// deadlock waiting on a telemetry game_active=0 datapoint that may never arrive
+// for a failed game. A naturally COMPLETED game is left to the telemetry-driven
+// onGameEnd → ConcludeGame path, which folds its real fitness sample; releasing
+// it here would drop that sample. ReleaseGame is idempotent, so even if the
+// telemetry path raced ahead this is a safe no-op. After a release it nudges
+// AllocateAndSpawn so the freed slot is refilled promptly.
+func (e *experimentLoop) onGameTerminal(gameID string, outcome gamerunner.Outcome) {
+	if outcome == gamerunner.OutcomeCompleted {
+		// Natural completion: the telemetry path concludes it with its fitness
+		// sample. Do not release here (that would discard the sample).
+		return
+	}
+	reason := "game ended without usable fitness sample: " + string(outcome)
+	if e.registry.ReleaseGame(gameID, reason) {
+		e.log.Warn("experiment: released in-flight slot for non-concluding game (#1014)",
+			"game_id", gameID, "outcome", outcome)
+		// Refill the freed slot (respecting the kill-switch).
 		e.allocateIfEnabled(context.Background())
 	}
 }

--- a/services/agent/experiment_loop.go
+++ b/services/agent/experiment_loop.go
@@ -323,15 +323,32 @@ func (e *experimentLoop) onGameEnd(gc gamecontext.GameContext) {
 // AllocateAndSpawn so the freed slot is refilled promptly.
 func (e *experimentLoop) onGameTerminal(gameID string, outcome gamerunner.Outcome) {
 	if outcome == gamerunner.OutcomeCompleted {
-		// Natural completion: the telemetry path concludes it with its fitness
-		// sample. Do not release here (that would discard the sample).
+		// Natural completion: the telemetry path (onGameEnd → ConcludeGame) concludes
+		// it WITH its fitness sample. We deliberately do NOT release here because that
+		// would drop the sample (ReleaseGame is non-counting).
+		//
+		// KNOWN RESIDUAL RISK (#1014 follow-up): this trusts the telemetry
+		// game_active=0 datapoint to arrive for a COMPLETED game — the same signal this
+		// very backstop calls unreliable for ERRORED games. If telemetry drops a
+		// completed game's datapoint, its in-flight slot leaks identically and the
+		// effective_concurrency=1 loop deadlocks. The asymmetry is intentional for now:
+		// an errored game routinely loses its attribution (it can error at admission,
+		// before the experiment_id is ever stamped onto a span/metric), whereas a
+		// completed game has played long enough to emit a fully-attributed game-end
+		// datapoint, so the completed path is materially more reliable. A bounded
+		// grace backstop that releases a still-in-flight COMPLETED game non-counting
+		// after a timeout is the durable fix; it is tracked as a follow-up (#1020)
+		// rather than built here (it needs care not to race the fitness fold).
 		return
 	}
 	reason := "game ended without usable fitness sample: " + string(outcome)
 	if e.registry.ReleaseGame(gameID, reason) {
 		e.log.Warn("experiment: released in-flight slot for non-concluding game (#1014)",
 			"game_id", gameID, "outcome", outcome)
-		// Refill the freed slot (respecting the kill-switch).
+		// Refill the freed slot (respecting the kill-switch). context.Background is
+		// intentional: this runs on the drive goroutine, which has no tick/request
+		// context to thread through — the spawn it triggers is bounded by the runner's
+		// own RPC + ready timeouts, so an unbounded Background cannot stall here.
 		e.allocateIfEnabled(context.Background())
 	}
 }

--- a/services/agent/experiment_loop_test.go
+++ b/services/agent/experiment_loop_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/joustmania/agent/experiment"
 	"github.com/joustmania/agent/experiment/journal"
 	"github.com/joustmania/agent/gamecontext"
+	"github.com/joustmania/agent/gamerunner"
 	"github.com/joustmania/agent/promote"
 )
 
@@ -370,6 +371,86 @@ func TestExperimentLoop_OnGameEnd_IgnoresNonExperimentGames(t *testing.T) {
 	if n := loop.registry.TotalInFlight(); n != 0 {
 		t.Fatalf("non-experiment game-ends touched the registry (in-flight=%d)", n)
 	}
+}
+
+// TestExperimentLoop_OnGameTerminal_ReleasesErroredGame is the #1014 loop-level
+// AC: when a spawned game ends in game_error (OutcomeError), the terminal hook
+// releases the in-flight slot via the registry — WITHOUT folding a fitness
+// sample — so an effective_concurrency=1 loop does not deadlock. A naturally
+// COMPLETED game is left for the telemetry onGameEnd path (no release here).
+func TestExperimentLoop_OnGameTerminal_ReleasesErroredGame(t *testing.T) {
+	spawner := &recordingSpawner{}
+	resolve := func(context.Context) promote.Config { return promote.Config{Mode: promote.ModeIssue} }
+	loop := buildLoopForTest(t, spawner, resolve, &recordingRealDefault{}, &recordingGitHub{}, armFitness())
+	ctx := context.Background()
+
+	id, err := loop.registry.Declare(experiment.Intent{
+		Hypothesis: "h", FlagKey: "death_grace_period_seconds",
+		ExperimentalValue: 0.5, Objective: "engagement_balanced", TargetNPerArm: 3,
+	})
+	if err != nil {
+		t.Fatalf("Declare: %v", err)
+	}
+	if err := loop.registry.Start(ctx, id); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if n := loop.registry.AllocateAndSpawn(ctx); n == 0 {
+		t.Fatal("expected a spawn")
+	}
+	recs := spawner.drain()
+	if len(recs) == 0 {
+		t.Fatal("spawner recorded no game")
+	}
+	gameID := recs[0].gameID
+	if loop.registry.TotalInFlight() == 0 {
+		t.Fatal("expected in-flight games after spawn")
+	}
+
+	// A naturally completed game does NOT release here (telemetry concludes it):
+	// the specific game binding survives so the telemetry onGameEnd path can fold
+	// its fitness sample.
+	loop.onGameTerminal(gameID, gamerunner.OutcomeCompleted)
+	if !gameStillBound(loop, id, gameID) {
+		t.Fatal("OutcomeCompleted released the game binding; it must defer to the telemetry conclude path")
+	}
+
+	// A game_error releases THAT game's slot (no deadlock) without folding a
+	// sample. (The loop may immediately refill the freed slot with a NEW game —
+	// that is the correct no-deadlock behavior — so assert on the specific binding
+	// being gone, plus that no fitness sample was folded.)
+	loop.onGameTerminal(gameID, gamerunner.OutcomeError)
+	if gameStillBound(loop, id, gameID) {
+		t.Fatal("OutcomeError did not release the errored game's binding (slot leak / deadlock risk)")
+	}
+	cv, _ := loop.registry.CompactView(id)
+	for arm, a := range cv.Arms {
+		if a.Count != 0 {
+			t.Fatalf("arm %q folded a sample (count=%d) on an errored game; release must be non-counting", arm, a.Count)
+		}
+	}
+}
+
+// gameStillBound reports whether gameID is still an in-flight binding of the
+// experiment (a game_concluded/game_released event drops it). It inspects the
+// journal tail since the registry exposes no per-game accessor.
+func gameStillBound(loop *experimentLoop, expID, gameID string) bool {
+	cv, ok := loop.registry.CompactView(expID)
+	if !ok {
+		return false
+	}
+	assigned := false
+	for _, ev := range cv.RecentTail {
+		if ev.GameID != gameID {
+			continue
+		}
+		switch ev.Kind {
+		case journal.KindGameAssigned:
+			assigned = true
+		case journal.KindGameConcluded, journal.KindGameReleased:
+			assigned = false
+		}
+	}
+	return assigned
 }
 
 // TestBuildExperimentLoop_DisabledByDefault is the disabled-default AC: with the

--- a/services/agent/gamerunner/operations.go
+++ b/services/agent/gamerunner/operations.go
@@ -49,7 +49,89 @@ func (r *Runner) reserveControllers(ctx context.Context, cl *clients, spec Spec)
 	if len(serials) != spec.Players {
 		return serials, fmt.Errorf("AddControllers returned %d serials, want %d", len(serials), spec.Players)
 	}
+	// Reject DUPLICATE serials (#1013). The game roster is a serial-keyed map, so
+	// two identical serials collapse to one player and FFA aborts with "Need at
+	// least 2 players, got 1". A duplicate means the controller-manager handed back
+	// a serial it had already minted (the len()-based naming colliding with a prior
+	// game's not-yet-removed controller) — surface it here rather than start an
+	// under-populated game.
+	if dup := firstDuplicate(serials); dup != "" {
+		return serials, fmt.Errorf("AddControllers returned duplicate serial %q (got %v): under-populated roster", dup, serials)
+	}
+
+	// Readiness gate (#1013): wait until every reserved serial is VISIBLE to the
+	// mock service before the game is started. AddControllers is synchronous on the
+	// adapter, but this guards against any propagation lag between reservation and
+	// the coordinator reading the roster, so a spawned game reliably fields all
+	// spec.Players controllers.
+	if err := r.waitControllersReady(ctx, cl, serials); err != nil {
+		return serials, err
+	}
 	return serials, nil
+}
+
+// firstDuplicate returns the first serial that appears more than once in the
+// slice, or "" when every serial is unique.
+func firstDuplicate(serials []string) string {
+	seen := make(map[string]struct{}, len(serials))
+	for _, s := range serials {
+		if _, ok := seen[s]; ok {
+			return s
+		}
+		seen[s] = struct{}{}
+	}
+	return ""
+}
+
+// waitControllersReady polls ListMockControllers until every serial in want is
+// present (registered/visible), or the readiness timeout elapses (#1013). It
+// returns nil once all serials are visible, or an error describing which serials
+// never appeared. The poll is cheap (an in-memory list on the mock service) and
+// the happy path returns on the first check, so a normally-immediate registration
+// costs one extra RPC.
+func (r *Runner) waitControllersReady(ctx context.Context, cl *clients, want []string) error {
+	deadline := time.Now().Add(r.cfg.ReadyTimeout)
+	ticker := time.NewTicker(r.cfg.ReadyPollInterval)
+	defer ticker.Stop()
+
+	for {
+		missing := r.missingControllers(ctx, cl, want)
+		if len(missing) == 0 {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("reserved controllers not ready within %s: missing %v", r.cfg.ReadyTimeout, missing)
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("readiness wait cancelled: %w", ctx.Err())
+		case <-ticker.C:
+		}
+	}
+}
+
+// missingControllers returns the subset of want that ListMockControllers does not
+// currently report as present. A failed List leaves every serial "missing" so the
+// caller retries until the deadline rather than starting a game on stale state.
+func (r *Runner) missingControllers(ctx context.Context, cl *clients, want []string) []string {
+	rpcCtx, cancel := context.WithTimeout(ctx, r.cfg.RPCTimeout)
+	defer cancel()
+	resp, err := cl.mock.ListMockControllers(rpcCtx, &mockpb.ListRequest{})
+	if err != nil {
+		r.log.Debug("ListMockControllers failed during readiness wait", "error", err)
+		return append([]string(nil), want...)
+	}
+	present := make(map[string]struct{}, len(resp.GetSerials()))
+	for _, s := range resp.GetSerials() {
+		present[s] = struct{}{}
+	}
+	var missing []string
+	for _, s := range want {
+		if _, ok := present[s]; !ok {
+			missing = append(missing, s)
+		}
+	}
+	return missing
 }
 
 // removeControllers removes each serial best-effort. Cleanup must not fail the

--- a/services/agent/gamerunner/readiness_test.go
+++ b/services/agent/gamerunner/readiness_test.go
@@ -1,0 +1,160 @@
+package gamerunner
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	mockpb "github.com/joustmania/agent/gen/controller_manager_mock"
+	gcpb "github.com/joustmania/agent/gen/game_coordinator"
+)
+
+// TestReserveControllers_WaitsForDelayedRegistration covers the #1013 readiness
+// gate: AddControllers returns serials, but the controllers only become VISIBLE
+// to ListMockControllers after a delay. reserveControllers (via the start path)
+// must WAIT until all spec.Players serials are present before the game starts, so
+// the spawned game reliably fields all spec.Players controllers and FFA never
+// aborts with "Need at least 2 players".
+func TestReserveControllers_WaitsForDelayedRegistration(t *testing.T) {
+	const want = 2
+	serials := []string{"MOCK0000", "MOCK0001"}
+
+	var mu sync.Mutex
+	visible := map[string]bool{} // serials registration has propagated for
+
+	mock := &fakeMock{
+		addControllers: func(_ *mockpb.AddControllersRequest) (*mockpb.AddControllersResponse, error) {
+			// Reservation succeeds immediately, but only the FIRST serial is visible
+			// right away; the second propagates after a short delay (simulating the
+			// controller-manager registration lag #1013 describes).
+			mu.Lock()
+			visible[serials[0]] = true
+			mu.Unlock()
+			go func() {
+				time.Sleep(120 * time.Millisecond)
+				mu.Lock()
+				visible[serials[1]] = true
+				mu.Unlock()
+			}()
+			return &mockpb.AddControllersResponse{Success: true, Serials: serials}, nil
+		},
+		list: func() (*mockpb.ListResponse, error) {
+			mu.Lock()
+			defer mu.Unlock()
+			var present []string
+			for _, s := range serials {
+				if visible[s] {
+					present = append(present, s)
+				}
+			}
+			return &mockpb.ListResponse{Serials: present, Count: int32(len(present))}, nil
+		},
+	}
+	coord := &fakeCoord{
+		gameID: "game_ready_001",
+		events: []*gcpb.GameEvent{ev("game_starting"), ev("game_ended")},
+	}
+	h := newHarness(t, mock, coord)
+	defer h.stop()
+	h.runner.cfg.ReadyTimeout = 2 * time.Second
+	h.runner.cfg.ReadyPollInterval = 20 * time.Millisecond
+
+	spec := Spec{RunID: "r", GameName: "JoustFFA", Players: want, Sensitivity: 2}
+
+	cl, err := h.runner.connect()
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer cl.close()
+
+	start := time.Now()
+	got, err := h.runner.reserveControllers(context.Background(), cl, spec)
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("reserveControllers error: %v", err)
+	}
+	if len(got) != want {
+		t.Fatalf("reserved %d serials, want %d", len(got), want)
+	}
+	// It must have BLOCKED for the propagation delay rather than starting early.
+	if elapsed < 100*time.Millisecond {
+		t.Fatalf("reserveControllers returned in %s — it did not wait for delayed registration", elapsed)
+	}
+	// And by the time it returns, every reserved serial must be visible.
+	missing := h.runner.missingControllers(context.Background(), cl, got)
+	if len(missing) != 0 {
+		t.Fatalf("controllers still not visible after reserve: %v", missing)
+	}
+}
+
+// TestReserveControllers_RejectsDuplicateSerials covers the #1013 root-cause
+// guard: when AddControllers hands back a DUPLICATE serial (the len()-based mock
+// naming colliding with a prior game's not-yet-removed controller), the runner
+// must refuse to start an under-populated game rather than let the serial-keyed
+// roster collapse two players into one (the FFA "got 1" abort).
+func TestReserveControllers_RejectsDuplicateSerials(t *testing.T) {
+	mock := &fakeMock{
+		addControllers: func(_ *mockpb.AddControllersRequest) (*mockpb.AddControllersResponse, error) {
+			// count=2 but both serials identical (the collision bug).
+			return &mockpb.AddControllersResponse{
+				Success: true,
+				Serials: []string{"MOCK0001", "MOCK0001"},
+			}, nil
+		},
+	}
+	coord := &fakeCoord{gameID: "g"}
+	h := newHarness(t, mock, coord)
+	defer h.stop()
+
+	cl, err := h.runner.connect()
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer cl.close()
+
+	_, err = h.runner.reserveControllers(context.Background(), cl,
+		Spec{RunID: "r", GameName: "JoustFFA", Players: 2})
+	if err == nil {
+		t.Fatal("expected an error for duplicate reserved serials, got nil")
+	}
+	if !strings.Contains(err.Error(), "duplicate") {
+		t.Fatalf("error = %q, want it to mention the duplicate serial", err)
+	}
+}
+
+// TestReserveControllers_ReadyTimeout covers the failure path: if the reserved
+// controllers never become visible, reserveControllers fails (rather than starting
+// an under-populated game) once ReadyTimeout elapses.
+func TestReserveControllers_ReadyTimeout(t *testing.T) {
+	mock := &fakeMock{
+		addControllers: func(_ *mockpb.AddControllersRequest) (*mockpb.AddControllersResponse, error) {
+			return &mockpb.AddControllersResponse{Success: true, Serials: []string{"A", "B"}}, nil
+		},
+		// Never reports the reserved controllers as present.
+		list: func() (*mockpb.ListResponse, error) {
+			return &mockpb.ListResponse{}, nil
+		},
+	}
+	coord := &fakeCoord{gameID: "g"}
+	h := newHarness(t, mock, coord)
+	defer h.stop()
+	h.runner.cfg.ReadyTimeout = 80 * time.Millisecond
+	h.runner.cfg.ReadyPollInterval = 20 * time.Millisecond
+
+	cl, err := h.runner.connect()
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer cl.close()
+
+	_, err = h.runner.reserveControllers(context.Background(), cl,
+		Spec{RunID: "r", GameName: "JoustFFA", Players: 2})
+	if err == nil {
+		t.Fatal("expected a readiness-timeout error, got nil")
+	}
+	if !strings.Contains(err.Error(), "not ready") {
+		t.Fatalf("error = %q, want a readiness-timeout error", err)
+	}
+}

--- a/services/agent/gamerunner/runner.go
+++ b/services/agent/gamerunner/runner.go
@@ -401,6 +401,25 @@ func (r *Runner) StartExperimentGame(startCtx, driveCtx context.Context, spec Sp
 	// controllers and closes the clients on the way out (success, timeout, or
 	// shutdown), so no controller or connection leaks.
 	go func() {
+		// #1014 deadlock backstop: the WHOLE point of onTerminal is to guarantee the
+		// registry's in-flight slot is released even on a failed game, so the release
+		// must itself be panic-proof. Fire it from a deferred closure that defaults to
+		// OutcomeError and is updated to the real outcome once known — so a panic or
+		// any future early-return in driveGame/awaitTerminal still releases the slot
+		// (a non-concluding OutcomeError release, never a lost slot). Registered FIRST
+		// so LIFO runs it LAST — after controller removal and client close — which
+		// means the registry slot is released after this run's controllers are gone.
+		// onTerminal synchronously kicks off the NEXT game's reserve+start; that next
+		// reservation can therefore race ahead of game N's already-completed
+		// removeControllers, but each run reserves its OWN uniquely-tagged controllers
+		// (Spec.Tag = "agent:<RunID>"), so there is no controller-identity collision.
+		finalOutcome := OutcomeError
+		defer func() {
+			if r.onTerminal != nil {
+				r.onTerminal(gameID, finalOutcome)
+			}
+		}()
+
 		defer cl.close()
 		defer func() {
 			cleanupCtx, cancel := context.WithTimeout(context.Background(), r.cfg.RPCTimeout)
@@ -413,24 +432,11 @@ func (r *Runner) StartExperimentGame(startCtx, driveCtx context.Context, spec Sp
 		go r.driveGame(runDrive, cl, serials)
 
 		terminal, _, outcome := r.awaitTerminal(driveCtx, cl, stream, gameID)
+		finalOutcome = outcome
 		stopDrive()
 		r.log.Info("experiment shadow game finished",
 			"game_id", gameID, "run_id", spec.RunID, "experiment_id", spec.ExperimentID,
 			"arm", spec.Arm, "outcome", outcome, "terminal_event", terminal)
-
-		// Terminal-outcome hook (#1014): signal the registry the moment the game
-		// ends, regardless of outcome. For a game that did NOT conclude with a
-		// usable fitness sample (game_error / force-end / abort) the telemetry
-		// game_active=0 → ConcludeGame path may never fire (a game that errored at
-		// admission can be coalesced or lose its experiment attribution), leaking
-		// the in-flight slot and DEADLOCKING the effective_concurrency=1 loop. This
-		// hook lets the loop release the slot directly. It is a no-op when the
-		// telemetry path already concluded the game (ReleaseGame is idempotent on an
-		// unknown game_id). Runs BEFORE the deferred controller removal so the slot
-		// and the controllers free together.
-		if r.onTerminal != nil {
-			r.onTerminal(gameID, outcome)
-		}
 	}()
 
 	return gameID, nil

--- a/services/agent/gamerunner/runner.go
+++ b/services/agent/gamerunner/runner.go
@@ -101,6 +101,16 @@ type Config struct {
 	// RPCTimeout bounds individual unary RPCs (AddControllers, SimulateDeath,
 	// ForceEndGame, …).
 	RPCTimeout time.Duration
+
+	// ReadyTimeout bounds how long reserveControllers waits for its reserved
+	// controllers to become VISIBLE (registered) to the mock service before
+	// starting the game (#1013). A start that proceeds before all spec.Players
+	// controllers are present can admit an under-populated game that FFA aborts
+	// ("Need at least 2 players, got 1").
+	ReadyTimeout time.Duration
+	// ReadyPollInterval is how often the readiness gate re-checks the controller
+	// roster while waiting for all reserved serials to appear.
+	ReadyPollInterval time.Duration
 }
 
 // Default config values. Conservative and CI-friendly.
@@ -111,6 +121,13 @@ const (
 	DefaultMovementInterval = 250 * time.Millisecond
 	DefaultKillInterval     = 1500 * time.Millisecond
 	DefaultRPCTimeout       = 10 * time.Second
+	// DefaultReadyTimeout bounds the readiness gate (#1013). Controller
+	// registration is normally immediate, so this only ever absorbs a brief
+	// propagation lag; a generous ceiling keeps it from ever masking a genuine
+	// failure to reserve.
+	DefaultReadyTimeout = 10 * time.Second
+	// DefaultReadyPollInterval is the readiness-gate re-check cadence.
+	DefaultReadyPollInterval = 100 * time.Millisecond
 )
 
 // withDefaults returns a copy of c with any unset field filled from the
@@ -133,6 +150,12 @@ func (c Config) withDefaults() Config {
 	}
 	if c.RPCTimeout <= 0 {
 		c.RPCTimeout = DefaultRPCTimeout
+	}
+	if c.ReadyTimeout <= 0 {
+		c.ReadyTimeout = DefaultReadyTimeout
+	}
+	if c.ReadyPollInterval <= 0 {
+		c.ReadyPollInterval = DefaultReadyPollInterval
 	}
 	return c
 }
@@ -199,12 +222,25 @@ func defaultDialer(target string) (grpc.ClientConnInterface, func() error, error
 	return conn, conn.Close, nil
 }
 
+// TerminalCallback is invoked by an experiment game's background goroutine the
+// instant the game reaches a terminal outcome (#1014), carrying the
+// coordinator game_id and the classified Outcome. It is the SYNCHRONOUS,
+// telemetry-independent signal the experiment registry uses to release the
+// in-flight slot for a game that did NOT conclude with a usable fitness sample
+// (game_error / force-end / abort), so the effective_concurrency=1 loop can never
+// deadlock waiting on a metric that may never arrive for a failed game. It is
+// only ever called for an EXPERIMENT-bound game (StartExperimentGame).
+type TerminalCallback func(gameID string, outcome Outcome)
+
 // Runner drives shadow games against a coordinator + mock control service.
 type Runner struct {
 	cfg    Config
 	log    *slog.Logger
 	tracer trace.Tracer
 	dial   dialer
+	// onTerminal, when set, is called once an experiment game reaches a terminal
+	// outcome. nil ⇒ no callback (the #778 one-shot runner does not use it).
+	onTerminal TerminalCallback
 }
 
 // New builds a Runner with the given config. log may be nil (slog.Default used).
@@ -219,6 +255,12 @@ func New(cfg Config, log *slog.Logger) *Runner {
 		dial:   defaultDialer,
 	}
 }
+
+// SetTerminalCallback registers the #1014 terminal-outcome hook. It is invoked by
+// the background drive goroutine of StartExperimentGame the moment the game ends
+// (any outcome). The experiment loop wires it to release the in-flight slot for a
+// non-concluding outcome so the cohort loop cannot deadlock.
+func (r *Runner) SetTerminalCallback(cb TerminalCallback) { r.onTerminal = cb }
 
 // clients bundles the two gRPC clients a run needs plus their cleanup.
 type clients struct {
@@ -375,6 +417,20 @@ func (r *Runner) StartExperimentGame(startCtx, driveCtx context.Context, spec Sp
 		r.log.Info("experiment shadow game finished",
 			"game_id", gameID, "run_id", spec.RunID, "experiment_id", spec.ExperimentID,
 			"arm", spec.Arm, "outcome", outcome, "terminal_event", terminal)
+
+		// Terminal-outcome hook (#1014): signal the registry the moment the game
+		// ends, regardless of outcome. For a game that did NOT conclude with a
+		// usable fitness sample (game_error / force-end / abort) the telemetry
+		// game_active=0 → ConcludeGame path may never fire (a game that errored at
+		// admission can be coalesced or lose its experiment attribution), leaking
+		// the in-flight slot and DEADLOCKING the effective_concurrency=1 loop. This
+		// hook lets the loop release the slot directly. It is a no-op when the
+		// telemetry path already concluded the game (ReleaseGame is idempotent on an
+		// unknown game_id). Runs BEFORE the deferred controller removal so the slot
+		// and the controllers free together.
+		if r.onTerminal != nil {
+			r.onTerminal(gameID, outcome)
+		}
 	}()
 
 	return gameID, nil

--- a/services/agent/gamerunner/terminal_callback_test.go
+++ b/services/agent/gamerunner/terminal_callback_test.go
@@ -1,0 +1,121 @@
+package gamerunner
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	gcpb "github.com/joustmania/agent/gen/game_coordinator"
+)
+
+// captureTerminal records the (gameID, outcome) the runner reports.
+type captureTerminal struct {
+	mu     sync.Mutex
+	gameID string
+	out    Outcome
+	fired  bool
+}
+
+func (c *captureTerminal) cb(gameID string, outcome Outcome) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.gameID = gameID
+	c.out = outcome
+	c.fired = true
+}
+
+func (c *captureTerminal) snapshot() (string, Outcome, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.gameID, c.out, c.fired
+}
+
+// TestStartExperimentGame_TerminalCallbackFiresOnError covers the #1014 backstop:
+// a game that ends in game_error must invoke the terminal callback with the
+// errored game's id and OutcomeError, so the registry can release the in-flight
+// slot directly (the telemetry-independent deadlock backstop).
+func TestStartExperimentGame_TerminalCallbackFiresOnError(t *testing.T) {
+	mock := &fakeMock{}
+	coord := &fakeCoord{
+		gameID: "game_err_001",
+		events: []*gcpb.GameEvent{ev("game_starting"), ev("game_error")},
+	}
+	h := newHarness(t, mock, coord)
+	defer h.stop()
+
+	cap := &captureTerminal{}
+	h.runner.SetTerminalCallback(cap.cb)
+
+	driveCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	spec := Spec{
+		RunID: "r", GameName: "JoustFFA", Players: 2, Sensitivity: 2,
+		ExperimentID: "exp_x", Arm: "experimental",
+	}
+	gameID, err := h.runner.StartExperimentGame(context.Background(), driveCtx, spec)
+	if err != nil {
+		t.Fatalf("StartExperimentGame error: %v", err)
+	}
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, _, fired := cap.snapshot(); fired {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	gotID, gotOut, fired := cap.snapshot()
+	if !fired {
+		t.Fatal("terminal callback never fired for a game_error game")
+	}
+	if gotID != gameID {
+		t.Errorf("callback game_id = %q, want %q", gotID, gameID)
+	}
+	if gotOut != OutcomeError {
+		t.Errorf("callback outcome = %q, want %q", gotOut, OutcomeError)
+	}
+}
+
+// TestStartExperimentGame_TerminalCallbackFiresOnComplete confirms the callback
+// ALSO fires for a naturally completed game (with OutcomeCompleted) — the loop
+// uses the outcome to decide release-vs-conclude, so it must always be informed.
+func TestStartExperimentGame_TerminalCallbackFiresOnComplete(t *testing.T) {
+	mock := &fakeMock{}
+	coord := &fakeCoord{
+		gameID: "game_ok_001",
+		events: []*gcpb.GameEvent{ev("game_starting"), ev("game_ended")},
+	}
+	h := newHarness(t, mock, coord)
+	defer h.stop()
+
+	cap := &captureTerminal{}
+	h.runner.SetTerminalCallback(cap.cb)
+
+	driveCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	spec := Spec{
+		RunID: "r", GameName: "JoustFFA", Players: 2, Sensitivity: 2,
+		ExperimentID: "exp_x", Arm: "control",
+	}
+	if _, err := h.runner.StartExperimentGame(context.Background(), driveCtx, spec); err != nil {
+		t.Fatalf("StartExperimentGame error: %v", err)
+	}
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, _, fired := cap.snapshot(); fired {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	_, gotOut, fired := cap.snapshot()
+	if !fired {
+		t.Fatal("terminal callback never fired for a completed game")
+	}
+	if gotOut != OutcomeCompleted {
+		t.Errorf("callback outcome = %q, want %q", gotOut, OutcomeCompleted)
+	}
+}

--- a/services/agent/shadow_spawner.go
+++ b/services/agent/shadow_spawner.go
@@ -46,7 +46,19 @@ type shadowSpawner struct {
 	// shutdown (ctx cancel) stops in-flight shadow games and never leaks a goroutine
 	// (mirrors the #917 SetRootContext pattern). Set via SetRootContext before run.
 	root context.Context
+
+	// onTerminal, when set, is invoked the moment a spawned game reaches a terminal
+	// outcome (#1014). The experiment loop wires it to the registry so a game that
+	// ended WITHOUT a usable fitness sample (game_error / force-end) has its
+	// in-flight slot released directly, independent of the telemetry path — the
+	// deadlock backstop for effective_concurrency=1.
+	onTerminal gamerunner.TerminalCallback
 }
+
+// SetTerminalCallback registers the #1014 terminal-outcome hook, propagated to
+// every per-spawn gamerunner so the registry frees the slot for a non-concluding
+// game even if the telemetry game_active=0 path never fires for it.
+func (s *shadowSpawner) SetTerminalCallback(cb gamerunner.TerminalCallback) { s.onTerminal = cb }
 
 // newShadowSpawner builds the spawner over the gamerunner config + a template spec
 // drawn from the SHADOW_GAME_* env (the same spec the #778 one-shot runner uses), so
@@ -82,6 +94,9 @@ func (s *shadowSpawner) Spawn(ctx context.Context, experimentID, arm string) (st
 	spec.Arm = arm
 
 	runner := gamerunner.New(s.cfg, s.log)
+	if s.onTerminal != nil {
+		runner.SetTerminalCallback(s.onTerminal)
+	}
 
 	gameID, err := runner.StartExperimentGame(ctx, s.root, spec)
 	if err != nil {

--- a/services/controller_manager/multiplexer/mock_adapter.py
+++ b/services/controller_manager/multiplexer/mock_adapter.py
@@ -86,6 +86,14 @@ class MockAdapter(ControllerIOAdapter):
         self._num_controllers = num_controllers
         self.controllers: dict[str, dict] = {}
         self._observers: list[asyncio.Queue] = []
+        # Monotonic serial counter for auto-generated serials. It NEVER decreases,
+        # even when controllers are removed, so a freshly added controller can never
+        # collide with one whose removal is still in flight (issue #1013): the old
+        # len()-based scheme reused MOCK000N after a removal, so a new AddControllers
+        # could hand back a serial already held by a not-yet-removed prior game,
+        # collapsing two distinct players to one serial and aborting FFA with
+        # "Need at least 2 players, got 1".
+        self._next_serial = 0
         logger.info(f"MockAdapter initialized with {num_controllers} controllers")
 
     @property
@@ -271,7 +279,16 @@ class MockAdapter(ControllerIOAdapter):
             tag: Identifies the owning agent/game (orphan cleanup, debugging).
         """
         if serial is None:
-            serial = f"MOCK{len(self.controllers):04d}"
+            # Use a monotonic counter (never reused after removal) so an
+            # auto-generated serial is globally unique for the adapter's lifetime
+            # and cannot collide with a controller whose removal is still in flight
+            # (#1013). Skip any serial that somehow already exists (e.g. a caller
+            # passed an explicit "MOCK000N" earlier) to keep the guarantee absolute.
+            serial = f"MOCK{self._next_serial:04d}"
+            self._next_serial += 1
+            while serial in self.controllers:
+                serial = f"MOCK{self._next_serial:04d}"
+                self._next_serial += 1
         if serial in self.controllers:
             logger.warning(f"Mock: Controller {serial} already exists")
             return serial

--- a/services/controller_manager/tests/test_mock_adapter.py
+++ b/services/controller_manager/tests/test_mock_adapter.py
@@ -253,6 +253,51 @@ class TestMockAdapterExtraMethods:
         serial = adapter.add_controller("mock_controller_0")
         assert serial == "mock_controller_0"
 
+    def test_auto_serial_is_monotonic_and_never_reused_after_removal(self):
+        """Regression for #1013: auto-generated serials must never be reused.
+
+        The old len()-based scheme generated MOCK{len(controllers):04d}, so a
+        removal shrank len() and the NEXT add re-minted a just-removed serial.
+        When the previous shadow game's controllers were still being removed, a
+        new AddControllers could hand back a serial already held by a not-yet-
+        removed controller, collapsing two distinct players to one serial and
+        aborting FFA with "Need at least 2 players, got 1". A monotonic counter
+        guarantees every auto serial is unique for the adapter's lifetime.
+        """
+        adapter = MockAdapter(num_controllers=0)
+        adapter.discover()
+
+        # Game 1 reserves two controllers.
+        a = adapter.add_controller()
+        b = adapter.add_controller()
+        assert [a, b] == ["MOCK0000", "MOCK0001"]
+
+        # Game 1 ends: remove ONE controller (simulating an in-flight cleanup
+        # where the other removal has not landed yet).
+        assert adapter.remove_controller(a) is True
+
+        # Game 2 reserves two more. Under the old len()-based scheme call 1 would
+        # have re-minted MOCK0001 (len()==1) — colliding with the surviving b and
+        # returning a DUPLICATE. The monotonic counter keeps every serial unique.
+        c = adapter.add_controller()
+        d = adapter.add_controller()
+        assert c not in (a, b), f"reused a prior serial: {c}"
+        assert d not in (a, b, c), f"reused a prior serial: {d}"
+        assert c != d, "AddControllers handed back two identical serials"
+        # All currently-tracked serials are distinct.
+        assert len(set(adapter.controllers)) == len(adapter.controllers)
+
+    def test_auto_serial_skips_collisions_with_explicit_serials(self):
+        """A monotonic auto serial that collides with an earlier explicit add
+        is skipped, preserving the uniqueness guarantee (#1013)."""
+        adapter = MockAdapter(num_controllers=0)
+        adapter.discover()
+        # Pre-seed the serial the counter would generate first.
+        adapter.add_controller("MOCK0000")
+        auto = adapter.add_controller()
+        assert auto != "MOCK0000"
+        assert auto in adapter.controllers
+
     def test_remove_controller(self):
         adapter = MockAdapter(num_controllers=1)
         adapter.discover()


### PR DESCRIPTION
Fixes two related bugs in the agent's shadow-game lifecycle, both surfaced in the 2026-06-14 post-fix validation dry run. They live in the same gamerunner spawn→drive→finish path, so they are fixed together.

Part of #1013 and #1014.

## #1013 — shadow games intermittently start with <2 players → FFA `game_error`

**Confirmed race (root cause):** the mock controller adapter generated auto serials as `MOCK{len(self.controllers):04d}`. A shadow game's reserved controllers are removed asynchronously (the drive goroutine's deferred cleanup). When game *N*'s removal was still in flight, game *N+1*'s `AddControllers(count=2)` re-minted a serial still held by a not-yet-removed controller — `add_controller` saw it already existed and returned it **without adding**, so `AddControllers` handed back a **duplicate serial** (`["MOCK0001", "MOCK0001"]`). The game roster is a serial-keyed dict, so the two identical serials collapse to one player and FFA aborts in `_initialize_players` with `Need at least 2 players, got 1`. This was intermittent (only when a removal raced a reservation) and only fatal once #998 capped effective concurrency at 1.

**Fixes (defense in depth):**
- **Mock adapter (root cause):** a monotonic `_next_serial` counter that is never reused after a removal, so an auto serial is globally unique for the adapter's lifetime and can never collide with an in-flight removal.
- **gamerunner `reserveControllers`:** reject duplicate serials outright (never start an under-populated game), plus a **readiness gate** that polls `ListMockControllers` until every reserved serial is visible (bounded by `ReadyTimeout`) before `StartExperimentGame` admits — so a spawned game reliably fields all `spec.Players` controllers. `spec.Players` is already env-clamped to ≥2 (default 4).

## #1014 — `game_error` leaks the in-flight slot → deadlock at `effective_concurrency=1`

Slot release relied **solely** on the telemetry `game_active=0` → `onGameEnd` → `ConcludeGame` path. For a game that errors at admission that signal can be coalesced or lose its experiment attribution, so `ConcludeGame` never fires — leaking the only in-flight slot and hard-deadlocking the loop (`in_flight=1`, no further spawns).

**Fix — terminal-outcome backstop:** the drive goroutine in `StartExperimentGame` now invokes a `TerminalCallback` on **any** terminal outcome. The experiment loop wires it so a **non-concluding** outcome (`game_error` / force-end / abort) calls the new `Registry.ReleaseGame` — an **idempotent, NON-COUNTING** release that frees the in-flight slot and removes its controllers **without** folding a fitness sample (a transient failure must not pollute the cohort with a fabricated 0). The controllers are still removed by the existing deferred cleanup. A naturally **completed** game is left to the telemetry conclude path so it keeps its real fitness sample. Result: at `effective_concurrency=1` an errored game frees the slot and the loop spawns the next game — no deadlock. A `game_released` journal event records the non-counting release for the audit trail.

## Tests
- `gamerunner`: readiness gate waits for delayed registration; duplicate-serial rejection; readiness timeout; terminal callback fires with `OutcomeError` on `game_error` and `OutcomeCompleted` on `game_ended`.
- `experiment`: `ReleaseGame` frees the slot without folding a sample (count stays 0, `game_released` recorded, no `game_concluded`); idempotent; **`effective_concurrency=1` no-deadlock regression** (errored game frees the only slot, next allocate spawns).
- `experiment_loop`: `onGameTerminal` releases an errored game's binding (and does not on a completed game).
- `controller_manager`: monotonic-serial regression (no reuse after removal; explicit-serial collision skip).

Validation: `go test ./... -race`, `go vet ./...`, `gofmt -l .` clean; `make lint` (ruff) passes; relevant Python suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)