### PR TITLE
feat(dashboard): live experiments view for the cohort framework (#981)

### DIFF
--- a/services/dashboard/.gitignore
+++ b/services/dashboard/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/services/dashboard/src/components/ExperimentsView.ts
+++ b/services/dashboard/src/components/ExperimentsView.ts
@@ -1,0 +1,135 @@
+/**
+ * Experiments View Component (issue #981).
+ *
+ * Renders one card per cohort experiment with its arms, per-arm sample counts,
+ * the fitness delta (experimental − control), and the current verdict. Data
+ * comes from the agent's experiment telemetry in Loki (see ../experiments.ts);
+ * the view polls on a fixed cadence to update live during a shadow run.
+ */
+import type { ArmAggregate, ExperimentView } from "../experiments.js";
+
+export class ExperimentsView {
+  private readonly container: HTMLElement;
+  private hasRendered = false;
+
+  constructor(containerId: string) {
+    const container = document.getElementById(containerId);
+    if (!container) {
+      throw new Error(`Container element not found: ${containerId}`);
+    }
+    this.container = container;
+  }
+
+  setError(message: string) {
+    this.container.innerHTML = `<div class="loading">${escapeHtml(message)}</div>`;
+    this.hasRendered = true;
+  }
+
+  render(experiments: ExperimentView[]) {
+    this.hasRendered = true;
+
+    if (experiments.length === 0) {
+      this.container.innerHTML =
+        '<div class="loading">No experiments running. ' +
+        "Start a shadow run with the cohort framework enabled to see live arms here.</div>";
+      return;
+    }
+
+    this.container.innerHTML = experiments
+      .map((exp) => this.renderCard(exp))
+      .join("");
+  }
+
+  /** True once any render/error has painted (so we don't flash the loader). */
+  get rendered(): boolean {
+    return this.hasRendered;
+  }
+
+  private renderCard(exp: ExperimentView): string {
+    const verdict = normalizeVerdict(exp.verdict, exp.live);
+    const armsHtml = exp.arms.map((arm) => this.renderArm(arm)).join("");
+    const deltaHtml = this.renderDelta(exp.delta);
+
+    return `
+      <div class="experiment-card">
+        <div class="experiment-header">
+          <span class="experiment-id" title="${escapeHtml(exp.experimentId)}">
+            ${escapeHtml(exp.experimentId)}
+          </span>
+          <span class="experiment-verdict ${verdict.cssClass}">${escapeHtml(verdict.label)}</span>
+        </div>
+        <div class="experiment-arms">
+          ${armsHtml}
+        </div>
+        <div class="experiment-footer">
+          ${deltaHtml}
+          ${exp.reason ? `<div class="experiment-reason" title="${escapeHtml(exp.reason)}">${escapeHtml(exp.reason)}</div>` : ""}
+        </div>
+      </div>
+    `;
+  }
+
+  private renderArm(arm: ArmAggregate): string {
+    const inFlight = Math.max(0, arm.assignedCount - arm.sampleCount);
+    return `
+      <div class="experiment-arm">
+        <div class="arm-name">${escapeHtml(prettyArm(arm.arm))}</div>
+        <div class="arm-stats">
+          <span class="arm-count" title="games concluded with a fitness sample">
+            n=${arm.sampleCount}
+          </span>
+          <span class="arm-mean" title="mean fitness across this arm's samples">
+            x&#772;=${arm.sampleCount > 0 ? arm.meanFitness.toFixed(3) : "&mdash;"}
+          </span>
+          ${inFlight > 0 ? `<span class="arm-inflight" title="games assigned but not yet concluded">+${inFlight} in&nbsp;flight</span>` : ""}
+        </div>
+      </div>
+    `;
+  }
+
+  private renderDelta(delta: number | null): string {
+    if (delta === null) {
+      return `<div class="experiment-delta delta-neutral">&Delta; &mdash; <span class="delta-label">(awaiting both arms)</span></div>`;
+    }
+    const sign = delta > 0 ? "+" : "";
+    const cssClass =
+      delta > 0 ? "delta-positive" : delta < 0 ? "delta-negative" : "delta-neutral";
+    return `<div class="experiment-delta ${cssClass}">&Delta; ${sign}${delta.toFixed(3)} <span class="delta-label">(experimental &minus; control fitness)</span></div>`;
+  }
+}
+
+function prettyArm(arm: string): string {
+  if (arm === "experimental") return "Experimental";
+  if (arm === "control") return "Control";
+  return arm;
+}
+
+interface NormalizedVerdict {
+  label: string;
+  cssClass: string;
+}
+
+function normalizeVerdict(verdict: string, live: boolean): NormalizedVerdict {
+  const v = verdict.toLowerCase();
+  if (v === "promote" || v === "promoted" || v === "done") {
+    return { label: "Promote", cssClass: "verdict-promote" };
+  }
+  if (v === "discard" || v === "discarded" || v === "rejected") {
+    return { label: "Discard", cssClass: "verdict-discard" };
+  }
+  if (v === "inconclusive") {
+    return { label: "Inconclusive", cssClass: "verdict-inconclusive" };
+  }
+  if (!live) {
+    return { label: verdict || "Concluded", cssClass: "verdict-inconclusive" };
+  }
+  return { label: "Running", cssClass: "verdict-running" };
+}
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}

