### PR TITLE
feat(agent): migrate runtime-tunable experiment config to live agent.json flags (#1044)

### DIFF
--- a/services/agent/README.md
+++ b/services/agent/README.md
@@ -914,6 +914,44 @@ All configuration is via environment variables:
 | `AGENT_EXPERIMENT_SEED_TARGET_N` | _unset_ | Target games per arm for the seed experiment (positive int; falls back to the registry default when unset) |
 | `AGENT_EXPERIMENT_SEED_HYPOTHESIS` | _generated_ | Free-text hypothesis recorded on the seed experiment's intent |
 
+> **#1044 — runtime-tunable experiment knobs are now LIVE `agent.json` flags.**
+> The experiment loop reads these on **every tick** from the `agent` flagd domain,
+> with the env var above as the **bootstrap default** the flag falls back to when
+> absent/unreadable (the kill-switch pattern: flag overrides, env is the floor). So
+> they are hot-reloadable / dashboard-controllable with **no container restart**, and
+> a fresh `agent.json` (no new flags) reproduces byte-identical env behavior. The
+> migrated flags (see [`services/flagd/agent.json`](../flagd/agent.json)):
+>
+> | flag (`agent.json`) | env bootstrap default |
+> |---|---|
+> | `experiments_enabled` | `AGENT_EXPERIMENTS_ENABLED` |
+> | `experiment_dynamic_enabled` | `AGENT_EXPERIMENT_DYNAMIC_ENABLED` |
+> | `experiment_tick_seconds` | `AGENT_EXPERIMENT_TICK_SECONDS` |
+> | `experiment_dynamic_max_concurrent` | `AGENT_EXPERIMENT_DYNAMIC_MAX_CONCURRENT` |
+> | `experiment_shadow_effective_concurrency` | `AGENT_SHADOW_EFFECTIVE_CONCURRENCY` |
+> | `experiment_max_games` | `AGENT_EXPERIMENT_MAX_GAMES` |
+> | `verdict_min_n` | `AGENT_VERDICT_MIN_N` |
+> | `verdict_min_pairs` | `AGENT_VERDICT_MIN_PAIRS` |
+>
+> **Startup-gate inversion:** the loop + dynamic declarer are now **always built and
+> run**; they self-gate each tick on the live `experiments_enabled` /
+> `experiment_dynamic_enabled` flags. An off→on flip **starts** the loop (it runs the
+> deferred rehydrate + seed bootstrap and begins allocating); an on→off flip **stops**
+> it cleanly (`AbortAll` strips targeting and frees capacity — in-flight shadow games
+> conclude/release normally). The master `enabled` kill-switch still wins: a disabled
+> agent does nothing regardless of these flags. **`agent.json` is human-owned** — the
+> agent has **no** write path to it (its only flagd write is `experiment.Writer`,
+> hardcoded to `game.json` + the `:ro` mount backstop), so it can never enable its own
+> experiments.
+>
+> **Stays env (NOT migrated):** `AGENT_EXPERIMENT_DIR` (filesystem concern), the
+> one-shot `AGENT_EXPERIMENT_SEED_*` (startup seed), and the two **list-valued**
+> declarer knobs `AGENT_EXPERIMENT_DYNAMIC_CANDIDATES` / `_DENYLIST` — a top-level
+> flagd **LIST** flag hits a `get_object_value` `TYPE_MISMATCH` (only the in-process
+> resolver reads list flags; the agent uses the RPC resolver), so a list flag here
+> would be silently broken. `AGENT_VERDICT_EFFECT_THRESHOLD` also stays env for now
+> (it ties to the #1042 practical-significance floor; not part of this migration).
+
 > The Go agent uses the flagd **RPC** resolver (gRPC evaluation port `8013`),
 > not the in-process sync port `8015` that the Python services use.
 

--- a/services/agent/dynamic_declarer.go
+++ b/services/agent/dynamic_declarer.go
@@ -148,12 +148,17 @@ type dynamicDeclarer struct {
 }
 
 // newDynamicDeclarerFromEnv builds the declarer from the AGENT_EXPERIMENT_DYNAMIC_*
-// env vars, or returns nil when the opt-in is off (so the caller wires nothing).
-// pressure is the optional live signal seam (nil ⇒ default-objective fallback).
+// env vars. pressure is the optional live signal seam (nil ⇒ default-objective
+// fallback).
+//
+// #1044: the declarer is ALWAYS built now — the on/off gate moved to the LIVE
+// experiment_dynamic_enabled flag, checked PER TICK by the loop
+// (declareDynamicIfEnabled), so an off→on flip at runtime starts dynamic
+// declaration with no restart. The env AGENT_EXPERIMENT_DYNAMIC_ENABLED is the
+// BOOTSTRAP DEFAULT that flag falls back to. The candidate-set + objective +
+// target-N + denylist remain env-configured (the candidate/denylist LISTS stay env
+// per the flagd list-flag trap; see flags.go), read once here at build.
 func newDynamicDeclarerFromEnv(gameFlagPath string, pressure pressureFunc) *dynamicDeclarer {
-	if !dynamicEnabled() {
-		return nil
-	}
 	objective := strings.TrimSpace(os.Getenv(envDynamicObjective))
 	if !decision.IsExperimentable(objective) {
 		objective = decision.ObjectiveBalanced

--- a/services/agent/dynamic_declarer_test.go
+++ b/services/agent/dynamic_declarer_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/joustmania/agent/decision"
 	"github.com/joustmania/agent/experiment"
+	"github.com/joustmania/agent/flags"
 )
 
 // dynamic_declarer_test.go is the #995 acceptance suite for the HEURISTIC dynamic
@@ -120,17 +121,25 @@ func TestDynamicDeclarer_GatePassesObjectAndBoolFlags(t *testing.T) {
 	}
 }
 
-// TestDynamicDeclarer_DisabledByDefault is the regression guard: with the opt-in
-// unset, newDynamicDeclarerFromEnv returns nil, so the loop wires no declarer and
-// the env-seed path is byte-identical.
+// TestDynamicDeclarer_DisabledByDefault is the regression guard (#1044 update):
+// the declarer is ALWAYS constructed now, but with experiment_dynamic_enabled OFF
+// (the default, here via a zero-value ExperimentConfig) declareDynamicIfEnabled is
+// a no-op — the env-seed path is byte-identical. It also asserts a nil declarer is
+// safe (the test/degraded wiring).
 func TestDynamicDeclarer_DisabledByDefault(t *testing.T) {
 	t.Setenv(envDynamicEnabled, "") // explicitly unset/empty
-	if d := newDynamicDeclarerFromEnv("/etc/flagd/game.json", nil); d != nil {
-		t.Fatal("declarer constructed while opt-in is OFF (default) — must be nil")
+	// The declarer is built regardless of the opt-in now (gating moved to the LIVE
+	// flag, checked per tick).
+	if d := newDynamicDeclarerFromEnv("/etc/flagd/game.json", nil); d == nil {
+		t.Fatal("declarer must always be constructed (#1044) — gating is per-tick via the live flag")
 	}
-	// Also assert the loop's hook is a no-op with a nil declarer (no panic, no work).
+	// A nil declarer is a no-op (test/degraded wiring): no panic, no work.
 	loop := &experimentLoop{dynamic: nil, log: testLogger()}
-	loop.declareDynamicIfEnabled(context.Background()) // must not panic / touch a nil registry.
+	loop.declareDynamicIfEnabled(context.Background(), flags.ExperimentConfig{DynamicEnabled: true})
+	// A wired declarer with DynamicEnabled=false (the live flag off) is ALSO a no-op
+	// even though the declarer is present — proving the per-tick flag gate.
+	loop.dynamic = &dynamicDeclarer{gameFlagPath: "/etc/flagd/game.json"}
+	loop.declareDynamicIfEnabled(context.Background(), flags.ExperimentConfig{DynamicEnabled: false})
 }
 
 // TestDynamicDeclarer_EnabledFromEnv asserts the opt-in constructs a declarer and
@@ -312,9 +321,40 @@ func loopWithRealRegistry(t *testing.T, maxShadow int) (*experimentLoop, string)
 	loop := &experimentLoop{
 		registry: reg,
 		log:      log,
-		tick:     time.Hour,
+		// #1044: the tick cadence is now resolved from the live config; tests drive
+		// allocation explicitly, so a long bootstrap-default tick is ample. The
+		// configOverride keeps the loop's gates ON so allocateIfEnabled-based tests
+		// exercise the declare path (per-test overrides may flip it).
+		expDefaults: flags.ExperimentDefaults{
+			Enabled:                    true,
+			DynamicEnabled:             true,
+			Tick:                       time.Hour,
+			DynamicMaxConcurrent:       defaultDynamicMaxConcurrent,
+			ShadowEffectiveConcurrency: 4,
+		},
+	}
+	loop.configOverride = func(context.Context) flags.ExperimentConfig {
+		return flags.ExperimentConfig{
+			Enabled:                    true,
+			DynamicEnabled:             true,
+			Tick:                       time.Hour,
+			DynamicMaxConcurrent:       defaultDynamicMaxConcurrent,
+			ShadowEffectiveConcurrency: 4,
+		}
 	}
 	return loop, gamePath
+}
+
+// dynCfg is a test helper: a live ExperimentConfig with the loop + dynamic gates ON
+// and the given concurrent-experiment budget (#1044). It replaces the former
+// loop.dynamicMaxConcurrent field the declare-path tests set directly.
+func dynCfg(maxConcurrent int) flags.ExperimentConfig {
+	return flags.ExperimentConfig{
+		Enabled:                    true,
+		DynamicEnabled:             true,
+		DynamicMaxConcurrent:       maxConcurrent,
+		ShadowEffectiveConcurrency: 4,
+	}
 }
 
 // TestDeclareDynamic_DeclaresAndStarts asserts the loop's hook declares a fresh
@@ -327,9 +367,9 @@ func TestDeclareDynamic_DeclaresAndStarts(t *testing.T) {
 		candidates:       []string{"sensitivity", "num_teams"},
 		defaultObjective: decision.ObjectiveBalanced,
 	}
-	loop.dynamicMaxConcurrent = 5
+	cfg := dynCfg(5)
 
-	loop.declareDynamicIfEnabled(context.Background())
+	loop.declareDynamicIfEnabled(context.Background(), cfg)
 	if got := loop.registry.LiveCount(); got != 1 {
 		t.Fatalf("after 1 dynamic declare LiveCount = %d, want 1", got)
 	}
@@ -339,7 +379,7 @@ func TestDeclareDynamic_DeclaresAndStarts(t *testing.T) {
 	}
 
 	// Second call: sensitivity is now active ⇒ the declarer must pick num_teams.
-	loop.declareDynamicIfEnabled(context.Background())
+	loop.declareDynamicIfEnabled(context.Background(), cfg)
 	if got := loop.registry.LiveCount(); got != 2 {
 		t.Fatalf("after 2 dynamic declares LiveCount = %d, want 2", got)
 	}
@@ -358,10 +398,10 @@ func TestDeclareDynamic_RespectsConcurrentBackstop(t *testing.T) {
 		candidates:       []string{"sensitivity", "num_teams", "fight_club.min_rounds"},
 		defaultObjective: decision.ObjectiveBalanced,
 	}
-	loop.dynamicMaxConcurrent = 2 // budget of 2 (well under capacity 8)
+	cfg := dynCfg(2) // budget of 2 (well under capacity 8)
 
 	for i := 0; i < 5; i++ {
-		loop.declareDynamicIfEnabled(context.Background())
+		loop.declareDynamicIfEnabled(context.Background(), cfg)
 	}
 	if got := loop.registry.LiveCount(); got != 2 {
 		t.Fatalf("declarer exceeded the concurrent backstop: LiveCount = %d, want 2", got)
@@ -378,10 +418,10 @@ func TestDeclareDynamic_BackstopClampedToCapacity(t *testing.T) {
 		candidates:       []string{"sensitivity", "num_teams", "fight_club.min_rounds"},
 		defaultObjective: decision.ObjectiveBalanced,
 	}
-	loop.dynamicMaxConcurrent = 99 // huge — but capacity clamps it to 1
+	cfg := dynCfg(99) // huge — but capacity clamps it to 1
 
 	for i := 0; i < 5; i++ {
-		loop.declareDynamicIfEnabled(context.Background())
+		loop.declareDynamicIfEnabled(context.Background(), cfg)
 	}
 	if got := loop.registry.LiveCount(); got != 1 {
 		t.Fatalf("budget not clamped to capacity: LiveCount = %d, want 1", got)
@@ -404,7 +444,7 @@ func TestDeclareDynamic_ConcurrentCallersRespectBudget(t *testing.T) {
 		defaultObjective: decision.ObjectiveBalanced,
 	}
 	const budget = 2
-	loop.dynamicMaxConcurrent = budget // well under capacity 16
+	cfg := dynCfg(budget) // well under capacity 16
 
 	const goroutines = 8
 	var wg sync.WaitGroup
@@ -412,7 +452,7 @@ func TestDeclareDynamic_ConcurrentCallersRespectBudget(t *testing.T) {
 	for i := 0; i < goroutines; i++ {
 		go func() {
 			defer wg.Done()
-			loop.declareDynamicIfEnabled(context.Background())
+			loop.declareDynamicIfEnabled(context.Background(), cfg)
 		}()
 	}
 	wg.Wait()
@@ -437,7 +477,6 @@ func TestDeclareDynamic_KillSwitchOffDeclaresNothing(t *testing.T) {
 		candidates:       []string{"sensitivity"},
 		defaultObjective: decision.ObjectiveBalanced,
 	}
-	loop.dynamicMaxConcurrent = 5
 	loop.enabledOverride = func(context.Context) bool { return false } // kill-switch OFF
 
 	loop.allocateIfEnabled(context.Background())

--- a/services/agent/experiment/registry.go
+++ b/services/agent/experiment/registry.go
@@ -1431,6 +1431,55 @@ func (r *Registry) Capacity() int { return r.maxCap }
 // 1) and clamped to Capacity.
 func (r *Registry) EffectiveCapacity() int { return r.effectiveCap }
 
+// Reconfigure live-updates the registry's runtime caps (#1044) so a hot-reload of
+// experiment_shadow_effective_concurrency / experiment_max_games / verdict_min_n
+// takes effect with NO restart. The experiment loop calls it each tick from the
+// live agent.json flags; the env-derived value is the bootstrap default the flag
+// falls back to, so a fresh agent.json reproduces byte-identical behavior.
+//
+// SAFETY (the #1044 hard-part-2 requirement): every field is updated UNDER r.mu,
+// the same lock that guards all capacity/lifecycle bookkeeping (spawnsInFlight,
+// the games maps, tombstones, the round-robin cursors). It only changes the cap
+// VALUES the allocator reads on its next pass — it never touches an in-flight
+// game, a reservation, or a tombstone — so lowering a cap mid-run simply stops NEW
+// allocations until in-flight drains below it; existing shadow games conclude /
+// release normally. minN is mirrored onto the verdict too (via SetThresholds) so
+// the two stay coherent, exactly as construction did. Non-positive inputs are
+// treated per-field as the constructor does:
+//   - effectiveConcurrency <= 0 ⇒ ignored (keep current; a zero cap would stall
+//     every experiment — misconfiguration);
+//   - maxGames < 0 ⇒ normalized to 0 (explicit "disable the games budget"); 0 is a
+//     legitimate disable and is honored verbatim;
+//   - minN <= 0 ⇒ ignored (keep current; the verdict's own floor also guards).
+//
+// minPairs is verdict-only (the registry does not mirror it); it is forwarded to
+// the verdict via SetThresholds. A negative minPairs is ignored there.
+func (r *Registry) Reconfigure(effectiveConcurrency, maxGames, minN, minPairs int) {
+	r.mu.Lock()
+	if effectiveConcurrency > 0 {
+		eff := effectiveConcurrency
+		if eff > r.maxCap {
+			eff = r.maxCap // never exceed the capacity-bookkeeping bound.
+		}
+		r.effectiveCap = eff
+	}
+	if maxGames >= 0 {
+		r.maxGames = maxGames // 0 ⇒ disable the games budget (other guards still terminate).
+	}
+	if minN > 0 {
+		r.minN = minN
+	}
+	r.mu.Unlock()
+
+	// Mirror the verdict gates outside r.mu (the verdict has its OWN lock; holding
+	// both is unnecessary and invites a lock-ordering question). SetThresholds
+	// ignores a non-positive value per gate, so a transient flagd hiccup never
+	// loosens the verdict.
+	if v, ok := r.verdict.(*Verdict); ok {
+		v.SetThresholds(minN, minPairs)
+	}
+}
+
 // Live returns the ids of experiments that may be allocated shadow capacity —
 // i.e. those in RUNNING (targeting written, ready to accrue games), sorted. A
 // PROPOSED experiment occupies a registry slot but is not yet spawnable, so it is

--- a/services/agent/experiment/registry_test.go
+++ b/services/agent/experiment/registry_test.go
@@ -1353,3 +1353,43 @@ func TestQuiescentRegistryHasNoTombstones(t *testing.T) {
 		t.Fatalf("releaseTombstones = %d on a quiescent registry, want 0", tombs)
 	}
 }
+
+// TestReconfigure_LiveCaps is the #1044 live-caps AC: Reconfigure applies
+// experiment_shadow_effective_concurrency / experiment_max_games / verdict_min_n /
+// verdict_min_pairs to the live registry (+ its Verdict) with no restart, clamps the
+// effective concurrency to the capacity bookkeeping bound, honors a 0 games-budget as
+// an explicit disable, and IGNORES a non-positive concurrency (never clobbering the
+// current cap on a flagd hiccup).
+func TestReconfigure_LiveCaps(t *testing.T) {
+	verdict := NewVerdict(8, 0.2, nil)
+	reg := NewRegistry(RegistryConfig{
+		Root:                  t.TempDir(),
+		MaxShadowGames:        20,
+		EffectiveConcurrency:  4,
+		MaxGamesPerExperiment: 50,
+		VerdictMinN:           8,
+		Verdict:               verdict,
+		Log:                   nil, // NewRegistry defaults to slog.Default()
+	})
+	if reg.EffectiveCapacity() != 4 {
+		t.Fatalf("setup EffectiveCapacity = %d, want 4", reg.EffectiveCapacity())
+	}
+
+	// Raise concurrency to 8, disable the games budget (0), tighten min-N/min-pairs.
+	reg.Reconfigure(8, 0, 16, 12)
+	if reg.EffectiveCapacity() != 8 {
+		t.Fatalf("Reconfigure did not raise EffectiveCapacity: got %d, want 8", reg.EffectiveCapacity())
+	}
+
+	// A non-positive concurrency must NOT clobber the live value (keep 8).
+	reg.Reconfigure(0, 50, 8, 5)
+	if reg.EffectiveCapacity() != 8 {
+		t.Fatalf("Reconfigure(0,...) clobbered EffectiveCapacity: got %d, want 8", reg.EffectiveCapacity())
+	}
+
+	// Concurrency is clamped to the capacity bookkeeping bound (maxCap = 20).
+	reg.Reconfigure(999, 50, 8, 5)
+	if reg.EffectiveCapacity() != 20 {
+		t.Fatalf("Reconfigure did not clamp EffectiveCapacity to maxCap: got %d, want 20", reg.EffectiveCapacity())
+	}
+}

--- a/services/agent/experiment/verdict.go
+++ b/services/agent/experiment/verdict.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/joustmania/agent/experiment/journal"
 )
@@ -121,17 +122,41 @@ func (effectSizeGate) Effect(experimental, control journal.Welford) (float64, bo
 // FitnessMeasurer and decision loop already use), so a positive effect means the
 // experimental arm beat control.
 type Verdict struct {
+	// mu guards the live-tunable thresholds (minN / minPairs) so SetThresholds
+	// (#1044, called from the experiment loop's tick goroutine) and Evaluate (called
+	// under the registry lock from a ConcludeGame goroutine) never race. The other
+	// fields (effectThreshold / stat) are construction-immutable and read without the
+	// lock.
+	mu sync.RWMutex
 	// minN is the minimum Count both arms must reach for a conclusive TWO-ARM verdict
-	// (the fallback path).
+	// (the fallback path). Live-tunable via SetThresholds (#1044, verdict_min_n).
 	minN int
 	// minPairs is the minimum completed-pair count PairDiff must reach for a conclusive
-	// PAIRED verdict (the primary path when CRN pairs exist).
+	// PAIRED verdict (the primary path when CRN pairs exist). Live-tunable via
+	// SetThresholds (#1044, verdict_min_pairs).
 	minPairs int
 	// effectThreshold is the minimum |effect| for a promote/discard verdict. It gates
 	// both the two-arm Cohen's d and the paired d_z (both are standardized effects).
 	effectThreshold float64
 	// stat is the swappable comparison strategy (default effectSizeGate).
 	stat CohortStat
+}
+
+// SetThresholds live-updates the min-N and min-pairs gates (#1044) so a hot-reload
+// of verdict_min_n / verdict_min_pairs takes effect on the NEXT Evaluate with no
+// restart. A non-positive value is IGNORED for that gate (keeps the current value),
+// mirroring the constructor's fail-safe floor — a transient flagd hiccup that
+// resolves a knob to 0 must not silently make every thin sample "conclusive". It is
+// safe to call concurrently with Evaluate; both take v.mu.
+func (v *Verdict) SetThresholds(minN, minPairs int) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	if minN > 0 {
+		v.minN = minN
+	}
+	if minPairs > 0 {
+		v.minPairs = minPairs
+	}
 }
 
 // NewVerdict builds a Verdict with explicit thresholds. A non-positive minN falls
@@ -237,6 +262,14 @@ func NewVerdictFromEnv() *Verdict {
 // so the registry leaves any prior verdict untouched rather than overwriting it
 // with a vacuous one.
 func (v *Verdict) Evaluate(s journal.Summary) (journal.Verdict, bool) {
+	// Snapshot the live-tunable gates ONCE under the lock (#1044) so a concurrent
+	// SetThresholds cannot tear them mid-evaluation; the rest of the method uses the
+	// locals.
+	v.mu.RLock()
+	minN := v.minN
+	minPairs := v.minPairs
+	v.mu.RUnlock()
+
 	// PAIRED PATH (#1004): when seed-matched (experimental, control) pairs have
 	// completed (#1003), difference fitness PER PAIR. Common Random Numbers remove the
 	// shared game variance inside each d_i = f_exp_i − f_ctl_i, so the standardized
@@ -245,7 +278,7 @@ func (v *Verdict) Evaluate(s journal.Summary) (journal.Verdict, bool) {
 	// whenever at least one pair has completed; otherwise we fall through to the
 	// two-arm path so legacy/unpaired experiments are unaffected (the fallback).
 	if s.PairDiff != nil && s.PairDiff.Count > 0 {
-		return v.evaluatePaired(*s.PairDiff)
+		return v.evaluatePaired(*s.PairDiff, minPairs)
 	}
 
 	expStat, expOK := s.Arms[ArmExperimental]
@@ -262,13 +295,13 @@ func (v *Verdict) Evaluate(s journal.Summary) (journal.Verdict, bool) {
 
 	// Min-N gate FIRST: an under-powered cohort is inconclusive regardless of the
 	// observed delta or effect (the #979 acceptance: never a false positive).
-	if exp.Count < v.minN || ctl.Count < v.minN {
+	if exp.Count < minN || ctl.Count < minN {
 		return journal.Verdict{
 			Outcome:     OutcomeInconclusive,
 			Delta:       delta,
 			Significant: false,
 			Reason: fmt.Sprintf("under-powered: n_experimental=%d n_control=%d < min_n=%d",
-				exp.Count, ctl.Count, v.minN),
+				exp.Count, ctl.Count, minN),
 		}, true
 	}
 
@@ -330,16 +363,16 @@ func (v *Verdict) Evaluate(s journal.Summary) (journal.Verdict, bool) {
 // Delta carries mean(d) (the average per-pair fitness improvement) for the audit
 // trail. The bool is always true: a non-nil non-empty PairDiff is a meaningful
 // (possibly interim) verdict the registry should record.
-func (v *Verdict) evaluatePaired(pd journal.Welford) (journal.Verdict, bool) {
+func (v *Verdict) evaluatePaired(pd journal.Welford, minPairs int) (journal.Verdict, bool) {
 	meanD := pd.Mean
 
-	if pd.Count < v.minPairs {
+	if pd.Count < minPairs {
 		return journal.Verdict{
 			Outcome:     OutcomeInconclusive,
 			Delta:       meanD,
 			Significant: false,
 			Reason: fmt.Sprintf("paired under-powered: pairs=%d < min_pairs=%d",
-				pd.Count, v.minPairs),
+				pd.Count, minPairs),
 		}, true
 	}
 

--- a/services/agent/experiment/verdict_test.go
+++ b/services/agent/experiment/verdict_test.go
@@ -295,3 +295,38 @@ type constantStat struct {
 }
 
 func (c constantStat) Effect(_, _ journal.Welford) (float64, bool) { return c.effect, c.ok }
+
+// TestVerdict_SetThresholds_Live is the #1044 live-tunable-gate AC: SetThresholds
+// retunes the min-N / min-pairs gates with no reconstruction (a hot-reload of
+// verdict_min_n / verdict_min_pairs), and a non-positive value is IGNORED (keeps the
+// current gate — the fail-safe floor that never loosens the verdict on a flagd hiccup).
+func TestVerdict_SetThresholds_Live(t *testing.T) {
+	v := NewVerdict(4, 0.2, nil) // start at min-N 4
+	// 8 samples/arm with a clear positive effect: conclusive at min-N 4.
+	s := summaryWith(armFrom(spread(8, 0.9, 0.02)...), armFrom(spread(8, 0.1, 0.02)...))
+	if got, _ := v.Evaluate(s); !got.Significant {
+		t.Fatalf("min-N 4 with 8/arm + large effect should be conclusive, got %+v", got)
+	}
+
+	// Tighten min-N to 16 live: the SAME 8/arm summary is now under-powered.
+	v.SetThresholds(16, 16)
+	got, ok := v.Evaluate(s)
+	if !ok {
+		t.Fatal("Evaluate ok=false for a populated summary")
+	}
+	if got.Significant {
+		t.Fatalf("after SetThresholds(16) the 8/arm summary must be inconclusive (under-powered), got %+v", got)
+	}
+
+	// A non-positive update is ignored (min-N stays 16): still under-powered.
+	v.SetThresholds(0, -1)
+	if got, _ := v.Evaluate(s); got.Significant {
+		t.Fatalf("non-positive SetThresholds loosened the gate; want still inconclusive, got %+v", got)
+	}
+
+	// Loosen back to min-N 4 live: conclusive again.
+	v.SetThresholds(4, 3)
+	if got, _ := v.Evaluate(s); !got.Significant {
+		t.Fatalf("after SetThresholds(4) the 8/arm summary should be conclusive again, got %+v", got)
+	}
+}

--- a/services/agent/experiment_config_flags_test.go
+++ b/services/agent/experiment_config_flags_test.go
@@ -1,0 +1,199 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/joustmania/agent/experiment"
+	"github.com/joustmania/agent/flags"
+)
+
+// experiment_config_flags_test.go is the #1044 loop-level acceptance suite: the
+// migrated AGENT_EXPERIMENT_* knobs are now LIVE agent.json flags (read each tick)
+// with the env value as the bootstrap default. It proves the startup-gate inversion
+// (experiments_enabled off->on->off at runtime), the kill-switch precedence, and the
+// ownership invariant (the agent has NO write path to these agent.json flags). The
+// per-knob flag-overrides-env / fallback / live-reread behavior is covered in
+// flags/flags_test.go (TestExperiment_FlagOverridesEnvDefault), and the registry /
+// verdict live-cap reconfigure in experiment/{registry,verdict}_test.go.
+
+// liveConfig is a goroutine-safe settable ExperimentConfig for the configOverride seam.
+type liveConfig struct {
+	mu  sync.Mutex
+	cfg flags.ExperimentConfig
+}
+
+func (l *liveConfig) set(c flags.ExperimentConfig) {
+	l.mu.Lock()
+	l.cfg = c
+	l.mu.Unlock()
+}
+
+func (l *liveConfig) get(context.Context) flags.ExperimentConfig {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.cfg
+}
+
+// loopForConfigTest builds an experimentLoop over a REAL registry + recording
+// spawner with a settable live ExperimentConfig (the configOverride seam), so a
+// test can flip experiments_enabled / caps at runtime WITHOUT a flagd dependency.
+func loopForConfigTest(t *testing.T, maxShadow int) (*experimentLoop, *recordingSpawner, *liveConfig) {
+	t.Helper()
+	log := testLogger()
+	gamePath := newGameFileForLoop(t)
+	spawner := &recordingSpawner{}
+	writer := experiment.NewWriter(gamePath, log)
+	gate := experiment.NewGate(writer, nil, log)
+	targeting := experiment.NewGateTargetingWriter(gate, writer)
+	reg := experiment.NewRegistry(experiment.RegistryConfig{
+		Root:           t.TempDir(),
+		MaxShadowGames: maxShadow,
+		Spawner:        spawner,
+		Verdict:        experiment.NewVerdict(3, 0.5, nil),
+		Targeting:      targeting,
+		Log:            log,
+	})
+	lc := &liveConfig{}
+	lc.set(flags.ExperimentConfig{Enabled: false}) // default-off, like a fresh agent.json
+	loop := &experimentLoop{
+		registry: reg,
+		log:      log,
+		expDefaults: flags.ExperimentDefaults{
+			Enabled: false, Tick: time.Hour, DynamicMaxConcurrent: defaultDynamicMaxConcurrent,
+		},
+		configOverride: lc.get,
+		// Kill-switch ON via the seam so experiments_enabled is the variable under test.
+		enabledOverride: func(context.Context) bool { return true },
+		seed: &experiment.Intent{
+			Hypothesis: "h", FlagKey: "invincibility_seconds",
+			ExperimentalValue: 6.0, Objective: "balanced", TargetNPerArm: 50,
+		},
+	}
+	return loop, spawner, lc
+}
+
+// TestExperimentsEnabled_OffOnOff is the startup-gate-inversion AC (#1044): the loop
+// is always running, but a runtime off->on flip STARTS it (rehydrate+seed+allocate)
+// and an on->off flip STOPS it cleanly (AbortAll strips targeting + frees capacity),
+// all with no restart and no in-flight corruption.
+func TestExperimentsEnabled_OffOnOff(t *testing.T) {
+	loop, spawner, lc := loopForConfigTest(t, 8)
+	ctx := context.Background()
+
+	// OFF (default): an allocate tick does nothing — no bootstrap, no live experiment.
+	loop.allocateIfEnabled(ctx)
+	if loop.startedOnce {
+		t.Fatal("disabled loop ran its rehydrate+seed bootstrap; must defer until enabled")
+	}
+	if got := loop.registry.LiveCount(); got != 0 {
+		t.Fatalf("disabled loop declared work: LiveCount=%d, want 0", got)
+	}
+	if recs := spawner.drain(); len(recs) != 0 {
+		t.Fatalf("disabled loop spawned shadow games: %d, want 0", len(recs))
+	}
+
+	// Flip ON: the off->on flip must START the loop — bootstrap the seed + allocate.
+	lc.set(flags.ExperimentConfig{Enabled: true, ShadowEffectiveConcurrency: 4})
+	loop.allocateIfEnabled(ctx)
+	if !loop.startedOnce {
+		t.Fatal("off->on flip did not run the deferred rehydrate+seed bootstrap")
+	}
+	if got := loop.registry.LiveCount(); got != 1 {
+		t.Fatalf("off->on flip did not declare+start the seed experiment: LiveCount=%d, want 1", got)
+	}
+	if recs := spawner.drain(); len(recs) == 0 {
+		t.Fatal("off->on flip did not spawn any shadow game")
+	}
+
+	// Flip OFF: the on->off flip must STOP the loop cleanly — AbortAll the live
+	// experiment (targeting stripped, capacity freed).
+	lc.set(flags.ExperimentConfig{Enabled: false})
+	loop.allocateIfEnabled(ctx)
+	if got := loop.registry.LiveCount(); got != 0 {
+		t.Fatalf("on->off flip did not abort the live experiment: LiveCount=%d, want 0", got)
+	}
+	if n := loop.registry.TotalInFlight(); n != 0 {
+		t.Fatalf("on->off flip left in-flight shadow slots: %d, want 0 (no leaked capacity)", n)
+	}
+}
+
+// TestExperimentsEnabled_KillSwitchStillWins asserts the master kill-switch
+// (agent.json enabled) still beats experiments_enabled: a disabled agent does
+// nothing even with experiments_enabled=true.
+func TestExperimentsEnabled_KillSwitchStillWins(t *testing.T) {
+	loop, spawner, lc := loopForConfigTest(t, 8)
+	loop.enabledOverride = func(context.Context) bool { return false } // kill-switch OFF
+	lc.set(flags.ExperimentConfig{Enabled: true, ShadowEffectiveConcurrency: 4})
+
+	loop.allocateIfEnabled(context.Background())
+	if got := loop.registry.LiveCount(); got != 0 {
+		t.Fatalf("kill-switch off must override experiments_enabled=true: LiveCount=%d, want 0", got)
+	}
+	if recs := spawner.drain(); len(recs) != 0 {
+		t.Fatalf("kill-switch off spawned shadow games: %d, want 0", len(recs))
+	}
+}
+
+// TestExperimentsEnabled_DefaultSafeFreshConfig is the default-safe regression
+// (#1044): with NO live config override and a nil flags client (the "fresh
+// agent.json + no flag" shape), config() returns the env bootstrap defaults
+// verbatim — and the default bootstrap (env unset) keeps experiments OFF, so a fresh
+// deployment's behavior is byte-identical to the pre-#1044 disabled default.
+func TestExperimentsEnabled_DefaultSafeFreshConfig(t *testing.T) {
+	loop, spawner, _ := loopForConfigTest(t, 8)
+	loop.configOverride = nil // force the real config() path: nil flags -> expDefaults
+	loop.flags = nil
+	// expDefaults from loopForConfigTest is Enabled:false (env unset = OFF).
+	cfg := loop.config(context.Background())
+	if cfg.Enabled {
+		t.Fatal("DEFAULT-SAFE VIOLATION: a fresh config enabled experiments")
+	}
+	loop.allocateIfEnabled(context.Background())
+	if loop.registry.LiveCount() != 0 || len(spawner.drain()) != 0 {
+		t.Fatal("default-safe loop did work while disabled by default")
+	}
+}
+
+// TestOwnership_AgentHasNoWritePathToAgentJSON is the ownership invariant (#1044):
+// agent.json is human-owned; the agent must NEVER write its own experiment-enable
+// flags. The agent's ONLY flagd write path is experiment.Writer/Gate, which are
+// hardcoded to game.json (basename guard) and reject any agent.json target — so
+// there is no path by which the agent could set experiments_enabled on itself.
+func TestOwnership_AgentHasNoWritePathToAgentJSON(t *testing.T) {
+	dir := t.TempDir()
+	// Stage an agent.json so a (rejected) write would be observable as a mutation.
+	agentPath := filepath.Join(dir, "agent.json")
+	const agentBefore = `{"metadata":{"flagSetId":"agent"},"flags":{"experiments_enabled":{"state":"ENABLED","variants":{"on":true,"off":false},"defaultVariant":"off"}}}`
+	if err := os.WriteFile(agentPath, []byte(agentBefore), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// The Writer the agent uses is pinned to game.json. Point a Gate at agent.json
+	// (the misconfiguration the invariant must catch) and confirm it refuses.
+	log := testLogger()
+	writer := experiment.NewWriter(agentPath, log) // deliberately wrong target
+	gate := experiment.NewGate(writer, nil, log)
+	err := gate.Review(context.Background(), experiment.Proposal{
+		FlagKey:           "experiments_enabled",
+		ExperimentID:      experiment.MintExperimentID(),
+		ExperimentalValue: true,
+		Rationale:         "agent tries to enable itself (must be blocked)",
+	})
+	if err == nil {
+		t.Fatal("OWNERSHIP VIOLATION: the Gate accepted a write targeting agent.json")
+	}
+	if !strings.Contains(err.Error(), string(experiment.ReasonNonGameTarget)) {
+		t.Fatalf("expected a non_game_target rejection, got: %v", err)
+	}
+	// The file must be byte-unchanged: no agent.json mutation occurred.
+	after, _ := os.ReadFile(agentPath)
+	if string(after) != agentBefore {
+		t.Fatalf("agent.json was mutated despite the gate rejection:\nbefore=%s\nafter =%s", agentBefore, after)
+	}
+}

--- a/services/agent/experiment_loop.go
+++ b/services/agent/experiment_loop.go
@@ -105,24 +105,42 @@ type experimentLoop struct {
 	spawner  *shadowSpawner
 	flags    *flags.Flags
 	log      *slog.Logger
-	tick     time.Duration
 
-	// seed, when set, is the one experiment Declared+Started at startup (the
-	// env-gated declaration trigger). Nil ⇒ no seed (the registry rehydrates
-	// prior experiments and runs them, but declares nothing new).
+	// expDefaults are the BOOTSTRAP defaults for the migrated runtime knobs (#1044):
+	// the values resolved ONCE at startup from the AGENT_EXPERIMENT_* env vars. Each
+	// tick's live config(ctx) read falls back to these when the matching agent.json
+	// flag is absent/unreadable — so flag overrides, env is the floor, and a fresh
+	// agent.json reproduces byte-identical env behavior.
+	expDefaults flags.ExperimentDefaults
+
+	// seed, when set, is the one experiment Declared+Started when the loop FIRST
+	// becomes enabled (the env-gated declaration trigger). Nil ⇒ no seed (the
+	// registry rehydrates prior experiments and runs them, but declares nothing new).
 	seed *experiment.Intent
 
-	// dynamic, when set (AGENT_EXPERIMENT_DYNAMIC_ENABLED=true), is the heuristic
-	// dynamic declarer (#995): on each allocate tick the loop asks it to CHOOSE a
-	// fresh experiment Intent from the live game.json surface and declares it,
-	// subject to the dynamicMaxConcurrent backstop and the per-flag dedup. Nil ⇒
-	// the default: declaration is the static env seed only (byte-identical pre-#995).
+	// dynamic is the heuristic dynamic declarer (#995). #1044: it is ALWAYS built
+	// now; whether it actually declares each tick is gated by the LIVE
+	// experiment_dynamic_enabled flag (checked in declareDynamicIfEnabled), so an
+	// off→on flip starts dynamic declaration with no restart. nil only in tests that
+	// do not wire it.
 	dynamic *dynamicDeclarer
 
-	// dynamicMaxConcurrent caps how many LIVE experiments the dynamic declarer keeps
-	// going at once (the over-declaration backstop, #995). Clamped to the registry
-	// shadow capacity. Only consulted when dynamic != nil.
-	dynamicMaxConcurrent int
+	// configOverride, when non-nil, supplies the live ExperimentConfig instead of
+	// reading e.flags.Experiment — the injectable seam tests use to drive the
+	// startup-gate inversion (off→on→off) and the per-knob live reads without a flagd
+	// dependency. Production leaves it nil (the real flags client is consulted).
+	configOverride func(ctx context.Context) flags.ExperimentConfig
+
+	// startMu guards startedOnce so the deferred bootstrap runs EXACTLY once even
+	// though allocateIfEnabled is called concurrently from several goroutines (tick,
+	// immediate allocate, per-partition onGameEnd, onGameTerminal, grace timer).
+	startMu sync.Mutex
+	// startedOnce guards the one-time rehydrate+seed that runs the FIRST time the
+	// loop observes experiments_enabled=true (the startup-gate inversion, #1044): the
+	// loop is always running, but its declaration bootstrap is deferred until the
+	// flag turns on, so an agent that starts with experiments off and is flipped on
+	// later still rehydrates prior experiments and declares its seed.
+	startedOnce bool
 
 	// enabledOverride, when non-nil, supplies the kill-switch state instead of
 	// reading e.flags — the injectable seam tests use to drive a disabled agent
@@ -182,15 +200,23 @@ func buildExperimentLoop(
 	gameFlagPath string,
 	logger *slog.Logger,
 ) *experimentLoop {
-	if !experimentsEnabled() {
-		return nil // default-off: no Registry, no seams, no goroutines.
-	}
+	// #1044 startup-gate inversion: the loop is ALWAYS built now (no nil return).
+	// experiments_enabled is a LIVE agent.json flag, so the loop must exist + run so
+	// an off→on flip at runtime starts it with no restart. It SELF-GATES each tick on
+	// the live flag (allocateIfEnabled / run): while disabled it does nothing —
+	// rehydrate+seed are deferred (startedOnce) and AllocateAndSpawn is skipped — so
+	// the disabled agent's behavior is byte-identical to the pre-#1044 nil-loop case.
+	// The env AGENT_EXPERIMENTS_ENABLED becomes the BOOTSTRAP DEFAULT the flag falls
+	// back to.
+	expDefaults := experimentDefaultsFromEnv()
 
-	logger.Warn("Experiment cohort loop ENABLED (#991, epic #982) — opt-in is ON",
-		"tick", experimentTick(),
+	logger.Info("Experiment cohort loop constructed (#991/#1044) — gated LIVE by agent.json experiments_enabled",
+		"env_enabled_default", expDefaults.Enabled,
+		"env_dynamic_default", expDefaults.DynamicEnabled,
+		"tick_default", expDefaults.Tick,
 		"completed_grace", completedGrace(),
 		"max_shadow_games", experiment.MaxShadowGamesFromEnv(),
-		"effective_concurrency", experiment.EffectiveConcurrencyFromEnv(),
+		"effective_concurrency_default", expDefaults.ShadowEffectiveConcurrency,
 		"seed_flag", os.Getenv(envSeedFlag))
 
 	// TargetingWriter (#977): a Gate over a Writer pinned to the game flagset. The
@@ -218,22 +244,19 @@ func buildExperimentLoop(
 	})
 
 	loop := &experimentLoop{
-		registry:             registry,
-		spawner:              spawner,
-		flags:                flagsClient,
-		log:                  logger,
-		tick:                 experimentTick(),
-		seed:                 seedIntentFromEnv(),
-		fitness:              defaultGameFitness,
-		completedGrace:       completedGrace(),
-		dynamic:              newDynamicDeclarerFromEnv(gameFlagPath, nil),
-		dynamicMaxConcurrent: dynamicMaxConcurrent(),
+		registry:       registry,
+		spawner:        spawner,
+		flags:          flagsClient,
+		log:            logger,
+		expDefaults:    expDefaults,
+		seed:           seedIntentFromEnv(),
+		fitness:        defaultGameFitness,
+		completedGrace: completedGrace(),
+		dynamic:        newDynamicDeclarerFromEnv(gameFlagPath, nil),
 	}
-	if loop.dynamic != nil {
-		logger.Warn("Dynamic experiment declarer ENABLED (#995) — the agent will CHOOSE which game.json flag to experiment on",
-			"max_concurrent", loop.dynamicMaxConcurrent,
-			"candidates", os.Getenv(envDynamicCandidates))
-	}
+	logger.Info("Dynamic experiment declarer constructed (#995/#1044) — gated LIVE by agent.json experiment_dynamic_enabled",
+		"env_dynamic_default", expDefaults.DynamicEnabled,
+		"candidates", os.Getenv(envDynamicCandidates))
 	// Wire the #1014 terminal-outcome backstop: each spawned game signals its
 	// terminal outcome here, and a non-concluding game releases its in-flight slot
 	// directly (independent of the telemetry game_active=0 path), so the
@@ -262,45 +285,40 @@ func promotionConfigResolver(f *flags.Flags) promote.ConfigResolver {
 // run starts the experiment loop and blocks until ctx is cancelled, then returns.
 // It is started in its own goroutine by serverComponents.run (#923) so its
 // lifecycle is owned alongside every other agent goroutine and torn down on
-// shutdown. The loop:
-//  1. Rehydrates the registry from the durable journal (the #831 in-memory-loss
-//     fix): any non-terminal experiment from a prior run is resumed.
-//  2. Declares + Starts the seed experiment (env-gated trigger) if configured.
-//  3. Ticks AllocateAndSpawn to refill free shadow capacity — and, when the #995
-//     dynamic declarer is opted-in, asks it to CHOOSE and declare a fresh
-//     experiment each tick (bounded by the concurrent-experiment backstop).
-//  4. On ctx cancellation, AbortAll (kill-switch / shutdown teardown) and returns.
+// shutdown.
 //
-// SEED + DYNAMIC COMPOSITION (#995): the two declaration triggers COEXIST under
-// one capacity ceiling. The static AGENT_EXPERIMENT_SEED_FLAG seed (if set) is
-// declared ONCE at startup here; the dynamic declarer then takes over on the
-// allocate ticks, declaring additional experiments until the live set reaches the
-// dynamic concurrent-experiment backstop (which COUNTS the seed). The seed flag is
-// also in the declarer's active-flag dedup set once Started, so the declarer never
-// duplicates the operator's seeded flag. Result: seed first, dynamic fills the
-// rest — simple and safe, no override either way.
+// STARTUP-GATE INVERSION (#1044): the loop is ALWAYS running now — experiments_enabled
+// is a LIVE agent.json flag, not a build-time env gate. Each tick the loop reads the
+// live ExperimentConfig and SELF-GATES:
+//   - DISABLED (experiments_enabled false, the default) ⇒ AbortAll every live
+//     experiment and do nothing else. No rehydrate, no seed, no allocate. This is
+//     byte-identical to the pre-#1044 "loop was never built" behavior, and it
+//     subsumes the kill-switch teardown (a disabled agent and a disabled-experiments
+//     flag both tear the experiment surface down).
+//   - ENABLED ⇒ on the FIRST enabled tick run the one-time rehydrate (#831 durable
+//     resume) + seed declaration (startedOnce); then apply the live caps
+//     (Reconfigure) and refill shadow capacity (allocate + dynamic declare). An
+//     off→on flip therefore STARTS the loop (rehydrate+seed+allocate) and an on→off
+//     flip STOPS it cleanly (AbortAll strips targeting + releases capacity; in-flight
+//     shadow games conclude/release normally — no corruption).
 //
-// The kill-switch (agent.json `enabled` false) is also honored mid-run: each tick
-// re-reads it and AbortAll's every live experiment when the agent is disabled, so
-// flipping the kill-switch tears the experiment surface down with no restart — and
-// because the dynamic declarer is only reached from allocateIfEnabled AFTER the
-// kill-switch check, a disabled agent declares NOTHING dynamically either.
+// The tick CADENCE itself is live (experiment_tick_seconds): the ticker is re-armed
+// whenever the resolved interval moves, mirroring the #927 eviction-ticker pattern,
+// so retuning the cadence takes effect with no restart.
+//
+// SEED + DYNAMIC COMPOSITION (#995): unchanged. The seed (if set) is declared ONCE
+// on the first enabled tick; the dynamic declarer then fills the rest each tick,
+// bounded by the live concurrent-experiment backstop. The kill-switch (agent.json
+// `enabled`) is ALSO honored each tick (agentEnabled), independent of
+// experiments_enabled — either being off tears the surface down.
 func (e *experimentLoop) run(ctx context.Context) {
-	if err := e.rehydrate(); err != nil {
-		e.log.Error("experiment: rehydrate from journal failed (continuing without prior experiments)", "error", err)
-	}
-
-	if e.seed != nil {
-		if err := e.declareAndStart(ctx, *e.seed); err != nil {
-			e.log.Error("experiment: seed declare/start failed", "error", err)
-		}
-	}
-
-	// One immediate allocation so the seed accrues games without waiting a full
-	// tick, then refill on the cadence.
+	// First action immediately so an already-enabled agent accrues games without
+	// waiting a full tick (and a disabled one tears down promptly), then refill on
+	// the live cadence.
+	interval := e.tickInterval(ctx)
 	e.allocateIfEnabled(ctx)
 
-	ticker := time.NewTicker(e.tick)
+	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 	for {
 		select {
@@ -320,27 +338,87 @@ func (e *experimentLoop) run(ctx context.Context) {
 			return
 		case <-ticker.C:
 			e.allocateIfEnabled(ctx)
+			// Re-arm the ticker if experiment_tick_seconds was hot-reloaded (#1044),
+			// mirroring the #927 eviction-ticker live-cadence pattern.
+			if next := e.tickInterval(ctx); next > 0 && next != interval {
+				interval = next
+				ticker.Reset(interval)
+				e.log.Info("experiment: tick cadence hot-reloaded (#1044)", "tick", interval)
+			}
 		}
 	}
 }
 
-// allocateIfEnabled refills shadow capacity ONLY while the agent kill-switch is
-// on (agent.json `enabled` true). When the agent is disabled it AbortAll's every
-// live experiment instead — the mid-run kill-switch honor (design §10). This keeps
-// the experiment loop subordinate to the SAME kill-switch the decision loop obeys.
+// config resolves the live ExperimentConfig for one tick (#1044): the configOverride
+// seam (tests) takes precedence, else the live agent.json flags read via
+// flags.Experiment with the env-derived bootstrap defaults as the fallback floor. A
+// nil flags client (test wiring only) yields the bootstrap defaults verbatim.
+func (e *experimentLoop) config(ctx context.Context) flags.ExperimentConfig {
+	if e.configOverride != nil {
+		return e.configOverride(ctx)
+	}
+	if e.flags == nil {
+		return flags.ExperimentConfig{
+			Enabled:                    e.expDefaults.Enabled,
+			DynamicEnabled:             e.expDefaults.DynamicEnabled,
+			Tick:                       e.expDefaults.Tick,
+			DynamicMaxConcurrent:       e.expDefaults.DynamicMaxConcurrent,
+			VerdictMinN:                e.expDefaults.VerdictMinN,
+			VerdictMinPairs:            e.expDefaults.VerdictMinPairs,
+			MaxGames:                   e.expDefaults.MaxGames,
+			ShadowEffectiveConcurrency: e.expDefaults.ShadowEffectiveConcurrency,
+		}
+	}
+	return e.flags.Experiment(ctx, e.expDefaults)
+}
+
+// tickInterval resolves the live AllocateAndSpawn cadence (experiment_tick_seconds),
+// flooring a non-positive value at the env-derived default (durationFlag already
+// guards this in the live path; the floor here covers the configOverride/test seam).
+func (e *experimentLoop) tickInterval(ctx context.Context) time.Duration {
+	d := e.config(ctx).Tick
+	if d <= 0 {
+		d = e.expDefaults.Tick
+	}
+	if d <= 0 {
+		d = defaultExperimentTick
+	}
+	return d
+}
+
+// allocateIfEnabled refills shadow capacity ONLY while BOTH the live
+// experiments_enabled flag (#1044) AND the agent kill-switch (agent.json `enabled`)
+// are on. When either is off it AbortAll's every live experiment instead — the
+// mid-run teardown that keeps the experiment loop subordinate to the same gates the
+// decision loop obeys. When enabled, it lazily runs the one-time rehydrate+seed
+// (startup-gate inversion), applies the live caps, then allocates.
 func (e *experimentLoop) allocateIfEnabled(ctx context.Context) {
+	cfg := e.config(ctx)
+	if !cfg.Enabled {
+		if ids := e.registry.AbortAll(ctx, "experiments_enabled flag off"); len(ids) > 0 {
+			e.log.Warn("experiment: experiments_enabled flag off — aborted live experiments (#1044)", "count", len(ids))
+		}
+		return
+	}
 	if !e.agentEnabled(ctx) {
 		if ids := e.registry.AbortAll(ctx, "kill-switch: agent disabled"); len(ids) > 0 {
 			e.log.Warn("experiment: kill-switch active — aborted live experiments", "count", len(ids))
 		}
 		return
 	}
-	// Heuristic dynamic declaration (#995): the kill-switch is on (checked above)
-	// and the dynamic declarer is opted-in, so let the agent CHOOSE a fresh
-	// experiment to declare — bounded by the concurrent-experiment backstop and the
-	// per-flag dedup. This runs BEFORE AllocateAndSpawn so a freshly-Started
-	// experiment can accrue games on the same tick.
-	e.declareDynamicIfEnabled(ctx)
+	// First enabled tick: run the deferred one-time rehydrate + seed declaration (the
+	// startup-gate inversion bootstrap, #1044).
+	e.ensureStarted(ctx)
+	// Apply the live runtime caps (#1044) before allocating so a hot-reloaded
+	// concurrency / games-budget / min-N takes effect on THIS tick's allocation +
+	// verdict evaluation.
+	e.registry.Reconfigure(cfg.ShadowEffectiveConcurrency, cfg.MaxGames, cfg.VerdictMinN, cfg.VerdictMinPairs)
+	// Heuristic dynamic declaration (#995): both gates are on (checked above) and the
+	// declarer is opted-in (live experiment_dynamic_enabled, #1044), so let the agent
+	// CHOOSE a fresh experiment to declare — bounded by the LIVE concurrent-experiment
+	// backstop and the per-flag dedup. This runs BEFORE AllocateAndSpawn so a
+	// freshly-Started experiment can accrue games on the same tick.
+	e.declareDynamicIfEnabled(ctx, cfg)
 	if n := e.registry.AllocateAndSpawn(ctx); n > 0 {
 		e.log.Info("experiment: spawned shadow games this tick", "count", n,
 			"in_flight", e.registry.TotalInFlight(), "capacity", e.registry.Capacity())
@@ -370,13 +448,18 @@ func (e *experimentLoop) agentEnabled(ctx context.Context) bool {
 //   - the declarer can find a candidate game.json flag with no active experiment
 //     and a distinct alternate value (the per-flag dedup).
 //
-// It is a NO-OP when the declarer is off (the default), so the env-seed path is
-// byte-identical for everyone who has not opted in. It is only ever reached from
-// allocateIfEnabled, which has already confirmed the kill-switch is on — so the
-// declarer is subordinate to the SAME kill-switch as every other declaration.
-// At most one experiment is declared per call (one new flag explored per tick),
-// keeping the declaration rate bounded; the round-robin cursor rotates coverage
-// across ticks.
+// It is a NO-OP when the declarer is not wired (dynamic == nil) OR the LIVE
+// experiment_dynamic_enabled flag is off (#1044), so the env-seed path is
+// byte-identical for everyone who has not opted in — and an off→on flip of the flag
+// starts dynamic declaration on the next tick with no restart. It is only ever
+// reached from allocateIfEnabled, which has already confirmed BOTH experiments_enabled
+// AND the kill-switch are on — so the declarer is subordinate to the SAME gates as
+// every other declaration. At most one experiment is declared per call (one new flag
+// explored per tick), keeping the declaration rate bounded; the round-robin cursor
+// rotates coverage across ticks.
+//
+// The concurrent-experiment budget is the LIVE experiment_dynamic_max_concurrent
+// (#1044, from cfg), clamped to the shadow capacity.
 //
 // CONCURRENCY (#1040 review): allocateIfEnabled is called concurrently from several
 // goroutines (tick, immediate allocate, per-partition onGameEnd, onGameTerminal
@@ -388,9 +471,12 @@ func (e *experimentLoop) agentEnabled(ctx context.Context) bool {
 // own mutex (e.dynamic.mu) around the WHOLE decision path. That mutex WRAPS the
 // registry calls and the registry never calls back into the declarer, so there is
 // no lock-ordering deadlock with registry.mu.
-func (e *experimentLoop) declareDynamicIfEnabled(ctx context.Context) {
+func (e *experimentLoop) declareDynamicIfEnabled(ctx context.Context, cfg flags.ExperimentConfig) {
 	if e.dynamic == nil {
-		return // not opted in (default): env-seed behavior unchanged.
+		return // declarer not wired (test path): env-seed behavior unchanged.
+	}
+	if !cfg.DynamicEnabled {
+		return // LIVE experiment_dynamic_enabled off (#1044): env-seed behavior only.
 	}
 	// Serialize the entire select→budget-check→dedup→declare sequence so only one
 	// dynamic declare is ever in flight (closes the TOCTOU over-declaration window)
@@ -399,9 +485,14 @@ func (e *experimentLoop) declareDynamicIfEnabled(ctx context.Context) {
 	defer e.dynamic.mu.Unlock()
 
 	// Over-declaration backstop: stop once the LIVE experiment set fills the
-	// concurrent-experiment budget. The budget is clamped to the shadow capacity
-	// because an experiment with no shadow slot to ever run is pointless.
-	budget := e.dynamicMaxConcurrent
+	// concurrent-experiment budget. The budget is the LIVE
+	// experiment_dynamic_max_concurrent (#1044), clamped to the shadow capacity
+	// because an experiment with no shadow slot to ever run is pointless. A
+	// non-positive live value falls back to the env-derived default.
+	budget := cfg.DynamicMaxConcurrent
+	if budget <= 0 {
+		budget = e.expDefaults.DynamicMaxConcurrent
+	}
 	if capacity := e.registry.Capacity(); capacity > 0 && budget > capacity {
 		budget = capacity
 	}
@@ -422,6 +513,30 @@ func (e *experimentLoop) declareDynamicIfEnabled(ctx context.Context) {
 	}
 	e.log.Info("experiment: dynamic declarer declared a new experiment (#995)",
 		"flag_key", intent.FlagKey, "value", intent.ExperimentalValue, "objective", intent.Objective)
+}
+
+// ensureStarted runs the deferred ONE-TIME bootstrap the FIRST time the loop
+// observes experiments_enabled=true (the startup-gate inversion, #1044): rehydrate
+// the durable journal (#831 resume) and declare+start the env seed. It is
+// idempotent + concurrency-safe (startMu + startedOnce), so the many concurrent
+// callers of allocateIfEnabled run it exactly once. A rehydrate error is logged and
+// the bootstrap is STILL marked done (we do not want to re-rehydrate every tick); a
+// seed declare error is logged and tolerated (the loop proceeds without the seed).
+func (e *experimentLoop) ensureStarted(ctx context.Context) {
+	e.startMu.Lock()
+	defer e.startMu.Unlock()
+	if e.startedOnce {
+		return
+	}
+	e.startedOnce = true
+	if err := e.rehydrate(); err != nil {
+		e.log.Error("experiment: rehydrate from journal failed (continuing without prior experiments)", "error", err)
+	}
+	if e.seed != nil {
+		if err := e.declareAndStart(ctx, *e.seed); err != nil {
+			e.log.Error("experiment: seed declare/start failed", "error", err)
+		}
+	}
 }
 
 // rehydrate rebuilds the live registry from the durable journal on startup.
@@ -704,6 +819,26 @@ func timelinePhaseDuration(timeline []gamecontext.TimelineEvent) (float64, bool)
 		return 0, false
 	}
 	return d, true
+}
+
+// experimentDefaultsFromEnv resolves the BOOTSTRAP defaults for the eight migrated
+// runtime knobs (#1044) from the AGENT_EXPERIMENT_* env vars (#1041/#1043). These
+// become the per-tick fallback floor the live agent.json flags override: a fresh
+// agent.json (no new flags) reproduces byte-identical env behavior, and an
+// unreachable flagd falls back to exactly these values. It reuses the SAME env
+// resolvers the registry/verdict already own (no duplicate parsing), so the
+// bootstrap layer stays coherent with #1041/#1043.
+func experimentDefaultsFromEnv() flags.ExperimentDefaults {
+	return flags.ExperimentDefaults{
+		Enabled:                    experimentsEnabled(),
+		DynamicEnabled:             dynamicEnabled(),
+		Tick:                       experimentTick(),
+		DynamicMaxConcurrent:       dynamicMaxConcurrent(),
+		VerdictMinN:                experiment.MinNFromEnv(),
+		VerdictMinPairs:            experiment.MinPairsFromEnv(),
+		MaxGames:                   experiment.MaxGamesPerExperimentFromEnv(),
+		ShadowEffectiveConcurrency: experiment.EffectiveConcurrencyFromEnv(),
+	}
 }
 
 // experimentTick resolves the AllocateAndSpawn cadence from

--- a/services/agent/experiment_loop_test.go
+++ b/services/agent/experiment_loop_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/joustmania/agent/experiment"
 	"github.com/joustmania/agent/experiment/journal"
+	"github.com/joustmania/agent/flags"
 	"github.com/joustmania/agent/gamecontext"
 	"github.com/joustmania/agent/gamerunner"
 	"github.com/joustmania/agent/promote"
@@ -186,8 +187,21 @@ func buildLoopForTest(
 	return &experimentLoop{
 		registry: reg,
 		log:      log,
-		tick:     time.Hour, // tests drive allocation explicitly
 		fitness:  fitness,
+		// #1044: the loop self-gates each tick on the live ExperimentConfig. With a nil
+		// flags client these tests drive allocation explicitly, so prime the bootstrap
+		// defaults ENABLED (the loop's gate ON) and a long tick — preserving the
+		// pre-#1044 "the loop runs and allocates" behavior the conclusion/grace tests
+		// assert. config(ctx) with a nil flags client returns these defaults verbatim.
+		expDefaults: flags.ExperimentDefaults{
+			Enabled:              true,
+			Tick:                 time.Hour, // tests drive allocation explicitly
+			DynamicMaxConcurrent: defaultDynamicMaxConcurrent,
+			// ShadowEffectiveConcurrency LEFT 0 on purpose: Reconfigure ignores a
+			// non-positive concurrency, so the loop's allocateIfEnabled does NOT clobber
+			// the registry's own EffectiveConcurrency (some tests pin concurrency=1 by
+			// swapping in their own registry). Production resolves a positive env/flag value.
+		},
 	}
 }
 
@@ -786,21 +800,37 @@ func newRegistryConcurrency1(t *testing.T, spawner experiment.ShadowSpawner, res
 	})
 }
 
-// TestBuildExperimentLoop_DisabledByDefault is the disabled-default AC: with the
-// opt-in OFF (the default, env unset), buildExperimentLoop returns nil — NO
-// Registry, NO seams, NO goroutines. The agent's normal behavior is unchanged.
+// TestBuildExperimentLoop_DisabledByDefault is the disabled-default AC (#1044
+// startup-gate inversion). The loop is ALWAYS built now (so an off→on flag flip can
+// start it at runtime), but with the opt-in OFF (the default, env unset) it
+// SELF-GATES to a no-op: experiments_enabled defaults to false, so allocateIfEnabled
+// runs no rehydrate, no seed, no allocate — byte-identical to the pre-#1044
+// nil-loop behavior. The env value is only the BOOTSTRAP DEFAULT.
 func TestBuildExperimentLoop_DisabledByDefault(t *testing.T) {
 	// Ensure the opt-in env is unset (the default).
 	t.Setenv(envExperimentsEnabled, "")
 	loop := buildExperimentLoop(nil, nil, "/nonexistent/game.json", testLogger())
-	if loop != nil {
-		t.Fatalf("buildExperimentLoop must return nil when AGENT_EXPERIMENTS_ENABLED is unset (default-off)")
+	if loop == nil {
+		t.Fatalf("buildExperimentLoop must ALWAYS build the loop now (#1044); gating is the live flag, not a nil return")
+	}
+	if loop.expDefaults.Enabled {
+		t.Fatalf("with AGENT_EXPERIMENTS_ENABLED unset the bootstrap default must be disabled, got Enabled=true")
+	}
+	// The loop self-gates OFF: an allocate tick with the disabled default does no
+	// work (no live experiments declared).
+	loop.allocateIfEnabled(context.Background())
+	if got := loop.registry.LiveCount(); got != 0 {
+		t.Fatalf("disabled-by-default loop declared work: LiveCount = %d, want 0", got)
+	}
+	if loop.startedOnce {
+		t.Fatalf("disabled-by-default loop ran its rehydrate+seed bootstrap; it must defer until enabled")
 	}
 
 	// Explicit "false" is also off.
 	t.Setenv(envExperimentsEnabled, "false")
-	if buildExperimentLoop(nil, nil, "/nonexistent/game.json", testLogger()) != nil {
-		t.Fatalf("buildExperimentLoop must return nil when AGENT_EXPERIMENTS_ENABLED=false")
+	loop2 := buildExperimentLoop(nil, nil, "/nonexistent/game.json", testLogger())
+	if loop2 == nil || loop2.expDefaults.Enabled {
+		t.Fatalf("AGENT_EXPERIMENTS_ENABLED=false must build a loop with the disabled bootstrap default")
 	}
 }
 
@@ -831,8 +861,9 @@ func TestExperimentLoop_RunShutdownNoLeak(t *testing.T) {
 	}
 	loop := buildLoopForTest(t, spawner, resolve, &recordingRealDefault{}, &recordingGitHub{}, armFitness())
 	// A short tick so the allocate loop actually fires during the test, proving it
-	// stops on ctx cancel rather than merely never having started.
-	loop.tick = 5 * time.Millisecond
+	// stops on ctx cancel rather than merely never having started. #1044: the tick is
+	// resolved live from expDefaults.Tick (nil flags client), so set it there.
+	loop.expDefaults.Tick = 5 * time.Millisecond
 	// Seed an experiment so the loop has live work each tick.
 	loop.seed = &experiment.Intent{
 		FlagKey: "invincibility_seconds", ExperimentalValue: 6.0, Objective: "balanced", TargetNPerArm: 100,

--- a/services/agent/flags/flags.go
+++ b/services/agent/flags/flags.go
@@ -116,6 +116,31 @@ const (
 	keySessionGraceSeconds  = "lifecycle.session_grace_seconds"
 	keyEvictIntervalSeconds = "lifecycle.evict_interval_seconds"
 	keyDecisionThrottleSecs = "decision.throttle_seconds"
+
+	// Experiment / cohort framework runtime knobs (#1044). These migrate the
+	// runtime-tunable AGENT_EXPERIMENT_* env vars to LIVE agent.json flags so they
+	// are hot-reloadable / dashboard-controllable with no container restart, exactly
+	// like the kill-switch + llm.* gate flags. They are read LIVE each experiment
+	// tick (experiment_loop.go) — NOT cached — so a flag flip takes effect on the
+	// next tick. The ENV value (#1041/#1043 bootstrap passthrough) stays the
+	// DEFAULT each read falls back to when the flag is absent/unreadable: flag
+	// overrides, env is the floor (fail-safe, exactly the kill-switch pattern).
+	//
+	// The flagd numeric-flag gotcha applies: every numeric one MUST use the typed
+	// getter (a numeric flag read via ObjectValue silently TYPE_MISMATCHes to its
+	// default — see llmGate). The two LIST-valued declarer knobs
+	// (AGENT_EXPERIMENT_DYNAMIC_CANDIDATES / _DENYLIST) deliberately STAY as env:
+	// top-level LIST flags hit the same get_object_value TYPE_MISMATCH and only the
+	// in-process resolver (port 8015) reads them, so a list flag here would be
+	// silently broken (the issue permits keeping those two as env).
+	keyExperimentsEnabled          = "experiments_enabled"
+	keyExperimentDynamicEnabled    = "experiment_dynamic_enabled"
+	keyExperimentTickSeconds       = "experiment_tick_seconds"
+	keyExperimentDynamicMaxConcur  = "experiment_dynamic_max_concurrent"
+	keyVerdictMinN                 = "verdict_min_n"
+	keyVerdictMinPairs             = "verdict_min_pairs"
+	keyExperimentMaxGames          = "experiment_max_games"
+	keyExperimentShadowConcurrency = "experiment_shadow_effective_concurrency"
 )
 
 // Safe defaults applied when flagd is unreachable or a flag is undefined.
@@ -536,6 +561,83 @@ func (f *Flags) Promotion(ctx context.Context) PromotionConfig {
 	return PromotionConfig{
 		Mode:   f.stringFlag(ctx, keyPromotionMode, DefaultPromotionMode),
 		Target: f.stringFlag(ctx, keyPromotionTarget, DefaultPromotionTarget),
+	}
+}
+
+// ExperimentDefaults carries the BOOTSTRAP defaults for the experiment runtime
+// knobs (#1044): the values resolved ONCE at startup from the AGENT_EXPERIMENT_*
+// env vars (#1041/#1043). Each Experiment() read falls back to the matching field
+// here when its agent.json flag is absent/unreadable — so flag overrides, env is
+// the floor, and a fresh agent.json (no new flags) reproduces byte-identical
+// env-based behavior. The caller (experiment_loop.go) builds this from the env
+// resolvers it already owns and hands it in, keeping the flags package free of any
+// AGENT_EXPERIMENT_* env knowledge.
+type ExperimentDefaults struct {
+	// Enabled is AGENT_EXPERIMENTS_ENABLED (the loop opt-in).
+	Enabled bool
+	// DynamicEnabled is AGENT_EXPERIMENT_DYNAMIC_ENABLED (the #995 declarer opt-in).
+	DynamicEnabled bool
+	// Tick is AGENT_EXPERIMENT_TICK_SECONDS as a duration (the AllocateAndSpawn cadence).
+	Tick time.Duration
+	// DynamicMaxConcurrent is AGENT_EXPERIMENT_DYNAMIC_MAX_CONCURRENT.
+	DynamicMaxConcurrent int
+	// VerdictMinN is AGENT_VERDICT_MIN_N.
+	VerdictMinN int
+	// VerdictMinPairs is AGENT_VERDICT_MIN_PAIRS.
+	VerdictMinPairs int
+	// MaxGames is AGENT_EXPERIMENT_MAX_GAMES (per-experiment termination budget).
+	MaxGames int
+	// ShadowEffectiveConcurrency is AGENT_SHADOW_EFFECTIVE_CONCURRENCY.
+	ShadowEffectiveConcurrency int
+}
+
+// ExperimentConfig is the LIVE-resolved experiment runtime configuration (#1044),
+// re-read each experiment tick so a flag flip takes effect with no restart. Every
+// field mirrors an ExperimentDefaults field, with the agent.json flag taking
+// precedence when present and the env-derived default applying otherwise.
+type ExperimentConfig struct {
+	// Enabled gates the WHOLE experiment loop (experiments_enabled). When false the
+	// loop does nothing — no rehydrate-spawn, no seed, no allocate. Flipping it on
+	// at runtime starts the loop; flipping it off aborts every live experiment.
+	Enabled bool
+	// DynamicEnabled gates the #995 heuristic declarer (experiment_dynamic_enabled).
+	// When false the loop declares only the static env seed (if any).
+	DynamicEnabled bool
+	// Tick is the AllocateAndSpawn cadence (experiment_tick_seconds). A non-positive
+	// flag value falls back to the env default (durationFlag guard).
+	Tick time.Duration
+	// DynamicMaxConcurrent caps simultaneously-live dynamically-declared experiments
+	// (experiment_dynamic_max_concurrent).
+	DynamicMaxConcurrent int
+	// VerdictMinN is the verdict min-N-per-arm gate (verdict_min_n).
+	VerdictMinN int
+	// VerdictMinPairs is the paired-verdict min-completed-pairs gate (verdict_min_pairs).
+	VerdictMinPairs int
+	// MaxGames is the per-experiment termination budget (experiment_max_games).
+	MaxGames int
+	// ShadowEffectiveConcurrency is the in-flight shadow-spawn concurrency cap
+	// (experiment_shadow_effective_concurrency).
+	ShadowEffectiveConcurrency int
+}
+
+// Experiment evaluates the eight migrated experiment runtime knobs (#1044) for one
+// experiment tick. Read LIVE (never cached) so a hot-reload of any knob takes
+// effect on the next tick. Each flag falls back to the matching ExperimentDefaults
+// field (the env-derived bootstrap default) on any evaluation error or flag
+// absence — so flag overrides, env is the floor, and a fresh agent.json reproduces
+// byte-identical env behavior. Numeric flags use the TYPED getters (the flagd
+// numeric-flag gotcha — see llmGate); the duration uses durationFlag (which floors
+// a non-positive value at the default).
+func (f *Flags) Experiment(ctx context.Context, def ExperimentDefaults) ExperimentConfig {
+	return ExperimentConfig{
+		Enabled:                    f.boolFlag(ctx, keyExperimentsEnabled, def.Enabled),
+		DynamicEnabled:             f.boolFlag(ctx, keyExperimentDynamicEnabled, def.DynamicEnabled),
+		Tick:                       f.durationFlag(ctx, keyExperimentTickSeconds, def.Tick.Seconds()),
+		DynamicMaxConcurrent:       f.intFlag(ctx, keyExperimentDynamicMaxConcur, def.DynamicMaxConcurrent),
+		VerdictMinN:                f.intFlag(ctx, keyVerdictMinN, def.VerdictMinN),
+		VerdictMinPairs:            f.intFlag(ctx, keyVerdictMinPairs, def.VerdictMinPairs),
+		MaxGames:                   f.intFlag(ctx, keyExperimentMaxGames, def.MaxGames),
+		ShadowEffectiveConcurrency: f.intFlag(ctx, keyExperimentShadowConcurrency, def.ShadowEffectiveConcurrency),
 	}
 }
 

--- a/services/agent/flags/flags_test.go
+++ b/services/agent/flags/flags_test.go
@@ -639,3 +639,108 @@ func TestPromotion(t *testing.T) {
 		}
 	})
 }
+
+// TestExperiment_FlagOverridesEnvDefault is the #1044 acceptance: each migrated
+// experiment knob takes the agent.json flag value when present and falls back to
+// the env-derived bootstrap default (ExperimentDefaults) when the flag is absent.
+func TestExperiment_FlagOverridesEnvDefault(t *testing.T) {
+	// The env-derived bootstrap defaults the loop hands in.
+	def := ExperimentDefaults{
+		Enabled:                    false,
+		DynamicEnabled:             false,
+		Tick:                       30 * time.Second,
+		DynamicMaxConcurrent:       3,
+		VerdictMinN:                8,
+		VerdictMinPairs:            5,
+		MaxGames:                   50,
+		ShadowEffectiveConcurrency: 4,
+	}
+
+	t.Run("flags present override every env default", func(t *testing.T) {
+		stub := stubEvaluator{
+			booleans: map[string]bool{
+				keyExperimentsEnabled:       true,
+				keyExperimentDynamicEnabled: true,
+			},
+			floats: map[string]float64{keyExperimentTickSeconds: 10},
+			ints: map[string]int64{
+				keyExperimentDynamicMaxConcur:  6,
+				keyVerdictMinN:                 16,
+				keyVerdictMinPairs:             10,
+				keyExperimentMaxGames:          100,
+				keyExperimentShadowConcurrency: 8,
+			},
+		}
+		got := New(stub, nil).Experiment(context.Background(), def)
+		want := ExperimentConfig{
+			Enabled:                    true,
+			DynamicEnabled:             true,
+			Tick:                       10 * time.Second,
+			DynamicMaxConcurrent:       6,
+			VerdictMinN:                16,
+			VerdictMinPairs:            10,
+			MaxGames:                   100,
+			ShadowEffectiveConcurrency: 8,
+		}
+		if got != want {
+			t.Fatalf("Experiment with flags present = %+v, want %+v", got, want)
+		}
+	})
+
+	t.Run("flags absent fall back to the env bootstrap defaults", func(t *testing.T) {
+		// An empty stub returns the passed default for every key (flag absent).
+		got := New(stubEvaluator{}, nil).Experiment(context.Background(), def)
+		want := ExperimentConfig{
+			Enabled:                    def.Enabled,
+			DynamicEnabled:             def.DynamicEnabled,
+			Tick:                       def.Tick,
+			DynamicMaxConcurrent:       def.DynamicMaxConcurrent,
+			VerdictMinN:                def.VerdictMinN,
+			VerdictMinPairs:            def.VerdictMinPairs,
+			MaxGames:                   def.MaxGames,
+			ShadowEffectiveConcurrency: def.ShadowEffectiveConcurrency,
+		}
+		if got != want {
+			t.Fatalf("Experiment with flags absent = %+v, want env defaults %+v", got, want)
+		}
+	})
+
+	t.Run("flagd errors fall back to the env bootstrap defaults (fail-safe)", func(t *testing.T) {
+		errAll := map[string]error{
+			keyExperimentsEnabled:          errors.New("down"),
+			keyExperimentDynamicEnabled:    errors.New("down"),
+			keyExperimentTickSeconds:       errors.New("down"),
+			keyExperimentDynamicMaxConcur:  errors.New("down"),
+			keyVerdictMinN:                 errors.New("down"),
+			keyVerdictMinPairs:             errors.New("down"),
+			keyExperimentMaxGames:          errors.New("down"),
+			keyExperimentShadowConcurrency: errors.New("down"),
+		}
+		got := New(stubEvaluator{errs: errAll}, nil).Experiment(context.Background(), def)
+		if got.Enabled != def.Enabled || got.Tick != def.Tick || got.VerdictMinN != def.VerdictMinN ||
+			got.MaxGames != def.MaxGames || got.ShadowEffectiveConcurrency != def.ShadowEffectiveConcurrency {
+			t.Fatalf("Experiment under flagd error did not fall back to env defaults: %+v", got)
+		}
+	})
+
+	t.Run("live re-read: a changed flag is reflected on the next call (never cached)", func(t *testing.T) {
+		stub := stubEvaluator{booleans: map[string]bool{keyExperimentsEnabled: false}}
+		f := New(stub, nil)
+		if f.Experiment(context.Background(), def).Enabled {
+			t.Fatal("expected disabled on first read")
+		}
+		// Flip the live flag value and re-read — Experiment must NOT cache.
+		stub.booleans[keyExperimentsEnabled] = true
+		if !f.Experiment(context.Background(), def).Enabled {
+			t.Fatal("Experiment cached the flag; a live change was not reflected on re-read")
+		}
+	})
+
+	t.Run("max_games=0 (disable budget) is honored verbatim, not floored", func(t *testing.T) {
+		stub := stubEvaluator{ints: map[string]int64{keyExperimentMaxGames: 0}}
+		got := New(stub, nil).Experiment(context.Background(), def)
+		if got.MaxGames != 0 {
+			t.Fatalf("max_games=0 must pass through as the explicit disable, got %d", got.MaxGames)
+		}
+	})
+}

--- a/services/agent/main.go
+++ b/services/agent/main.go
@@ -649,11 +649,15 @@ func main() {
 
 	// M7 / #991 experiment cohort loop — FINAL ASSEMBLY (epic #982). buildExperimentLoop
 	// constructs the experiment.Registry with the REAL seams (#976 spawner, #977
-	// targeting Gate/Writer, #979 verdict, #980/#961 promoter) ONLY when the opt-in
-	// AGENT_EXPERIMENTS_ENABLED=true. The DEFAULT (unset) returns nil: NO Registry,
-	// NO shadow spawns, NO targeting writes, NO promotions — the agent's behavior is
-	// byte-unchanged. The real-default promotion path stays behind ALL of #961's
-	// gates (the promoter built above + the kill-switch via the ConfigResolver).
+	// targeting Gate/Writer, #979 verdict, #980/#961 promoter). #1044 startup-gate
+	// inversion: the loop is ALWAYS built + run now, and SELF-GATES each tick on the
+	// LIVE agent.json experiments_enabled flag (default off, env AGENT_EXPERIMENTS_ENABLED
+	// is the bootstrap default). When disabled — the default — the loop does NOTHING:
+	// no rehydrate, no seed, no shadow spawn, no targeting write, no promotion — so the
+	// agent's behavior is byte-identical to the pre-#1044 nil-loop case, but an off→on
+	// flip at runtime starts it with no restart. The real-default promotion path stays
+	// behind ALL of #961's gates (the promoter built above + the kill-switch via the
+	// ConfigResolver).
 	expLoop := buildExperimentLoop(agentFlags, promoter, getEnv("GAME_FLAG_PATH", experiment.DefaultGamePath), logger)
 	if expLoop != nil {
 		// Bind the spawner's background game-drive goroutines to the agent's root

--- a/services/flagd/agent.json
+++ b/services/flagd/agent.json
@@ -443,6 +443,76 @@
         "github": "github"
       },
       "defaultVariant": "local"
+    },
+    "experiments_enabled": {
+      "state": "ENABLED",
+      "variants": {
+        "on": true,
+        "off": false
+      },
+      "defaultVariant": "off"
+    },
+    "experiment_dynamic_enabled": {
+      "state": "ENABLED",
+      "variants": {
+        "on": true,
+        "off": false
+      },
+      "defaultVariant": "off"
+    },
+    "experiment_tick_seconds": {
+      "state": "ENABLED",
+      "variants": {
+        "fast": 10,
+        "default": 30,
+        "slow": 60
+      },
+      "defaultVariant": "default"
+    },
+    "experiment_dynamic_max_concurrent": {
+      "state": "ENABLED",
+      "variants": {
+        "one": 1,
+        "default": 3,
+        "wide": 6
+      },
+      "defaultVariant": "default"
+    },
+    "verdict_min_n": {
+      "state": "ENABLED",
+      "variants": {
+        "quick": 4,
+        "default": 8,
+        "strict": 16
+      },
+      "defaultVariant": "default"
+    },
+    "verdict_min_pairs": {
+      "state": "ENABLED",
+      "variants": {
+        "quick": 3,
+        "default": 5,
+        "strict": 10
+      },
+      "defaultVariant": "default"
+    },
+    "experiment_max_games": {
+      "state": "ENABLED",
+      "variants": {
+        "default": 50,
+        "long": 100,
+        "unlimited": 0
+      },
+      "defaultVariant": "default"
+    },
+    "experiment_shadow_effective_concurrency": {
+      "state": "ENABLED",
+      "variants": {
+        "one": 1,
+        "default": 4,
+        "wide": 8
+      },
+      "defaultVariant": "default"
     }
   }
 }

--- a/services/flagd/ci/agent.json
+++ b/services/flagd/ci/agent.json
@@ -443,6 +443,76 @@
         "github": "github"
       },
       "defaultVariant": "local"
+    },
+    "experiments_enabled": {
+      "state": "ENABLED",
+      "variants": {
+        "on": true,
+        "off": false
+      },
+      "defaultVariant": "off"
+    },
+    "experiment_dynamic_enabled": {
+      "state": "ENABLED",
+      "variants": {
+        "on": true,
+        "off": false
+      },
+      "defaultVariant": "off"
+    },
+    "experiment_tick_seconds": {
+      "state": "ENABLED",
+      "variants": {
+        "fast": 10,
+        "default": 30,
+        "slow": 60
+      },
+      "defaultVariant": "default"
+    },
+    "experiment_dynamic_max_concurrent": {
+      "state": "ENABLED",
+      "variants": {
+        "one": 1,
+        "default": 3,
+        "wide": 6
+      },
+      "defaultVariant": "default"
+    },
+    "verdict_min_n": {
+      "state": "ENABLED",
+      "variants": {
+        "quick": 4,
+        "default": 8,
+        "strict": 16
+      },
+      "defaultVariant": "default"
+    },
+    "verdict_min_pairs": {
+      "state": "ENABLED",
+      "variants": {
+        "quick": 3,
+        "default": 5,
+        "strict": 10
+      },
+      "defaultVariant": "default"
+    },
+    "experiment_max_games": {
+      "state": "ENABLED",
+      "variants": {
+        "default": 50,
+        "long": 100,
+        "unlimited": 0
+      },
+      "defaultVariant": "default"
+    },
+    "experiment_shadow_effective_concurrency": {
+      "state": "ENABLED",
+      "variants": {
+        "one": 1,
+        "default": 4,
+        "wide": 8
+      },
+      "defaultVariant": "default"
     }
   }
 }


### PR DESCRIPTION
Part of #1044.

Migrates the runtime-tunable `AGENT_EXPERIMENT_*` config from static env vars to **LIVE `agent.json` flagd flags** (hot-reloadable / dashboard-controllable, no container restart). Mirrors the existing kill-switch / `llm.*` / `fitness.*` live-flag pattern: **flag overrides, env is the bootstrap-default floor.**

## Migrated to live `agent.json` flags (read each tick, env = bootstrap default)
| flag | env default |
|---|---|
| `experiments_enabled` | `AGENT_EXPERIMENTS_ENABLED` |
| `experiment_dynamic_enabled` | `AGENT_EXPERIMENT_DYNAMIC_ENABLED` |
| `experiment_tick_seconds` | `AGENT_EXPERIMENT_TICK_SECONDS` |
| `experiment_dynamic_max_concurrent` | `AGENT_EXPERIMENT_DYNAMIC_MAX_CONCURRENT` |
| `experiment_shadow_effective_concurrency` | `AGENT_SHADOW_EFFECTIVE_CONCURRENCY` |
| `experiment_max_games` | `AGENT_EXPERIMENT_MAX_GAMES` |
| `verdict_min_n` | `AGENT_VERDICT_MIN_N` |
| `verdict_min_pairs` | `AGENT_VERDICT_MIN_PAIRS` |

## The three hard sub-parts
1. **Startup-gate inversion** — the loop + dynamic declarer are now **always built and run**; they self-gate each tick on the live `experiments_enabled` / `experiment_dynamic_enabled` flags. Rehydrate+seed are deferred to the first enabled tick (`startedOnce`), so off→on **starts** the loop and on→off **stops** it cleanly (`AbortAll` strips targeting + frees capacity; in-flight shadow games conclude/release normally — no corruption). Tick cadence is re-armed live (mirrors the #927 eviction-ticker pattern).
2. **Registry caps** — `Registry.Reconfigure(effConcurrency, maxGames, minN, minPairs)` applies the live caps under `r.mu` each tick (only changes the cap *values* the allocator reads next pass; never touches in-flight games / reservations / tombstones). `Verdict.SetThresholds(minN, minPairs)` is its own-mutex live setter; non-positive values are ignored (fail-safe floor).
3. **flagd list-flag trap** — the two **list-valued** declarer knobs (`AGENT_EXPERIMENT_DYNAMIC_CANDIDATES` / `_DENYLIST`) **stay env** with a clear comment: a top-level flagd LIST flag `TYPE_MISMATCH`es via the RPC resolver the agent uses, so a list flag would be silently broken.

## Invariants held
- **Default-safe:** with the new flags absent (fresh `agent.json`), every read falls back to the env default → byte-identical behavior; default `experiments_enabled=off`.
- **Ownership:** the agent has **no write path** to `agent.json` (its only flagd write is `experiment.Writer`, hardcoded to `game.json` + `:ro` mount backstop). Test asserts a Gate write targeting `agent.json` is rejected (`non_game_target`) and the file is byte-unchanged.
- **Kill-switch precedence:** the master `enabled` kill-switch still wins.
- `AGENT_EXPERIMENT_DIR` + one-shot `AGENT_EXPERIMENT_SEED_*` stay env.

## Tests
Per-knob flag-overrides-env / fallback / live-reread (flags pkg); `Reconfigure` + `SetThresholds` live caps (experiment pkg); startup-gate inversion off→on→off, kill-switch precedence, default-safe, ownership (main pkg). `go build` / `go vet` / `gofmt -l` / `go test ./... -race` all clean; `agent.json`/ci JSON validated; `make lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
