### PR TITLE
fix(ci): exempt trailing inline comments in CRN RNG-isolation gate (#1032)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -304,12 +304,17 @@ jobs:
       # (random.shuffle/sample/choice/uniform/...) silently breaks both CRN
       # pairing and concurrency isolation, so fail the build on any bare
       # `random.<lowercase>` under games/. `random.Random` (the per-instance ctor)
-      # is allowed; comment lines are ignored.
+      # is allowed; comments (full-line OR trailing-inline) are ignored.
       - name: CRN RNG-isolation gate
         if: matrix.service == 'game_coordinator'
         run: |
+          # grep emits `path:line:content`; strip any trailing `#` comment from the
+          # content portion (preserving the path:line: prefix) BEFORE matching, so a
+          # `random.` inside a comment — full-line or trailing-inline — never trips
+          # the gate, while a real bare `random.<lowercase>` call still does (#1032).
           if grep -rnE '(^|[^._a-zA-Z0-9])random\.[a-z]' services/game_coordinator/games --include='*.py' \
-               | grep -vE '^[^:]+:[0-9]+:[[:space:]]*#'; then
+               | sed -E 's/(^[^:]+:[0-9]+:[^#]*)#.*$/\1/' \
+               | grep -E '(^|[^._a-zA-Z0-9])random\.[a-z]'; then
             echo "::error::Bare module-global random.* call found under services/game_coordinator/games."
             echo "Use the per-instance self._rng (random.Random(seed)) instead — see #1003."
             exit 1


### PR DESCRIPTION
## Problem

The CRN RNG-isolation gate in `.github/workflows/ci.yml` (added in #1003 / PR #1026) blocks bare module-global `random.<lowercase>` calls under `services/game_coordinator/games`. Its comment-exemption filter `grep -vE '^[^:]+:[0-9]+:[[:space:]]*#'` only stripped **full-line** comments, so a **trailing inline** comment like `x = 1  # random.shuffle(y)` would false-positive and fail the build.

The gate fails safe (blocks rather than silently passing) and the current tree is clean, so this was low-severity — but it could produce a confusing red build for a future contributor.

## Fix

Strip any trailing `#` comment from each grep hit's content portion (preserving the `path:line:` prefix so error output still points at the offending location) before the final match:

```bash
grep -rnE '(^|[^._a-zA-Z0-9])random\.[a-z]' services/game_coordinator/games --include='*.py' \
  | sed -E 's/(^[^:]+:[0-9]+:[^#]*)#.*$/\1/' \
  | grep -E '(^|[^._a-zA-Z0-9])random\.[a-z]'
```

The `[^#]*` guard ensures the comment-strip only touches content after the `path:line:` prefix. A real bare module-global call is still caught; `random.Random` (per-instance ctor) and `self._rng.` remain allowed.

## Verification

| Case | Input | Result |
|------|-------|--------|
| (a) real bare call | `random.shuffle(x)` | MATCHED — gate fails ✅ |
| (b) trailing inline comment | `x = 1  # random.shuffle(y)` | no match — gate passes ✅ |
| (c) per-instance ctor | `self._rng = random.Random(seed)` | no match — gate passes ✅ |
| (d) full-line comment | `# random.choice(stuff)` | no match — gate passes ✅ |

Also confirmed: real call + trailing comment (`random.shuffle(x)  # do it`) still caught, `self._rng.shuffle(x)` not caught, and the pipeline run against the actual `services/game_coordinator/games` tree passes (tree is clean). YAML validated with `python3 -c "import yaml; yaml.safe_load(...)"`.

Part of #1032 — relates #1003 (PR #1026).

🤖 Generated with [Claude Code](https://claude.com/claude-code)