--- a/services/dashboard/src/experiments.ts
+++ b/services/dashboard/src/experiments.ts
@@ -1,0 +1,288 @@
+/**
+ * Experiments data source (issue #981).
+ *
+ * The agent runs the cohort/experiment framework (epic #982) and emits its
+ * progress as structured slog lines on stdout:
+ *
+ *   experiment.game_assigned   experiment_id, game_id, arm, pair_index
+ *   experiment.game_concluded  experiment_id, game_id, arm, fitness
+ *   experiment.concluded       experiment_id, outcome
+ *   experiment.torn_down       experiment_id, status, reason
+ *
+ * Those container logs are tailed by the OTEL collector's `logs/containers`
+ * pipeline and shipped to Loki labeled `service_name="agent"` (see
+ * services/otel-collector/config.yaml + services/envoy/envoy.yaml `/loki/*`).
+ *
+ * The dashboard already embeds the same observability stack (Grafana / Jaeger
+ * iframes) and reaches it through envoy. This module reuses that exact data path
+ * — it queries the Loki HTTP API at `/loki/...` — rather than inventing a new
+ * transport. Loki has no aggregation for our slog-text bodies, so we pull the raw
+ * agent log lines over a window and fold them into per-experiment / per-arm
+ * aggregates here, mirroring what the agent's own journal summary.json holds.
+ */
+
+const BASE_URL = import.meta.env.DEV ? "" : globalThis.location.origin;
+
+/** Loki LogQL selector for the agent's experiment lifecycle log lines. */
+const EXPERIMENT_LOG_QUERY =
+  '{service_name="agent"} |= "experiment."';
+
+/** How far back to look for experiment activity. */
+const LOOKBACK_SECONDS = 60 * 60; // 1 hour
+
+/** Max log lines Loki returns per query (newest first). */
+const QUERY_LIMIT = 5000;
+
+/** Per-arm rolling aggregate folded from `experiment.game_concluded` lines. */
+export interface ArmAggregate {
+  arm: string;
+  /** Games concluded with a fitness sample for this arm. */
+  sampleCount: number;
+  /** Mean fitness across this arm's samples (0 when no samples yet). */
+  meanFitness: number;
+  /** Games assigned (bound to a shadow game) for this arm. */
+  assignedCount: number;
+}
+
+/** Folded live state for a single experiment. */
+export interface ExperimentView {
+  experimentId: string;
+  arms: ArmAggregate[];
+  /**
+   * experimental_mean − control_mean when both named arms have samples;
+   * null when the delta cannot be computed yet.
+   */
+  delta: number | null;
+  /** "running" | "promote" | "discard" | "inconclusive" | "torn_down". */
+  verdict: string;
+  /** Free-text verdict/teardown reason (carries d_z=... / effect=... when present). */
+  reason: string;
+  /** Epoch ms of the most recent log line touching this experiment. */
+  lastUpdatedMs: number;
+  /** True until a terminal (concluded / torn_down) line is seen. */
+  live: boolean;
+}
+
+/** The two canonical arm names (mirror journal.ArmExperimental / ArmControl). */
+const ARM_EXPERIMENTAL = "experimental";
+const ARM_CONTROL = "control";
+
+interface LokiStreamResult {
+  stream: Record<string, string>;
+  values: [string, string][]; // [nanosecond-ts-string, log line]
+}
+
+interface LokiQueryResponse {
+  status: string;
+  data: {
+    resultType: string;
+    result: LokiStreamResult[];
+  };
+}
+
+/**
+ * Parse a slog TextHandler line into a flat key→value map.
+ *
+ * slog emits logfmt-style `key=value` pairs, quoting values that contain
+ * spaces, e.g.:
+ *   time=2026-06-14T... level=INFO msg=experiment.game_concluded \
+ *     experiment_id=exp_a1b2 arm=control fitness=0.42
+ *   ...msg=experiment.torn_down ... reason="paired: d_z=0.81 (pairs=6)"
+ *
+ * Container-log shippers may prefix the line (stream/timestamp); we tolerate
+ * that by scanning for `key=value` tokens anywhere in the line.
+ */
+export function parseLogfmt(line: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  // key=value where value is either a double-quoted string or a run of
+  // non-space characters.
+  const re = /([\w.]+)=("(?:[^"\\]|\\.)*"|[^\s]+)/g;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(line)) !== null) {
+    const key = match[1];
+    let value = match[2];
+    if (value.startsWith('"') && value.endsWith('"')) {
+      value = value.slice(1, -1).replace(/\\"/g, '"').replace(/\\\\/g, "\\");
+    }
+    out[key] = value;
+  }
+  return out;
+}
+
+interface MutableArm {
+  arm: string;
+  sampleCount: number;
+  fitnessSum: number;
+  assignedCount: number;
+}
+
+interface MutableExperiment {
+  experimentId: string;
+  arms: Map<string, MutableArm>;
+  verdict: string;
+  reason: string;
+  lastUpdatedMs: number;
+  live: boolean;
+}
+
+function getArm(exp: MutableExperiment, arm: string): MutableArm {
+  let a = exp.arms.get(arm);
+  if (!a) {
+    a = { arm, sampleCount: 0, fitnessSum: 0, assignedCount: 0 };
+    exp.arms.set(arm, a);
+  }
+  return a;
+}
+
+function touch(exp: MutableExperiment, tsMs: number) {
+  if (tsMs > exp.lastUpdatedMs) exp.lastUpdatedMs = tsMs;
+}
+
+/**
+ * Fold a batch of agent log lines into per-experiment aggregates.
+ *
+ * Each entry is [logLine, epochMs]. Order-independent: counts/sums are additive
+ * and terminal state is sticky (a torn-down experiment never flips back live).
+ */
+export function aggregateLogLines(
+  lines: { line: string; tsMs: number }[],
+): ExperimentView[] {
+  const experiments = new Map<string, MutableExperiment>();
+
+  const getExp = (id: string): MutableExperiment => {
+    let e = experiments.get(id);
+    if (!e) {
+      e = {
+        experimentId: id,
+        arms: new Map(),
+        verdict: "running",
+        reason: "",
+        lastUpdatedMs: 0,
+        live: true,
+      };
+      experiments.set(id, e);
+    }
+    return e;
+  };
+
+  for (const { line, tsMs } of lines) {
+    const fields = parseLogfmt(line);
+    const msg = fields["msg"];
+    const id = fields["experiment_id"];
+    if (!msg || !id || !msg.startsWith("experiment.")) continue;
+
+    const exp = getExp(id);
+    touch(exp, tsMs);
+
+    switch (msg) {
+      case "experiment.game_assigned": {
+        if (fields["arm"]) getArm(exp, fields["arm"]).assignedCount += 1;
+        break;
+      }
+      case "experiment.game_concluded": {
+        const arm = fields["arm"];
+        const fitness = Number.parseFloat(fields["fitness"]);
+        if (arm && Number.isFinite(fitness)) {
+          const a = getArm(exp, arm);
+          a.sampleCount += 1;
+          a.fitnessSum += fitness;
+        }
+        break;
+      }
+      case "experiment.concluded": {
+        if (fields["outcome"]) exp.verdict = fields["outcome"];
+        break;
+      }
+      case "experiment.torn_down": {
+        // Terminal: prefer the explicit status, fall back to a label.
+        exp.verdict = fields["status"] || exp.verdict || "torn_down";
+        if (fields["reason"]) exp.reason = fields["reason"];
+        exp.live = false;
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  return Array.from(experiments.values())
+    .map(finalizeExperiment)
+    .sort((a, b) => b.lastUpdatedMs - a.lastUpdatedMs);
+}
+
+function finalizeExperiment(exp: MutableExperiment): ExperimentView {
+  const arms: ArmAggregate[] = Array.from(exp.arms.values())
+    .map((a) => ({
+      arm: a.arm,
+      sampleCount: a.sampleCount,
+      assignedCount: a.assignedCount,
+      meanFitness: a.sampleCount > 0 ? a.fitnessSum / a.sampleCount : 0,
+    }))
+    // Stable, readable order: experimental, control, then any others.
+    .sort((x, y) => armRank(x.arm) - armRank(y.arm) || x.arm.localeCompare(y.arm));
+
+  const experimental = exp.arms.get(ARM_EXPERIMENTAL);
+  const control = exp.arms.get(ARM_CONTROL);
+  let delta: number | null = null;
+  if (
+    experimental &&
+    control &&
+    experimental.sampleCount > 0 &&
+    control.sampleCount > 0
+  ) {
+    delta =
+      experimental.fitnessSum / experimental.sampleCount -
+      control.fitnessSum / control.sampleCount;
+  }
+
+  return {
+    experimentId: exp.experimentId,
+    arms,
+    delta,
+    verdict: exp.verdict,
+    reason: exp.reason,
+    lastUpdatedMs: exp.lastUpdatedMs,
+    live: exp.live,
+  };
+}
+
+function armRank(arm: string): number {
+  if (arm === ARM_EXPERIMENTAL) return 0;
+  if (arm === ARM_CONTROL) return 1;
+  return 2;
+}
+
+/**
+ * Query Loki for recent agent experiment logs and fold them into per-experiment
+ * views. Throws on transport / HTTP error so the caller can surface a retry.
+ */
+export async function fetchExperiments(): Promise<ExperimentView[]> {
+  const endNs = BigInt(Date.now()) * 1_000_000n;
+  const startNs = endNs - BigInt(LOOKBACK_SECONDS) * 1_000_000_000n;
+
+  const params = new URLSearchParams({
+    query: EXPERIMENT_LOG_QUERY,
+    start: startNs.toString(),
+    end: endNs.toString(),
+    limit: String(QUERY_LIMIT),
+    direction: "backward",
+  });
+
+  const url = `${BASE_URL}/loki/loki/api/v1/query_range?${params.toString()}`;
+  const response = await fetch(url, { headers: { Accept: "application/json" } });
+  if (!response.ok) {
+    throw new Error(`Loki query failed: ${response.status} ${response.statusText}`);
+  }
+
+  const body = (await response.json()) as LokiQueryResponse;
+  const lines: { line: string; tsMs: number }[] = [];
+  for (const stream of body.data?.result ?? []) {
+    for (const [tsNs, line] of stream.values) {
+      // ns string → ms number (precision loss here is irrelevant for display).
+      const tsMs = Number(BigInt(tsNs) / 1_000_000n);
+      lines.push({ line, tsMs });
+    }
+  }
+
+  return aggregateLogLines(lines);
+}

--- a/services/dashboard/src/index.html
+++ b/services/dashboard/src/index.html
@@ -42,6 +42,9 @@
         <button class="tab-btn active" data-tab="controllers">
           <span class="tab-icon">&#127918;</span> Controllers
         </button>
+        <button class="tab-btn" data-tab="experiments">
+          <span class="tab-icon">&#129514;</span> Experiments
+        </button>
         <button class="tab-btn" data-tab="metrics">
           <span class="tab-icon">&#128200;</span> Metrics
         </button>
@@ -56,6 +59,17 @@
           <div id="controller-grid" class="controller-grid">
             <!-- Controller cards will be rendered here -->
             <div class="loading">Connecting to controller manager...</div>
+          </div>
+        </div>
+
+        <!-- Experiments Tab (cohort framework, #981) -->
+        <div id="tab-experiments" class="tab-panel">
+          <div class="embed-header experiments-header">
+            <h3>Agent Experiments <span class="experiments-subtitle">live cohort runs</span></h3>
+            <a href="/grafana/explore?left=%7B%22datasource%22:%22loki%22%7D" target="_blank" class="external-link">Open logs in Grafana &#8599;</a>
+          </div>
+          <div id="experiments-grid" class="experiments-grid">
+            <div class="loading">Loading experiments&hellip;</div>
           </div>
         </div>
 

--- a/services/dashboard/src/main.ts
+++ b/services/dashboard/src/main.ts
@@ -7,7 +7,14 @@ import { controllerClient, gameClient, menuClient } from "./client.js";
 import { ControllerGrid } from "./components/ControllerGrid.js";
 import { GameStatus } from "./components/GameStatus.js";
 import { Controls } from "./components/Controls.js";
+import { ExperimentsView } from "./components/ExperimentsView.js";
+import { fetchExperiments } from "./experiments.js";
 import type { GameplayData } from "./gen/controller_manager_pb.js";
+
+// Poll cadence for the agent experiment view (Loki query). Matches the slow,
+// human-readable refresh rate of the embedded observability panels rather than
+// the 30Hz controller stream — experiment state moves on the order of games.
+const EXPERIMENTS_POLL_MS = 5000;
 
 // State
 interface AppState {
@@ -32,6 +39,7 @@ const state: AppState = {
 let controllerGrid: ControllerGrid;
 let gameStatus: GameStatus;
 let controls: Controls;
+let experimentsView: ExperimentsView;
 
 // Initialize the dashboard
 async function init() {
@@ -45,6 +53,7 @@ async function init() {
     onStopGame: handleStopGame,
     onModeChange: handleModeChange,
   });
+  experimentsView = new ExperimentsView("experiments-grid");
 
   // Set up tab navigation
   setupTabs();
@@ -54,6 +63,9 @@ async function init() {
 
   // Start streaming game events
   startGameEventStream();
+
+  // Start polling the agent experiment telemetry (Loki)
+  startExperimentsPolling();
 
   console.log("Dashboard initialized");
 }
@@ -133,6 +145,27 @@ async function startGameEventStream() {
     // Retry after delay
     setTimeout(startGameEventStream, 2000);
   }
+}
+
+// Poll the agent's experiment telemetry from Loki and refresh the view.
+// Self-rescheduling timeout (not setInterval) so a slow query can never stack
+// overlapping requests.
+function startExperimentsPolling() {
+  const tick = async () => {
+    try {
+      const experiments = await fetchExperiments();
+      experimentsView.render(experiments);
+    } catch (error) {
+      console.error("Experiments poll error:", error);
+      // Keep whatever is on screen if we've rendered before; otherwise show why.
+      if (!experimentsView.rendered) {
+        experimentsView.setError("Could not reach Loki for experiment telemetry.");
+      }
+    } finally {
+      setTimeout(tick, EXPERIMENTS_POLL_MS);
+    }
+  };
+  tick();
 }
 
 // Handle game events

--- a/services/dashboard/src/style.css
+++ b/services/dashboard/src/style.css
@@ -457,3 +457,169 @@ body {
     gap: 20px;
   }
 }
+
+/* ===================================================================== */
+/* Experiments view (#981) — agent cohort framework live runs            */
+/* ===================================================================== */
+
+.experiments-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  padding: 12px 4px;
+}
+
+.experiments-header h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.experiments-subtitle {
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  font-weight: normal;
+  margin-left: 8px;
+}
+
+.experiments-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 16px;
+  padding: 4px;
+}
+
+.experiment-card {
+  background: var(--bg-card);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: var(--border-radius);
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.experiment-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+}
+
+.experiment-id {
+  font-family: monospace;
+  font-size: 0.9rem;
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.experiment-verdict {
+  font-size: 0.75rem;
+  font-weight: bold;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 3px 10px;
+  border-radius: 12px;
+  white-space: nowrap;
+}
+
+.verdict-running {
+  background: rgba(33, 150, 243, 0.18);
+  color: var(--accent-info);
+}
+
+.verdict-promote {
+  background: rgba(76, 175, 80, 0.18);
+  color: var(--accent-success);
+}
+
+.verdict-discard {
+  background: rgba(233, 69, 96, 0.18);
+  color: var(--accent-primary);
+}
+
+.verdict-inconclusive {
+  background: rgba(255, 152, 0, 0.18);
+  color: var(--accent-warning);
+}
+
+.experiment-arms {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.experiment-arm {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: rgba(0, 0, 0, 0.2);
+  border-radius: 6px;
+  padding: 8px 12px;
+}
+
+.arm-name {
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.arm-stats {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+.arm-count,
+.arm-mean {
+  font-family: monospace;
+  color: var(--text-primary);
+}
+
+.arm-inflight {
+  font-size: 0.7rem;
+  color: var(--accent-info);
+}
+
+.experiment-footer {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+  padding-top: 10px;
+}
+
+.experiment-delta {
+  font-family: monospace;
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.delta-positive {
+  color: var(--accent-success);
+}
+
+.delta-negative {
+  color: var(--accent-primary);
+}
+
+.delta-neutral {
+  color: var(--text-secondary);
+}
+
+.delta-label {
+  font-family: inherit;
+  font-weight: normal;
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+}
+
+.experiment-reason {
+  font-size: 0.78rem;
+  color: var(--text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/services/dashboard/vite.config.ts
+++ b/services/dashboard/vite.config.ts
@@ -15,6 +15,14 @@ export default defineConfig({
         target: 'http://localhost:8080',
         changeOrigin: true,
       },
+      // Proxy Loki queries (agent experiment telemetry, #981) through envoy,
+      // which routes /loki/* to the Loki HTTP API (port 80 entry point). In
+      // production the dashboard is served behind the same envoy, so this proxy
+      // only matters for `vite dev`.
+      '/loki': {
+        target: 'http://localhost:80',
+        changeOrigin: true,
+      },
     },
   },
 })


### PR DESCRIPTION
Part of #981.

Adds an **Experiments** tab to the dashboard that visualizes the agent's cohort/experiment framework (epic #982) live, so an operator can watch the decision loop during a shadow run.

## Data source (reuses the existing observability path)
The dashboard already embeds the observability stack via envoy (Grafana / Jaeger iframes). The agent emits its experiment lifecycle as structured slog lines — `experiment.game_assigned` / `experiment.game_concluded` / `experiment.concluded` / `experiment.torn_down` — which the OTEL collector's `logs/containers` pipeline ships to Loki labeled `service_name="agent"`. This view queries the **Loki HTTP API through envoy's existing `/loki/*` route** (browser-reachable, same family as the embedded panels). No new transport is invented.

Loki has no aggregation for slog-text bodies, so the lines are parsed (logfmt) and folded **client-side** into per-experiment / per-arm aggregates that mirror the agent's journal `summary.json`.

## What it renders
Per live experiment, a card showing:
- **Arms** (experimental / control, plus any non-standard arms)
- **Sample counts** per arm (games concluded with a fitness sample) + mean fitness + in-flight assignments
- **Fitness delta** (experimental − control mean)
- **Verdict** (running / promote / discard / inconclusive) with the teardown reason string (carries `d_z=...` / `effect=...`)

Polls every 5s, self-rescheduling so a slow query never stacks overlapping requests. Styling matches the existing dashboard cards/badges.

## Files
- `src/experiments.ts` — Loki query + logfmt parser + per-arm fold (pure, order-independent)
- `src/components/ExperimentsView.ts` — card rendering, verdict/delta styling, HTML-escaped
- `src/index.html` / `src/style.css` — Experiments tab + panel
- `src/main.ts` — poll wiring; `vite.config.ts` — `/loki` dev proxy through envoy; `.gitignore` for node_modules/dist

## Verification
- `tsc` + `vite build` clean.
- Aggregation logic exercised against realistic slog lines: per-arm counts, means, delta, verdict, teardown reason, and live→terminal transitions all correct.
- **Live multi-experiment verification is a follow-up** the maintainer will run against a running dry-run stack (`make dry-run` with `AGENT_EXPERIMENT_DYNAMIC_ENABLED=true` once #1043/#1044 land). The real Loki query path is wired, not faked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)