### PR TITLE
feat(agent): heuristic dynamic experiment declarer (#995)

### DIFF
--- a/services/agent/dynamic_declarer.go
+++ b/services/agent/dynamic_declarer.go
@@ -1,0 +1,400 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/joustmania/agent/decision"
+	"github.com/joustmania/agent/experiment"
+)
+
+// dynamic_declarer.go is the HEURISTIC (no-LLM) dynamic experiment declarer
+// (#995): instead of only the static AGENT_EXPERIMENT_SEED_FLAG env seed (one
+// operator-named flag), the agent CHOOSES which existing game.json flag to
+// experiment on by itself, using observed signals — so the parameterized surface
+// gets explored autonomously. It is the unblocked autonomy increment: the LLM
+// Proposer→Intents path (#960) is deferred (inert until the inference backend
+// #738/#742 lands); this delivers dynamic declaration NOW.
+//
+// SAFETY BOUNDARY — the declarer ADDS NO new write surface. It only ever picks:
+//   - an EXISTING game.json flag (never invents flags — the Gate's ReasonUnknownFlag
+//     still rejects a non-existent key), from a configurable candidate set;
+//   - an experimental value that is one of the flag's OWN existing variant values
+//     (a bounded, pre-vetted, JSON-kind-compatible perturbation of the default —
+//     it passes the Gate's checkTypeCompatible by construction); and
+//   - an EXPERIMENTABLE objective (decision.IsExperimentable; chaos is never
+//     chosen and is rejected at Registry.Declare anyway).
+//
+// Every Intent it builds therefore flows through the SAME #977 Gate + #978
+// Registry caps as the env seed; the declarer is a SELECTION heuristic in front
+// of the unchanged declare path, not a new privilege.
+//
+// GATING — default-off, byte-identical for everyone who does not opt in. The
+// declarer only runs when AGENT_EXPERIMENT_DYNAMIC_ENABLED=true AND the rest of
+// the experiment loop's gates are satisfied (AGENT_EXPERIMENTS_ENABLED + the
+// agent.json kill-switch — the loop only invokes the declarer from
+// allocateIfEnabled, which already self-aborts when the kill-switch is off).
+
+const (
+	// envDynamicEnabled is the opt-in for the heuristic dynamic declarer (#995).
+	// Default false ⇒ the loop declares ONLY the static env seed (if any),
+	// byte-identical to pre-#995 behavior. Subordinate to AGENT_EXPERIMENTS_ENABLED
+	// and the kill-switch.
+	envDynamicEnabled = "AGENT_EXPERIMENT_DYNAMIC_ENABLED"
+
+	// envDynamicCandidates overrides the candidate game.json flag set the declarer
+	// rotates over: a comma-separated list of flag keys. Empty/unset ⇒ ALL tunable
+	// game.json flags (every flag with at least two variants). A key that is not
+	// present in game.json is skipped (the Gate would reject it anyway).
+	envDynamicCandidates = "AGENT_EXPERIMENT_DYNAMIC_CANDIDATES"
+
+	// envDynamicObjective overrides the default objective the declarer uses when no
+	// fitness-pressure signal is available. Default balanced (experimentable). A
+	// non-experimentable value (chaos) falls back to balanced.
+	envDynamicObjective = "AGENT_EXPERIMENT_DYNAMIC_OBJECTIVE"
+
+	// envDynamicTargetN overrides the target games-per-arm for dynamically declared
+	// experiments. Non-positive/unset ⇒ 0 (the Registry reconciles it up to the
+	// verdict min-N, #1001).
+	envDynamicTargetN = "AGENT_EXPERIMENT_DYNAMIC_TARGET_N"
+)
+
+// dynamicEnabled reports whether the heuristic dynamic declarer opt-in is on.
+// This is the distinct, default-off #995 gate — independent of (and subordinate
+// to) the experiment-loop opt-in and the kill-switch.
+func dynamicEnabled() bool {
+	return strings.EqualFold(strings.TrimSpace(os.Getenv(envDynamicEnabled)), "true")
+}
+
+// pressureFunc returns the current per-objective failing-fitness pressure
+// (objective → pressure in [0,1], higher = more failing). It is the selection
+// SIGNAL: the declarer targets the objective under highest pressure when one is
+// available. nil (or an empty map) ⇒ no signal, so the declarer falls back to the
+// configured default objective and pure round-robin flag rotation. Injected so it
+// is deterministic / testable (the production wiring may pass nil until a live
+// pressure source is wired — the declarer is correct either way).
+type pressureFunc func() map[string]float64
+
+// dynamicDeclarer selects and builds a fresh experiment Intent on its own from
+// the live game.json flag surface (#995). It holds a persisted round-robin cursor
+// so successive declarations cover DIFFERENT candidate flags deterministically (no
+// wall-clock / rand — variety comes from the cursor, the #995 testability rule).
+type dynamicDeclarer struct {
+	// gameFlagPath is the live game.json the declarer reads candidate flags +
+	// their current defaults/variants from (re-read each call so a hot-reloaded
+	// file is reflected).
+	gameFlagPath string
+	// candidates, when non-empty, restricts/orders the flags the declarer rotates
+	// over. Empty ⇒ all tunable flags discovered in game.json (sorted, stable).
+	candidates []string
+	// defaultObjective is the experimentable objective used when no pressure signal
+	// is available.
+	defaultObjective string
+	// targetN is the target games-per-arm stamped on each declared Intent (0 ⇒ the
+	// Registry reconciles to min-N).
+	targetN int
+	// pressure is the optional fitness-pressure selection signal (may be nil).
+	pressure pressureFunc
+
+	// cursor is the persisted round-robin position across candidate flags. It only
+	// advances when a declaration is actually emitted, so a tick that finds no
+	// declarable flag does not skip the surface. NOT a clock — pure rotation.
+	cursor int
+}
+
+// newDynamicDeclarerFromEnv builds the declarer from the AGENT_EXPERIMENT_DYNAMIC_*
+// env vars, or returns nil when the opt-in is off (so the caller wires nothing).
+// pressure is the optional live signal seam (nil ⇒ default-objective fallback).
+func newDynamicDeclarerFromEnv(gameFlagPath string, pressure pressureFunc) *dynamicDeclarer {
+	if !dynamicEnabled() {
+		return nil
+	}
+	objective := strings.TrimSpace(os.Getenv(envDynamicObjective))
+	if !decision.IsExperimentable(objective) {
+		objective = decision.ObjectiveBalanced
+	}
+	if objective == "" {
+		objective = decision.ObjectiveBalanced
+	}
+	return &dynamicDeclarer{
+		gameFlagPath:     gameFlagPath,
+		candidates:       parseCandidates(os.Getenv(envDynamicCandidates)),
+		defaultObjective: objective,
+		targetN:          parseDynamicTargetN(os.Getenv(envDynamicTargetN)),
+		pressure:         pressure,
+	}
+}
+
+// activeFlags is the set of flag keys that already have a live (non-terminal)
+// experiment. The declarer skips them so it never stacks a second concurrent
+// experiment on a flag that is already under test (the #995 dedup rule). It is
+// supplied by the loop from the Registry's live view.
+type activeFlags map[string]struct{}
+
+// Declare selects ONE fresh experiment Intent from the candidate surface, or
+// returns ok=false when nothing is declarable (no readable candidate flag without
+// an active experiment, or no flag has a distinct alternate value). It advances
+// the round-robin cursor only when it emits an Intent, so successive Declares
+// cover different flags. It performs NO writes and consults NO clock — given the
+// same inputs (file, active set, cursor, pressure) it is fully deterministic.
+//
+// The caller (the loop) is responsible for the capacity check (registry caps) and
+// for actually calling Registry.Declare/Start with the returned Intent; this
+// keeps the heuristic pure and unit-testable in isolation from the registry.
+func (d *dynamicDeclarer) Declare(active activeFlags) (experiment.Intent, bool) {
+	flags := d.readCandidateFlags()
+	if len(flags) == 0 {
+		return experiment.Intent{}, false
+	}
+	order := d.candidateOrder(flags)
+	if len(order) == 0 {
+		return experiment.Intent{}, false
+	}
+
+	objective := d.selectObjective()
+
+	// Round-robin scan from the persisted cursor: the FIRST candidate that has no
+	// active experiment and a distinct alternate value wins. Scanning the whole
+	// ring guarantees we find a declarable flag if one exists, while the cursor
+	// start makes successive calls prefer the next flag (rotation/coverage).
+	n := len(order)
+	for i := 0; i < n; i++ {
+		idx := (d.cursor + i) % n
+		key := order[idx]
+		if active != nil {
+			if _, busy := active[key]; busy {
+				continue
+			}
+		}
+		value, ok := perturbValue(flags[key])
+		if !ok {
+			continue // no distinct alternate value to try (e.g. single-variant flag).
+		}
+		// Emit on this flag; advance the cursor PAST it so the next Declare starts at
+		// the following candidate (deterministic rotation across the surface).
+		d.cursor = (idx + 1) % n
+		return experiment.Intent{
+			Hypothesis:        d.hypothesis(key, value, objective),
+			FlagKey:           key,
+			ExperimentalValue: value,
+			Objective:         objective,
+			TargetNPerArm:     d.targetN,
+		}, true
+	}
+	return experiment.Intent{}, false
+}
+
+// candidateFlag is the declarer's read model of one game.json flag: its current
+// default value and the full set of (variant name → value) it may perturb toward.
+type candidateFlag struct {
+	defaultValue any
+	variants     map[string]json.RawMessage
+}
+
+// candidateOrder returns the candidate flag keys in the declarer's rotation order:
+// the configured candidate list (filtered to flags actually present + tunable), or
+// — when no list is configured — every discovered tunable flag in a STABLE sorted
+// order (deterministic rotation independent of map iteration).
+func (d *dynamicDeclarer) candidateOrder(flags map[string]candidateFlag) []string {
+	if len(d.candidates) > 0 {
+		order := make([]string, 0, len(d.candidates))
+		for _, k := range d.candidates {
+			if _, ok := flags[k]; ok {
+				order = append(order, k)
+			}
+		}
+		return order
+	}
+	order := make([]string, 0, len(flags))
+	for k := range flags {
+		order = append(order, k)
+	}
+	sort.Strings(order)
+	return order
+}
+
+// selectObjective picks the experimentable objective the declared experiment
+// optimizes: the objective under HIGHEST fitness pressure when a pressure signal
+// is available (target what is failing most), else the configured default. A
+// non-experimentable objective (chaos) is never returned — it has no fitness
+// function and would only fold worst-case 0 (and Registry.Declare rejects it).
+func (d *dynamicDeclarer) selectObjective() string {
+	if d.pressure != nil {
+		if obj, ok := highestPressureObjective(d.pressure()); ok {
+			return obj
+		}
+	}
+	return d.defaultObjective
+}
+
+// highestPressureObjective returns the experimentable objective with the greatest
+// positive pressure, or ok=false when no experimentable objective has positive
+// pressure. Ties break by objective name (deterministic).
+func highestPressureObjective(pressure map[string]float64) (string, bool) {
+	best := ""
+	bestP := 0.0
+	for obj, p := range pressure {
+		if p <= 0 || !decision.IsExperimentable(obj) {
+			continue
+		}
+		if p > bestP || (p == bestP && (best == "" || obj < best)) {
+			best = obj
+			bestP = p
+		}
+	}
+	return best, best != ""
+}
+
+// readCandidateFlags reads the live game.json and returns every TUNABLE flag (one
+// with at least two variants — a single-variant flag has no alternate value to
+// experiment toward) as a candidateFlag (its default value + variants). A
+// read/parse error returns an empty map (fail-closed: nothing is declarable until
+// the file is readable again), mirroring gameFlagVocab.
+func (d *dynamicDeclarer) readCandidateFlags() map[string]candidateFlag {
+	raw, err := os.ReadFile(d.gameFlagPath)
+	if err != nil {
+		return nil
+	}
+	var doc struct {
+		Flags map[string]struct {
+			Variants       map[string]json.RawMessage `json:"variants"`
+			DefaultVariant string                     `json:"defaultVariant"`
+		} `json:"flags"`
+	}
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		return nil
+	}
+	out := make(map[string]candidateFlag, len(doc.Flags))
+	for key, f := range doc.Flags {
+		if len(f.Variants) < 2 {
+			continue // not tunable: no alternate value to perturb toward.
+		}
+		dv, ok := f.Variants[f.DefaultVariant]
+		if !ok {
+			continue // malformed: default points at a missing variant — skip.
+		}
+		var def any
+		if err := json.Unmarshal(dv, &def); err != nil {
+			continue
+		}
+		out[key] = candidateFlag{defaultValue: def, variants: f.Variants}
+	}
+	return out
+}
+
+// perturbValue picks a BOUNDED, JSON-kind-compatible experimental value for a
+// flag: the variant value ADJACENT to the current default in the flag's own
+// sorted variant ordering (a small, pre-vetted step off the default). Choosing an
+// EXISTING variant value guarantees the value passes the Gate's type check by
+// construction (it is, by definition, the same kind as the flag's variants) and
+// stays within the flag's intended range — the safest possible perturbation. It
+// returns ok=false when the flag has no variant value distinct from its default.
+func perturbValue(f candidateFlag) (any, bool) {
+	defRaw, err := json.Marshal(f.defaultValue)
+	if err != nil {
+		return nil, false
+	}
+	// Stable order over variant NAMES so the choice is deterministic regardless of
+	// map iteration order.
+	names := make([]string, 0, len(f.variants))
+	for name := range f.variants {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	defIdx := -1
+	for i, name := range names {
+		if jsonRawEqual(f.variants[name], defRaw) {
+			defIdx = i
+			break
+		}
+	}
+	// Prefer the variant immediately AFTER the default (wrapping), so successive
+	// flags step consistently off their default; fall back to the first distinct
+	// variant when the default is not found among the variant values.
+	start := 0
+	if defIdx >= 0 {
+		start = defIdx + 1
+	}
+	for off := 0; off < len(names); off++ {
+		name := names[(start+off)%len(names)]
+		cand := f.variants[name]
+		if jsonRawEqual(cand, defRaw) {
+			continue // same as default — not a perturbation.
+		}
+		var v any
+		if err := json.Unmarshal(cand, &v); err != nil {
+			continue
+		}
+		return v, true
+	}
+	return nil, false
+}
+
+// hypothesis builds the human-readable hypothesis string stamped on a dynamically
+// declared Intent (mirrors seedIntentFromEnv's shape). It records that this was
+// the agent's own heuristic choice and what it is trying.
+func (d *dynamicDeclarer) hypothesis(flagKey string, value any, objective string) string {
+	vb, err := json.Marshal(value)
+	v := string(vb)
+	if err != nil {
+		v = "<value>"
+	}
+	return "dynamic declarer (#995): try " + flagKey + "=" + v +
+		" to improve objective " + objective
+}
+
+// parseCandidates splits a comma-separated candidate-flag override into a trimmed,
+// non-empty key list (order preserved). Empty input ⇒ nil (all tunable flags).
+func parseCandidates(raw string) []string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+	parts := strings.Split(raw, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if k := strings.TrimSpace(p); k != "" {
+			out = append(out, k)
+		}
+	}
+	return out
+}
+
+// parseDynamicTargetN parses the dynamic target-N override; non-positive/invalid ⇒
+// 0 (the Registry reconciles target_n up to the verdict min-N).
+func parseDynamicTargetN(raw string) int {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return 0
+	}
+	n := 0
+	for _, c := range raw {
+		if c < '0' || c > '9' {
+			return 0
+		}
+		n = n*10 + int(c-'0')
+	}
+	return n
+}
+
+// jsonRawEqual compares two raw JSON values by their decoded form (so 4 and 4.0
+// compare equal, and whitespace differences are ignored) — the same kind-aware
+// equality the Gate relies on for numbers.
+func jsonRawEqual(a, b json.RawMessage) bool {
+	var av, bv any
+	if err := json.Unmarshal(a, &av); err != nil {
+		return false
+	}
+	if err := json.Unmarshal(b, &bv); err != nil {
+		return false
+	}
+	ab, err1 := json.Marshal(av)
+	bb, err2 := json.Marshal(bv)
+	if err1 != nil || err2 != nil {
+		return false
+	}
+	return string(ab) == string(bb)
+}

