### PR TITLE
test(menu): integration tests for admin core flows (#823)

### DIFF
--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -68,8 +68,19 @@ services:
   # menu-driven flag write lands in the file flagd reads, not a stale base copy.
   # !override replaces the base [./services/flagd:/etc/flagd] mount.
   menu:
+    # The menu persists admin-mode settings (sensitivity, num_teams, game
+    # selection) by writing game.json/user.json in the bind-mounted CI flag dir.
+    # The image runs as nonroot (uid 65532) but the host flag files are owned by
+    # the checkout user, so the nonroot menu cannot write them. Run as root in CI
+    # so the admin write path is exercisable end-to-end — same pattern other
+    # bind-mount writers use (jaeger/grafana run as user "0" in the base compose).
+    user: "0"
     volumes: !override
       - ./services/flagd/ci:/etc/flagd
+    environment:
+      # Shorten the admin trigger-hold force-start window for integration tests
+      # so they don't have to sleep the full 3s real-play hold (#823).
+      - ADMIN_FORCE_START_SECONDS=0.6
 
   # Pairing Daemon - Requires hardware, excluded from CI
   pairing-daemon:

--- a/services/menu/handlers/admin.py
+++ b/services/menu/handlers/admin.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
 import time
 from typing import TYPE_CHECKING, Protocol
 
@@ -130,7 +131,10 @@ class AdminModeHandler:
         # Trigger hold tracking for force start
         self._trigger_press_time: float | None = None
         self._trigger_hold_task: asyncio.Task | None = None
-        self._force_start_threshold = 3.0  # seconds
+        # Hold duration (seconds) before a trigger-hold force-starts the game.
+        # Defaults to 3s for real play; CI overrides via ADMIN_FORCE_START_SECONDS
+        # to a short hold so integration tests don't sleep for the full duration.
+        self._force_start_threshold = float(os.environ.get("ADMIN_FORCE_START_SECONDS", "3.0"))
 
     # ControllerHandler protocol methods
 

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -688,6 +688,207 @@ class GameEventCollector:
         self._event_conditions.clear()
 
 
+class MenuEventCollector:
+    """Collects menu events from StreamMenuEvents for the whole test duration.
+
+    Mirror of GameEventCollector for the Menu service's server-stream RPC
+    (StreamMenuEvents -> stream MenuEvent). Menu admin flows (force start, game
+    selection) publish their outcomes here, so a collector started before the
+    button presses captures them without racing the stream.
+
+    MenuEvent has the same shape the collector relies on: ``event_type`` (str)
+    and ``data`` (map<string,string>). There is no game_id on menu events, so
+    no filtering is needed.
+
+    Usage:
+        async with MenuEventCollector(menu_client) as collector:
+            # ... drive admin buttons ...
+            evt = await collector.wait_for_event("game_requested", timeout=10)
+            assert evt.data["source"] == "admin_force_start"
+    """
+
+    def __init__(self, menu_client):
+        self.menu_client = menu_client
+        self.events: list = []
+        self._task: asyncio.Task | None = None
+        self._event_conditions: dict[str, asyncio.Event] = {}
+
+    async def __aenter__(self):
+        await self.start()
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        await self.stop()
+        return False
+
+    async def start(self):
+        """Start collecting menu events in the background."""
+        self._task = asyncio.create_task(self._collect())
+
+    async def _collect(self):
+        try:
+            async for event in self.menu_client.StreamMenuEvents(
+                menu_pb2.StreamMenuEventsRequest()
+            ):
+                self.events.append(event)
+                if event.event_type in self._event_conditions:
+                    self._event_conditions[event.event_type].set()
+        except asyncio.CancelledError:
+            pass
+
+    async def stop(self):
+        if self._task:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+            self._task = None
+
+    async def wait_for_event(self, event_type: str, timeout: float = 10.0):
+        """Wait for a specific menu event type; return it (or raise TimeoutError)."""
+        for event in self.events:
+            if event.event_type == event_type:
+                return event
+
+        if event_type not in self._event_conditions:
+            self._event_conditions[event_type] = asyncio.Event()
+
+        try:
+            await asyncio.wait_for(
+                self._event_conditions[event_type].wait(), timeout=timeout
+            )
+        except asyncio.TimeoutError:
+            raise TimeoutError(
+                f"Menu did not emit '{event_type}' within {timeout} seconds"
+            )
+        for event in reversed(self.events):
+            if event.event_type == event_type:
+                return event
+
+    def get_events(self, event_type: str | None = None) -> list:
+        if event_type:
+            return [e for e in self.events if e.event_type == event_type]
+        return list(self.events)
+
+
+# =============================================================================
+# Admin-mode button helpers (#823)
+#
+# Admin mode is driven entirely by mock SimulateButton presses. The combo is
+# detected INCREMENTALLY in the menu (servicer.on_button): each face-button
+# press updates the per-serial button_state, and entry fires on the press that
+# completes Cross+Circle+Square+Triangle. So the combo helper presses the four
+# face buttons WITHOUT releasing them (the 4th press triggers entry), then the
+# caller releases all four so the ``combo_shown`` latch resets for re-entry.
+# In-admin button actions are debounced 300ms (admin.py), so press/release
+# cycles must leave >=~0.35s between presses of the same button.
+# =============================================================================
+
+# Buttons used to enter admin mode (all four held simultaneously).
+_ADMIN_COMBO_BUTTONS = (
+    controller_manager_mock_pb2.ButtonRequest.Button.CROSS,
+    controller_manager_mock_pb2.ButtonRequest.Button.CIRCLE,
+    controller_manager_mock_pb2.ButtonRequest.Button.SQUARE,
+    controller_manager_mock_pb2.ButtonRequest.Button.TRIANGLE,
+)
+
+# Admin-mode white LED (GAME_EFFECT_ADMIN_ENTER settles to Colors.White).
+ADMIN_WHITE = (255, 255, 255)
+
+# In-admin button debounce is 300ms; leave margin between same-button presses.
+ADMIN_DEBOUNCE_GAP = 0.4
+
+
+async def _set_button(mock_client, serial: str, button, pressed: bool):
+    """Set a single mock button's pressed state (no auto-release)."""
+    await mock_client.SimulateButton(
+        controller_manager_mock_pb2.ButtonRequest(
+            serial=serial, button=button, pressed=pressed
+        )
+    )
+
+
+async def press_admin_combo(mock_client, serial: str, buttons=None):
+    """Press the admin entry combo by holding face buttons incrementally.
+
+    Presses Cross, Circle, Square, Triangle in sequence WITHOUT releasing
+    (the menu detects the combo on the 4th press), then releases all four so
+    the ``combo_shown`` latch resets and admin mode can be re-entered later.
+
+    Args:
+        mock_client: Mock controller service gRPC client.
+        serial: Controller serial number.
+        buttons: Optional subset of the four face buttons to press. Used by the
+            partial-combo negative test (press 3 -> must NOT enter admin).
+    """
+    combo = buttons if buttons is not None else _ADMIN_COMBO_BUTTONS
+    for button in combo:
+        await _set_button(mock_client, serial, button, True)
+        await asyncio.sleep(0.05)
+    # Release all face buttons so the combo_shown latch clears for re-entry.
+    for button in _ADMIN_COMBO_BUTTONS:
+        await _set_button(mock_client, serial, button, False)
+        await asyncio.sleep(0.02)
+
+
+async def enter_admin_mode(mock_client, serial: str, timeout: float = 5.0):
+    """Press the admin combo and poll until the controller LED is admin-white.
+
+    GAME_EFFECT_ADMIN_ENTER plays a brief white flash then holds white, so the
+    LED is polled with a deadline rather than read once (a single read can land
+    in the flash's dark phase).
+
+    Raises:
+        AssertionError: if the LED never settles to white within ``timeout``.
+    """
+    await press_admin_combo(mock_client, serial)
+    deadline = time.time() + timeout
+    last = None
+    while time.time() < deadline:
+        last = await get_controller_color(mock_client, serial)
+        if last == ADMIN_WHITE:
+            return
+        await asyncio.sleep(0.1)
+    raise AssertionError(
+        f"{serial} did not enter admin mode (LED never reached {ADMIN_WHITE}, last={last})"
+    )
+
+
+async def press_admin_button(mock_client, serial: str, button, gap: float = ADMIN_DEBOUNCE_GAP):
+    """Press-and-release a single button while in admin mode, honoring debounce.
+
+    Leaves ``gap`` (>= the 300ms admin debounce) before AND after so successive
+    calls to the SAME button are each processed.
+    """
+    await _set_button(mock_client, serial, button, True)
+    await asyncio.sleep(0.05)
+    await _set_button(mock_client, serial, button, False)
+    await asyncio.sleep(gap)
+
+
+async def exit_admin_mode(mock_client, serial: str):
+    """Exit admin mode via the PS button (press + release)."""
+    await press_admin_button(
+        mock_client, serial, controller_manager_mock_pb2.ButtonRequest.Button.PS
+    )
+
+
+async def hold_trigger_for_force_start(mock_client, serial: str, hold_seconds: float = 1.5):
+    """Hold the trigger long enough to force-start the game, then release.
+
+    The menu force-start threshold defaults to 3s but CI sets
+    ADMIN_FORCE_START_SECONDS=0.6, so a 1.5s hold clears it with margin.
+    """
+    await _set_button(
+        mock_client, serial, controller_manager_mock_pb2.ButtonRequest.Button.TRIGGER, True
+    )
+    await asyncio.sleep(hold_seconds)
+    await _set_button(
+        mock_client, serial, controller_manager_mock_pb2.ButtonRequest.Button.TRIGGER, False
+    )
+
+
 # =============================================================================
 # Force end helpers
 # =============================================================================

--- a/tests/integration/test_admin_flow.py
+++ b/tests/integration/test_admin_flow.py
@@ -1,0 +1,409 @@
+"""End-to-end admin-mode integration tests (#823).
+
+Admin mode is the controller-driven settings/force-start surface: a controller
+holds all four face buttons (Cross+Circle+Square+Triangle) to ENTER, then uses
+Move (cycle option), Select/Start (adjust value), face buttons (sensitivity /
+game mode / etc.), a trigger-hold (force start), and PS (exit). It has rich unit
+coverage (services/menu/tests/test_admin_handler.py) but no integration coverage
+until now; admin mode "regularly breaks" precisely at the seams these unit tests
+cannot reach — the mock-button -> controller-manager -> menu combo detection,
+the FlagConfigWriter -> flagd file the writes actually land in, and the
+menu->coordinator force-start handoff. These tests exercise all three against
+the real docker-compose stack.
+
+Mechanics (verified against the live code):
+
+- Entry combo detection is INCREMENTAL in the menu (servicer.on_button): each
+  face-button press updates a per-serial button_state, and entry fires on the
+  press that completes the four-button set. So we press the four face buttons
+  without releasing (helpers.press_admin_combo), then release all four so the
+  ``combo_shown`` latch clears for the next entry.
+- ADMIN_ENTER drives the controller LED to white (255,255,255); we poll the
+  mock GetColor RPC with a deadline because the enter effect briefly flashes.
+- Settings persist by FlagConfigWriter flipping a flag's ``defaultVariant`` in
+  the CI flag files (services/flagd/ci/{game,user}.json) — the SAME files flagd
+  serves in CI (#959/#962). The ``admin_flags`` fixture snapshots and restores
+  them so no mutation leaks between tests or into the repo.
+- Force start publishes a menu ``game_requested`` event (source
+  ``admin_force_start``); the coordinator then emits ``game_started``.
+- The 3s real-play trigger-hold is shortened to 0.6s in CI via
+  ADMIN_FORCE_START_SECONDS (docker-compose.ci.yml) so a ~1.5s hold suffices.
+
+The surviving controller-cycled surface after the #815 rationalization (PR
+#1010) is sensitivity / num_teams / force_all_start (admin.py option_names), so
+these tests target those; the removed-from-controller tunables are not tested
+here.
+"""
+
+import asyncio
+import json
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+
+from proto import (  # noqa: E402
+    controller_manager_mock_pb2,
+    menu_pb2,
+)
+
+from tests.integration.helpers import (  # noqa: E402
+    ADMIN_WHITE,
+    MenuEventCollector,
+    active_flag_file,
+    enter_admin_mode,
+    exit_admin_mode,
+    get_controller_color,
+    get_controller_serials,
+    get_game_client,
+    get_menu_client,
+    get_mock_client,
+    hold_trigger_for_force_start,
+    press_admin_button,
+    press_admin_combo,
+    select_game_mode,
+    setup_mock_controllers,
+)
+
+GAME_FLAG_PATH = active_flag_file("game")
+USER_FLAG_PATH = active_flag_file("user")
+
+# How long a settings write is given to round-trip to the host flag file.
+PERSIST_TIMEOUT_SECONDS = 5.0
+
+_Button = controller_manager_mock_pb2.ButtonRequest.Button
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def admin_flags():
+    """Snapshot game.json + user.json; restore byte-for-byte on teardown.
+
+    Admin settings changes persist by flipping ``defaultVariant`` in these CI
+    flag files (the files flagd serves). Snapshot/restore keeps each test
+    isolated and prevents any mutation leaking into the repo or later tests.
+    """
+    with open(GAME_FLAG_PATH) as fh:
+        game_backup = fh.read()
+    with open(USER_FLAG_PATH) as fh:
+        user_backup = fh.read()
+
+    yield
+
+    with open(GAME_FLAG_PATH, "w") as fh:
+        fh.write(game_backup)
+    with open(USER_FLAG_PATH, "w") as fh:
+        fh.write(user_backup)
+
+
+@pytest.fixture
+async def menu_client(docker_compose):
+    client, channel = await get_menu_client(docker_compose)
+    yield client
+    await channel.close()
+
+
+@pytest.fixture
+async def mock_client(docker_compose):
+    client, channel = await get_mock_client(docker_compose)
+    yield client
+    await channel.close()
+
+
+# =============================================================================
+# Helpers local to admin tests
+# =============================================================================
+
+
+async def _start_menu_with_controllers(
+    docker_compose, menu_client, game_mode: str = "JoustFFA", count: int = 4
+) -> list[str]:
+    """Start a fresh menu with ``count`` connected (not-ready) controllers.
+
+    Stops then starts the menu so controller state is clean, selects a game
+    mode, and waits until the menu has registered the controllers (each gets a
+    lobby base color via the connection events). Returns the controller serials.
+    Controllers are left CONNECTED (not ready) so the admin combo is detected in
+    the CONNECTED state, the way a human enters admin from the lobby.
+    """
+    # Clear any running game and stale menu state, then start fresh.
+    game_client, game_channel = await get_game_client(docker_compose)
+    try:
+        from proto import game_coordinator_pb2
+
+        await game_client.ForceEndGame(
+            game_coordinator_pb2.ForceEndGameRequest(reason="admin_test_setup")
+        )
+    finally:
+        await game_channel.close()
+    await asyncio.sleep(0.2)
+
+    await setup_mock_controllers(docker_compose, count=count)
+
+    await menu_client.StopMenu(menu_pb2.StopMenuRequest())
+    await asyncio.sleep(0.1)
+    start = await menu_client.StartMenu(menu_pb2.StartMenuRequest())
+    assert start.success, f"failed to start menu: {start.error}"
+    await asyncio.sleep(0.3)
+
+    await select_game_mode(menu_client, game_mode)
+
+    serials = await get_controller_serials(docker_compose)
+    assert serials, "no controllers connected to menu"
+    # Give the menu a moment to apply lobby base colors from connection events.
+    await asyncio.sleep(0.3)
+    return serials
+
+
+def _default_variant(path: str, flag_key: str) -> str:
+    with open(path) as fh:
+        doc = json.load(fh)
+    return doc["flags"][flag_key]["defaultVariant"]
+
+
+async def _wait_default_variant_changes(
+    path: str, flag_key: str, baseline: str, timeout: float = PERSIST_TIMEOUT_SECONDS
+) -> str:
+    """Poll the flag file until ``flag_key``'s defaultVariant differs from baseline."""
+    deadline = asyncio.get_event_loop().time() + timeout
+    current = baseline
+    while asyncio.get_event_loop().time() < deadline:
+        current = _default_variant(path, flag_key)
+        if current != baseline:
+            return current
+        await asyncio.sleep(0.1)
+    return current
+
+
+# =============================================================================
+# 1. Combo entry -> admin white LED
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_combo_entry_lights_admin_white(docker_compose, menu_client, mock_client):
+    """Holding the four face buttons enters admin mode: the controller LED
+    settles to admin white (255,255,255)."""
+    serials = await _start_menu_with_controllers(docker_compose, menu_client)
+    admin_serial = serials[0]
+
+    # enter_admin_mode presses the combo and polls until the LED is white.
+    await enter_admin_mode(mock_client, admin_serial)
+    assert await get_controller_color(mock_client, admin_serial) == ADMIN_WHITE
+
+    # Clean up: leave admin mode so the controller doesn't stay latched.
+    await exit_admin_mode(mock_client, admin_serial)
+
+
+# =============================================================================
+# 2. PS exit -> LED leaves admin white (returns to lobby)
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_ps_exit_restores_lobby_color(docker_compose, menu_client, mock_client):
+    """PS while in admin mode exits: the LED leaves admin white and returns to
+    the (dim) lobby color the controller had before entering."""
+    serials = await _start_menu_with_controllers(docker_compose, menu_client)
+    admin_serial = serials[0]
+
+    await enter_admin_mode(mock_client, admin_serial)
+    assert await get_controller_color(mock_client, admin_serial) == ADMIN_WHITE
+
+    await exit_admin_mode(mock_client, admin_serial)
+
+    # ADMIN_EXIT restores the pre-admin base (lobby) color instantly; assert the
+    # LED is no longer the admin white. The exact lobby color depends on the
+    # connection state, so we assert "left admin white" rather than a literal.
+    deadline = asyncio.get_event_loop().time() + 5.0
+    color = await get_controller_color(mock_client, admin_serial)
+    while color == ADMIN_WHITE and asyncio.get_event_loop().time() < deadline:
+        await asyncio.sleep(0.1)
+        color = await get_controller_color(mock_client, admin_serial)
+    assert color != ADMIN_WHITE, f"LED stayed admin-white after PS exit (={color})"
+
+
+# =============================================================================
+# 3. Partial combo (3 of 4 buttons) does NOT enter admin
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_partial_combo_does_not_enter_admin(docker_compose, menu_client, mock_client):
+    """Pressing only three of the four face buttons must NOT enter admin mode:
+    the LED never goes admin-white."""
+    serials = await _start_menu_with_controllers(docker_compose, menu_client)
+    admin_serial = serials[0]
+
+    # Press only 3 of the 4 face buttons (omit TRIANGLE).
+    await press_admin_combo(
+        mock_client,
+        admin_serial,
+        buttons=(_Button.CROSS, _Button.CIRCLE, _Button.SQUARE),
+    )
+
+    # Give the menu a window to (incorrectly) react, then assert NOT white. This
+    # absence assertion is a bounded wait by design — there is no event to await
+    # when the correct behavior is "nothing happens".
+    await asyncio.sleep(1.0)
+    color = await get_controller_color(mock_client, admin_serial)
+    assert color != ADMIN_WHITE, (
+        f"partial combo entered admin mode (LED={color}, expected non-white)"
+    )
+
+
+# =============================================================================
+# 4. Sensitivity change (Circle) persists to game.json
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_sensitivity_change_persists(docker_compose, menu_client, mock_client, admin_flags):
+    """In admin mode, Circle cycles sensitivity; the change persists by advancing
+    the ``sensitivity`` flag's defaultVariant in the served game.json."""
+    serials = await _start_menu_with_controllers(docker_compose, menu_client)
+    admin_serial = serials[0]
+
+    baseline = _default_variant(GAME_FLAG_PATH, "sensitivity")
+
+    await enter_admin_mode(mock_client, admin_serial)
+    # Circle = cycle sensitivity forward.
+    await press_admin_button(mock_client, admin_serial, _Button.CIRCLE)
+
+    new_variant = await _wait_default_variant_changes(
+        GAME_FLAG_PATH, "sensitivity", baseline
+    )
+    assert new_variant != baseline, (
+        f"sensitivity defaultVariant did not change (still {baseline})"
+    )
+    # It advanced to the next variant in the file's variant order.
+    order = ["ultra_slow", "slow", "medium", "fast", "ultra_fast"]
+    assert new_variant == order[(order.index(baseline) + 1) % len(order)], (
+        f"sensitivity advanced to unexpected variant: {baseline} -> {new_variant}"
+    )
+
+    await exit_admin_mode(mock_client, admin_serial)
+
+
+# =============================================================================
+# 5. Option cycle (Move) + value adjust (Select) persists num_teams
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_option_cycle_and_value_change_persists(
+    docker_compose, menu_client, mock_client, admin_flags
+):
+    """Move cycles the selected option (sensitivity -> num_teams), then Select
+    increments the now-selected option's value, persisted to game.json.
+
+    The option order is ``[sensitivity, num_teams, force_all_start]`` and starts
+    at index 0 (sensitivity) on entry, so one Move lands on num_teams.
+    """
+    serials = await _start_menu_with_controllers(docker_compose, menu_client)
+    admin_serial = serials[0]
+
+    baseline = _default_variant(GAME_FLAG_PATH, "num_teams")
+
+    await enter_admin_mode(mock_client, admin_serial)
+    # Move: sensitivity -> num_teams (current_option index 0 -> 1).
+    await press_admin_button(mock_client, admin_serial, _Button.MOVE)
+    # Select: increment the current option (num_teams) forward.
+    await press_admin_button(mock_client, admin_serial, _Button.SELECT)
+
+    new_variant = await _wait_default_variant_changes(
+        GAME_FLAG_PATH, "num_teams", baseline
+    )
+    assert new_variant != baseline, (
+        f"num_teams defaultVariant did not change after Move+Select (still {baseline})"
+    )
+    order = ["two", "three", "four", "five", "six"]
+    assert new_variant == order[(order.index(baseline) + 1) % len(order)], (
+        f"num_teams advanced to unexpected variant: {baseline} -> {new_variant}"
+    )
+
+    await exit_admin_mode(mock_client, admin_serial)
+
+
+# =============================================================================
+# 6. Trigger-hold force start -> menu game_requested + game game_started
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_force_start_requests_game(docker_compose, menu_client, mock_client, admin_flags):
+    """Holding the trigger in admin mode force-starts the game: the menu publishes
+    a ``game_requested`` event with source=admin_force_start naming the current
+    game mode.
+
+    NOTE (behavioral finding, #823): ``AdminModeHandler.handle_force_start`` only
+    publishes this event and sets the menu state to GAME_STARTING — it does NOT
+    invoke the menu's ``_start_game`` coordinator path (unlike the ready-flow's
+    ``start_game_callback``), and nothing in the menu bridges the
+    ``game_requested`` event back to it. So admin force-start does not actually
+    start a coordinator game today; this test asserts the real current behavior
+    (the menu event), which is the contract the surface exposes.
+    """
+    serials = await _start_menu_with_controllers(docker_compose, menu_client)
+    admin_serial = serials[0]
+
+    async with MenuEventCollector(menu_client) as menu_collector:
+        await enter_admin_mode(mock_client, admin_serial)
+
+        # Hold the trigger past the (CI-shortened) force-start threshold.
+        await hold_trigger_for_force_start(mock_client, admin_serial, hold_seconds=1.5)
+
+        requested = await menu_collector.wait_for_event("game_requested", timeout=10.0)
+        assert requested.data.get("source") == "admin_force_start", (
+            f"unexpected force-start source: {dict(requested.data)}"
+        )
+        assert requested.data.get("game_name"), (
+            f"force-start request carried no game_name: {dict(requested.data)}"
+        )
+
+
+# =============================================================================
+# 7. Force start respects the admin-selected game mode (Cross cycles mode)
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_force_start_respects_selected_game_mode(
+    docker_compose, menu_client, mock_client, admin_flags
+):
+    """Force start requests the game mode currently selected in the menu (not a
+    hardcoded default): with JoustTeams selected, admin force start publishes a
+    ``game_requested`` naming JoustTeams.
+
+    NOTE (behavioral finding, #823): the plan's "Cross cycles the mode in admin"
+    path is currently DEAD — ``AdminModeHandler.handle_game_mode`` reads
+    ``callbacks.get_game_options()``, but ``MenuServicer.get_game_options``
+    returns ``self.game_options`` which is never populated (always []), so Cross
+    in admin logs "No game options available" and changes nothing. This test
+    therefore drives the selection through the WORKING menu path
+    (``select_game_mode``) and asserts force start respects it — the real
+    "respects selected mode" contract.
+    """
+    selected_mode = "JoustTeams"
+    serials = await _start_menu_with_controllers(
+        docker_compose, menu_client, game_mode=selected_mode
+    )
+    admin_serial = serials[0]
+
+    async with MenuEventCollector(menu_client) as menu_collector:
+        await enter_admin_mode(mock_client, admin_serial)
+
+        # Force start: the requested mode must be the menu's current selection.
+        await hold_trigger_for_force_start(mock_client, admin_serial, hold_seconds=1.5)
+        requested = await menu_collector.wait_for_event("game_requested", timeout=10.0)
+        assert requested.data.get("source") == "admin_force_start"
+        assert requested.data.get("game_name") == selected_mode, (
+            f"force start requested {requested.data.get('game_name')}, "
+            f"expected menu-selected {selected_mode}"
+        )


### PR DESCRIPTION
## Summary

Part of #823. Adds end-to-end integration coverage for admin mode — the controller-driven settings/force-start surface that "regularly breaks" and previously had only unit coverage. Targets the surviving surface after the #815/#1010 rationalization (sensitivity / num_teams / force_all_start / force start), exercised against the real docker-compose stack via mock `SimulateButton` presses.

## Tests added (`tests/integration/test_admin_flow.py`, all green)

1. `test_combo_entry_lights_admin_white` — four-button combo enters admin; LED settles to white (255,255,255)
2. `test_ps_exit_restores_lobby_color` — PS exits admin; LED leaves admin white
3. `test_partial_combo_does_not_enter_admin` — 3 of 4 face buttons does NOT enter admin
4. `test_sensitivity_change_persists` — Circle cycles sensitivity, persists to served `game.json` (`defaultVariant` advances)
5. `test_option_cycle_and_value_change_persists` — Move (sensitivity→num_teams) + Select increments, persists `num_teams`
6. `test_force_start_requests_game` — trigger-hold publishes menu `game_requested` (source=`admin_force_start`)
7. `test_force_start_respects_selected_game_mode` — force start requests the menu-selected mode (JoustTeams)

```
7 passed in 82.89s
```

## Supporting changes

- `tests/integration/helpers.py`: `MenuEventCollector` (StreamMenuEvents mirror of `GameEventCollector`) + admin button helpers (`press_admin_combo`, `enter_admin_mode`, `press_admin_button`, `exit_admin_mode`, `hold_trigger_for_force_start`). Combo entry presses the four face buttons incrementally (menu-side incremental detection), then releases all four to clear the `combo_shown` latch for re-entry. Settings tests snapshot/restore `game.json`/`user.json` so no flag mutation leaks.
- `services/menu/handlers/admin.py`: the 3s force-start hold is now env-configurable via `ADMIN_FORCE_START_SECONDS` (defaults 3.0) so CI holds ~0.6s instead of sleeping the full duration. The 122 admin-handler unit tests still pass.
- `docker-compose.ci.yml`: sets `ADMIN_FORCE_START_SECONDS=0.6` and runs the menu as `user: "0"` so it can write the bind-mounted CI flag files — the nonroot image uid (65532) can't write the host-owned `game.json`/`user.json` (this blocked the persistence tests). Matches the existing bind-mount-writer pattern in the base compose.

## Behavioral findings surfaced while testing

Both are asserted as the *current* behavior (not masked), so the tests are honest and will catch a future fix as a change:

- **Admin force-start never starts a coordinator game.** `AdminModeHandler.handle_force_start` only publishes `game_requested` and sets the menu state to `GAME_STARTING`; it does not call the menu's `_start_game` coordinator path (the ready-flow does), and nothing bridges the event back to it.
- **Admin Cross game-mode cycling is dead.** `handle_game_mode` reads `callbacks.get_game_options()`, but `MenuServicer.get_game_options()` returns `self.game_options`, which is never populated → always `[]`, so Cross logs "No game options available" and changes nothing. Test 7 therefore drives the selection through the working `select_game_mode` menu path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)