### PR TITLE
fix(agent): persist experiment journal across container recreation (#1023)

### DIFF
--- a/docker-compose.dry-run.yml
+++ b/docker-compose.dry-run.yml
@@ -43,6 +43,12 @@ services:
     # mount (compose merges array values by default).
     volumes: !override
       - ./services/flagd/ci:/etc/flagd
+      # !override REPLACES the base agent volumes list, which would otherwise drop
+      # the durable experiment journal volume (#1023). Re-declare it here so the
+      # dry-run/demo stack also keeps cohort journal state across recreation. The
+      # top-level `agent-experiments:` volume is defined in docker-compose.yml and
+      # carries through the compose merge — no redeclaration needed here.
+      - agent-experiments:/var/lib/joustmania/agent/experiments
     environment:
       # Master opt-in for the #982/#991 experiment cohort loop.
       - AGENT_EXPERIMENTS_ENABLED=${AGENT_EXPERIMENTS_ENABLED:-true}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -680,6 +680,14 @@ services:
       # it and the game coordinator converges on its contents (#730). In-place
       # rewrite (no temp+rename) avoids EBUSY on this bind mount.
       - ./services/flagd:/etc/flagd
+      # Durable experiment journal (#1023, completes #831). The agent writes the
+      # per-experiment intent/events.jsonl/summary.json under AGENT_EXPERIMENT_DIR
+      # (default /var/lib/joustmania/agent/experiments; see
+      # services/agent/experiment/journal/store.go). #831 made the journal survive
+      # a process restart; this named volume makes it survive container recreation
+      # (`docker compose down`, image upgrade) too, so a long-running cohort's
+      # accumulated per-arm samples + verdict state are not silently wiped.
+      - agent-experiments:/var/lib/joustmania/agent/experiments
     depends_on:
       flagd:
         condition: service_started
@@ -753,3 +761,6 @@ volumes:
   loki-data:
   jaeger-data:
   controller-names:
+  # Durable experiment journal for the agent (#1023). See the agent service's
+  # volumes block for the rationale and the matching AGENT_EXPERIMENT_DIR path.
+  agent-experiments:


### PR DESCRIPTION
## What

Adds a named `agent-experiments` Docker volume mounted at the agent's experiment journal directory so cohort journal state survives `docker compose down` and image upgrades — not just process restarts.

## Why

The agent writes its experiment journal (per-experiment intent, `events.jsonl`, Welford `summary.json`) under `AGENT_EXPERIMENT_DIR`, default `/var/lib/joustmania/agent/experiments` (`services/agent/experiment/journal/store.go:23`). #831 made this durable across a **process** restart, but no named volume was mounted in `docker-compose.yml`, so the journal lived only in the container's writable layer — wiped on any `down`/upgrade, the exact events that recreate the container. A long-running cohort's accumulated per-arm samples + verdict state were silently restarting from empty. This completes the #831 durability guarantee (the gap surfaced by the #1012 spike).

## Changes

- `docker-compose.yml`: add `agent-experiments:/var/lib/joustmania/agent/experiments` to the agent service volumes (alongside the existing `./services/flagd:/etc/flagd` bind) + declare the named volume in the top-level `volumes:` map.
- `docker-compose.dry-run.yml`: the agent `volumes: !override` REPLACES the base list, so it would otherwise drop the journal volume. Re-declared it there too so the demo/dry-run stack also keeps journal state across recreation. The top-level volume definition carries through the compose merge from the base file.

## Path confirmation

`AGENT_EXPERIMENT_DIR` is not set in compose, so the code default applies. Confirmed via `services/agent/experiment/journal/store.go` (`DefaultDir = "/var/lib/joustmania/agent/experiments"`, resolved by `DirFromEnv()`); documented in `services/agent/README.md`. Mount path matches exactly.

## Writability

The agent runtime image is `alpine:3.23` with no `USER` directive (runs as root; not the chainguard/nonroot Python services), so the fresh named volume is writable with no permission trap. The journal store creates the dir as needed.

## Validation

- `python -c "import yaml; yaml.safe_load(...)"` — both files OK
- `docker compose -f docker-compose.yml config` — resolves; agent gets the volume, top-level defined
- Merged dry-run render (`-f base -f override -f ci -f dry-run --profile agent`) — agent keeps the journal volume under `!override`, serving `/etc/flagd/ci`

Part of #831. Relates #1012, #982.

🤖 Generated with [Claude Code](https://claude.com/claude-code)