--- a/services/agent/dynamic_declarer.go
+++ b/services/agent/dynamic_declarer.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/joustmania/agent/decision"
 	"github.com/joustmania/agent/experiment"
@@ -59,7 +60,27 @@ const (
 	// experiments. Non-positive/unset ⇒ 0 (the Registry reconciles it up to the
 	// verdict min-N, #1001).
 	envDynamicTargetN = "AGENT_EXPERIMENT_DYNAMIC_TARGET_N"
+
+	// envDynamicDenylist overrides the set of flag keys EXCLUDED from the DEFAULT
+	// (unset-candidates) rotation: a comma-separated list of flag keys. Unset ⇒
+	// defaultDynamicDenylist (the agent/experiment-machinery knobs below). The
+	// denylist applies ONLY when AGENT_EXPERIMENT_DYNAMIC_CANDIDATES is empty — an
+	// explicit candidate list is honored verbatim (the operator named them on purpose).
+	envDynamicDenylist = "AGENT_EXPERIMENT_DYNAMIC_DENYLIST"
 )
+
+// defaultDynamicDenylist is the set of game.json flag keys the autonomous declarer
+// excludes from its DEFAULT (all-tunable-flags) rotation: agent/experiment-control
+// knobs that are the declarer's OWN plumbing, not game-tuning parameters. The
+// declarer must never experiment on its own machinery (e.g. shadow_policy=block
+// would block the very shadow games the experiment needs to accrue samples).
+// Overridable via AGENT_EXPERIMENT_DYNAMIC_DENYLIST; bypassed entirely when an
+// explicit candidate list is configured.
+var defaultDynamicDenylist = map[string]struct{}{
+	// shadow_policy (#837): gates whether shadow games may start at all — tuning it
+	// to "block" would starve the declarer's own experiments. Pure agent plumbing.
+	"shadow_policy": {},
+}
 
 // dynamicEnabled reports whether the heuristic dynamic declarer opt-in is on.
 // This is the distinct, default-off #995 gate — independent of (and subordinate
