### PR TITLE
fix(menu): let nonroot menu persist flag writes in prod (#1031)

### DIFF
--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -67,14 +67,19 @@ services:
   # settings). Point it at the SAME CI flag directory flagd serves (#959) so a
   # menu-driven flag write lands in the file flagd reads, not a stale base copy.
   # !override replaces the base [./services/flagd:/etc/flagd] mount.
+  # Flag-dir permission init (#1031) — point it at the CI flag dir so the nonroot
+  # menu can persist admin writes to the same files flagd serves. !override
+  # replaces the base [./services/flagd:/etc/flagd] mount with the CI dir.
+  flag-dir-init:
+    volumes: !override
+      - ./services/flagd/ci:/etc/flagd
+
   menu:
     # The menu persists admin-mode settings (sensitivity, num_teams, game
     # selection) by writing game.json/user.json in the bind-mounted CI flag dir.
-    # The image runs as nonroot (uid 65532) but the host flag files are owned by
-    # the checkout user, so the nonroot menu cannot write them. Run as root in CI
-    # so the admin write path is exercisable end-to-end — same pattern other
-    # bind-mount writers use (jaeger/grafana run as user "0" in the base compose).
-    user: "0"
+    # The image runs as nonroot (uid 65532). #1031: flag-dir-init makes the CI flag
+    # dir group-writable, so the menu persists writes as nonroot — the `user: "0"`
+    # hack is gone and the prod-like (nonroot) admin write path is exercised in CI.
     volumes: !override
       - ./services/flagd/ci:/etc/flagd
     environment:

--- a/docker-compose.lite.yml
+++ b/docker-compose.lite.yml
@@ -12,6 +12,36 @@
 # Use IMAGE_TAG environment variable to specify version (default: latest)
 
 services:
+  # Flag-dir permission init (#1031). The lite stack is a STANDALONE compose
+  # (not layered on docker-compose.yml), so it needs its own copy of this
+  # sidecar. The menu persists admin settings — game.json / user.json — by
+  # writing the bind-mounted flag files via lib/flag_config_writer.py (an
+  # in-place "w" truncate, so write perm on the FILE is what matters). The menu
+  # image runs nonroot (uid 65532, chainguard); the host flag files are owned by
+  # the deploy user (mode 644), so a nonroot write fails with PermissionError
+  # and the change is silently lost. This one-shot root sidecar makes the files
+  # the lite menu writes group-owned by the menu's nonroot gid (65532) and
+  # group-writable, so the nonroot menu can persist writes WITHOUT running as
+  # root. We chmod the SPECIFIC files the lite menu mounts (game.json,
+  # user.json) — lite bind-mounts individual files, not the whole dir, and the
+  # menu only ever writes these two. The sidecar mounts the whole dir to reach
+  # them on the same host inodes the menu sees.
+  #
+  # Lite has NO agent service, so the #819 agent.json kill-switch is not present
+  # here and agent.json persistence is out of scope. flagd only READS the files,
+  # so it does NOT depend on this step (a future reader should not "fix" that
+  # asymmetry — it would needlessly serialize flagd startup behind a chmod).
+  flag-dir-init:
+    image: busybox:1.37.0
+    container_name: joustmania-flag-dir-init
+    user: "0"  # must be root to chgrp/chmod the bind-mounted host files
+    command:
+      - "sh"
+      - "-c"
+      - "chgrp 65532 /etc/flagd/game.json /etc/flagd/user.json && chmod g+w /etc/flagd/game.json /etc/flagd/user.json"
+    volumes:
+      - ./services/flagd:/etc/flagd
+    restart: "no"
   # flagd for feature flag evaluation
   flagd:
     image: ghcr.io/open-feature/flagd:v0.16.0
@@ -147,6 +177,11 @@ services:
     depends_on:
       flagd:
         condition: service_started
+      # Wait for the flag files to be made group-writable so the nonroot menu
+      # can persist admin settings on first start (#1031). flagd intentionally
+      # does NOT depend on flag-dir-init — it only reads the files.
+      flag-dir-init:
+        condition: service_completed_successfully
     networks:
       - joustmania
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,6 +52,12 @@ services:
   # them; it does not touch the agent's mount or relax the agent.json invariant
   # (that rests on code-level path guards, not filesystem perms — see
   # docs/OWNERSHIP_MODEL.md §2).
+  #
+  # Only the menu `depends_on` this step — intentionally NOT flagd or the agent.
+  # flagd only READS the flag files, and the agent runs as root and writes in
+  # place (O_TRUNC), so group perms are irrelevant to both. Adding a dependency
+  # there would needlessly serialize their startup behind this chmod for no gain.
+  # No `networks:` — this only chmods a local bind mount and needs no network.
   flag-dir-init:
     image: busybox:1.37.0
     container_name: joustmania-flag-dir-init
@@ -62,8 +68,6 @@ services:
       - "chgrp -R 65532 /etc/flagd && chmod -R g+w /etc/flagd && find /etc/flagd -type d -exec chmod g+s {} +"
     volumes:
       - ./services/flagd:/etc/flagd
-    networks:
-      - joustmania
     restart: "no"
     logging: *default-logging
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,38 @@ x-logging: &default-logging
     labels: "com.docker.compose.service,com.docker.compose.image"
 
 services:
+  # Flag-dir permission init (#1031). The menu persists admin settings — game.json
+  # / user.json and the #819 kill-switch (agent.json interventions_allowed) — by
+  # writing the bind-mounted flag dir via lib/flag_config_writer.py. The menu image
+  # runs nonroot (uid 65532, chainguard); the host flag files are owned by the
+  # checkout/deploy user (mode 644), so a nonroot write fails with PermissionError
+  # and the change is silently lost. This one-shot root sidecar makes the shared
+  # flag dir group-owned by the menu's nonroot gid (65532) and group-writable, so
+  # the nonroot menu can persist writes WITHOUT the menu itself running as root.
+  #
+  # Why this and not a named volume: flagd, the agent and the menu all bind-mount
+  # the SAME host ./services/flagd dir (single source of truth, #959). A named
+  # volume would diverge from the host repo files. Why group, not chown owner:
+  # leaves the host user as file OWNER (still editable on a dev checkout), only the
+  # group is reassigned. flagd and the agent run as root, so this is invisible to
+  # them; it does not touch the agent's mount or relax the agent.json invariant
+  # (that rests on code-level path guards, not filesystem perms — see
+  # docs/OWNERSHIP_MODEL.md §2).
+  flag-dir-init:
+    image: busybox:1.37.0
+    container_name: joustmania-flag-dir-init
+    user: "0"  # must be root to chgrp/chmod the bind-mounted host files
+    command:
+      - "sh"
+      - "-c"
+      - "chgrp -R 65532 /etc/flagd && chmod -R g+w /etc/flagd && find /etc/flagd -type d -exec chmod g+s {} +"
+    volumes:
+      - ./services/flagd:/etc/flagd
+    networks:
+      - joustmania
+    restart: "no"
+    logging: *default-logging
+
   # flagd for feature flag evaluation
   flagd:
     image: ghcr.io/open-feature/flagd:v0.16.0
@@ -382,6 +414,10 @@ services:
     depends_on:
       flagd:
         condition: service_started
+      # Wait for the flag dir to be made group-writable so the nonroot menu can
+      # persist admin settings on first start (#1031).
+      flag-dir-init:
+        condition: service_completed_successfully
     networks:
       - joustmania
     restart: unless-stopped

--- a/docs/OWNERSHIP_MODEL.md
+++ b/docs/OWNERSHIP_MODEL.md
@@ -73,6 +73,20 @@ agent policy; the agent cannot persist its own governor (§1, §6.2).
 > the RW dir would be a sound defense-in-depth addition, but is not what the
 > guarantee currently rests on.
 
+> **How the nonroot menu can write the bind-mounted flag dir (#1031).** The menu
+> image runs nonroot (uid 65532, chainguard distroless) while the host flag files
+> are owned by the checkout/deploy user (mode 644), so a nonroot write would fail
+> with `PermissionError` and the admin setting would silently not persist — which
+> would also break the #819 kill-switch (`agent.json` `interventions_allowed`). A
+> one-shot root sidecar (`flag-dir-init` in `docker-compose.yml`) makes the shared
+> flag dir group-owned by the menu's nonroot gid and group-writable before the menu
+> starts, so the menu persists writes **without itself running as root**. This does
+> NOT relax the agent-never-writes-`agent.json` invariant above: that rests on
+> code-level path guards, and the agent already mounts the dir read-write and runs
+> as root (the permission change is invisible to it). As a defensive backstop, the
+> writer ([`lib/flag_config_writer.py`](../lib/flag_config_writer.py)) now logs a
+> permission/OS write failure loudly (CRITICAL) instead of swallowing it.
+
 ## 3. Parameter Ownership Table
 
 The eight admin flags. All are read once by the menu into `StartGameConfig`

--- a/lib/flag_config_writer.py
+++ b/lib/flag_config_writer.py
@@ -82,6 +82,28 @@ class FlagConfigWriter:
         except json.JSONDecodeError as e:
             logger.error(f"Invalid JSON in {self.file_path}: {e}")
             return False
+        except PermissionError as e:
+            # #1031: the menu runs nonroot (uid 65532) and the bind-mounted flag
+            # files are host-owned. A permission denial here means the admin
+            # setting did NOT persist — surface it loudly and unmistakably
+            # instead of letting it disappear into the generic catch-all. This is
+            # safety-relevant: the #819 agent kill-switch (agent.json
+            # interventions_allowed) is written through this path.
+            logger.critical(
+                f"PERMISSION DENIED writing flag '{flag_key}' to {self.file_path}: {e}. "
+                "Admin setting NOT persisted. The service cannot write the flag dir — "
+                "ensure the flag-dir-init step made it group-writable (#1031).",
+                exc_info=True,
+            )
+            return False
+        except OSError as e:
+            # Disk full, read-only filesystem, I/O error, etc. — also a real
+            # non-persistence failure, not something to swallow quietly.
+            logger.error(
+                f"OS error writing flag '{flag_key}' to {self.file_path}: {e}. Admin setting NOT persisted.",
+                exc_info=True,
+            )
+            return False
         except Exception as e:
             logger.error(f"Error updating flag '{flag_key}': {e}")
             return False

--- a/lib/tests/test_flag_config_writer.py
+++ b/lib/tests/test_flag_config_writer.py
@@ -86,6 +86,60 @@ class TestUpdateDefaultVariant:
 
         assert result is False
 
+    def test_permission_error_logged_loudly_not_swallowed(self, tmp_path, monkeypatch, caplog):
+        """#1031: a nonroot write that fails with PermissionError must NOT be
+        silently swallowed — it is logged at CRITICAL so non-persistence is
+        visible (safety-relevant: the #819 kill-switch is written this way)."""
+        import logging
+
+        path = _write_flag_file(tmp_path)
+        writer = FlagConfigWriter(path)
+
+        real_open = open
+
+        def fake_open(file, mode="r", *args, **kwargs):
+            # Reads succeed; only the write open is denied (the prod failure mode).
+            if "w" in mode:
+                raise PermissionError(13, "Permission denied")
+            return real_open(file, mode, *args, **kwargs)
+
+        monkeypatch.setattr("builtins.open", fake_open)
+
+        with caplog.at_level(logging.CRITICAL):
+            result = writer.update_default_variant("sensitivity", "fast")
+
+        assert result is False
+        # Loud, searchable evidence — distinct from the generic catch-all.
+        assert any(rec.levelno == logging.CRITICAL for rec in caplog.records)
+        assert any("PERMISSION DENIED" in rec.getMessage() for rec in caplog.records)
+
+        # The on-disk file must be left as it was (write never landed).
+        data = json.loads(Path(path).read_text())
+        assert data["flags"]["sensitivity"]["defaultVariant"] == "medium"
+
+    def test_os_error_logged_not_swallowed(self, tmp_path, monkeypatch, caplog):
+        """A generic OSError on write (disk full, RO fs) is surfaced at ERROR
+        with a clear 'NOT persisted' message, not silently dropped."""
+        import logging
+
+        path = _write_flag_file(tmp_path)
+        writer = FlagConfigWriter(path)
+
+        real_open = open
+
+        def fake_open(file, mode="r", *args, **kwargs):
+            if "w" in mode:
+                raise OSError(28, "No space left on device")
+            return real_open(file, mode, *args, **kwargs)
+
+        monkeypatch.setattr("builtins.open", fake_open)
+
+        with caplog.at_level(logging.ERROR):
+            result = writer.update_default_variant("sensitivity", "fast")
+
+        assert result is False
+        assert any("NOT persisted" in rec.getMessage() for rec in caplog.records)
+
     def test_atomic_write_produces_valid_json(self, tmp_path):
         path = _write_flag_file(tmp_path)
         writer = FlagConfigWriter(path)


### PR DESCRIPTION
## Problem

Part of #1031. The menu image runs **nonroot** (uid 65532, chainguard distroless) while the bind-mounted flag files (`./services/flagd`) are host-owned (mode `644`). A nonroot write therefore fails with `PermissionError`, which `lib/flag_config_writer.update_default_variant` swallowed in its broad `except Exception` → admin settings **silently** failed to persist in production:

- `game.json` / `user.json` (sensitivity, num_teams, game selection)
- **`agent.json` `interventions_allowed` — the #819 on-device agent kill-switch.** This is the human's control over the agent, so silent non-persistence is safety-relevant.

The agent (runs as root) and flagd (read-only) were unaffected — the menu is the only nonroot writer. #1028 papered over this in CI with `user: "0"` on the menu; the same constraint bites in prod.

## Fix

A one-shot **root `flag-dir-init` sidecar** makes the shared flag dir group-owned by the menu's nonroot gid (65532) and group-writable before the menu starts (`depends_on: service_completed_successfully`). The menu then persists writes **without itself running as root**. Added to **both** stacks that run the nonroot menu:

- **`docker-compose.yml`** (full stack): `chgrp -R 65532 + chmod -R g+w`, `g+s` on dirs over the whole bind-mounted `./services/flagd`.
- **`docker-compose.lite.yml`** (standalone Raspberry Pi / production stack): lite bind-mounts **individual files** (`game.json`, `user.json`), not the whole dir, and has **no agent service** — so only `game.json`/`user.json` admin persistence is in scope (no `agent.json` kill-switch present to persist). The sidecar mounts the dir to reach those host inodes and chmods exactly the two files the lite menu writes.

### Why this approach (trade-offs vs alternatives)
- **Bind mount, not a named volume** — flagd, the agent and the menu all share the same host `./services/flagd` dir (single-source-of-truth, #959). A named volume would diverge from the host repo files. ✅ invariant preserved.
- **chgrp group, not chown owner** — the host user stays the file **owner**, so a dev checkout stays editable; only the group is reassigned. (git doesn't track group-write bits, so no spurious mode churn.)
- **Portable** — no hardcoded host uid (rejected option (b)); works on dev and the Pi.
- **No entrypoint chown in the menu image** — would require the menu to start as root, defeating the nonroot posture (rejected option (a)).
- **Only the menu `depends_on` the sidecar** — flagd only reads the files, and the agent runs as root with in-place `O_TRUNC` writes, so group perms are irrelevant to both; depending on the sidecar there would needlessly serialize their startup. Documented inline so the asymmetry isn't "fixed" away.

### Ownership model intact
The agent-never-writes-`agent.json` invariant rests on **code-level path guards** (`experiment/gate.go` + hardcoded writer paths), not filesystem perms — the agent already mounts the dir read-write and runs as root, so the permission change is invisible to it and grants it nothing new. Documented in `docs/OWNERSHIP_MODEL.md` §2.

### CI `user: "0"` hack dropped
`docker-compose.ci.yml`: removed `user: "0"` from the menu and pointed `flag-dir-init` at the CI flag dir. **This is the end-to-end regression guard:** the existing admin persistence integration tests now run with the menu **nonroot** (prod-like), so a regression of the #1031 silent-non-persistence bug fails CI.

### Defensive hardening (regardless)
`update_default_variant` now logs `PermissionError` at **CRITICAL** and `OSError` at **ERROR** with a clear "Admin setting NOT persisted" message + `exc_info`, instead of swallowing them in the generic catch-all.

## Validation
- **Regression guard (integration):** the existing `tests/integration/test_admin_flow.py` persistence suite (`test_sensitivity_change_persists`, `test_option_cycle_and_value_change_persists`, etc.) is **not modified** by this PR — it is the guard precisely because dropping `user: "0"` in `docker-compose.ci.yml` makes it exercise the **nonroot** admin write path through `flag-dir-init` end-to-end. Before this fix the nonroot write would fail; the suite passing on the nonroot menu is the proof the sidecar works.
- **Unit (new):** `lib/tests/test_flag_config_writer.py` — 23 passed. The **2 new tests** added by this PR live here (not in `test_admin_flow.py`): they mock `builtins.open` to assert a write `PermissionError`/`OSError` is logged **loudly** (CRITICAL/ERROR) and not swallowed. They cover the loud-logging behavior, not the sidecar/real filesystem perms (which the CI nonroot integration run covers).
- `docker compose -f docker-compose.lite.yml config` resolves; `docker compose -f docker-compose.yml ... config` resolves; YAML validated for both compose files.
- `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
