### PR TITLE
fix(agent): bounded-grace backstop for completed shadow game slot leak (#1020)

### DIFF
--- a/services/agent/experiment_loop.go
+++ b/services/agent/experiment_loop.go
@@ -116,6 +116,14 @@ type experimentLoop struct {
 	// them on shutdown (no goroutine/timer leak past teardown).
 	graceMu     sync.Mutex
 	graceTimers map[string]func() bool
+	// graceShutdown is set under graceMu by stopAllCompletedGrace and checked at the
+	// top of fireCompletedGrace. time.AfterFunc(...).Stop() does NOT wait for an
+	// already-firing callback, so on shutdown a grace goroutine can enter
+	// fireCompletedGrace after run() has called stopAllCompletedGrace() and returned.
+	// This flag makes that already-firing callback bail (drop its entry and return
+	// without ReleaseGame/allocate) so no shadow game is spawned during/after
+	// shutdown — honoring run()'s "no goroutine outlives run()" contract (#1020).
+	graceShutdown bool
 }
 
 // gameFitnessFunc scores a finished game (its pre-reset GameContext) into one
@@ -438,6 +446,14 @@ func (e *experimentLoop) armCompletedGrace(gameID string) {
 func (e *experimentLoop) fireCompletedGrace(gameID string) {
 	e.graceMu.Lock()
 	delete(e.graceTimers, gameID)
+	// Shutdown race guard (#1020): if stopAllCompletedGrace already ran, this timer
+	// was firing while run() tore down (its Stop() returned false — too late). Drop
+	// the entry and bail WITHOUT ReleaseGame/allocate so we never spawn a shadow game
+	// during/after shutdown. Both setter and checker hold graceMu, so this is race-free.
+	if e.graceShutdown {
+		e.graceMu.Unlock()
+		return
+	}
 	e.graceMu.Unlock()
 
 	reason := "completed game's telemetry game_active=0 datapoint never arrived (#1020 grace backstop)"
@@ -472,6 +488,9 @@ func (e *experimentLoop) stopCompletedGrace(gameID string) {
 // cancellation alongside AbortAll.
 func (e *experimentLoop) stopAllCompletedGrace() {
 	e.graceMu.Lock()
+	// Latch shutdown FIRST: any callback already firing (whose Stop() returns false)
+	// will observe this under graceMu in fireCompletedGrace and bail without spawning.
+	e.graceShutdown = true
 	for id, stop := range e.graceTimers {
 		stop()
 		delete(e.graceTimers, id)

--- a/services/agent/experiment_loop.go
+++ b/services/agent/experiment_loop.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/joustmania/agent/decision"
@@ -43,6 +44,13 @@ const (
 	// registry refills free shadow capacity on each tick.
 	envExperimentTick = "AGENT_EXPERIMENT_TICK_SECONDS"
 
+	// envCompletedGrace overrides the bounded-grace backstop window (seconds) for a
+	// COMPLETED shadow game whose telemetry game_active=0 datapoint never arrives
+	// (#1020). After this grace elapses without ConcludeGame having folded the game,
+	// onGameTerminal releases its in-flight slot non-counting so the
+	// effective_concurrency=1 loop cannot deadlock on a dropped completed datapoint.
+	envCompletedGrace = "AGENT_EXPERIMENT_COMPLETED_GRACE_SECONDS"
+
 	// Seed-experiment env vars (the simplest env-gated declaration trigger; see
 	// the declaration-trigger note below). When envSeedFlag is set the loop
 	// Declares ONE experiment at startup so the cohort loop has something to run.
@@ -56,6 +64,17 @@ const (
 // defaultExperimentTick is the AllocateAndSpawn cadence when unset. Shadow games
 // are minutes-long, so a 30s refill tick is ample headroom over game duration.
 const defaultExperimentTick = 30 * time.Second
+
+// defaultCompletedGrace is the bounded-grace window (#1020) for a COMPLETED game
+// whose telemetry game_active=0 datapoint may never arrive. It must COMFORTABLY
+// exceed the worst-case telemetry-arrival lag so a game that concludes slightly
+// late is still CONCLUDED with its real fitness sample (the grace fires only after
+// ConcludeGame has had ample time and still has not folded the game). The
+// game-end datapoint is emitted at session teardown and folded by onGameEnd within
+// a handful of seconds in practice; 60s is an order of magnitude over that typical
+// conclude latency yet still bounded — far short of leaking the slot "forever",
+// which is the failure this backstop removes. Tunable via envCompletedGrace.
+const defaultCompletedGrace = 60 * time.Second
 
 // experimentsEnabled reports whether the experiment LOOP opt-in is on. This is the
 // distinct, default-off gate (#991) — separate from the code-improvement gate.
@@ -82,6 +101,21 @@ type experimentLoop struct {
 	// fitness maps a game-end GameContext to a single fitness scalar fed to
 	// ConcludeGame. Injected so it is overridable / testable.
 	fitness gameFitnessFunc
+
+	// completedGrace is the bounded-grace window (#1020): how long onGameTerminal
+	// waits after a COMPLETED game before releasing its in-flight slot non-counting
+	// if ConcludeGame has not folded it. Resolved from envCompletedGrace.
+	completedGrace time.Duration
+
+	// afterFunc schedules f to run after d, returning a stop func (true if it
+	// cancelled a not-yet-fired timer). Defaults to a time.AfterFunc adapter;
+	// tests inject a fake clock so the grace can fire without a real sleep.
+	afterFunc func(d time.Duration, f func()) (stop func() bool)
+
+	// graceMu guards the set of pending completed-grace timers so run() can stop
+	// them on shutdown (no goroutine/timer leak past teardown).
+	graceMu     sync.Mutex
+	graceTimers map[string]func() bool
 }
 
 // gameFitnessFunc scores a finished game (its pre-reset GameContext) into one
@@ -113,6 +147,7 @@ func buildExperimentLoop(
 
 	logger.Warn("Experiment cohort loop ENABLED (#991, epic #982) — opt-in is ON",
 		"tick", experimentTick(),
+		"completed_grace", completedGrace(),
 		"max_shadow_games", experiment.MaxShadowGamesFromEnv(),
 		"effective_concurrency", experiment.EffectiveConcurrencyFromEnv(),
 		"seed_flag", os.Getenv(envSeedFlag))
@@ -142,13 +177,14 @@ func buildExperimentLoop(
 	})
 
 	loop := &experimentLoop{
-		registry: registry,
-		spawner:  spawner,
-		flags:    flagsClient,
-		log:      logger,
-		tick:     experimentTick(),
-		seed:     seedIntentFromEnv(),
-		fitness:  defaultGameFitness,
+		registry:       registry,
+		spawner:        spawner,
+		flags:          flagsClient,
+		log:            logger,
+		tick:           experimentTick(),
+		seed:           seedIntentFromEnv(),
+		fitness:        defaultGameFitness,
+		completedGrace: completedGrace(),
 	}
 	// Wire the #1014 terminal-outcome backstop: each spawned game signals its
 	// terminal outcome here, and a non-concluding game releases its in-flight slot
@@ -209,8 +245,11 @@ func (e *experimentLoop) run(ctx context.Context) {
 		select {
 		case <-ctx.Done():
 			// Shutdown / kill-switch teardown: abort every live experiment so its
-			// targeting branch is stripped and capacity released. Use a short
-			// background context so teardown's file I/O still runs after ctx cancel.
+			// targeting branch is stripped and capacity released. Cancel any pending
+			// completed-grace timers first so none fires after the loop returns (#1020).
+			e.stopAllCompletedGrace()
+			// Use a short background context so teardown's file I/O still runs after
+			// ctx cancel.
 			tctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			ids := e.registry.AbortAll(tctx, "agent shutdown")
 			cancel()
@@ -324,23 +363,28 @@ func (e *experimentLoop) onGameEnd(gc gamecontext.GameContext) {
 func (e *experimentLoop) onGameTerminal(gameID string, outcome gamerunner.Outcome) {
 	if outcome == gamerunner.OutcomeCompleted {
 		// Natural completion: the telemetry path (onGameEnd → ConcludeGame) concludes
-		// it WITH its fitness sample. We deliberately do NOT release here because that
-		// would drop the sample (ReleaseGame is non-counting).
+		// it WITH its fitness sample. We deliberately do NOT release here on the
+		// HAPPY path because that would drop the sample (ReleaseGame is non-counting).
 		//
-		// KNOWN RESIDUAL RISK (#1014 follow-up): this trusts the telemetry
-		// game_active=0 datapoint to arrive for a COMPLETED game — the same signal this
-		// very backstop calls unreliable for ERRORED games. If telemetry drops a
-		// completed game's datapoint, its in-flight slot leaks identically and the
-		// effective_concurrency=1 loop deadlocks. The asymmetry is intentional for now:
-		// an errored game routinely loses its attribution (it can error at admission,
-		// before the experiment_id is ever stamped onto a span/metric), whereas a
-		// completed game has played long enough to emit a fully-attributed game-end
-		// datapoint, so the completed path is materially more reliable. A bounded
-		// grace backstop that releases a still-in-flight COMPLETED game non-counting
-		// after a timeout is the durable fix; it is tracked as a follow-up (#1020)
-		// rather than built here (it needs care not to race the fitness fold).
+		// BOUNDED-GRACE BACKSTOP (#1020): the completed-game path trusts the telemetry
+		// game_active=0 datapoint to arrive — the same signal #1014 treats as
+		// unreliable for ERRORED games. If telemetry DROPS a completed game's
+		// datapoint, its in-flight slot would leak forever and the
+		// effective_concurrency=1 loop deadlocks (#998). So arm a generous grace
+		// timer: if ConcludeGame has NOT folded this game by the time it fires, release
+		// the slot non-counting. The grace COMFORTABLY exceeds worst-case telemetry lag
+		// (defaultCompletedGrace), so a game that concludes slightly late still folds
+		// its sample first — and because ReleaseGame/ConcludeGame are idempotent (both
+		// findGameLocked → delete; whoever runs second no-ops), the timer firing AFTER
+		// a legitimate conclude is a harmless no-op. The only sacrifice is a real-but-
+		// very-late conclude arriving AFTER the grace, which the issue accepts.
+		e.armCompletedGrace(gameID)
 		return
 	}
+	// A non-completed terminal outcome supersedes any pending completed-grace timer
+	// for this id (defensive: the runner reports one terminal outcome per game, but
+	// stop the timer so it can never double-release a since-reused id).
+	e.stopCompletedGrace(gameID)
 	reason := "game ended without usable fitness sample: " + string(outcome)
 	if e.registry.ReleaseGame(gameID, reason) {
 		e.log.Warn("experiment: released in-flight slot for non-concluding game (#1014)",
@@ -351,6 +395,88 @@ func (e *experimentLoop) onGameTerminal(gameID string, outcome gamerunner.Outcom
 		// own RPC + ready timeouts, so an unbounded Background cannot stall here.
 		e.allocateIfEnabled(context.Background())
 	}
+}
+
+// armCompletedGrace schedules the #1020 bounded-grace backstop for a COMPLETED
+// game: after e.completedGrace, if ConcludeGame has not folded the game, release
+// its in-flight slot non-counting (no fabricated fitness sample) so the
+// effective_concurrency=1 loop cannot deadlock on a dropped game_active=0
+// datapoint. The timer is tracked so run() can stop it on shutdown, and is
+// self-removing once it fires.
+func (e *experimentLoop) armCompletedGrace(gameID string) {
+	if e.completedGrace <= 0 {
+		return // grace disabled (non-positive) — preserve the pre-#1020 trust-telemetry behavior.
+	}
+	after := e.afterFunc
+	if after == nil {
+		after = func(d time.Duration, f func()) func() bool {
+			t := time.AfterFunc(d, f)
+			return t.Stop
+		}
+	}
+	e.graceMu.Lock()
+	if e.graceTimers == nil {
+		e.graceTimers = make(map[string]func() bool)
+	}
+	// Replace any prior timer for this id (a reused/duplicate signal): stop the old
+	// one first so only one grace fires per live binding.
+	if stop, ok := e.graceTimers[gameID]; ok {
+		stop()
+	}
+	stop := after(e.completedGrace, func() { e.fireCompletedGrace(gameID) })
+	e.graceTimers[gameID] = stop
+	e.graceMu.Unlock()
+}
+
+// fireCompletedGrace is the grace-timer callback: it forgets the timer and, if the
+// game is still in-flight (ConcludeGame never folded it — a dropped telemetry
+// datapoint), releases its slot non-counting and refills. If ConcludeGame already
+// ran, ReleaseGame finds nothing and no-ops (slot freed, sample folded already), so
+// a legitimate late conclude is never clobbered — the idempotency the #1019 review
+// verified. A fired backstop is logged distinctly so a real telemetry drop is
+// OBSERVABLE rather than silent.
+func (e *experimentLoop) fireCompletedGrace(gameID string) {
+	e.graceMu.Lock()
+	delete(e.graceTimers, gameID)
+	e.graceMu.Unlock()
+
+	reason := "completed game's telemetry game_active=0 datapoint never arrived (#1020 grace backstop)"
+	if e.registry.ReleaseGame(gameID, reason) {
+		// The slot was STILL in-flight after the full grace ⇒ the completed game's
+		// conclude datapoint was genuinely dropped. Audit it at Warn (distinct from the
+		// normal conclude path) so the drop is visible in the agent's logs/metrics.
+		e.log.Warn("experiment: completed-game grace backstop fired — released leaked slot (#1020)",
+			"game_id", gameID, "grace", e.completedGrace)
+		// Refill the freed slot (respecting the kill-switch). context.Background is
+		// intentional here for the same reason as the #1014 release path: this runs on
+		// a runtime timer goroutine with no request/tick context to thread.
+		e.allocateIfEnabled(context.Background())
+	}
+	// else: ConcludeGame already folded the game — the happy path won the race and the
+	// backstop is a silent no-op (no slot freed, sample already counted).
+}
+
+// stopCompletedGrace cancels and forgets a pending completed-grace timer for
+// gameID, if any. It is idempotent (a missing entry is a no-op).
+func (e *experimentLoop) stopCompletedGrace(gameID string) {
+	e.graceMu.Lock()
+	if stop, ok := e.graceTimers[gameID]; ok {
+		stop()
+		delete(e.graceTimers, gameID)
+	}
+	e.graceMu.Unlock()
+}
+
+// stopAllCompletedGrace cancels every pending completed-grace timer (shutdown
+// teardown), so no timer fires after the loop returns. Called from run() on ctx
+// cancellation alongside AbortAll.
+func (e *experimentLoop) stopAllCompletedGrace() {
+	e.graceMu.Lock()
+	for id, stop := range e.graceTimers {
+		stop()
+		delete(e.graceTimers, id)
+	}
+	e.graceMu.Unlock()
 }
 
 // defaultGameFitness scores a finished game into one fitness scalar in [0,1] using
@@ -438,6 +564,20 @@ func experimentTick() time.Duration {
 		}
 	}
 	return defaultExperimentTick
+}
+
+// completedGrace resolves the #1020 bounded-grace window from
+// AGENT_EXPERIMENT_COMPLETED_GRACE_SECONDS, falling back to defaultCompletedGrace
+// on an unset/invalid value. A value of 0 (or negative) explicitly DISABLES the
+// backstop — restoring the pre-#1020 trust-telemetry behavior — which is why a
+// non-positive override is honored verbatim rather than coerced to the default.
+func completedGrace() time.Duration {
+	if v := strings.TrimSpace(os.Getenv(envCompletedGrace)); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			return time.Duration(n) * time.Second
+		}
+	}
+	return defaultCompletedGrace
 }
 
 // seedIntentFromEnv builds the single seed experiment Intent from the

--- a/services/agent/experiment_loop_test.go
+++ b/services/agent/experiment_loop_test.go
@@ -453,6 +453,219 @@ func gameStillBound(loop *experimentLoop, expID, gameID string) bool {
 	return assigned
 }
 
+// fakeAfter is an injectable afterFunc (#1020) that captures scheduled callbacks
+// instead of relying on the wall clock, so the bounded-grace backstop can be fired
+// deterministically in a test without sleeping the real grace (60s by default).
+type fakeAfter struct {
+	mu      sync.Mutex
+	pending map[int]func()
+	seq     int
+}
+
+func newFakeAfter() *fakeAfter { return &fakeAfter{pending: map[int]func(){}} }
+
+// schedule matches the experimentLoop.afterFunc signature: it stores f under a
+// fresh id and returns a stop func that removes it (true if it was still pending).
+func (f *fakeAfter) schedule(_ time.Duration, fn func()) func() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.seq++
+	id := f.seq
+	f.pending[id] = fn
+	return func() bool {
+		f.mu.Lock()
+		defer f.mu.Unlock()
+		if _, ok := f.pending[id]; ok {
+			delete(f.pending, id)
+			return true
+		}
+		return false
+	}
+}
+
+// fireAll invokes (and removes) every still-pending timer — simulating the grace
+// window elapsing. Returns how many fired.
+func (f *fakeAfter) fireAll() int {
+	f.mu.Lock()
+	fns := make([]func(), 0, len(f.pending))
+	for id, fn := range f.pending {
+		fns = append(fns, fn)
+		delete(f.pending, id)
+	}
+	f.mu.Unlock()
+	for _, fn := range fns {
+		fn()
+	}
+	return len(fns)
+}
+
+func (f *fakeAfter) pendingCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.pending)
+}
+
+// TestExperimentLoop_CompletedGrace_ReleasesOnDroppedDatapoint is the headline
+// #1020 AC: a COMPLETED shadow game whose telemetry game_active=0 datapoint never
+// arrives (onGameEnd → ConcludeGame never runs) has its in-flight slot released by
+// the bounded-grace backstop after the grace elapses — so the loop can spawn again
+// at effective_concurrency=1 instead of deadlocking on the leaked slot. The grace
+// is fired via an injected fake clock so the test does not sleep the real 60s.
+func TestExperimentLoop_CompletedGrace_ReleasesOnDroppedDatapoint(t *testing.T) {
+	spawner := &recordingSpawner{}
+	resolve := func(context.Context) promote.Config { return promote.Config{Mode: promote.ModeIssue} }
+	loop := buildLoopForTest(t, spawner, resolve, &recordingRealDefault{}, &recordingGitHub{}, armFitness())
+	ctx := context.Background()
+
+	// Pin effective_concurrency=1 (the #998 default that #1014/#1020 protect): a
+	// single leaked slot is a full deadlock. A fake clock drives the grace.
+	fake := newFakeAfter()
+	loop.afterFunc = fake.schedule
+	loop.completedGrace = 60 * time.Second
+	loop.registry = newRegistryConcurrency1(t, spawner, resolve)
+
+	id, err := loop.registry.Declare(experiment.Intent{
+		Hypothesis: "h", FlagKey: "death_grace_period_seconds",
+		ExperimentalValue: 0.5, Objective: "engagement_balanced", TargetNPerArm: 5,
+	})
+	if err != nil {
+		t.Fatalf("Declare: %v", err)
+	}
+	if err := loop.registry.Start(ctx, id); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	if n := loop.registry.AllocateAndSpawn(ctx); n == 0 {
+		t.Fatal("expected a spawn")
+	}
+	recs := spawner.drain()
+	if len(recs) != 1 {
+		t.Fatalf("expected exactly 1 spawn at concurrency=1, got %d", len(recs))
+	}
+	first := recs[0].gameID
+
+	// The single slot is now occupied — a second allocate cannot spawn (deadlock
+	// territory if the slot never frees).
+	if n := loop.registry.AllocateAndSpawn(ctx); n != 0 {
+		t.Fatalf("concurrency=1 should block a second spawn while a slot is held, got %d", n)
+	}
+
+	// The game COMPLETES but its telemetry datapoint is DROPPED: onGameTerminal sees
+	// OutcomeCompleted (arming the grace) and onGameEnd → ConcludeGame NEVER fires.
+	loop.onGameTerminal(first, gamerunner.OutcomeCompleted)
+	if fake.pendingCount() != 1 {
+		t.Fatalf("completed game should arm exactly one grace timer, pending=%d", fake.pendingCount())
+	}
+	if !gameStillBound(loop, id, first) {
+		t.Fatal("before the grace fires the completed game must stay bound (a late conclude could still win)")
+	}
+
+	// Grace elapses with no conclude in sight ⇒ the backstop releases the slot AND
+	// (inside fireCompletedGrace) nudges AllocateAndSpawn to refill it, proving the
+	// loop makes progress again rather than deadlocking on the leaked slot.
+	if fired := fake.fireAll(); fired != 1 {
+		t.Fatalf("expected the grace timer to fire once, fired=%d", fired)
+	}
+	if gameStillBound(loop, id, first) {
+		t.Fatal("grace backstop did not release the leaked completed-game slot (#1020): deadlock at concurrency=1")
+	}
+	// The release was NON-COUNTING: no fabricated fitness sample folded.
+	cv, _ := loop.registry.CompactView(id)
+	for arm, a := range cv.Arms {
+		if a.Count != 0 {
+			t.Fatalf("arm %q folded a sample (count=%d); grace release must be non-counting", arm, a.Count)
+		}
+	}
+
+	// The freed slot WAS reused: the backstop's refill spawned a fresh game (a
+	// different game_id), so the loop is unblocked at concurrency=1.
+	refill := spawner.drain()
+	if len(refill) != 1 || refill[0].gameID == first {
+		t.Fatalf("grace backstop did not refill the freed slot with a new spawn (got %+v); loop still deadlocked", refill)
+	}
+}
+
+// TestExperimentLoop_CompletedGrace_NoReleaseWhenConcluded is the no-regression AC:
+// a normally-concluding completed game folds its fitness sample via the telemetry
+// onGameEnd → ConcludeGame path, and when the grace timer later fires it is a no-op
+// (ReleaseGame finds nothing — the game already left in-flight). The sample stays
+// counted; the backstop never fabricates a non-counting release for a healthy game.
+func TestExperimentLoop_CompletedGrace_NoReleaseWhenConcluded(t *testing.T) {
+	spawner := &recordingSpawner{}
+	resolve := func(context.Context) promote.Config { return promote.Config{Mode: promote.ModeIssue} }
+	loop := buildLoopForTest(t, spawner, resolve, &recordingRealDefault{}, &recordingGitHub{}, armFitness())
+	ctx := context.Background()
+
+	fake := newFakeAfter()
+	loop.afterFunc = fake.schedule
+	loop.completedGrace = 60 * time.Second
+
+	id, err := loop.registry.Declare(experiment.Intent{
+		Hypothesis: "h", FlagKey: "death_grace_period_seconds",
+		ExperimentalValue: 0.5, Objective: "engagement_balanced", TargetNPerArm: 5,
+	})
+	if err != nil {
+		t.Fatalf("Declare: %v", err)
+	}
+	if err := loop.registry.Start(ctx, id); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if n := loop.registry.AllocateAndSpawn(ctx); n == 0 {
+		t.Fatal("expected a spawn")
+	}
+	rec := spawner.drain()[0]
+
+	// Completed terminal arms the grace, THEN telemetry concludes it normally
+	// (folding the experimental arm's high fitness sample) — the healthy path.
+	loop.onGameTerminal(rec.gameID, gamerunner.OutcomeCompleted)
+	loop.onGameEnd(gcFor(rec.gameID, rec.experimentID, rec.arm))
+
+	if gameStillBound(loop, id, rec.gameID) {
+		t.Fatal("ConcludeGame should have folded + freed the game before the grace fires")
+	}
+	cv, _ := loop.registry.CompactView(id)
+	if cv.Arms[rec.arm].Count != 1 {
+		t.Fatalf("normal conclude must fold exactly 1 sample into arm %q, got count=%d", rec.arm, cv.Arms[rec.arm].Count)
+	}
+	folded := cv.Arms[rec.arm].Count
+
+	// The grace timer fires LATE (after the legitimate conclude already won the
+	// race). It must be a pure no-op: no extra release, the sample stays counted.
+	fake.fireAll()
+	cv2, _ := loop.registry.CompactView(id)
+	if cv2.Arms[rec.arm].Count != folded {
+		t.Fatalf("late grace timer changed the folded sample count (%d → %d): it must be a no-op",
+			folded, cv2.Arms[rec.arm].Count)
+	}
+	if gameStillBound(loop, id, rec.gameID) {
+		t.Fatal("late grace timer re-bound or disturbed the concluded game")
+	}
+}
+
+// newRegistryConcurrency1 builds a registry pinned to effective_concurrency=1 (one
+// in-flight shadow game cap) so the #1020 deadlock condition is exercised exactly
+// as the #998 default deploys it. It mirrors buildLoopForTest's registry wiring.
+func newRegistryConcurrency1(t *testing.T, spawner experiment.ShadowSpawner, resolve promote.ConfigResolver) *experiment.Registry {
+	t.Helper()
+	log := testLogger()
+	gamePath := newGameFileForLoop(t)
+	writer := experiment.NewWriter(gamePath, log)
+	gate := experiment.NewGate(writer, nil, log)
+	targeting := experiment.NewGateTargetingWriter(gate, writer)
+	base := promote.NewPromoter(&recordingGitHub{}, nil, &recordingRealDefault{}, nil, nil, promote.RepoRef{}, nil, log)
+	promo := promote.NewExperimentPromoter(base, resolve)
+	return experiment.NewRegistry(experiment.RegistryConfig{
+		Root:                 t.TempDir(),
+		MaxShadowGames:       8,
+		EffectiveConcurrency: 1,
+		Spawner:              spawner,
+		Verdict:              experiment.NewVerdict(3, 0.5, nil),
+		Promoter:             promo,
+		Targeting:            targeting,
+		Log:                  log,
+	})
+}
+
 // TestBuildExperimentLoop_DisabledByDefault is the disabled-default AC: with the
 // opt-in OFF (the default, env unset), buildExperimentLoop returns nil — NO
 // Registry, NO seams, NO goroutines. The agent's normal behavior is unchanged.

--- a/services/agent/experiment_loop_test.go
+++ b/services/agent/experiment_loop_test.go
@@ -642,6 +642,125 @@ func TestExperimentLoop_CompletedGrace_NoReleaseWhenConcluded(t *testing.T) {
 	}
 }
 
+// TestExperimentLoop_CompletedGrace_StopAllRaceGuard is the #1020 concurrency
+// regression anchor (review suggestion #3). It exercises the shutdown timer-fire
+// race that the synchronous fakeAfter seam cannot: grace timers are armed for
+// genuinely in-flight shadow games, then their callbacks fire on real goroutines
+// concurrently with stopAllCompletedGrace() from another goroutine. The afterFunc
+// seam returns a stop that always reports "too late" (false) — exactly the
+// adversarial case where time.AfterFunc(...).Stop() loses to an already-firing
+// callback — so the graceShutdown guard is the ONLY thing that can prevent a
+// callback firing after shutdown from calling ReleaseGame + allocateIfEnabled and
+// spawning a brand-new shadow game during/after teardown. Two assertions, both
+// load-bearing because the games are really bound (ReleaseGame would return true):
+//   - under -race: no data race / panic across the graceTimers map + guard;
+//   - callbacks that fire AFTER stopAll has returned (guard latched) must NOT spawn.
+func TestExperimentLoop_CompletedGrace_StopAllRaceGuard(t *testing.T) {
+	spawner := &recordingSpawner{}
+	resolve := func(context.Context) promote.Config { return promote.Config{Mode: promote.ModeIssue} }
+	loop := buildLoopForTest(t, spawner, resolve, &recordingRealDefault{}, &recordingGitHub{}, armFitness())
+	loop.completedGrace = 60 * time.Second
+	ctx := context.Background()
+
+	// captureAfter records each scheduled callback (instead of firing it on a wall
+	// clock) so the test fires them on real goroutines interleaved with stopAll. Its
+	// stop ALWAYS returns false, modeling a callback already past the point Stop()
+	// can cancel it — forcing the guard (not Stop) to be what blocks a post-shutdown spawn.
+	var capMu sync.Mutex
+	var callbacks []func()
+	captureAfter := func(_ time.Duration, fn func()) func() bool {
+		capMu.Lock()
+		callbacks = append(callbacks, fn)
+		capMu.Unlock()
+		return func() bool { return false }
+	}
+	loop.afterFunc = captureAfter
+
+	// Declare + start an experiment and put a game in-flight (AllocateAndSpawn spawns
+	// one per call into the free slot), so the armed grace timer is for a game the
+	// registry STILL holds — ReleaseGame would return true, meaning a non-guarded late
+	// callback WOULD ReleaseGame + refill-spawn a brand-new game during shutdown.
+	id, err := loop.registry.Declare(experiment.Intent{
+		Hypothesis: "h", FlagKey: "death_grace_period_seconds",
+		ExperimentalValue: 0.5, Objective: "engagement_balanced", TargetNPerArm: 50,
+	})
+	if err != nil {
+		t.Fatalf("Declare: %v", err)
+	}
+	if err := loop.registry.Start(ctx, id); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if n := loop.registry.AllocateAndSpawn(ctx); n == 0 {
+		t.Fatal("expected the registry to spawn into a free in-flight slot")
+	}
+	inFlight := spawner.drain()
+	if len(inFlight) == 0 {
+		t.Fatal("expected an in-flight shadow game to arm grace for")
+	}
+	boundGame := inFlight[0].gameID
+
+	// Phase 1 (race coverage): concurrently arm many grace timers for distinct (not
+	// in-flight) ids while stopAllCompletedGrace runs — this is the map-mutation +
+	// guard-latch interleaving the -race detector validates. These ids aren't bound,
+	// so even if a callback fires unguarded it can't spawn; the point here is purely
+	// no-data-race / no-panic on graceTimers + graceShutdown under concurrency.
+	const churn = 32
+	var armWG sync.WaitGroup
+	for i := 0; i < churn; i++ {
+		armWG.Add(1)
+		go func(n int) {
+			defer armWG.Done()
+			loop.armCompletedGrace("game_churn_" + itoa(n))
+		}(i)
+	}
+	armWG.Add(1)
+	go func() {
+		defer armWG.Done()
+		loop.stopAllCompletedGrace()
+	}()
+	armWG.Wait()
+
+	// Phase 2 (load-bearing guard assertion): stopAll has now latched graceShutdown.
+	// Arm grace for the STILL-in-flight game (armCompletedGrace records the timer even
+	// post-latch — only fireCompletedGrace is guarded), capture its callback, and fire
+	// it on goroutines. Each enters fireCompletedGrace with graceShutdown=true, so the
+	// guard must make it bail BEFORE ReleaseGame/allocateIfEnabled. Without the guard,
+	// it would ReleaseGame(true)+refill and spawn a brand-new game during shutdown.
+	capMu.Lock()
+	callbacks = nil // drop the phase-1 churn callbacks; we only fire the bound-game one.
+	capMu.Unlock()
+	loop.armCompletedGrace(boundGame)
+	capMu.Lock()
+	fired := append([]func(){}, callbacks...)
+	capMu.Unlock()
+	if len(fired) != 1 {
+		t.Fatalf("expected exactly one armed grace timer for the bound game, captured %d", len(fired))
+	}
+
+	var postWG sync.WaitGroup
+	for i := 0; i < 8; i++ { // fire the same callback repeatedly on goroutines (race + idempotency).
+		postWG.Add(1)
+		go func() {
+			defer postWG.Done()
+			fired[0]()
+		}()
+	}
+	postWG.Wait()
+
+	if recs := spawner.drain(); len(recs) != 0 {
+		t.Fatalf("grace callback spawned %d game(s) AFTER stopAll shutdown latched; the #1020 guard must prevent any post-shutdown spawn", len(recs))
+	}
+	if !gameStillBound(loop, id, boundGame) {
+		t.Fatal("the guarded callback released the in-flight game during shutdown; it must bail before ReleaseGame")
+	}
+	loop.graceMu.Lock()
+	shuttingDown := loop.graceShutdown
+	loop.graceMu.Unlock()
+	if !shuttingDown {
+		t.Fatal("stopAllCompletedGrace must latch graceShutdown so a later-firing callback bails")
+	}
+}
+
 // newRegistryConcurrency1 builds a registry pinned to effective_concurrency=1 (one
 // in-flight shadow game cap) so the #1020 deadlock condition is exercised exactly
 // as the #998 default deploys it. It mirrors buildLoopForTest's registry wiring.


### PR DESCRIPTION
Part of #1020. Follow-up to #1019 (#1014).

## Problem

`experimentLoop.onGameTerminal` deliberately no-ops for `OutcomeCompleted`, trusting the telemetry `game_active=0 → onGameEnd → ConcludeGame` path to fold the real fitness sample and free the in-flight registry slot. But that path trusts the very datapoint #1014 treats as unreliable. If telemetry drops a *completed* game's datapoint, its slot leaks forever, and at `effective_concurrency=1` (#998 default) the cohort loop deadlocks exactly as #1014 described — only for a completed game instead of an errored one.

## Fix — bounded grace backstop

When `onGameTerminal` sees `OutcomeCompleted` it now arms a bounded grace timer. After the grace elapses, if `ConcludeGame` has not folded the game (still in-flight), it calls `ReleaseGame` **non-counting** (no fabricated fitness sample) and refills the freed slot.

- **No race with the legitimate fold.** The grace comfortably exceeds worst-case telemetry lag, so a game that concludes slightly late still folds its sample first. Relies on the existing `ReleaseGame`/`ConcludeGame` idempotency (both `findGameLocked → delete`; whoever runs second no-ops) verified in #1019's review — a timer firing after a real conclude is a harmless no-op. The only sacrifice is a real-but-very-late conclude arriving *after* the grace, which the issue accepts.
- **No goroutine/timer leak.** `time.AfterFunc` (no persistent goroutine until fired); pending timers tracked in a map and stopped on shutdown alongside `AbortAll`.
- **Configurable.** `AGENT_EXPERIMENT_COMPLETED_GRACE_SECONDS`, default **60s** — an order of magnitude over the typical few-second conclude latency, yet bounded (vs. leaking "forever"). A non-positive value disables the backstop (restores pre-#1020 trust-telemetry behavior). Resolved the same way as the other `AGENT_EXPERIMENT_*` knobs.
- **Observable.** A fired backstop logs at `Warn` (distinct from the normal conclude path) so a real telemetry drop is visible, not silent.

The asymmetry comment in `onGameTerminal` is updated from "tracked as a follow-up (#1020)" to document the implemented backstop.

## Tests

- `TestExperimentLoop_CompletedGrace_ReleasesOnDroppedDatapoint`: a completed game whose `ConcludeGame` never arrives, pinned at `effective_concurrency=1`, has its slot released by the backstop and refilled with a fresh spawn (no deadlock). Non-counting verified (arm counts stay 0).
- `TestExperimentLoop_CompletedGrace_NoReleaseWhenConcluded`: a normally-concluding completed game folds its sample via `ConcludeGame`; the late grace timer is a pure no-op (sample count unchanged, no re-release).
- Both use an injected fake clock (`fakeAfter`) so the grace fires deterministically without sleeping 60s.
- Existing `experiment` / `experiment_loop` tests still pass (`go test ./... -race`, `go vet`, `gofmt -l`, `make lint` all green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)