@@ -78,17 +99,38 @@ func dynamicEnabled() bool {
 type pressureFunc func() map[string]float64
 
 // dynamicDeclarer selects and builds a fresh experiment Intent on its own from
-// the live game.json flag surface (#995). It holds a persisted round-robin cursor
-// so successive declarations cover DIFFERENT candidate flags deterministically (no
-// wall-clock / rand — variety comes from the cursor, the #995 testability rule).
+// the live game.json flag surface (#995). It holds an in-memory round-robin cursor
+// (resets on restart) so successive declarations cover DIFFERENT candidate flags
+// deterministically (no wall-clock / rand — variety comes from the cursor, the
+// #995 testability rule).
+//
+// CONCURRENCY (#1040 review): the whole select→budget-check→dedup→declare path is
+// reached CONCURRENTLY from several experiment-loop goroutines (tick, immediate
+// allocate, per-partition onGameEnd, onGameTerminal drive, fireCompletedGrace
+// timer). The declarer exposes mu so the loop can serialize that ENTIRE sequence
+// (LiveCount + ActiveFlags + cursor-advance + Declare) atomically — closing the
+// TOCTOU over-declaration window and the d.cursor data race. mu wraps the registry
+// calls (never the reverse) and the registry never calls back into the declarer, so
+// there is no lock-ordering deadlock with registry.mu.
 type dynamicDeclarer struct {
+	// mu serializes the loop's declare decision path (see the type doc). It is held
+	// by the caller (declareDynamicIfEnabled) around LiveCount/ActiveFlags/Declare so
+	// only ONE dynamic declare is ever in flight; it also guards d.cursor, which
+	// Declare mutates.
+	mu sync.Mutex
+
 	// gameFlagPath is the live game.json the declarer reads candidate flags +
 	// their current defaults/variants from (re-read each call so a hot-reloaded
 	// file is reflected).
 	gameFlagPath string
 	// candidates, when non-empty, restricts/orders the flags the declarer rotates
-	// over. Empty ⇒ all tunable flags discovered in game.json (sorted, stable).
+	// over. Empty ⇒ all tunable flags discovered in game.json (sorted, stable),
+	// minus denylist.
 	candidates []string
+	// denylist is the set of flag keys excluded from the DEFAULT (empty-candidates)
+	// rotation — agent/experiment-control knobs the declarer must not tune. Ignored
+	// when candidates is non-empty (an explicit list is honored verbatim).
+	denylist map[string]struct{}
 	// defaultObjective is the experimentable objective used when no pressure signal
 	// is available.
 	defaultObjective string
@@ -98,9 +140,10 @@ type dynamicDeclarer struct {
 	// pressure is the optional fitness-pressure selection signal (may be nil).
 	pressure pressureFunc
 
-	// cursor is the persisted round-robin position across candidate flags. It only
-	// advances when a declaration is actually emitted, so a tick that finds no
-	// declarable flag does not skip the surface. NOT a clock — pure rotation.
+	// cursor is the in-memory round-robin position across candidate flags (resets to
+	// 0 on restart — not journaled). It only advances when a declaration is actually
+	// emitted, so a tick that finds no declarable flag does not skip the surface. NOT
+	// a clock — pure rotation. Mutated only under mu (held by the loop's declare path).
 	cursor int
 }
 
@@ -121,6 +164,7 @@ func newDynamicDeclarerFromEnv(gameFlagPath string, pressure pressureFunc) *dyna
 	return &dynamicDeclarer{
 		gameFlagPath:     gameFlagPath,
 		candidates:       parseCandidates(os.Getenv(envDynamicCandidates)),
+		denylist:         denylistFromEnv(),
 		defaultObjective: objective,
 		targetN:          parseDynamicTargetN(os.Getenv(envDynamicTargetN)),
 		pressure:         pressure,
@@ -207,8 +251,15 @@ func (d *dynamicDeclarer) candidateOrder(flags map[string]candidateFlag) []strin
 		}
 		return order
 	}
+	deny := d.denylist
+	if deny == nil {
+		deny = defaultDynamicDenylist
+	}
 	order := make([]string, 0, len(flags))
 	for k := range flags {
+		if _, blocked := deny[k]; blocked {
+			continue // agent/experiment-control knob — never tune our own machinery.
+		}
 		order = append(order, k)
 	}
 	sort.Strings(order)
@@ -361,6 +412,23 @@ func parseCandidates(raw string) []string {
 		}
 	}
 	return out
+}
+
+// denylistFromEnv resolves the default-rotation denylist from
+// AGENT_EXPERIMENT_DYNAMIC_DENYLIST: UNSET ⇒ nil (caller falls back to
+// defaultDynamicDenylist); SET (even to empty) ⇒ exactly the parsed key set, so an
+// operator can shrink it or disable it entirely (empty value ⇒ empty set ⇒ no
+// exclusions). Always overridable.
+func denylistFromEnv() map[string]struct{} {
+	raw, ok := os.LookupEnv(envDynamicDenylist)
+	if !ok {
+		return nil // unset ⇒ use defaultDynamicDenylist.
+	}
+	set := make(map[string]struct{})
+	for _, k := range parseCandidates(raw) {
+		set[k] = struct{}{}
+	}
+	return set // possibly empty (explicit opt-out of all exclusions).
 }
 
 // parseDynamicTargetN parses the dynamic target-N override; non-positive/invalid ⇒

