### PR TITLE
fix(menu): admin force-start launches coordinator + Cross game-mode cycling (#1029 #1030)

### DIFF
--- a/services/menu/handlers/admin.py
+++ b/services/menu/handlers/admin.py
@@ -642,7 +642,14 @@ class AdminModeHandler:
                 span.set_attribute("old_selection", current_selection)
                 span.set_attribute("new_selection", new_selection)
 
-                # Publish selection change
+                # Actually apply the selection through the menu so the coordinator
+                # start path (and the dashboard) see it — not just a fire-and-forget
+                # event nobody consumes (#1030). Route through the same working path
+                # as handle_game_mode so a future re-wiring (e.g. a backward-cycle
+                # button) can't silently reintroduce the dead-application bug.
+                await self.callbacks.select_game_mode(new_selection)
+
+                # Mirror the selection as an event for any listeners (dashboard).
                 await self._publish_event(
                     "game_selection_changed",
                     {"game_name": new_selection, "source": "admin_mode", "serial": serial},

--- a/services/menu/handlers/admin.py
+++ b/services/menu/handlers/admin.py
@@ -65,6 +65,14 @@ class AdminModeCallbacks(Protocol):
         """Get list of available game options."""
         ...
 
+    async def select_game_mode(self, game_name: str) -> None:
+        """Select a game mode by name (updates menu selection + persists)."""
+        ...
+
+    async def start_game(self, serial: str, source: str, controllers: list[str] | None = None) -> None:
+        """Start a coordinator game with an optional explicit controller roster."""
+        ...
+
 
 class AdminModeHandler:
     """
@@ -560,7 +568,13 @@ class AdminModeHandler:
                 span.set_attribute("old_selection", current_selection)
                 span.set_attribute("new_selection", new_selection)
 
-                # Publish selection change
+                # Actually apply the selection through the menu so the coordinator
+                # start path (and the dashboard) see it — not just a fire-and-
+                # forget event nobody consumes (#1030). select_game_mode updates
+                # current_selection, the state_manager game mode, and persists.
+                await self.callbacks.select_game_mode(new_selection)
+
+                # Mirror the selection as an event for any listeners (dashboard).
                 await self._publish_event(
                     "game_selection_changed",
                     {"game_name": new_selection, "source": "admin_mode", "serial": serial},
@@ -706,29 +720,38 @@ class AdminModeHandler:
                     },
                 )
 
+                # Capture the selected mode before exit() tears down session state.
+                game_name = self._current_game_mode
+
                 # Exit admin mode (ends session_span)
                 await self.exit()
 
                 # Small delay for visual feedback
                 await asyncio.sleep(0.3)
 
-                # Start the game
+                # Mark the menu as starting and announce the request (consumed by
+                # the dashboard / integration tests).
                 from proto import menu_pb2
 
                 self.callbacks.set_menu_state(menu_pb2.MenuState.GAME_STARTING)
                 await self._publish_event(
                     "game_requested",
                     {
-                        "game_name": self._current_game_mode,
+                        "game_name": game_name,
                         "source": "admin_force_start",
                         "serial": serial,
                         "controllers": json.dumps(controllers),
                     },
                 )
 
+                # Actually launch the game through the coordinator start path
+                # (#1029) with the force_all_start-aware roster — previously this
+                # only lit up the menu but no game began. _start_game resets the
+                # menu state if the roster is too small, so we don't get stuck.
+                await self.callbacks.start_game(serial, "admin_force_start", controllers)
+
                 logger.info(
-                    f"Force starting game '{self._current_game_mode}' via admin controller {serial} "
-                    f"with {len(controllers)} players"
+                    f"Force starting game '{game_name}' via admin controller {serial} with {len(controllers)} players"
                 )
 
             except Exception as e:

--- a/services/menu/servicer.py
+++ b/services/menu/servicer.py
@@ -613,29 +613,51 @@ class MenuServicer(menu_pb2_grpc.MenuServiceServicer):
                 if self.state == menu_pb2.MenuState.GAME_STARTING:
                     self.state = menu_pb2.MenuState.RUNNING
                     await self.event_publisher.publish("game_start_cancelled", {})
+                # Restore lobby LEDs. The button monitor and lobby music are still
+                # running (we abort before _prepare_game_start), so a full
+                # _restart_lobby would be wrong here — but admin force-start sends a
+                # white flash before this path, so re-register controllers to set
+                # the proper lobby colors back. state_manager.reset() re-runs the
+                # CONNECTED on_enter handlers which set lobby colors.
+                await self.state_manager.reset()
                 return
 
             await self._prepare_game_start()
 
-            # Build player list and config
-            players = [
-                game_coordinator_pb2.Player(serial=s, team=i % 2, alive=True, score=0) for i, s in enumerate(roster)
-            ]
-            config = self._build_game_config(self.current_selection, players)
+            # _prepare_game_start() has already set state=GAME_STARTING and torn
+            # down the lobby (button monitor + lobby music). If anything in the
+            # prep/build window below throws (bad mode config, stub creation,
+            # audio/button RPC error), restore the lobby and reset state instead
+            # of leaving the menu stuck in GAME_STARTING with no lobby. The
+            # exception otherwise only surfaces in the background task's
+            # done-callback. _run_game_event_stream already self-protects, so this
+            # only needs to cover the synchronous prep/build window before it.
+            try:
+                # Build player list and config
+                players = [
+                    game_coordinator_pb2.Player(serial=s, team=i % 2, alive=True, score=0) for i, s in enumerate(roster)
+                ]
+                config = self._build_game_config(self.current_selection, players)
 
-            # Inject trace context into gRPC metadata
-            metadata = self._build_trace_metadata()
+                # Inject trace context into gRPC metadata
+                metadata = self._build_trace_metadata()
 
-            # Call GameCoordinator.StreamGameEvents with start_config
-            stub = game_coordinator_pb2_grpc.GameCoordinatorServiceStub(self.game_coordinator_channel)
-            request = game_coordinator_pb2.StreamEventsRequest(start_config=config)
+                # Call GameCoordinator.StreamGameEvents with start_config
+                stub = game_coordinator_pb2_grpc.GameCoordinatorServiceStub(self.game_coordinator_channel)
+                request = game_coordinator_pb2.StreamEventsRequest(start_config=config)
 
-            logger.info(
-                f"Starting game via GameCoordinator stream ({source}): "
-                f"{self.current_selection.name} with {len(roster)} players"
-            )
+                logger.info(
+                    f"Starting game via GameCoordinator stream ({source}): "
+                    f"{self.current_selection.name} with {len(roster)} players"
+                )
 
-            await self._run_game_event_stream(stub, request, metadata, span)
+                await self._run_game_event_stream(stub, request, metadata, span)
+            except Exception as e:
+                logger.error(f"Game start failed during preparation: {e}", exc_info=True)
+                span.record_exception(e)
+                if self.state == menu_pb2.MenuState.GAME_STARTING:
+                    await self._restart_lobby()
+                raise
 
     async def _prepare_game_start(self) -> None:
         """Stop lobby services in preparation for game start."""

--- a/services/menu/servicer.py
+++ b/services/menu/servicer.py
@@ -61,6 +61,10 @@ class MenuServicer(menu_pb2_grpc.MenuServiceServicer):
         """Initialize menu service."""
         self.state = menu_pb2.MenuState.STOPPED
         self.current_selection: Games = Games.JoustFFA
+        # Selectable game modes, exposed to the admin handler so controller Cross
+        # cycling and the dashboard share one source of truth (#1030). GAME_MODES
+        # already excludes unimplemented/meta modes.
+        self.game_options: list[str] = list(GAME_MODES)
 
         # Persistent gRPC channels
         from lib.grpc_utils import create_channel
@@ -189,7 +193,34 @@ class MenuServicer(menu_pb2_grpc.MenuServiceServicer):
 
     def get_game_options(self) -> list[str]:
         """Get list of available game options (AdminModeCallbacks)."""
-        return self.game_options if hasattr(self, "game_options") else []
+        return list(self.game_options)
+
+    async def select_game_mode(self, game_name: str) -> None:
+        """Select a game mode by name (AdminModeCallbacks).
+
+        Mirrors the web/controller select path so admin Cross cycling lands in
+        the SAME state the coordinator start path reads (#1030): it updates the
+        servicer's ``current_selection``, the state_manager's game mode (the
+        value the admin handler displays), and persists the choice to flagd.
+        """
+        game_mode = Games.from_name(game_name)
+        if game_mode is None or game_name not in GAME_MODES:
+            logger.warning(f"Admin selected unknown game mode: {game_name}")
+            return
+        self.current_selection = game_mode
+        self.state_manager.set_game_mode(game_mode)
+        await self.event_publisher.publish("selection_changed", {"game_name": game_mode.name, "source": "admin"})
+        self.user_prefs_writer.update_default_variant("current_game", game_mode.name)
+        logger.info(f"Game selected via admin: {game_mode.name}")
+
+    async def start_game(self, serial: str, source: str, controllers: list[str] | None = None) -> None:
+        """Start a coordinator game (AdminModeCallbacks).
+
+        Lets the admin force-start path launch the selected mode through the same
+        coordinator start path the ready/web flow uses (#1029), optionally with an
+        explicit controller roster (admin force-start honors force_all_start).
+        """
+        await self._start_game(serial, source=source, controllers=controllers)
 
     # ControllerEventCallbacks protocol implementation
 
@@ -505,7 +536,7 @@ class MenuServicer(menu_pb2_grpc.MenuServiceServicer):
         await self.audio_channel.close()
         logger.info("Menu service gRPC channels closed")
 
-    async def _start_game(self, serial: str, source: str = "controller"):
+    async def _start_game(self, serial: str, source: str = "controller", controllers: list[str] | None = None):
         """
         Schedule game start as a background task.
 
@@ -516,6 +547,8 @@ class MenuServicer(menu_pb2_grpc.MenuServiceServicer):
         Args:
             serial: Controller serial that triggered the start (for logging)
             source: Source of the start request ("controller" or "web")
+            controllers: Optional explicit roster (admin force-start passes the
+                force_all_start-aware list); None uses the ready controllers.
         """
         # Cancel any existing game lifecycle task (defensive)
         if self._game_lifecycle_task is not None and not self._game_lifecycle_task.done():
@@ -525,7 +558,7 @@ class MenuServicer(menu_pb2_grpc.MenuServiceServicer):
                 await self._game_lifecycle_task
 
         # Schedule game lifecycle as background task to avoid blocking button monitor
-        self._game_lifecycle_task = asyncio.create_task(self._run_game_lifecycle(serial, source))
+        self._game_lifecycle_task = asyncio.create_task(self._run_game_lifecycle(serial, source, controllers))
 
         # Log any exceptions from the background task
         def _log_exception(t):
@@ -537,7 +570,7 @@ class MenuServicer(menu_pb2_grpc.MenuServiceServicer):
 
         self._game_lifecycle_task.add_done_callback(_log_exception)
 
-    async def _run_game_lifecycle(self, serial: str, source: str = "controller"):
+    async def _run_game_lifecycle(self, serial: str, source: str = "controller", controllers: list[str] | None = None):
         """
         Run the full game lifecycle via StreamGameEvents.
 
@@ -550,6 +583,8 @@ class MenuServicer(menu_pb2_grpc.MenuServiceServicer):
         Args:
             serial: Controller serial that triggered the start (for logging)
             source: Source of the start request ("controller" or "web")
+            controllers: Optional explicit roster (admin force-start passes the
+                force_all_start-aware list); None uses the ready controllers.
         """
         from proto import game_coordinator_pb2, game_coordinator_pb2_grpc
 
@@ -567,20 +602,24 @@ class MenuServicer(menu_pb2_grpc.MenuServiceServicer):
             span.set_attribute("game.name", self.current_selection.name)
             span.set_attribute("game.source", source)
 
-            # Get controllers from state_manager (source of truth)
-            controllers = list(self.state_manager.ready_controllers)
-            span.set_attribute("controller.count", len(controllers))
+            # Roster: an explicit list (admin force-start, force_all_start-aware)
+            # overrides the default ready-controllers source of truth.
+            roster = list(controllers) if controllers is not None else list(self.state_manager.ready_controllers)
+            span.set_attribute("controller.count", len(roster))
 
-            if len(controllers) < 2:
-                logger.warning(f"Not enough players to start game: {len(controllers)}")
+            if len(roster) < 2:
+                logger.warning(f"Not enough players to start game: {len(roster)}")
+                # Don't leave the menu stuck in GAME_STARTING if a start aborts.
+                if self.state == menu_pb2.MenuState.GAME_STARTING:
+                    self.state = menu_pb2.MenuState.RUNNING
+                    await self.event_publisher.publish("game_start_cancelled", {})
                 return
 
             await self._prepare_game_start()
 
             # Build player list and config
             players = [
-                game_coordinator_pb2.Player(serial=s, team=i % 2, alive=True, score=0)
-                for i, s in enumerate(controllers)
+                game_coordinator_pb2.Player(serial=s, team=i % 2, alive=True, score=0) for i, s in enumerate(roster)
             ]
             config = self._build_game_config(self.current_selection, players)
 
@@ -593,7 +632,7 @@ class MenuServicer(menu_pb2_grpc.MenuServiceServicer):
 
             logger.info(
                 f"Starting game via GameCoordinator stream ({source}): "
-                f"{self.current_selection.name} with {len(controllers)} players"
+                f"{self.current_selection.name} with {len(roster)} players"
             )
 
             await self._run_game_event_stream(stub, request, metadata, span)

--- a/services/menu/tests/test_admin_handler.py
+++ b/services/menu/tests/test_admin_handler.py
@@ -26,6 +26,8 @@ def mock_callbacks():
     """Create mock callbacks."""
     callbacks = MagicMock()
     callbacks.get_game_options = MagicMock(return_value=["JoustFFA", "JoustTeams"])
+    callbacks.select_game_mode = AsyncMock()
+    callbacks.start_game = AsyncMock()
     return callbacks
 
 
@@ -418,6 +420,59 @@ class TestHandleForceStartFlagd:
         handler._publish_event.assert_called()
         call_args = handler._publish_event.call_args[0]
         assert call_args[0] == "game_requested"
+
+    @pytest.mark.asyncio
+    async def test_handle_force_start_invokes_coordinator_start(self, handler, mock_state_manager):
+        """Force start must actually launch the game through the coordinator start
+        path (#1029) — not merely publish the menu event. The selected mode +
+        force_all_start-aware roster must be passed to the start callback."""
+        mock_state_manager.current_game_mode.name = "JoustTeams"
+        mock_state_manager.connected_controllers = {"s1", "s2", "s3"}
+        mock_state_manager.ready_controllers = {"s1"}
+        handler._publish_event = AsyncMock()
+        handler.exit = AsyncMock()
+
+        # force_all_start=True -> start with ALL connected controllers.
+        mock_gs_client = MagicMock()
+        mock_gs_client.get_boolean_value = MagicMock(return_value=True)
+
+        with (
+            patch("services.menu.handlers.admin.asyncio.sleep", new_callable=AsyncMock),
+            patch("lib.feature_flags.get_flag_client", return_value=mock_gs_client),
+        ):
+            await handler.handle_force_start("test_serial")
+
+        handler.callbacks.start_game.assert_awaited_once()
+        args = handler.callbacks.start_game.await_args
+        assert args.args[0] == "test_serial"
+        assert args.args[1] == "admin_force_start"
+        # Roster honors force_all_start: all connected controllers.
+        roster = args.args[2]
+        assert set(roster) == {"s1", "s2", "s3"}
+
+    @pytest.mark.asyncio
+    async def test_handle_force_start_roster_uses_ready_when_not_force_all(self, handler, mock_state_manager):
+        """Without force_all_start, the start roster is the ready controllers
+        plus the admin controller (#1029)."""
+        mock_state_manager.current_game_mode.name = "JoustFFA"
+        mock_state_manager.connected_controllers = {"s1", "s2", "s3"}
+        mock_state_manager.ready_controllers = {"s1", "s2"}
+        handler._publish_event = AsyncMock()
+        handler.exit = AsyncMock()
+
+        mock_gs_client = MagicMock()
+        mock_gs_client.get_boolean_value = MagicMock(return_value=False)
+
+        with (
+            patch("services.menu.handlers.admin.asyncio.sleep", new_callable=AsyncMock),
+            patch("lib.feature_flags.get_flag_client", return_value=mock_gs_client),
+        ):
+            await handler.handle_force_start("admin_serial")
+
+        handler.callbacks.start_game.assert_awaited_once()
+        roster = handler.callbacks.start_game.await_args.args[2]
+        # ready (s1, s2) + admin (admin_serial), no duplicates.
+        assert set(roster) == {"s1", "s2", "admin_serial"}
 
 
 # ============================================================================
@@ -863,6 +918,18 @@ class TestHandleGameMode:
         await handler.handle_game_mode("test_serial")
 
         mock_state_manager.publish_event.assert_not_called()
+        handler.callbacks.select_game_mode.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_applies_selection_via_callback(self, handler, mock_state_manager):
+        """Cross cycling must actually apply the new selection through the menu
+        (#1030) — not just publish a fire-and-forget event."""
+        mock_state_manager.current_game_mode.name = "JoustFFA"
+        handler.callbacks.get_game_options.return_value = ["JoustFFA", "JoustTeams", "Werewolf"]
+
+        await handler.handle_game_mode("test_serial")
+
+        handler.callbacks.select_game_mode.assert_awaited_once_with("JoustTeams")
 
 
 class TestHandleGameModeChange:

--- a/services/menu/tests/test_admin_handler.py
+++ b/services/menu/tests/test_admin_handler.py
@@ -959,6 +959,29 @@ class TestHandleGameModeChange:
         await handler.handle_game_mode_change("test_serial")
 
         mock_state_manager.publish_event.assert_not_called()
+        handler.callbacks.select_game_mode.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_forward_applies_selection_via_callback(self, handler, mock_state_manager):
+        """Forward cycling must actually apply the new selection through the menu
+        (same path as handle_game_mode) — not just publish a fire-and-forget
+        event (#1030). Guards against a future re-wiring reintroducing the bug."""
+        mock_state_manager.current_game_mode.name = "JoustFFA"
+        handler.callbacks.get_game_options.return_value = ["JoustFFA", "JoustTeams", "Werewolf"]
+
+        await handler.handle_game_mode_change("test_serial", forward=True)
+
+        handler.callbacks.select_game_mode.assert_awaited_once_with("JoustTeams")
+
+    @pytest.mark.asyncio
+    async def test_backward_applies_selection_via_callback(self, handler, mock_state_manager):
+        """Backward cycling must also apply the selection through the menu."""
+        mock_state_manager.current_game_mode.name = "JoustFFA"
+        handler.callbacks.get_game_options.return_value = ["JoustFFA", "JoustTeams", "Werewolf"]
+
+        await handler.handle_game_mode_change("test_serial", forward=False)
+
+        handler.callbacks.select_game_mode.assert_awaited_once_with("Werewolf")
 
 
 class TestHandleBattery:

--- a/services/menu/tests/test_lobby_feedback.py
+++ b/services/menu/tests/test_lobby_feedback.py
@@ -72,12 +72,12 @@ class TestMenuServicerBasic:
         assert menu_servicer.get_menu_state() == menu_pb2.MenuState.RUNNING
 
     def test_get_game_options(self, menu_servicer):
-        """Test getting game options."""
-        # get_game_options returns game_options attribute if set, else empty
+        """get_game_options is populated from GAME_MODES so admin Cross cycling
+        works (#1030) — it is no longer the always-empty stub."""
         options = menu_servicer.get_game_options()
         assert isinstance(options, list)
-        # By default returns empty list until game_options is set
-        # This is used by AdminModeCallbacks
+        assert options == GAME_MODES
+        assert "JoustFFA" in options
 
 
 @pytest.mark.asyncio

--- a/services/menu/tests/test_servicer.py
+++ b/services/menu/tests/test_servicer.py
@@ -1539,3 +1539,83 @@ class TestClearReadyState:
             MenuServicer._clear_ready_state(servicer)
 
         mock_metrics.player_ready.clear.assert_called_once()
+
+
+class TestRunGameLifecycleMidStartFailure:
+    """Tests for _run_game_lifecycle recovery when prep/build throws.
+
+    _prepare_game_start() sets state=GAME_STARTING and tears down the lobby. If
+    anything between there and the protected _run_game_event_stream throws (bad
+    mode config, stub creation, audio/button RPC error), the menu must not get
+    stuck in GAME_STARTING with no lobby — it should restore the lobby and reset
+    to RUNNING, then re-raise so the failure still surfaces.
+    """
+
+    @pytest.fixture
+    def servicer(self):
+        s = FakeMenuServicer()
+        # _run_game_lifecycle + _prepare_game_start + _restart_lobby dependencies
+        s.idle_monitor = MagicMock()
+        s.stop_button_monitor = AsyncMock()
+        s.start_button_monitor = AsyncMock()
+        # Two ready controllers so the roster check passes and we reach the
+        # prep/build window we want to exercise.
+        s.state_manager.controller_states = {
+            "s1": ControllerState.READY,
+            "s2": ControllerState.READY,
+        }
+        return s
+
+    async def _run(self, servicer):
+        """Call the real _run_game_lifecycle bound to the fake servicer."""
+        from unittest.mock import patch
+
+        from services.menu.servicer import MenuServicer
+
+        with patch("services.menu.servicer.metrics"):
+            await MenuServicer._run_game_lifecycle(servicer, "s1", source="web")
+
+    @pytest.mark.asyncio
+    async def test_build_config_exception_restores_lobby(self, servicer):
+        """An exception in _build_game_config restores the lobby and re-raises."""
+        from services.menu.servicer import MenuServicer
+
+        # Bind the real prep/restore helpers so we exercise the actual teardown +
+        # restore, but make config-building blow up mid-start.
+        servicer._prepare_game_start = lambda: MenuServicer._prepare_game_start(servicer)
+        servicer._restart_lobby = lambda: MenuServicer._restart_lobby(servicer)
+        servicer._build_trace_metadata = MagicMock(return_value=[])
+        servicer._build_game_config = MagicMock(side_effect=RuntimeError("bad mode config"))
+
+        with pytest.raises(RuntimeError, match="bad mode config"):
+            await self._run(servicer)
+
+        # Lobby restored, not stuck in GAME_STARTING.
+        assert servicer.state == menu_pb2.MenuState.RUNNING
+        servicer.start_button_monitor.assert_awaited()
+        servicer.audio.start_lobby_music.assert_awaited()
+        servicer.state_manager.reset.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_no_recovery_when_not_game_starting(self, servicer):
+        """If the failure happens after the lobby was already restored (state no
+        longer GAME_STARTING), we don't double-restore — but we still re-raise."""
+        from services.menu.servicer import MenuServicer
+
+        servicer._prepare_game_start = lambda: MenuServicer._prepare_game_start(servicer)
+        restart = AsyncMock()
+        servicer._restart_lobby = restart
+        servicer._build_trace_metadata = MagicMock(return_value=[])
+
+        def build_then_flip(*_args, **_kwargs):
+            # Simulate the stream already having restored the lobby.
+            servicer.state = menu_pb2.MenuState.RUNNING
+            raise RuntimeError("late failure")
+
+        servicer._build_game_config = MagicMock(side_effect=build_then_flip)
+
+        with pytest.raises(RuntimeError, match="late failure"):
+            await self._run(servicer)
+
+        # State already RUNNING, so the guard skips the redundant restore.
+        restart.assert_not_awaited()

--- a/tests/integration/test_admin_flow.py
+++ b/tests/integration/test_admin_flow.py
@@ -46,6 +46,8 @@ import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
 
+from openfeature.evaluation_context import EvaluationContext  # noqa: E402
+
 from proto import (  # noqa: E402
     controller_manager_mock_pb2,
     menu_pb2,
@@ -53,10 +55,13 @@ from proto import (  # noqa: E402
 
 from tests.integration.helpers import (  # noqa: E402
     ADMIN_WHITE,
+    GameEventCollector,
     MenuEventCollector,
     active_flag_file,
+    async_poll_until,
     enter_admin_mode,
     exit_admin_mode,
+    flagd_probe_client,
     get_controller_color,
     get_controller_serials,
     get_game_client,
@@ -67,6 +72,7 @@ from tests.integration.helpers import (  # noqa: E402
     press_admin_combo,
     select_game_mode,
     setup_mock_controllers,
+    wait_for_lobby_colors,
 )
 
 GAME_FLAG_PATH = active_flag_file("game")
@@ -169,6 +175,22 @@ def _default_variant(path: str, flag_key: str) -> str:
     return doc["flags"][flag_key]["defaultVariant"]
 
 
+def _set_default_variant(path: str, flag_key: str, variant: str) -> None:
+    """Flip a flag's defaultVariant in the served CI flag file (idempotent).
+
+    flagd hot-reloads the file; the ``admin_flags`` fixture restores it. Safe to
+    call repeatedly as a ``poll_until`` rewrite to self-heal a coalesced
+    file-watch event under CI load.
+    """
+    with open(path) as fh:
+        doc = json.load(fh)
+    if doc["flags"][flag_key]["defaultVariant"] == variant:
+        return
+    doc["flags"][flag_key]["defaultVariant"] = variant
+    with open(path, "w") as fh:
+        json.dump(doc, fh, indent=2)
+
+
 async def _wait_default_variant_changes(
     path: str, flag_key: str, baseline: str, timeout: float = PERSIST_TIMEOUT_SECONDS
 ) -> str:
@@ -237,7 +259,9 @@ async def test_ps_exit_restores_lobby_color(docker_compose, menu_client, mock_cl
 
 
 @pytest.mark.asyncio
-async def test_partial_combo_does_not_enter_admin(docker_compose, menu_client, mock_client):
+async def test_partial_combo_does_not_enter_admin(
+    docker_compose, menu_client, mock_client
+):
     """Pressing only three of the four face buttons must NOT enter admin mode:
     the LED never goes admin-white."""
     serials = await _start_menu_with_controllers(docker_compose, menu_client)
@@ -266,7 +290,9 @@ async def test_partial_combo_does_not_enter_admin(docker_compose, menu_client, m
 
 
 @pytest.mark.asyncio
-async def test_sensitivity_change_persists(docker_compose, menu_client, mock_client, admin_flags):
+async def test_sensitivity_change_persists(
+    docker_compose, menu_client, mock_client, admin_flags
+):
     """In admin mode, Circle cycles sensitivity; the change persists by advancing
     the ``sensitivity`` flag's defaultVariant in the served game.json."""
     serials = await _start_menu_with_controllers(docker_compose, menu_client)
@@ -340,35 +366,92 @@ async def test_option_cycle_and_value_change_persists(
 
 
 @pytest.mark.asyncio
-async def test_force_start_requests_game(docker_compose, menu_client, mock_client, admin_flags):
+async def test_force_start_requests_game(
+    docker_compose, menu_client, mock_client, admin_flags
+):
     """Holding the trigger in admin mode force-starts the game: the menu publishes
-    a ``game_requested`` event with source=admin_force_start naming the current
-    game mode.
+    a ``game_requested`` event (source=admin_force_start) AND actually invokes the
+    coordinator start path (#1029).
 
-    NOTE (behavioral finding, #823): ``AdminModeHandler.handle_force_start`` only
-    publishes this event and sets the menu state to GAME_STARTING — it does NOT
-    invoke the menu's ``_start_game`` coordinator path (unlike the ready-flow's
-    ``start_game_callback``), and nothing in the menu bridges the
-    ``game_requested`` event back to it. So admin force-start does not actually
-    start a coordinator game today; this test asserts the real current behavior
-    (the menu event), which is the contract the surface exposes.
+    Previously ``handle_force_start`` only published the menu event and set
+    GAME_STARTING; it never invoked the menu's ``start_game`` coordinator path, so
+    the menu lit up but NO start was ever attempted. The fix wires force-start
+    through ``MenuServicer.start_game`` with the force_all_start-aware roster.
+
+    We enable ``force_all_start`` so the roster is the menu's CONNECTED
+    controllers (no dependence on cross-test ready state) and poll flagd until the
+    write is served. The decisive #1029 signal is that the menu now *invokes* the
+    coordinator start: it either reaches ``game_started`` (roster intact) or, if
+    the shared-session roster has churned below the minimum, surfaces
+    ``game_start_cancelled`` from inside ``_start_game`` — BOTH happen only because
+    ``start_game`` is now called. Before the fix neither occurred (the menu sat in
+    GAME_STARTING with no coordinator contact at all).
     """
+    # Enable force_all_start and confirm flagd is serving it (rewrite self-heal
+    # covers a coalesced file-watch event under CI load) before force-starting.
+    _set_default_variant(GAME_FLAG_PATH, "force_all_start", "on")
+    with flagd_probe_client(docker_compose, "game") as probe:
+        served = await async_poll_until(
+            lambda: (
+                probe.get_boolean_value("force_all_start", False, EvaluationContext())
+                is True
+            ),
+            rewrite=lambda: _set_default_variant(
+                GAME_FLAG_PATH, "force_all_start", "on"
+            ),
+        )
+    assert served, "flagd never served force_all_start=on"
+
     serials = await _start_menu_with_controllers(docker_compose, menu_client)
     admin_serial = serials[0]
 
-    async with MenuEventCollector(menu_client) as menu_collector:
-        await enter_admin_mode(mock_client, admin_serial)
+    # Wait until the controllers are registered in the lobby (they only get a
+    # lobby color once the menu sees them connected).
+    await wait_for_lobby_colors(mock_client, serials, timeout=15.0)
 
-        # Hold the trigger past the (CI-shortened) force-start threshold.
-        await hold_trigger_for_force_start(mock_client, admin_serial, hold_seconds=1.5)
+    game_client, game_channel = await get_game_client(docker_compose)
+    try:
+        async with (
+            MenuEventCollector(menu_client) as menu_collector,
+            GameEventCollector(game_client) as game_collector,
+        ):
+            await enter_admin_mode(mock_client, admin_serial)
 
-        requested = await menu_collector.wait_for_event("game_requested", timeout=10.0)
-        assert requested.data.get("source") == "admin_force_start", (
-            f"unexpected force-start source: {dict(requested.data)}"
-        )
-        assert requested.data.get("game_name"), (
-            f"force-start request carried no game_name: {dict(requested.data)}"
-        )
+            # Hold the trigger past the (CI-shortened) force-start threshold.
+            await hold_trigger_for_force_start(
+                mock_client, admin_serial, hold_seconds=1.5
+            )
+
+            requested = await menu_collector.wait_for_event(
+                "game_requested", timeout=10.0
+            )
+            assert requested.data.get("source") == "admin_force_start", (
+                f"unexpected force-start source: {dict(requested.data)}"
+            )
+            assert requested.data.get("game_name"), (
+                f"force-start request carried no game_name: {dict(requested.data)}"
+            )
+
+            # #1029: force-start must INVOKE the coordinator start path. Accept
+            # either a real coordinator start (game_started) or the menu's
+            # start-aborted signal (game_start_cancelled) — both prove start_game
+            # was called; before the fix, neither ever fired.
+            started_task = asyncio.create_task(
+                game_collector.wait_for_event("game_started", timeout=15.0)
+            )
+            cancelled_task = asyncio.create_task(
+                menu_collector.wait_for_event("game_start_cancelled", timeout=15.0)
+            )
+            done, pending = await asyncio.wait(
+                {started_task, cancelled_task},
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            for task in pending:
+                task.cancel()
+            invoked = any(not t.cancelled() and t.exception() is None for t in done)
+            assert invoked, "force-start did not invoke the coordinator start path"
+    finally:
+        await game_channel.close()
 
 
 # =============================================================================
@@ -380,33 +463,41 @@ async def test_force_start_requests_game(docker_compose, menu_client, mock_clien
 async def test_force_start_respects_selected_game_mode(
     docker_compose, menu_client, mock_client, admin_flags
 ):
-    """Force start requests the game mode currently selected in the menu (not a
-    hardcoded default): with JoustTeams selected, admin force start publishes a
-    ``game_requested`` naming JoustTeams.
+    """Admin Cross cycles the game mode (#1030) and force start respects it:
+    starting from JoustFFA, one Cross press in admin advances the menu selection
+    to JoustTeams (the next entry in the game registry), and a subsequent force
+    start publishes a ``game_requested`` naming JoustTeams.
 
-    NOTE (behavioral finding, #823): the plan's "Cross cycles the mode in admin"
-    path is currently DEAD — ``AdminModeHandler.handle_game_mode`` reads
-    ``callbacks.get_game_options()``, but ``MenuServicer.get_game_options``
-    returns ``self.game_options`` which is never populated (always []), so Cross
-    in admin logs "No game options available" and changes nothing. This test
-    therefore drives the selection through the WORKING menu path
-    (``select_game_mode``) and asserts force start respects it — the real
-    "respects selected mode" contract.
+    Previously the Cross path was DEAD: ``get_game_options()`` always returned []
+    so Cross logged "No game options available" and changed nothing. The fix
+    populates ``MenuServicer.game_options`` from the game registry and applies the
+    selection through the menu, so admin Cross cycling is now live.
     """
-    selected_mode = "JoustTeams"
+    # Start on JoustFFA; one Cross press advances to the next registry entry.
     serials = await _start_menu_with_controllers(
-        docker_compose, menu_client, game_mode=selected_mode
+        docker_compose, menu_client, game_mode="JoustFFA"
     )
     admin_serial = serials[0]
+    expected_mode = "JoustTeams"  # GAME_MODES[index(JoustFFA) + 1]
 
     async with MenuEventCollector(menu_client) as menu_collector:
         await enter_admin_mode(mock_client, admin_serial)
 
-        # Force start: the requested mode must be the menu's current selection.
+        # Cross: cycle the game mode forward. This must actually change the menu's
+        # selection now (not just log "No game options available").
+        await press_admin_button(mock_client, admin_serial, _Button.CROSS)
+        selection = await menu_collector.wait_for_event(
+            "selection_changed", timeout=10.0
+        )
+        assert selection.data.get("game_name") == expected_mode, (
+            f"admin Cross did not advance selection to {expected_mode}: {dict(selection.data)}"
+        )
+
+        # Force start: the requested mode must be the admin-cycled selection.
         await hold_trigger_for_force_start(mock_client, admin_serial, hold_seconds=1.5)
         requested = await menu_collector.wait_for_event("game_requested", timeout=10.0)
         assert requested.data.get("source") == "admin_force_start"
-        assert requested.data.get("game_name") == selected_mode, (
+        assert requested.data.get("game_name") == expected_mode, (
             f"force start requested {requested.data.get('game_name')}, "
-            f"expected menu-selected {selected_mode}"
+            f"expected admin-cycled {expected_mode}"
         )


### PR DESCRIPTION
## Summary

Fixes two admin-mode bugs surfaced by the #823 integration tests. They share `services/menu/handlers/admin.py` + `services/menu/servicer.py`, fixed together.

### #1029 — admin force-start never started a coordinator game
`handle_force_start` only published the `game_requested` event and set `GAME_STARTING`; it never invoked the menu's coordinator start path, and nothing bridged the event back to a start. The menu lit up but no game began.

**Fix:** added a `MenuServicer.start_game` callback that delegates to the existing `_start_game` (the same path the ready/web flow uses) and wired `handle_force_start` to it, passing the `force_all_start`-aware roster. `_run_game_lifecycle` now accepts an optional explicit roster and, if the start aborts (roster too small), resets `GAME_STARTING -> RUNNING` and emits `game_start_cancelled` so the menu never gets stuck.

### #1030 — admin Cross game-mode cycling was dead
`handle_game_mode` read `callbacks.get_game_options()`, but `MenuServicer.game_options` was never populated (always `[]`), so Cross logged "No game options available" and no-opped.

**Fix (made it work):** populated `game_options` from the real game registry (`GAME_MODES` — the same source `select_game_mode` uses) and had `handle_game_mode` apply the new selection through a new `MenuServicer.select_game_mode` callback that mirrors the web select path (updates `current_selection` + `state_manager` game mode + persists to flagd). Chose to revive rather than remove: Cross cycling was wired into `option_names`/`handle_button_event` and asserted by `test_admin_flow` — it was dead due to the empty list, not deliberately cut by #815/#1010 (that rationalization trimmed the Move/Select/Start option-cycle surface, not Cross).

## Tests
- **Menu unit** (`services/menu/tests/test_admin_handler.py`): force-start invokes `start_game` with the correct `force_all`/ready roster; Cross applies the selection via `select_game_mode`. `test_lobby_feedback.py` asserts `get_game_options` is populated. All 377 menu unit tests pass.
- **Integration** (`tests/integration/test_admin_flow.py`): updated the two tests that documented the buggy behavior. `test_force_start_requests_game` now asserts the coordinator start path is invoked; `test_force_start_respects_selected_game_mode` now drives selection through the (now-working) admin Cross button. All 7 admin_flow tests pass against docker compose (`make test-dev`).
- `make lint` clean.

Part of #823, #814 (M9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)