--- a/services/agent/dynamic_declarer_test.go
+++ b/services/agent/dynamic_declarer_test.go
@@ -1,0 +1,415 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/joustmania/agent/decision"
+	"github.com/joustmania/agent/experiment"
+)
+
+// dynamic_declarer_test.go is the #995 acceptance suite for the HEURISTIC dynamic
+// experiment declarer:
+//   - it picks a valid, Gate-passing Intent from game.json flags (existing flag,
+//     type-compatible value, experimentable objective);
+//   - default-off: with AGENT_EXPERIMENT_DYNAMIC_ENABLED unset, NO dynamic
+//     declaration happens (env-seed behavior byte-identical) — the regression guard;
+//   - capacity/dedup: it won't declare a second experiment on a flag that already
+//     has an active one, nor beyond the concurrent-experiment backstop;
+//   - rotation: successive declarations cover DIFFERENT flags (deterministic cursor);
+//   - kill-switch off ⇒ the declarer declares nothing.
+
+// gameFileForDeclarer copies the experiment package's game.json fixture to a temp
+// file the declarer reads candidate flags from.
+func gameFileForDeclarer(t *testing.T) string {
+	t.Helper()
+	src, err := os.ReadFile(filepath.Join("experiment", "testdata", "game.json"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "game.json")
+	if err := os.WriteFile(path, src, 0o644); err != nil {
+		t.Fatalf("write temp fixture: %v", err)
+	}
+	return path
+}
+
+// TestDynamicDeclarer_PicksGatePassingIntent asserts the declarer's chosen Intent
+// (flag + experimental value) is accepted by the REAL Gate: the flag pre-exists,
+// the value is type-compatible (it is one of the flag's own variant values), and
+// the objective is experimentable.
+func TestDynamicDeclarer_PicksGatePassingIntent(t *testing.T) {
+	path := gameFileForDeclarer(t)
+	d := &dynamicDeclarer{
+		gameFlagPath:     path,
+		candidates:       []string{"sensitivity"}, // numeric flag, default medium=2
+		defaultObjective: decision.ObjectiveBalanced,
+	}
+
+	intent, ok := d.Declare(nil)
+	if !ok {
+		t.Fatal("declarer returned no intent for a tunable flag")
+	}
+	if intent.FlagKey != "sensitivity" {
+		t.Fatalf("flag = %q, want sensitivity", intent.FlagKey)
+	}
+	if intent.ExperimentalValue == nil {
+		t.Fatal("experimental value is nil")
+	}
+	if !decision.IsExperimentable(intent.Objective) {
+		t.Fatalf("objective %q is not experimentable", intent.Objective)
+	}
+
+	// The value must be type-compatible: a number for the numeric sensitivity flag.
+	if _, ok := intent.ExperimentalValue.(float64); !ok {
+		t.Fatalf("value %v (%T) is not a number for a numeric flag", intent.ExperimentalValue, intent.ExperimentalValue)
+	}
+	// And it must DIFFER from the default (2): a perturbation, not a no-op.
+	if v := intent.ExperimentalValue.(float64); v == 2 {
+		t.Fatalf("value %v equals the default (2); not a perturbation", v)
+	}
+
+	// The full Intent must pass the REAL Gate when Started: feed the equivalent
+	// Proposal through Gate.Review (which writes shadow targeting) and assert accept.
+	writer := experiment.NewWriter(path, testLogger())
+	gate := experiment.NewGate(writer, nil, testLogger())
+	p := experiment.Proposal{
+		FlagKey:           intent.FlagKey,
+		ExperimentID:      experiment.MintExperimentID(),
+		ExperimentalValue: intent.ExperimentalValue,
+		Rationale:         intent.Hypothesis,
+	}
+	if err := gate.Review(context.Background(), p); err != nil {
+		t.Fatalf("Gate rejected the declarer's chosen intent: %v", err)
+	}
+}
+
+// TestDynamicDeclarer_GatePassesObjectAndBoolFlags asserts the chosen value for a
+// non-numeric flag (an object-valued flag with pre-existing targeting, and a bool
+// flag) is ALSO accepted by the Gate — the perturbation picks an existing variant
+// value of the matching JSON kind, so the type guard + invariant hold for every
+// kind, not just numbers.
+func TestDynamicDeclarer_GatePassesObjectAndBoolFlags(t *testing.T) {
+	path := gameFileForDeclarer(t)
+	for _, flagKey := range []string{"windows", "random_assignment"} {
+		d := &dynamicDeclarer{
+			gameFlagPath:     path,
+			candidates:       []string{flagKey},
+			defaultObjective: decision.ObjectiveBalanced,
+		}
+		intent, ok := d.Declare(nil)
+		if !ok {
+			t.Fatalf("%s: no intent", flagKey)
+		}
+		writer := experiment.NewWriter(path, testLogger())
+		gate := experiment.NewGate(writer, nil, testLogger())
+		p := experiment.Proposal{
+			FlagKey:           intent.FlagKey,
+			ExperimentID:      experiment.MintExperimentID(),
+			ExperimentalValue: intent.ExperimentalValue,
+			Rationale:         intent.Hypothesis,
+		}
+		if err := gate.Review(context.Background(), p); err != nil {
+			t.Fatalf("%s: Gate rejected chosen intent: %v", flagKey, err)
+		}
+	}
+}
+
+// TestDynamicDeclarer_DisabledByDefault is the regression guard: with the opt-in
+// unset, newDynamicDeclarerFromEnv returns nil, so the loop wires no declarer and
+// the env-seed path is byte-identical.
+func TestDynamicDeclarer_DisabledByDefault(t *testing.T) {
+	t.Setenv(envDynamicEnabled, "") // explicitly unset/empty
+	if d := newDynamicDeclarerFromEnv("/etc/flagd/game.json", nil); d != nil {
+		t.Fatal("declarer constructed while opt-in is OFF (default) — must be nil")
+	}
+	// Also assert the loop's hook is a no-op with a nil declarer (no panic, no work).
+	loop := &experimentLoop{dynamic: nil, log: testLogger()}
+	loop.declareDynamicIfEnabled(context.Background()) // must not panic / touch a nil registry.
+}
+
+// TestDynamicDeclarer_EnabledFromEnv asserts the opt-in constructs a declarer and
+// honors the candidate / objective / target-N overrides.
+func TestDynamicDeclarer_EnabledFromEnv(t *testing.T) {
+	t.Setenv(envDynamicEnabled, "true")
+	t.Setenv(envDynamicCandidates, "sensitivity, num_teams ,")
+	t.Setenv(envDynamicObjective, "endurance")
+	t.Setenv(envDynamicTargetN, "5")
+	d := newDynamicDeclarerFromEnv("/x/game.json", nil)
+	if d == nil {
+		t.Fatal("declarer nil with opt-in ON")
+	}
+	if got := d.candidates; len(got) != 2 || got[0] != "sensitivity" || got[1] != "num_teams" {
+		t.Fatalf("candidates = %v, want [sensitivity num_teams]", got)
+	}
+	if d.defaultObjective != decision.ObjectiveEndurance {
+		t.Fatalf("objective = %q, want endurance", d.defaultObjective)
+	}
+	if d.targetN != 5 {
+		t.Fatalf("targetN = %d, want 5", d.targetN)
+	}
+}
+
+// TestDynamicDeclarer_NonExperimentableObjectiveFallsBack: a chaos default
+// objective is non-experimentable, so it is replaced with balanced.
+func TestDynamicDeclarer_NonExperimentableObjectiveFallsBack(t *testing.T) {
+	t.Setenv(envDynamicEnabled, "true")
+	t.Setenv(envDynamicObjective, decision.ObjectiveChaos)
+	d := newDynamicDeclarerFromEnv("/x/game.json", nil)
+	if d.defaultObjective != decision.ObjectiveBalanced {
+		t.Fatalf("chaos objective did not fall back to balanced, got %q", d.defaultObjective)
+	}
+}
+
+// TestDynamicDeclarer_Rotation asserts successive Declares cover DIFFERENT flags
+// via the deterministic cursor (no repeat until the candidate ring is exhausted).
+func TestDynamicDeclarer_Rotation(t *testing.T) {
+	path := gameFileForDeclarer(t)
+	d := &dynamicDeclarer{
+		gameFlagPath:     path,
+		candidates:       []string{"sensitivity", "num_teams", "fight_club.min_rounds"},
+		defaultObjective: decision.ObjectiveBalanced,
+	}
+	seen := map[string]int{}
+	for i := 0; i < 3; i++ {
+		intent, ok := d.Declare(nil)
+		if !ok {
+			t.Fatalf("declare %d returned no intent", i)
+		}
+		seen[intent.FlagKey]++
+	}
+	if len(seen) != 3 {
+		t.Fatalf("rotation covered %d distinct flags in 3 calls, want 3: %v", len(seen), seen)
+	}
+	// A 4th call wraps back to the first flag (deterministic ring).
+	intent, ok := d.Declare(nil)
+	if !ok || intent.FlagKey != "sensitivity" {
+		t.Fatalf("4th declare did not wrap to sensitivity, got %q ok=%v", intent.FlagKey, ok)
+	}
+}
+
+// TestDynamicDeclarer_DedupSkipsActiveFlag asserts a flag with an ALREADY-ACTIVE
+// experiment is skipped, so the declarer never stacks a second experiment on it.
+func TestDynamicDeclarer_DedupSkipsActiveFlag(t *testing.T) {
+	path := gameFileForDeclarer(t)
+	d := &dynamicDeclarer{
+		gameFlagPath:     path,
+		candidates:       []string{"sensitivity", "num_teams"},
+		defaultObjective: decision.ObjectiveBalanced,
+	}
+	// sensitivity is already under experiment ⇒ the declarer must pick num_teams.
+	active := activeFlags{"sensitivity": {}}
+	intent, ok := d.Declare(active)
+	if !ok {
+		t.Fatal("declare returned no intent despite a free candidate")
+	}
+	if intent.FlagKey != "num_teams" {
+		t.Fatalf("declarer chose %q, want num_teams (sensitivity is active)", intent.FlagKey)
+	}
+
+	// With BOTH candidates active, nothing is declarable.
+	active2 := activeFlags{"sensitivity": {}, "num_teams": {}}
+	if _, ok := d.Declare(active2); ok {
+		t.Fatal("declarer declared on an all-active candidate set; want no-op")
+	}
+}
+
+// TestDynamicDeclarer_SkipsSingleVariantFlag asserts a flag with no alternate
+// value (single variant) is never chosen — there is nothing to perturb toward.
+func TestDynamicDeclarer_SkipsSingleVariantFlag(t *testing.T) {
+	path := gameFileForDeclarer(t)
+	// nonstop.scoring has exactly one variant in the fixture.
+	d := &dynamicDeclarer{
+		gameFlagPath:     path,
+		candidates:       []string{"nonstop.scoring"},
+		defaultObjective: decision.ObjectiveBalanced,
+	}
+	if _, ok := d.Declare(nil); ok {
+		t.Fatal("declarer chose a single-variant flag; want no-op (nothing to perturb)")
+	}
+}
+
+// TestDynamicDeclarer_PressureSelectsObjective asserts the highest-pressure
+// experimentable objective is targeted when a pressure signal is available, and
+// that chaos (non-experimentable) is ignored even at max pressure.
+func TestDynamicDeclarer_PressureSelectsObjective(t *testing.T) {
+	path := gameFileForDeclarer(t)
+	d := &dynamicDeclarer{
+		gameFlagPath:     path,
+		candidates:       []string{"sensitivity"},
+		defaultObjective: decision.ObjectiveBalanced,
+		pressure: func() map[string]float64 {
+			return map[string]float64{
+				decision.ObjectiveChaos:      1.0, // highest, but NOT experimentable — ignored.
+				decision.ObjectiveAccelerate: 0.7,
+				decision.ObjectiveEndurance:  0.3,
+			}
+		},
+	}
+	intent, ok := d.Declare(nil)
+	if !ok {
+		t.Fatal("declare returned no intent")
+	}
+	if intent.Objective != decision.ObjectiveAccelerate {
+		t.Fatalf("objective = %q, want accelerate (highest experimentable pressure)", intent.Objective)
+	}
+}
+
+// TestDynamicDeclarer_NoPressureUsesDefaultObjective asserts the configured
+// default objective is used when no pressure signal is present.
+func TestDynamicDeclarer_NoPressureUsesDefaultObjective(t *testing.T) {
+	path := gameFileForDeclarer(t)
+	d := &dynamicDeclarer{
+		gameFlagPath:     path,
+		candidates:       []string{"sensitivity"},
+		defaultObjective: decision.ObjectiveEndurance,
+		pressure:         func() map[string]float64 { return nil }, // no signal
+	}
+	intent, _ := d.Declare(nil)
+	if intent.Objective != decision.ObjectiveEndurance {
+		t.Fatalf("objective = %q, want endurance (default, no pressure)", intent.Objective)
+	}
+}
+
+// TestDynamicDeclarer_ReadErrorIsNoOp asserts an unreadable game.json fails closed
+// (nothing declarable) rather than panicking or inventing a flag.
+func TestDynamicDeclarer_ReadErrorIsNoOp(t *testing.T) {
+	d := &dynamicDeclarer{
+		gameFlagPath:     filepath.Join(t.TempDir(), "does-not-exist.json"),
+		defaultObjective: decision.ObjectiveBalanced,
+	}
+	if _, ok := d.Declare(nil); ok {
+		t.Fatal("declarer declared from an unreadable file; want fail-closed no-op")
+	}
+}
+
+// --- loop-level wiring tests (declareDynamicIfEnabled against a real Registry) ---
+
+// loopWithRealRegistry builds an experimentLoop with a REAL Registry (Gate/Writer
+// over a temp game.json, recording spawner) so a test can exercise the actual
+// declare→Start→active-flag bookkeeping the dynamic declarer relies on. maxShadow
+// bounds the registry capacity (and thus clamps the dynamic concurrent backstop).
+func loopWithRealRegistry(t *testing.T, maxShadow int) (*experimentLoop, string) {
+	t.Helper()
+	log := testLogger()
+	gamePath := gameFileForDeclarer(t)
+	writer := experiment.NewWriter(gamePath, log)
+	gate := experiment.NewGate(writer, nil, log)
+	targeting := experiment.NewGateTargetingWriter(gate, writer)
+	reg := experiment.NewRegistry(experiment.RegistryConfig{
+		Root:           t.TempDir(),
+		MaxShadowGames: maxShadow,
+		Spawner:        &recordingSpawner{},
+		Verdict:        experiment.NewVerdict(3, 0.5, nil),
+		Targeting:      targeting,
+		Log:            log,
+	})
+	loop := &experimentLoop{
+		registry: reg,
+		log:      log,
+		tick:     time.Hour,
+	}
+	return loop, gamePath
+}
+
+// TestDeclareDynamic_DeclaresAndStarts asserts the loop's hook declares a fresh
+// experiment AND Starts it (writes shadow targeting → RUNNING), and that a second
+// call dedups the now-active flag onto a different one.
+func TestDeclareDynamic_DeclaresAndStarts(t *testing.T) {
+	loop, path := loopWithRealRegistry(t, 8)
+	loop.dynamic = &dynamicDeclarer{
+		gameFlagPath:     path,
+		candidates:       []string{"sensitivity", "num_teams"},
+		defaultObjective: decision.ObjectiveBalanced,
+	}
+	loop.dynamicMaxConcurrent = 5
+
+	loop.declareDynamicIfEnabled(context.Background())
+	if got := loop.registry.LiveCount(); got != 1 {
+		t.Fatalf("after 1 dynamic declare LiveCount = %d, want 1", got)
+	}
+	active := loop.registry.ActiveFlags()
+	if _, ok := active["sensitivity"]; !ok {
+		t.Fatalf("first declare did not make sensitivity active: %v", active)
+	}
+
+	// Second call: sensitivity is now active ⇒ the declarer must pick num_teams.
+	loop.declareDynamicIfEnabled(context.Background())
+	if got := loop.registry.LiveCount(); got != 2 {
+		t.Fatalf("after 2 dynamic declares LiveCount = %d, want 2", got)
+	}
+	active = loop.registry.ActiveFlags()
+	if _, ok := active["num_teams"]; !ok {
+		t.Fatalf("second declare did not make num_teams active: %v", active)
+	}
+}
+
+// TestDeclareDynamic_RespectsConcurrentBackstop asserts the declarer stops once the
+// live set reaches the concurrent-experiment budget.
+func TestDeclareDynamic_RespectsConcurrentBackstop(t *testing.T) {
+	loop, path := loopWithRealRegistry(t, 8)
+	loop.dynamic = &dynamicDeclarer{
+		gameFlagPath:     path,
+		candidates:       []string{"sensitivity", "num_teams", "fight_club.min_rounds"},
+		defaultObjective: decision.ObjectiveBalanced,
+	}
+	loop.dynamicMaxConcurrent = 2 // budget of 2 (well under capacity 8)
+
+	for i := 0; i < 5; i++ {
+		loop.declareDynamicIfEnabled(context.Background())
+	}
+	if got := loop.registry.LiveCount(); got != 2 {
+		t.Fatalf("declarer exceeded the concurrent backstop: LiveCount = %d, want 2", got)
+	}
+}
+
+// TestDeclareDynamic_BackstopClampedToCapacity asserts the budget is clamped to the
+// shadow capacity — a high budget cannot declare more experiments than there are
+// shadow slots for.
+func TestDeclareDynamic_BackstopClampedToCapacity(t *testing.T) {
+	loop, path := loopWithRealRegistry(t, 1) // capacity 1
+	loop.dynamic = &dynamicDeclarer{
+		gameFlagPath:     path,
+		candidates:       []string{"sensitivity", "num_teams", "fight_club.min_rounds"},
+		defaultObjective: decision.ObjectiveBalanced,
+	}
+	loop.dynamicMaxConcurrent = 99 // huge — but capacity clamps it to 1
+
+	for i := 0; i < 5; i++ {
+		loop.declareDynamicIfEnabled(context.Background())
+	}
+	if got := loop.registry.LiveCount(); got != 1 {
+		t.Fatalf("budget not clamped to capacity: LiveCount = %d, want 1", got)
+	}
+}
+
+// TestDeclareDynamic_KillSwitchOffDeclaresNothing asserts that with the agent
+// kill-switch OFF (disabled), allocateIfEnabled never reaches the dynamic declarer
+// — so nothing is declared. The declarer is subordinate to the SAME kill-switch as
+// every other declaration (it is only called AFTER the enabled check).
+func TestDeclareDynamic_KillSwitchOffDeclaresNothing(t *testing.T) {
+	loop, path := loopWithRealRegistry(t, 8)
+	loop.dynamic = &dynamicDeclarer{
+		gameFlagPath:     path,
+		candidates:       []string{"sensitivity"},
+		defaultObjective: decision.ObjectiveBalanced,
+	}
+	loop.dynamicMaxConcurrent = 5
+	loop.enabledOverride = func(context.Context) bool { return false } // kill-switch OFF
+
+	loop.allocateIfEnabled(context.Background())
+	if got := loop.registry.LiveCount(); got != 0 {
+		t.Fatalf("kill-switch off must declare nothing, LiveCount = %d", got)
+	}
+
+	// Flip the kill-switch ON: now the declarer runs and declares.
+	loop.enabledOverride = func(context.Context) bool { return true }
+	loop.allocateIfEnabled(context.Background())
+	if got := loop.registry.LiveCount(); got != 1 {
+		t.Fatalf("kill-switch on should let the declarer declare, LiveCount = %d", got)
+	}
+}

--- a/services/agent/dynamic_declarer_test.go
+++ b/services/agent/dynamic_declarer_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -384,6 +385,44 @@ func TestDeclareDynamic_BackstopClampedToCapacity(t *testing.T) {
 	}
 	if got := loop.registry.LiveCount(); got != 1 {
 		t.Fatalf("budget not clamped to capacity: LiveCount = %d, want 1", got)
+	}
+}
+
+// TestDeclareDynamic_ConcurrentCallersRespectBudget fires declareDynamicIfEnabled
+// from many goroutines at once — the REAL shape, since allocateIfEnabled is reached
+// concurrently from the tick, per-partition onGameEnd, onGameTerminal drive and the
+// grace-timer goroutines. Without the declarer mutex, concurrent callers all pass the
+// LiveCount<budget check before any commits its Declare (TOCTOU over-declaration) and
+// data-race d.cursor; with the mutex the whole select→budget-check→dedup→declare path
+// is atomic, so the live experiment set never exceeds the budget. Run under -race to
+// also catch the cursor race. (Reverting the mutex makes this fail: LiveCount > budget.)
+func TestDeclareDynamic_ConcurrentCallersRespectBudget(t *testing.T) {
+	loop, path := loopWithRealRegistry(t, 16) // ample capacity so the BUDGET is the bound
+	loop.dynamic = &dynamicDeclarer{
+		gameFlagPath:     path,
+		candidates:       []string{"sensitivity", "num_teams", "fight_club.min_rounds"},
+		defaultObjective: decision.ObjectiveBalanced,
+	}
+	const budget = 2
+	loop.dynamicMaxConcurrent = budget // well under capacity 16
+
+	const goroutines = 8
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			loop.declareDynamicIfEnabled(context.Background())
+		}()
+	}
+	wg.Wait()
+
+	got := loop.registry.LiveCount()
+	if got > budget {
+		t.Fatalf("concurrent declarers over-declared past the budget: LiveCount = %d, want <= %d", got, budget)
+	}
+	if got < 1 {
+		t.Fatalf("expected the concurrent declarers to declare at least one experiment, LiveCount = %d", got)
 	}
 }
 

--- a/services/agent/experiment/registry.go
+++ b/services/agent/experiment/registry.go
@@ -1441,6 +1441,39 @@ func (r *Registry) Live() []string {
 	return r.liveIDsLocked()
 }
 
+// ActiveFlags returns the set of flag keys that have at least one LIVE
+// (non-terminal: PROPOSED or RUNNING) experiment. The dynamic declarer (#995)
+// uses it to avoid stacking a second concurrent experiment on a flag that is
+// already under test. A flag torn down (terminal) is not included — its targeting
+// branch is stripped, so it is free to experiment on again.
+func (r *Registry) ActiveFlags() map[string]struct{} {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make(map[string]struct{}, len(r.entries))
+	for _, e := range r.entries {
+		if !e.status.IsTerminal() {
+			out[e.flagKey] = struct{}{}
+		}
+	}
+	return out
+}
+
+// LiveCount returns the number of LIVE (non-terminal) experiments the registry is
+// managing — PROPOSED + RUNNING + CONCLUDED/PROMOTING (anything not yet torn
+// down). The dynamic declarer (#995) uses it as the over-declaration backstop:
+// it stops declaring once the live set fills the concurrent-experiment budget.
+func (r *Registry) LiveCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	n := 0
+	for _, e := range r.entries {
+		if !e.status.IsTerminal() {
+			n++
+		}
+	}
+	return n
+}
+
 // CompactView returns the bounded journal view for an experiment (intent +
 // per-arm aggregates + recent tail) — the read surface the dashboard / LLM
 // consume. ok=false if unknown.

--- a/services/agent/experiment_loop.go
+++ b/services/agent/experiment_loop.go
@@ -377,10 +377,27 @@ func (e *experimentLoop) agentEnabled(ctx context.Context) bool {
 // At most one experiment is declared per call (one new flag explored per tick),
 // keeping the declaration rate bounded; the round-robin cursor rotates coverage
 // across ticks.
+//
+// CONCURRENCY (#1040 review): allocateIfEnabled is called concurrently from several
+// goroutines (tick, immediate allocate, per-partition onGameEnd, onGameTerminal
+// drive, fireCompletedGrace timer). The budget check, the per-flag dedup
+// (ActiveFlags), the cursor advance, and Declare must be ATOMIC as a unit — three
+// separate registry-lock acquisitions plus an unsynchronized cursor would otherwise
+// let N concurrent callers all pass the LiveCount<budget check and all declare
+// (TOCTOU over-declaration), and would data-race d.cursor. We hold the declarer's
+// own mutex (e.dynamic.mu) around the WHOLE decision path. That mutex WRAPS the
+// registry calls and the registry never calls back into the declarer, so there is
+// no lock-ordering deadlock with registry.mu.
 func (e *experimentLoop) declareDynamicIfEnabled(ctx context.Context) {
 	if e.dynamic == nil {
 		return // not opted in (default): env-seed behavior unchanged.
 	}
+	// Serialize the entire select→budget-check→dedup→declare sequence so only one
+	// dynamic declare is ever in flight (closes the TOCTOU over-declaration window)
+	// and d.cursor is mutated under the lock (closes the data race).
+	e.dynamic.mu.Lock()
+	defer e.dynamic.mu.Unlock()
+
 	// Over-declaration backstop: stop once the LIVE experiment set fills the
 	// concurrent-experiment budget. The budget is clamped to the shadow capacity
 	// because an experiment with no shadow slot to ever run is pointless.

--- a/services/agent/experiment_loop.go
+++ b/services/agent/experiment_loop.go
@@ -59,7 +59,21 @@ const (
 	envSeedObjective  = "AGENT_EXPERIMENT_SEED_OBJECTIVE"  // fitness objective (default balanced)
 	envSeedTargetN    = "AGENT_EXPERIMENT_SEED_TARGET_N"   // target games per arm
 	envSeedHypothesis = "AGENT_EXPERIMENT_SEED_HYPOTHESIS" // free-text hypothesis
+
+	// envDynamicMaxConcurrent caps the number of LIVE experiments the heuristic
+	// dynamic declarer (#995) will keep going at once — the over-declaration
+	// backstop. It is clamped to the shadow-game capacity (each experiment needs at
+	// least one shadow slot to make progress). Unset/non-positive ⇒
+	// defaultDynamicMaxConcurrent.
+	envDynamicMaxConcurrent = "AGENT_EXPERIMENT_DYNAMIC_MAX_CONCURRENT"
 )
+
+// defaultDynamicMaxConcurrent is the default ceiling on simultaneously-live
+// dynamically-declared experiments (#995). A small value keeps the autonomous
+// declarer from flooding the registry; it is further clamped to the shadow-game
+// capacity. The static env seed (if any) counts toward this ceiling too — the
+// declarer reads the registry's LIVE count, which includes the seed.
+const defaultDynamicMaxConcurrent = 3
 
 // defaultExperimentTick is the AllocateAndSpawn cadence when unset. Shadow games
 // are minutes-long, so a 30s refill tick is ample headroom over game duration.
@@ -97,6 +111,25 @@ type experimentLoop struct {
 	// env-gated declaration trigger). Nil ⇒ no seed (the registry rehydrates
 	// prior experiments and runs them, but declares nothing new).
 	seed *experiment.Intent
+
+	// dynamic, when set (AGENT_EXPERIMENT_DYNAMIC_ENABLED=true), is the heuristic
+	// dynamic declarer (#995): on each allocate tick the loop asks it to CHOOSE a
+	// fresh experiment Intent from the live game.json surface and declares it,
+	// subject to the dynamicMaxConcurrent backstop and the per-flag dedup. Nil ⇒
+	// the default: declaration is the static env seed only (byte-identical pre-#995).
+	dynamic *dynamicDeclarer
+
+	// dynamicMaxConcurrent caps how many LIVE experiments the dynamic declarer keeps
+	// going at once (the over-declaration backstop, #995). Clamped to the registry
+	// shadow capacity. Only consulted when dynamic != nil.
+	dynamicMaxConcurrent int
+
+	// enabledOverride, when non-nil, supplies the kill-switch state instead of
+	// reading e.flags — the injectable seam tests use to drive a disabled agent
+	// without a flagd dependency. Production leaves it nil (the real flags client is
+	// consulted). It governs BOTH AllocateAndSpawn and the #995 dynamic declarer, so
+	// a test can prove the declarer is subordinate to the kill-switch.
+	enabledOverride func(ctx context.Context) bool
 
 	// fitness maps a game-end GameContext to a single fitness scalar fed to
 	// ConcludeGame. Injected so it is overridable / testable.
@@ -185,14 +218,21 @@ func buildExperimentLoop(
 	})
 
 	loop := &experimentLoop{
-		registry:       registry,
-		spawner:        spawner,
-		flags:          flagsClient,
-		log:            logger,
-		tick:           experimentTick(),
-		seed:           seedIntentFromEnv(),
-		fitness:        defaultGameFitness,
-		completedGrace: completedGrace(),
+		registry:             registry,
+		spawner:              spawner,
+		flags:                flagsClient,
+		log:                  logger,
+		tick:                 experimentTick(),
+		seed:                 seedIntentFromEnv(),
+		fitness:              defaultGameFitness,
+		completedGrace:       completedGrace(),
+		dynamic:              newDynamicDeclarerFromEnv(gameFlagPath, nil),
+		dynamicMaxConcurrent: dynamicMaxConcurrent(),
+	}
+	if loop.dynamic != nil {
+		logger.Warn("Dynamic experiment declarer ENABLED (#995) — the agent will CHOOSE which game.json flag to experiment on",
+			"max_concurrent", loop.dynamicMaxConcurrent,
+			"candidates", os.Getenv(envDynamicCandidates))
 	}
 	// Wire the #1014 terminal-outcome backstop: each spawned game signals its
 	// terminal outcome here, and a non-concluding game releases its in-flight slot
@@ -226,12 +266,25 @@ func promotionConfigResolver(f *flags.Flags) promote.ConfigResolver {
 //  1. Rehydrates the registry from the durable journal (the #831 in-memory-loss
 //     fix): any non-terminal experiment from a prior run is resumed.
 //  2. Declares + Starts the seed experiment (env-gated trigger) if configured.
-//  3. Ticks AllocateAndSpawn to refill free shadow capacity.
+//  3. Ticks AllocateAndSpawn to refill free shadow capacity — and, when the #995
+//     dynamic declarer is opted-in, asks it to CHOOSE and declare a fresh
+//     experiment each tick (bounded by the concurrent-experiment backstop).
 //  4. On ctx cancellation, AbortAll (kill-switch / shutdown teardown) and returns.
+//
+// SEED + DYNAMIC COMPOSITION (#995): the two declaration triggers COEXIST under
+// one capacity ceiling. The static AGENT_EXPERIMENT_SEED_FLAG seed (if set) is
+// declared ONCE at startup here; the dynamic declarer then takes over on the
+// allocate ticks, declaring additional experiments until the live set reaches the
+// dynamic concurrent-experiment backstop (which COUNTS the seed). The seed flag is
+// also in the declarer's active-flag dedup set once Started, so the declarer never
+// duplicates the operator's seeded flag. Result: seed first, dynamic fills the
+// rest — simple and safe, no override either way.
 //
 // The kill-switch (agent.json `enabled` false) is also honored mid-run: each tick
 // re-reads it and AbortAll's every live experiment when the agent is disabled, so
-// flipping the kill-switch tears the experiment surface down with no restart.
+// flipping the kill-switch tears the experiment surface down with no restart — and
+// because the dynamic declarer is only reached from allocateIfEnabled AFTER the
+// kill-switch check, a disabled agent declares NOTHING dynamically either.
 func (e *experimentLoop) run(ctx context.Context) {
 	if err := e.rehydrate(); err != nil {
 		e.log.Error("experiment: rehydrate from journal failed (continuing without prior experiments)", "error", err)
@@ -276,19 +329,82 @@ func (e *experimentLoop) run(ctx context.Context) {
 // live experiment instead — the mid-run kill-switch honor (design §10). This keeps
 // the experiment loop subordinate to the SAME kill-switch the decision loop obeys.
 func (e *experimentLoop) allocateIfEnabled(ctx context.Context) {
-	// A nil flags client (test wiring only) is treated as enabled — production
-	// always injects one (buildExperimentLoop). This keeps the leak test free of a
-	// flagd dependency while the real path always consults the kill-switch.
-	if e.flags != nil && !e.flags.Evaluate(ctx).Enabled {
+	if !e.agentEnabled(ctx) {
 		if ids := e.registry.AbortAll(ctx, "kill-switch: agent disabled"); len(ids) > 0 {
 			e.log.Warn("experiment: kill-switch active — aborted live experiments", "count", len(ids))
 		}
 		return
 	}
+	// Heuristic dynamic declaration (#995): the kill-switch is on (checked above)
+	// and the dynamic declarer is opted-in, so let the agent CHOOSE a fresh
+	// experiment to declare — bounded by the concurrent-experiment backstop and the
+	// per-flag dedup. This runs BEFORE AllocateAndSpawn so a freshly-Started
+	// experiment can accrue games on the same tick.
+	e.declareDynamicIfEnabled(ctx)
 	if n := e.registry.AllocateAndSpawn(ctx); n > 0 {
 		e.log.Info("experiment: spawned shadow games this tick", "count", n,
 			"in_flight", e.registry.TotalInFlight(), "capacity", e.registry.Capacity())
 	}
+}
+
+// agentEnabled reports whether the agent kill-switch is ON (agent.json `enabled`
+// true). It consults the enabledOverride seam first (test wiring), then the live
+// flags client. A nil flags client (test wiring only) is treated as enabled —
+// production always injects one (buildExperimentLoop) — so the leak test stays
+// free of a flagd dependency while the real path always consults the kill-switch.
+func (e *experimentLoop) agentEnabled(ctx context.Context) bool {
+	if e.enabledOverride != nil {
+		return e.enabledOverride(ctx)
+	}
+	if e.flags == nil {
+		return true
+	}
+	return e.flags.Evaluate(ctx).Enabled
+}
+
+// declareDynamicIfEnabled lets the heuristic dynamic declarer (#995) CHOOSE and
+// declare ONE fresh experiment per call when:
+//   - the dynamic declarer is opted-in (dynamic != nil), AND
+//   - the live-experiment count is below the concurrent-experiment backstop
+//     (clamped to the shadow-game capacity — the over-declaration guard), AND
+//   - the declarer can find a candidate game.json flag with no active experiment
+//     and a distinct alternate value (the per-flag dedup).
+//
+// It is a NO-OP when the declarer is off (the default), so the env-seed path is
+// byte-identical for everyone who has not opted in. It is only ever reached from
+// allocateIfEnabled, which has already confirmed the kill-switch is on — so the
+// declarer is subordinate to the SAME kill-switch as every other declaration.
+// At most one experiment is declared per call (one new flag explored per tick),
+// keeping the declaration rate bounded; the round-robin cursor rotates coverage
+// across ticks.
+func (e *experimentLoop) declareDynamicIfEnabled(ctx context.Context) {
+	if e.dynamic == nil {
+		return // not opted in (default): env-seed behavior unchanged.
+	}
+	// Over-declaration backstop: stop once the LIVE experiment set fills the
+	// concurrent-experiment budget. The budget is clamped to the shadow capacity
+	// because an experiment with no shadow slot to ever run is pointless.
+	budget := e.dynamicMaxConcurrent
+	if capacity := e.registry.Capacity(); capacity > 0 && budget > capacity {
+		budget = capacity
+	}
+	if e.registry.LiveCount() >= budget {
+		return
+	}
+	// Per-flag dedup: never stack a second experiment on a flag already under test.
+	intent, ok := e.dynamic.Declare(e.registry.ActiveFlags())
+	if !ok {
+		return // nothing declarable this tick (no free candidate flag).
+	}
+	if err := e.declareAndStart(ctx, intent); err != nil {
+		// A type-mismatch / unknown-flag rejection at Start fails closed (no shadow
+		// game runs); log it and move on — the next tick rotates to another flag.
+		e.log.Warn("experiment: dynamic declare/start failed (#995)",
+			"flag_key", intent.FlagKey, "objective", intent.Objective, "error", err)
+		return
+	}
+	e.log.Info("experiment: dynamic declarer declared a new experiment (#995)",
+		"flag_key", intent.FlagKey, "value", intent.ExperimentalValue, "objective", intent.Objective)
 }
 
 // rehydrate rebuilds the live registry from the durable journal on startup.
@@ -597,6 +713,21 @@ func completedGrace() time.Duration {
 		}
 	}
 	return defaultCompletedGrace
+}
+
+// dynamicMaxConcurrent resolves the dynamic-declarer concurrent-experiment
+// backstop from AGENT_EXPERIMENT_DYNAMIC_MAX_CONCURRENT, falling back to
+// defaultDynamicMaxConcurrent on an unset/invalid/non-positive value (a
+// zero/negative cap would let the declarer either never declare or be unbounded,
+// so it is treated as misconfiguration). It is further clamped to the shadow
+// capacity in declareDynamicIfEnabled.
+func dynamicMaxConcurrent() int {
+	if v := strings.TrimSpace(os.Getenv(envDynamicMaxConcurrent)); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return defaultDynamicMaxConcurrent
 }
 
 // seedIntentFromEnv builds the single seed experiment Intent from the


### PR DESCRIPTION
## Summary

Part of #995. Implements the maintainer-chosen scope: a **HEURISTIC (no-LLM) dynamic experiment declarer** so the agent CHOOSES which `game.json` flag to experiment on based on observed signals, instead of only the static `AGENT_EXPERIMENT_SEED_FLAG` env seed. The LLM Proposer→Intents path (#960) stays deferred (inert until the inference backend #738/#742 lands); this delivers the unblocked autonomy increment now.

## Selection heuristic (deterministic — no `Date.now`/rand)

- **Flag**: round-robin rotation via a persisted cursor over a configurable candidate set (default = all *tunable* `game.json` flags, i.e. those with ≥2 variants). Skips flags that already have an active experiment and single-variant flags (nothing to perturb).
- **Value**: a bounded, JSON-kind-compatible perturbation = the flag's **own** variant value adjacent to its current default. Choosing an existing variant value means the value passes the Gate's `checkTypeCompatible` **by construction** and stays in the flag's intended range — the declarer adds **no new write surface**.
- **Objective**: the *experimentable* objective under highest fitness **pressure** when a pressure signal is wired, else a configurable default (`balanced`). Chaos is never chosen (`decision.IsExperimentable`) and is rejected at `Registry.Declare` anyway.

Every Intent flows through the **same** #977 Gate + #978 Registry caps as the env seed — the declarer is a selection heuristic in front of the unchanged declare path.

## Gating (default-off, regression-safe)

- Opt-in `AGENT_EXPERIMENT_DYNAMIC_ENABLED` (default **false**) — when unset the env-seed path is byte-identical (`newDynamicDeclarerFromEnv` returns nil ⇒ the loop wires nothing).
- Subordinate to the existing gates: only reached from `allocateIfEnabled` **after** the `AGENT_EXPERIMENTS_ENABLED` + agent.json kill-switch check, so a disabled agent declares nothing dynamically and self-aborts with the rest.
- **Seed + dynamic composition**: they coexist under one concurrent-experiment ceiling (`AGENT_EXPERIMENT_DYNAMIC_MAX_CONCURRENT`, default 3, clamped to shadow capacity). The static seed is declared once at startup and **counts toward the cap** and is in the dedup active-flag set, so the declarer never duplicates the operator's seeded flag — seed first, dynamic fills the rest.

## Over-declaration bound

Declares at most one experiment per tick; stops once `LiveCount()` reaches the (capacity-clamped) budget; never stacks a second experiment on a flag already under test (`ActiveFlags()` dedup).

## New env vars

- `AGENT_EXPERIMENT_DYNAMIC_ENABLED` (opt-in, default false)
- `AGENT_EXPERIMENT_DYNAMIC_CANDIDATES` (comma-list override; default all tunable flags)
- `AGENT_EXPERIMENT_DYNAMIC_OBJECTIVE` (default balanced)
- `AGENT_EXPERIMENT_DYNAMIC_TARGET_N` (default 0 → Registry reconciles to min-N)
- `AGENT_EXPERIMENT_DYNAMIC_MAX_CONCURRENT` (default 3, clamped to shadow capacity)

## Tests

New `dynamic_declarer_test.go` (15 tests): Gate-passing intent for numeric/object/bool flags; **default-off regression guard**; env overrides; chaos→balanced fallback; deterministic rotation/wrap; active-flag dedup; single-variant skip; pressure→objective selection (chaos ignored at max pressure); read-error fail-closed; loop-level declare→Start, concurrent backstop, capacity clamp, and **kill-switch off → declares nothing**.

`go test ./... -race`, `go vet ./...`, `gofmt -l .`, ruff all pass. Existing experiment_loop / registry tests unchanged and green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)