### PR TITLE
feat(agent): OpenAI-compatible Backend.Infer for propose + decision seams (#1048)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -696,6 +696,17 @@ services:
       # the remediation_allowed flag (rollout flagd domain, read from rollout.json).
       # After a rollback, re-expansion is suppressed for the cooldown below.
       - AGENT_ROLLOUT_COOLDOWN_SECONDS=${AGENT_ROLLOUT_COOLDOWN_SECONDS:-30}
+      # ---- Inference backend (#1048, per the #1046 design) ----
+      # The real LLM inference seam for BOTH the proposer and the decision loop.
+      # ONE OpenAI-compatible HTTP client feeds both. Default = stub → no behavior
+      # change (the proposer proposes nothing, the decision chain degrades to rules),
+      # so a plain `up` stays inert. Set AGENT_INFERENCE_BACKEND=openai to point it at
+      # the HOST machine's Ollama (host.docker.internal:11434 via extra_hosts below,
+      # no key needed) or at a gateway/cloud endpoint (set the base URL + API key).
+      - AGENT_INFERENCE_BACKEND=${AGENT_INFERENCE_BACKEND:-stub}
+      - AGENT_INFERENCE_BASE_URL=${AGENT_INFERENCE_BASE_URL:-http://host.docker.internal:11434/v1}
+      - AGENT_INFERENCE_MODEL=${AGENT_INFERENCE_MODEL:-phi4-mini}
+      - AGENT_INFERENCE_API_KEY=${AGENT_INFERENCE_API_KEY:-}
       # Experiment cohort loop (#982/#991). Opt-in master switch + the optional
       # env-seeded single experiment. Declared here (with default-off / empty
       # defaults) so a host `export` or `.env` value reaches the container — a
@@ -740,6 +751,12 @@ services:
     depends_on:
       flagd:
         condition: service_started
+    # Reach the HOST machine's Ollama (#1048): host.docker.internal resolves to the
+    # host gateway so AGENT_INFERENCE_BASE_URL=http://host.docker.internal:11434/v1
+    # hits the host's Ollama from inside the container. Harmless when inference is
+    # stubbed (the default) — nothing dials it.
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     networks:
       - joustmania
     restart: unless-stopped

--- a/services/agent/decision/probe_backend.go
+++ b/services/agent/decision/probe_backend.go
@@ -56,6 +56,14 @@ type endpointBackend struct {
 	// so a future test of the real backend (not the resolver) could stub it, mirroring
 	// the Backend interface's own test seam. Nil means "use the default dialer".
 	dial func(ctx context.Context, addr string) (net.Conn, error)
+	// infer is the INJECTED real inference call (#1048). When non-nil, Infer
+	// delegates to it (the shared inference.OpenAIBackend client, OpenAI-compatible
+	// over HTTP) instead of returning errInferNotImplemented. main.go injects the
+	// SAME client instance into every chain tier when AGENT_INFERENCE_BACKEND=openai,
+	// so a resolved+reachable tier produces real model text; nil (the default,
+	// AGENT_INFERENCE_BACKEND=stub) keeps the honest not-implemented sentinel and the
+	// chain degrades to rules exactly as before — no behavior change.
+	infer func(ctx context.Context, prompt llm.Prompt) (string, error)
 }
 
 // newEndpointBackend builds a production probe for one tier. An empty addr yields a
@@ -63,6 +71,15 @@ type endpointBackend struct {
 // state for an unconfigured tier (no cloud credentials, no Jetson on the LAN).
 func newEndpointBackend(name, addr string) *endpointBackend {
 	return &endpointBackend{name: name, addr: addr}
+}
+
+// newEndpointBackendWithInfer builds a production probe whose Infer delegates to the
+// supplied inference function (#1048). It is the real-backend variant of
+// newEndpointBackend: Available is still the TCP dial, but a resolved+reachable tier
+// now calls a real OpenAI-compatible client instead of returning the sentinel. A nil
+// inferFn is tolerated (Infer then falls back to the sentinel error).
+func newEndpointBackendWithInfer(name, addr string, inferFn func(ctx context.Context, prompt llm.Prompt) (string, error)) *endpointBackend {
+	return &endpointBackend{name: name, addr: addr, infer: inferFn}
 }
 
 func (e *endpointBackend) Name() string { return e.name }
@@ -103,19 +120,21 @@ func (e *endpointBackend) Available(ctx context.Context) bool {
 // errors.Is it.
 var errInferNotImplemented = errors.New("decision: endpoint inference not implemented (blocked on #738 Jetson / #742 cloud)")
 
-// Infer is the PRODUCTION inference call seam (#739) — and is deliberately
-// NOT-YET-IMPLEMENTED. The real model call (Ollama /api/chat for the Jetson
-// gemma3:4b and localhost phi4-mini tiers, the cloud chat API for claude/copilot)
-// is OUT OF SCOPE here: the Jetson backend is hardware-blocked (#738) and the
-// cloud backend is credential-blocked (#742). Returning an error keeps the system
-// HONEST and SAFE: a tier whose endpoint TCP-dials open (so Available reports it
-// reachable, and inference.used names it) but has no client yet cannot fabricate
-// a Decision — llm_decide catches this error and falls back to rules with
-// FallbackUnparseable-class attribution. #738/#742 replace this body with: build
-// the provider request from `prompt` (System+User), POST to e.addr with a bounded
-// ctx, and return the model's raw response string for decode.go to parse. The
-// signature and the parse pipeline are already in place, so those issues only fill
-// in the transport.
-func (e *endpointBackend) Infer(_ context.Context, _ llm.Prompt) (string, error) {
+// Infer is the PRODUCTION inference call seam (#739/#1048). When an inference
+// delegate was injected (newEndpointBackendWithInfer, AGENT_INFERENCE_BACKEND=openai),
+// it forwards prompt to the real OpenAI-compatible client (#1048,
+// inference.OpenAIBackend) and returns the model's raw response for decode.go to
+// parse defensively. When NO delegate is injected (the default stub backend) it
+// returns errInferNotImplemented — the honest, safe state #738 (Jetson) / #742
+// (cloud) historically left it in: a tier whose endpoint TCP-dials open (so
+// Available reports it reachable, and inference.used names it) but has no client
+// cannot fabricate a Decision, so llm_decide falls back to rules. Either way a
+// delegate error (unreachable / non-2xx / timeout / unparseable) is just another
+// Infer error and degrades to rules SAFELY — the call site already treats every
+// error identically.
+func (e *endpointBackend) Infer(ctx context.Context, prompt llm.Prompt) (string, error) {
+	if e.infer != nil {
+		return e.infer(ctx, prompt)
+	}
 	return "", errInferNotImplemented
 }

--- a/services/agent/decision/probe_backend_test.go
+++ b/services/agent/decision/probe_backend_test.go
@@ -1,0 +1,85 @@
+package decision
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/joustmania/agent/llm"
+)
+
+// probe_backend_test.go covers the #1048 inference-delegate seam on the production
+// endpointBackend: with NO delegate (the stub default) Infer returns the honest
+// not-implemented sentinel so the chain degrades to rules; with a delegate injected
+// (AGENT_INFERENCE_BACKEND=openai) Infer forwards to the real client and surfaces
+// its result/error unchanged.
+
+func TestEndpointBackend_Infer_NoDelegateReturnsSentinel(t *testing.T) {
+	b := newEndpointBackend(TierPhi, "localhost:11434")
+	out, err := b.Infer(context.Background(), llm.Prompt{System: "s", User: "u"})
+	if !errors.Is(err, errInferNotImplemented) {
+		t.Fatalf("err = %v, want errInferNotImplemented", err)
+	}
+	if out != "" {
+		t.Errorf("out = %q, want empty", out)
+	}
+}
+
+func TestEndpointBackend_Infer_DelegateForwardsResult(t *testing.T) {
+	var gotPrompt llm.Prompt
+	b := newEndpointBackendWithInfer(TierPhi, "localhost:11434",
+		func(_ context.Context, p llm.Prompt) (string, error) {
+			gotPrompt = p
+			return "model said this", nil
+		})
+	out, err := b.Infer(context.Background(), llm.Prompt{System: "sys", User: "usr"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out != "model said this" {
+		t.Errorf("out = %q, want delegate result", out)
+	}
+	if gotPrompt.System != "sys" || gotPrompt.User != "usr" {
+		t.Errorf("delegate received %+v, want sys/usr forwarded", gotPrompt)
+	}
+}
+
+func TestEndpointBackend_Infer_DelegateErrorPropagates(t *testing.T) {
+	sentinel := errors.New("endpoint down")
+	b := newEndpointBackendWithInfer(TierPhi, "localhost:11434",
+		func(context.Context, llm.Prompt) (string, error) { return "", sentinel })
+	if _, err := b.Infer(context.Background(), llm.Prompt{}); !errors.Is(err, sentinel) {
+		t.Fatalf("err = %v, want delegate error propagated", err)
+	}
+}
+
+// TestDefaultChainWithInfer_InjectsDelegateIntoEveryTier asserts the delegate
+// reaches all three tiers (so whichever tier resolves uses the real backend), and
+// that nil keeps the sentinel (the stub default — no behavior change).
+func TestDefaultChainWithInfer_InjectsDelegateIntoEveryTier(t *testing.T) {
+	calls := 0
+	delegate := func(context.Context, llm.Prompt) (string, error) {
+		calls++
+		return "ok", nil
+	}
+	chain := DefaultChainWithInfer(Endpoints{Cloud: "c:1", Jetson: "j:1", Localhost: "l:1"}, delegate)
+	if len(chain) != 3 {
+		t.Fatalf("chain length = %d, want 3", len(chain))
+	}
+	for _, b := range chain {
+		if _, err := b.Infer(context.Background(), llm.Prompt{}); err != nil {
+			t.Errorf("tier %s Infer error: %v", b.Name(), err)
+		}
+	}
+	if calls != 3 {
+		t.Errorf("delegate calls = %d, want 3 (one per tier)", calls)
+	}
+
+	// nil delegate -> every tier returns the sentinel (DefaultChain behavior).
+	nilChain := DefaultChainWithInfer(Endpoints{Cloud: "c:1", Jetson: "j:1", Localhost: "l:1"}, nil)
+	for _, b := range nilChain {
+		if _, err := b.Infer(context.Background(), llm.Prompt{}); !errors.Is(err, errInferNotImplemented) {
+			t.Errorf("nil-delegate tier %s err = %v, want sentinel", b.Name(), err)
+		}
+	}
+}

--- a/services/agent/decision/resolver.go
+++ b/services/agent/decision/resolver.go
@@ -167,12 +167,26 @@ func NewResolver(chain []Backend, interval time.Duration) *Resolver {
 // localhost (#739). Each tier probes a TCP endpoint; in dev every endpoint is
 // unreachable, so the chain degrades to rules — which is exactly the standalone,
 // no-Jetson-no-cloud behavior #741 requires. main.go reads the endpoint addresses
-// from env (sensible defaults documented on the Endpoints fields).
+// from env (sensible defaults documented on the Endpoints fields). Every tier's
+// Infer returns the not-implemented sentinel (no real client) — use
+// DefaultChainWithInfer to wire a real OpenAI-compatible backend (#1048).
 func DefaultChain(eps Endpoints) []Backend {
+	return DefaultChainWithInfer(eps, nil)
+}
+
+// DefaultChainWithInfer is DefaultChain with a real inference delegate injected into
+// EVERY tier (#1048). When inferFn is non-nil (AGENT_INFERENCE_BACKEND=openai,
+// main.go passing the shared inference.OpenAIBackend.Infer), a resolved+reachable
+// tier calls the real OpenAI-compatible client instead of returning the sentinel —
+// the SAME client instance the proposer uses, so one backend feeds both seams. A
+// nil inferFn yields the exact DefaultChain behavior (sentinel error → rules), so
+// the stub default is unchanged. Availability is still the per-tier TCP dial; the
+// delegate only changes what a reachable tier returns from Infer.
+func DefaultChainWithInfer(eps Endpoints, inferFn func(ctx context.Context, prompt llm.Prompt) (string, error)) []Backend {
 	return []Backend{
-		newEndpointBackend(TierCloud, eps.Cloud),
-		newEndpointBackend(TierGemma, eps.Jetson),
-		newEndpointBackend(TierPhi, eps.Localhost),
+		newEndpointBackendWithInfer(TierCloud, eps.Cloud, inferFn),
+		newEndpointBackendWithInfer(TierGemma, eps.Jetson, inferFn),
+		newEndpointBackendWithInfer(TierPhi, eps.Localhost, inferFn),
 	}
 }
 

--- a/services/agent/inference/integration_test.go
+++ b/services/agent/inference/integration_test.go
@@ -1,0 +1,118 @@
+package inference
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/joustmania/agent/experiment"
+	"github.com/joustmania/agent/llm"
+)
+
+// integration_test.go proves the #1046 "one implementation feeds both seams"
+// claim end-to-end with the REAL openaiBackend pointed at a mock OpenAI-compatible
+// server (no live model): the SAME backend output drives (1) the experiment
+// Proposer to a written shadow Proposal, and (2) the decision-shaped consumer to
+// usable raw text. It uses only the public experiment API + the experiment package's
+// testdata fixture, so it exercises the actual decode/Gate pipeline.
+
+// proposalCompletion is a mock /chat/completions reply whose assistant content is a
+// valid one-flag proposal over the experiment testdata vocabulary.
+const proposalCompletion = `{
+  "choices": [
+    {"message": {"role": "assistant",
+      "content": "{\"flag\":\"death_grace_period_seconds\",\"value\":0.75,\"rationale\":\"longer grace may extend sessions\"}"}}
+  ]
+}`
+
+// tempGameFile copies the experiment testdata game.json into a temp file so the
+// Writer/Gate can mutate it without touching the fixture.
+func tempGameFile(t *testing.T) string {
+	t.Helper()
+	src, err := os.ReadFile(filepath.Join("..", "experiment", "testdata", "game.json"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "game.json")
+	if err := os.WriteFile(path, src, 0o644); err != nil {
+		t.Fatalf("write temp fixture: %v", err)
+	}
+	return path
+}
+
+func gameVocab(t *testing.T, path string) func() map[string]struct{} {
+	t.Helper()
+	return func() map[string]struct{} {
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			return nil
+		}
+		var doc struct {
+			Flags map[string]any `json:"flags"`
+		}
+		if err := json.Unmarshal(raw, &doc); err != nil {
+			return nil
+		}
+		set := make(map[string]struct{}, len(doc.Flags))
+		for k := range doc.Flags {
+			set[k] = struct{}{}
+		}
+		return set
+	}
+}
+
+// TestOpenAIBackend_FeedsProposerSeam runs the real openaiBackend (against a mock
+// server) through the experiment Proposer and asserts a shadow experiment is
+// proposed + written — the propose-side seam.
+func TestOpenAIBackend_FeedsProposerSeam(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, proposalCompletion)
+	}))
+	defer srv.Close()
+
+	backend := New(srv.URL+"/v1", "", "phi4-mini", WithHTTPClient(srv.Client()))
+
+	path := tempGameFile(t)
+	writer := experiment.NewWriter(path, nil)
+	gate := experiment.NewGate(writer, nil, nil)
+	proposer := experiment.NewProposer(backend, gate, gameVocab(t, path), nil, nil)
+
+	res := proposer.ProposeOnce(context.Background(), experiment.Narrative{GameMode: "joust"}, experiment.ProposerConfig{Engine: "openai"})
+	if res.Outcome != experiment.ProposeProposed {
+		t.Fatalf("outcome = %q, want proposed (err=%v)", res.Outcome, res.Err)
+	}
+	if res.Proposal == nil || res.Proposal.FlagKey != "death_grace_period_seconds" {
+		t.Fatalf("proposal = %+v, want death_grace_period_seconds", res.Proposal)
+	}
+}
+
+// TestOpenAIBackend_FeedsDecisionSeam proves the SAME backend type satisfies the
+// decision seam shape and returns usable raw text — what llm_decide parses.
+// decisionConsumer mirrors decision.Backend's Infer signature; assigning the
+// backend to it is a compile-time proof of structural satisfaction.
+func TestOpenAIBackend_FeedsDecisionSeam(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, proposalCompletion)
+	}))
+	defer srv.Close()
+
+	backend := New(srv.URL+"/v1", "", "phi4-mini", WithHTTPClient(srv.Client()))
+
+	// The decision seam is exactly Infer(ctx, llm.Prompt) (string, error). A var of
+	// that func type assigned from backend.Infer is a structural-satisfaction proof.
+	var consumer func(ctx context.Context, prompt llm.Prompt) (string, error) = backend.Infer
+	raw, err := consumer(context.Background(), llm.Prompt{System: "sys", User: "usr"})
+	if err != nil {
+		t.Fatalf("decision-seam Infer error: %v", err)
+	}
+	if raw == "" {
+		t.Fatal("decision-seam Infer returned empty text; want usable model content")
+	}
+}

--- a/services/agent/inference/live_test.go
+++ b/services/agent/inference/live_test.go
@@ -1,0 +1,63 @@
+package inference
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/joustmania/agent/llm"
+)
+
+// live_test.go runs a REAL Infer against a host Ollama OpenAI-compatible endpoint
+// (#1048 live smoke). It is OPT-IN via AGENT_LIVE_OLLAMA=1 and additionally probes
+// reachability, so a normal `go test ./...` (no env, no Ollama) SKIPS it cleanly —
+// it never fails CI or a dev box without a model. The maintainer runs it via
+// `make dry-run` with AGENT_INFERENCE_BACKEND=openai, or directly:
+//
+//	AGENT_LIVE_OLLAMA=1 go test ./inference -run TestLiveInfer -v
+//
+// AGENT_INFERENCE_BASE_URL overrides the endpoint (default the host-local Ollama
+// /v1); AGENT_INFERENCE_MODEL overrides the model (default phi4-mini).
+func TestLiveInfer(t *testing.T) {
+	if os.Getenv("AGENT_LIVE_OLLAMA") != "1" {
+		t.Skip("set AGENT_LIVE_OLLAMA=1 to run the live Ollama smoke test")
+	}
+
+	baseURL := os.Getenv("AGENT_INFERENCE_BASE_URL")
+	if baseURL == "" {
+		baseURL = "http://localhost:11434/v1"
+	}
+	model := os.Getenv("AGENT_INFERENCE_MODEL")
+	if model == "" {
+		model = DefaultModel
+	}
+
+	// Reachability probe so a misconfigured/unreachable endpoint skips rather than
+	// fails — the live test asserts behavior only when a model is genuinely present.
+	probeCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	req, _ := http.NewRequestWithContext(probeCtx, http.MethodGet, baseURL+"/models", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Skipf("Ollama not reachable at %s: %v", baseURL, err)
+	}
+	_ = resp.Body.Close()
+
+	b := New(baseURL, os.Getenv("AGENT_INFERENCE_API_KEY"), model)
+	ctx, cancel2 := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel2()
+
+	out, err := b.Infer(ctx, llm.Prompt{
+		System: "Reply with EXACTLY ONE JSON object and nothing else: {\"flag\":\"sensitivity\",\"value\":2,\"rationale\":\"<one sentence>\"}",
+		User:   "The players are tiring; propose one experiment.",
+	})
+	if err != nil {
+		t.Fatalf("live Infer against %s (model=%s) failed: %v", baseURL, model, err)
+	}
+	if out == "" {
+		t.Fatal("live Infer returned empty completion")
+	}
+	t.Logf("live completion (%d bytes): %s", len(out), out)
+}

--- a/services/agent/inference/openai.go
+++ b/services/agent/inference/openai.go
@@ -1,0 +1,236 @@
+// Package inference holds the agent's real LLM inference backend (#1048, per the
+// #1046 design): a single OpenAI-compatible HTTP client that satisfies BOTH the
+// propose seam (experiment.Backend) and the decision seam (decision.Backend),
+// which are the SAME narrow shape — Infer(ctx, llm.Prompt) (string, error). Go's
+// structural typing means one implementation feeds both; main.go builds ONE
+// OpenAIBackend and hands its Infer to the proposer and the decision chain.
+//
+// THE SEAM (#1046): a backend is just "take System+User text, return raw model
+// text". The caller builds a constrained prompt (buildProposalPrompt / llm.Build)
+// and the defensive decoder (decodeProposal / decode.go) rejects anything
+// unparseable or out-of-vocab — so a backend never needs tool-calling, streaming,
+// or an agent loop, only an HTTP round-trip to an OpenAI-compatible
+// /chat/completions endpoint.
+//
+// GRACEFUL DEGRADATION is the whole contract (#1048): on an unreachable endpoint,
+// a non-2xx status, a timeout/cancel, or an unparseable body, Infer returns a
+// CLEAN error. The proposer (ProposeNoBackend) and the decision path (rules
+// fallback) already treat any Infer error as "degrade safely this cycle" — so this
+// client must NEVER panic and never crash the loop; it only ever returns
+// (text, nil) or ("", err).
+//
+// NO NEW DEPS, CGO-FREE: pure stdlib net/http + encoding/json, so the agent stays
+// a static alpine/ARM64 binary (the #1046 constraint).
+package inference
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/joustmania/agent/llm"
+)
+
+// DefaultBaseURL points at the HOST machine's Ollama OpenAI-compatible endpoint
+// from inside the agent container (#1046 local no-key path). host.docker.internal
+// resolves to the host gateway when the compose service declares
+// extra_hosts: ["host.docker.internal:host-gateway"]. Ollama serves the
+// OpenAI-compatible API under /v1, so this is the chat/completions parent.
+const DefaultBaseURL = "http://host.docker.internal:11434/v1"
+
+// DefaultModel is the local Ollama model the #1046 design names as the free local
+// default — small enough for the dev host / a Pi-class box and adequate for the
+// one-flag JSON replies the proposer/decision prompts ask for.
+const DefaultModel = "phi4-mini"
+
+// defaultTimeout bounds a single Infer round-trip when the caller's ctx carries no
+// deadline. A local model on a modest box can take a few seconds for a short
+// completion; 60s is generous enough not to truncate a legitimate slow reply while
+// still guaranteeing a hung endpoint cannot wedge the (already async, off-hot-path)
+// inference goroutine forever. A caller-supplied ctx deadline still wins when it is
+// sooner — this only fills in a floor when none is set.
+const defaultTimeout = 60 * time.Second
+
+// OpenAIBackend is the OpenAI-compatible inference backend. It POSTs a System+User
+// prompt to <BaseURL>/chat/completions and returns choices[0].message.content as
+// raw text. The zero value is NOT usable — build it with New so the defaults and
+// the http.Client are populated.
+type OpenAIBackend struct {
+	// baseURL is the OpenAI-compatible API root (e.g. ".../v1"); /chat/completions
+	// is appended. Any trailing slash is trimmed at construction so the join is
+	// exactly one slash.
+	baseURL string
+	// apiKey, when non-empty, is sent as "Authorization: Bearer <apiKey>". Empty (the
+	// local Ollama path) sends NO Authorization header — Ollama ignores auth, and a
+	// gateway/cloud target sets the key via config.
+	apiKey string
+	// model is the model name put in the request body (e.g. "phi4-mini").
+	model string
+	// httpClient performs the request. Injected (defaulted in New) so tests can
+	// point it at a mock server / a failing transport without real I/O.
+	httpClient *http.Client
+}
+
+// Option customizes an OpenAIBackend at construction (functional options keep New's
+// signature stable as knobs are added — tests use WithHTTPClient).
+type Option func(*OpenAIBackend)
+
+// WithHTTPClient overrides the http.Client (tests inject a mock-server client or a
+// failing transport). Production relies on New's default timeout client.
+func WithHTTPClient(c *http.Client) Option {
+	return func(b *OpenAIBackend) {
+		if c != nil {
+			b.httpClient = c
+		}
+	}
+}
+
+// New builds an OpenAIBackend. An empty baseURL falls back to DefaultBaseURL and an
+// empty model to DefaultModel, so a partially-configured deployment still targets
+// the host Ollama rather than a broken empty URL. apiKey may be empty (the local,
+// no-key path). The default http.Client carries defaultTimeout as a backstop; a
+// per-call ctx deadline still applies on top of it.
+func New(baseURL, apiKey, model string, opts ...Option) *OpenAIBackend {
+	if strings.TrimSpace(baseURL) == "" {
+		baseURL = DefaultBaseURL
+	}
+	if strings.TrimSpace(model) == "" {
+		model = DefaultModel
+	}
+	b := &OpenAIBackend{
+		baseURL:    strings.TrimRight(baseURL, "/"),
+		apiKey:     apiKey,
+		model:      model,
+		httpClient: &http.Client{Timeout: defaultTimeout},
+	}
+	for _, opt := range opts {
+		opt(b)
+	}
+	return b
+}
+
+// chatMessage is one role/content pair in the OpenAI chat schema.
+type chatMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+// chatRequest is the minimal OpenAI-compatible /chat/completions request body: a
+// model and the system+user messages. No streaming, no tools — the prompt already
+// constrains the model to a single JSON object, and the defensive decoder validates
+// it, so nothing richer is needed (#1046).
+type chatRequest struct {
+	Model    string        `json:"model"`
+	Messages []chatMessage `json:"messages"`
+	// Stream is explicitly false: we read the full body in one shot. Sent so a server
+	// that defaults to streaming gives us a single JSON object instead.
+	Stream bool `json:"stream"`
+}
+
+// chatResponse is the slice of the OpenAI-compatible /chat/completions response we
+// consume: the first choice's message content. Extra fields in the real payload are
+// ignored by encoding/json.
+type chatResponse struct {
+	Choices []struct {
+		Message struct {
+			Content string `json:"content"`
+		} `json:"message"`
+	} `json:"choices"`
+	// Error mirrors the OpenAI error envelope some servers return WITH a 200 status;
+	// surfaced as a clean error so it degrades like any transport failure.
+	Error *struct {
+		Message string `json:"message"`
+	} `json:"error"`
+}
+
+// errEmptyCompletion is returned when the endpoint replied 2xx with a well-formed
+// body that carried no usable assistant text (no choices, or empty content). The
+// caller degrades exactly as it does for any other Infer error — better an honest
+// error than handing the decoder an empty string to "parse".
+var errEmptyCompletion = errors.New("inference: empty completion (no choices/content)")
+
+// Infer sends prompt.System and prompt.User as the system+user messages to
+// <baseURL>/chat/completions and returns choices[0].message.content as RAW text for
+// the caller's defensive decoder. It is ctx-aware (cancel/deadline propagate to the
+// HTTP request); when ctx has no deadline the client's defaultTimeout backstops it.
+//
+// EVERY failure mode returns a clean error and never panics, so the proposer
+// (no-proposal) and decision (rules) fallbacks engage:
+//   - request build failure (should not happen with stdlib marshaling),
+//   - transport error (endpoint unreachable / DNS / connection refused / timeout),
+//   - non-2xx status (the body is read, truncated, and included for diagnosis),
+//   - unparseable JSON body,
+//   - an OpenAI-style error envelope returned with a 2xx,
+//   - a 2xx with no usable completion text.
+func (b *OpenAIBackend) Infer(ctx context.Context, prompt llm.Prompt) (string, error) {
+	body, err := json.Marshal(chatRequest{
+		Model: b.model,
+		Messages: []chatMessage{
+			{Role: "system", Content: prompt.System},
+			{Role: "user", Content: prompt.User},
+		},
+		Stream: false,
+	})
+	if err != nil {
+		return "", fmt.Errorf("inference: marshal request: %w", err)
+	}
+
+	url := b.baseURL + "/chat/completions"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return "", fmt.Errorf("inference: build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	// Authorization ONLY when a key is configured (the local Ollama path sends none).
+	if b.apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+b.apiKey)
+	}
+
+	resp, err := b.httpClient.Do(req)
+	if err != nil {
+		// Unreachable / DNS / refused / timeout / ctx-cancel: a clean error, degrade.
+		return "", fmt.Errorf("inference: request to %s failed: %w", url, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// Cap the read so a misbehaving/huge response cannot exhaust memory. A legitimate
+	// one-JSON-object completion is far under this.
+	const maxBody = 1 << 20 // 1 MiB
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, maxBody))
+	if err != nil {
+		return "", fmt.Errorf("inference: read response body: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", fmt.Errorf("inference: endpoint %s returned status %d: %s",
+			url, resp.StatusCode, truncate(string(raw), 256))
+	}
+
+	var parsed chatResponse
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		return "", fmt.Errorf("inference: unparseable response body: %w", err)
+	}
+	if parsed.Error != nil && parsed.Error.Message != "" {
+		return "", fmt.Errorf("inference: endpoint returned error: %s", parsed.Error.Message)
+	}
+	if len(parsed.Choices) == 0 || parsed.Choices[0].Message.Content == "" {
+		return "", errEmptyCompletion
+	}
+	return parsed.Choices[0].Message.Content, nil
+}
+
+// truncate bounds a string for inclusion in an error message (so a large error body
+// does not bloat the log/span). It cuts on bytes, appending an ellipsis marker.
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "...(truncated)"
+}

--- a/services/agent/inference/openai_test.go
+++ b/services/agent/inference/openai_test.go
@@ -1,0 +1,207 @@
+package inference
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/joustmania/agent/llm"
+)
+
+// sampleCompletion is a realistic OpenAI-compatible /chat/completions response body.
+const sampleCompletion = `{
+  "id": "chatcmpl-abc",
+  "object": "chat.completion",
+  "model": "phi4-mini",
+  "choices": [
+    {"index": 0, "message": {"role": "assistant", "content": "{\"flag\":\"foo\",\"value\":3,\"rationale\":\"tighter\"}"}, "finish_reason": "stop"}
+  ]
+}`
+
+// newMockBackend points an OpenAIBackend at the test server and injects the
+// server's client so no real network I/O happens.
+func newMockBackend(srv *httptest.Server, apiKey, model string) *OpenAIBackend {
+	return New(srv.URL+"/v1", apiKey, model, WithHTTPClient(srv.Client()))
+}
+
+func TestInfer_ParsesCompletionAndRequestShape(t *testing.T) {
+	var gotMethod, gotPath, gotAuth, gotContentType string
+	var gotBody chatRequest
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		gotContentType = r.Header.Get("Content-Type")
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, sampleCompletion)
+	}))
+	defer srv.Close()
+
+	b := newMockBackend(srv, "secret-key", "phi4-mini")
+	out, err := b.Infer(context.Background(), llm.Prompt{System: "sys text", User: "user text"})
+	if err != nil {
+		t.Fatalf("Infer returned error: %v", err)
+	}
+
+	// Returned the raw model content verbatim (the decoder parses it downstream).
+	wantContent := `{"flag":"foo","value":3,"rationale":"tighter"}`
+	if out != wantContent {
+		t.Errorf("content = %q, want %q", out, wantContent)
+	}
+
+	// Request shape.
+	if gotMethod != http.MethodPost {
+		t.Errorf("method = %s, want POST", gotMethod)
+	}
+	if gotPath != "/v1/chat/completions" {
+		t.Errorf("path = %s, want /v1/chat/completions", gotPath)
+	}
+	if gotContentType != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", gotContentType)
+	}
+	if gotAuth != "Bearer secret-key" {
+		t.Errorf("Authorization = %q, want Bearer secret-key", gotAuth)
+	}
+	if gotBody.Model != "phi4-mini" {
+		t.Errorf("body model = %q, want phi4-mini", gotBody.Model)
+	}
+	if len(gotBody.Messages) != 2 {
+		t.Fatalf("messages = %d, want 2 (system+user)", len(gotBody.Messages))
+	}
+	if gotBody.Messages[0].Role != "system" || gotBody.Messages[0].Content != "sys text" {
+		t.Errorf("message[0] = %+v, want system/'sys text'", gotBody.Messages[0])
+	}
+	if gotBody.Messages[1].Role != "user" || gotBody.Messages[1].Content != "user text" {
+		t.Errorf("message[1] = %+v, want user/'user text'", gotBody.Messages[1])
+	}
+}
+
+func TestInfer_NoAuthHeaderWhenKeyUnset(t *testing.T) {
+	var sawAuth bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, sawAuth = r.Header["Authorization"]
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, sampleCompletion)
+	}))
+	defer srv.Close()
+
+	b := newMockBackend(srv, "", "phi4-mini") // no API key -> local Ollama path
+	if _, err := b.Infer(context.Background(), llm.Prompt{System: "s", User: "u"}); err != nil {
+		t.Fatalf("Infer error: %v", err)
+	}
+	if sawAuth {
+		t.Error("Authorization header sent despite empty API key; want none")
+	}
+}
+
+func TestInfer_Degradation(t *testing.T) {
+	t.Run("non-2xx status", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = io.WriteString(w, "boom")
+		}))
+		defer srv.Close()
+		b := newMockBackend(srv, "", "m")
+		out, err := b.Infer(context.Background(), llm.Prompt{})
+		if err == nil {
+			t.Fatal("want error on 500, got nil")
+		}
+		if out != "" {
+			t.Errorf("want empty output on error, got %q", out)
+		}
+		if !strings.Contains(err.Error(), "500") {
+			t.Errorf("error should mention status 500: %v", err)
+		}
+	})
+
+	t.Run("connection refused", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+		client := srv.Client()
+		srv.Close() // close immediately so the address refuses connections
+		b := New(srv.URL+"/v1", "", "m", WithHTTPClient(client))
+		if _, err := b.Infer(context.Background(), llm.Prompt{}); err == nil {
+			t.Fatal("want error on connection refused, got nil")
+		}
+	})
+
+	t.Run("timeout via ctx", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			time.Sleep(200 * time.Millisecond)
+			_, _ = io.WriteString(w, sampleCompletion)
+		}))
+		defer srv.Close()
+		b := newMockBackend(srv, "", "m")
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+		defer cancel()
+		if _, err := b.Infer(ctx, llm.Prompt{}); err == nil {
+			t.Fatal("want error on ctx timeout, got nil")
+		}
+	})
+
+	t.Run("malformed body", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, "not json {{{")
+		}))
+		defer srv.Close()
+		b := newMockBackend(srv, "", "m")
+		if _, err := b.Infer(context.Background(), llm.Prompt{}); err == nil {
+			t.Fatal("want error on malformed body, got nil")
+		}
+	})
+
+	t.Run("empty completion (no choices)", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"choices":[]}`)
+		}))
+		defer srv.Close()
+		b := newMockBackend(srv, "", "m")
+		_, err := b.Infer(context.Background(), llm.Prompt{})
+		if !errors.Is(err, errEmptyCompletion) {
+			t.Fatalf("want errEmptyCompletion, got %v", err)
+		}
+	})
+
+	t.Run("error envelope with 200", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"error":{"message":"model not found"}}`)
+		}))
+		defer srv.Close()
+		b := newMockBackend(srv, "", "m")
+		_, err := b.Infer(context.Background(), llm.Prompt{})
+		if err == nil || !strings.Contains(err.Error(), "model not found") {
+			t.Fatalf("want error envelope surfaced, got %v", err)
+		}
+	})
+}
+
+func TestNew_Defaults(t *testing.T) {
+	b := New("", "", "")
+	if b.baseURL != DefaultBaseURL {
+		t.Errorf("baseURL = %q, want default %q", b.baseURL, DefaultBaseURL)
+	}
+	if b.model != DefaultModel {
+		t.Errorf("model = %q, want default %q", b.model, DefaultModel)
+	}
+	if b.httpClient == nil || b.httpClient.Timeout != defaultTimeout {
+		t.Errorf("httpClient timeout = %v, want %v", b.httpClient.Timeout, defaultTimeout)
+	}
+}
+
+func TestNew_TrimsTrailingSlash(t *testing.T) {
+	b := New("http://x/v1/", "", "m")
+	if b.baseURL != "http://x/v1" {
+		t.Errorf("baseURL = %q, want trailing slash trimmed", b.baseURL)
+	}
+}

--- a/services/agent/inference_select_test.go
+++ b/services/agent/inference_select_test.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/joustmania/agent/experiment"
+	"github.com/joustmania/agent/llm"
+)
+
+// inference_select_test.go covers the #1048 env-driven backend selection in main:
+// the default/stub path returns NO delegate (so both seams keep their inert stubs,
+// no behavior change) and the openai path returns a real delegate that feeds both.
+
+func TestSelectInferenceBackend_DefaultIsStub(t *testing.T) {
+	t.Setenv("AGENT_INFERENCE_BACKEND", "") // unset/empty == stub
+	delegate, name := selectInferenceBackend()
+	if delegate != nil {
+		t.Error("delegate != nil for default backend; want nil (stub)")
+	}
+	if name != "stub" {
+		t.Errorf("name = %q, want stub", name)
+	}
+}
+
+func TestSelectInferenceBackend_UnknownValueFailsSafeToStub(t *testing.T) {
+	t.Setenv("AGENT_INFERENCE_BACKEND", "gpt-9000") // typo / unknown
+	delegate, name := selectInferenceBackend()
+	if delegate != nil || name != "stub" {
+		t.Errorf("unknown backend = (%v, %q), want (nil, stub)", delegate != nil, name)
+	}
+}
+
+func TestSelectInferenceBackend_OpenAISelectsRealDelegate(t *testing.T) {
+	t.Setenv("AGENT_INFERENCE_BACKEND", "OpenAI") // case-insensitive
+	delegate, name := selectInferenceBackend()
+	if delegate == nil {
+		t.Fatal("delegate == nil for openai backend; want a real client")
+	}
+	if name != "openai" {
+		t.Errorf("name = %q, want openai", name)
+	}
+}
+
+// proposeBackendFor: nil delegate -> the inert stub (returns the not-implemented
+// sentinel); a delegate -> a Backend that forwards to it.
+func TestProposeBackendFor(t *testing.T) {
+	// nil -> stub (degrades to no proposal).
+	stub := proposeBackendFor(nil)
+	if _, err := stub.Infer(context.Background(), llm.Prompt{}); err == nil {
+		t.Error("stub backend Infer returned nil error; want sentinel")
+	}
+
+	// delegate -> forwards.
+	want := "raw model text"
+	real := proposeBackendFor(func(context.Context, llm.Prompt) (string, error) {
+		return want, nil
+	})
+	out, err := real.Infer(context.Background(), llm.Prompt{})
+	if err != nil {
+		t.Fatalf("delegate-backed Infer error: %v", err)
+	}
+	if out != want {
+		t.Errorf("out = %q, want %q", out, want)
+	}
+
+	// Both satisfy experiment.Backend (compile-time + runtime).
+	var _ experiment.Backend = stub
+	var _ experiment.Backend = real
+}
+
+func TestProposeBackendFor_DelegateErrorPropagates(t *testing.T) {
+	sentinel := errors.New("boom")
+	b := proposeBackendFor(func(context.Context, llm.Prompt) (string, error) { return "", sentinel })
+	if _, err := b.Infer(context.Background(), llm.Prompt{}); !errors.Is(err, sentinel) {
+		t.Fatalf("err = %v, want delegate error", err)
+	}
+}

--- a/services/agent/main.go
+++ b/services/agent/main.go
@@ -35,6 +35,7 @@ import (
 	"github.com/joustmania/agent/gamesummary"
 	"github.com/joustmania/agent/gamewindow"
 	"github.com/joustmania/agent/gate"
+	"github.com/joustmania/agent/inference"
 	"github.com/joustmania/agent/infracontext"
 	"github.com/joustmania/agent/llm"
 	"github.com/joustmania/agent/promote"
@@ -313,6 +314,39 @@ func runShadowGame(ctx context.Context, logger *slog.Logger) {
 	)
 }
 
+// inferFunc is the shared inference seam shape (#1046/#1048): Infer(ctx, prompt) →
+// raw text. Both experiment.Backend (the proposer) and decision.Backend (the
+// chain) require exactly this method, so ONE value satisfies both. selectInferenceBackend
+// returns it (nil = the stub default) so main.go feeds the same backend to both seams.
+type inferFunc = func(ctx context.Context, prompt llm.Prompt) (string, error)
+
+// selectInferenceBackend reads the AGENT_INFERENCE_* env config (#1048) and returns
+// the inference delegate to feed BOTH the proposer and the decision chain — or nil
+// when the stub backend is selected (the DEFAULT → no behavior change: the proposer
+// keeps the inert proposeBackend{} stub and the decision chain keeps the
+// not-implemented sentinel, both degrading safely as before).
+//
+// AGENT_INFERENCE_BACKEND: "stub" (default) | "openai". Only "openai" (case-
+// insensitive) activates the real OpenAI-compatible client; any other value
+// (including unset/empty) selects the stub, so a typo fails SAFE to today's
+// behavior rather than to a broken backend. The base URL/model/key come from
+// AGENT_INFERENCE_BASE_URL (default the host Ollama), AGENT_INFERENCE_MODEL
+// (default phi4-mini), and AGENT_INFERENCE_API_KEY (optional — empty for the local
+// no-key path, set for a gateway/cloud target). Returns the chosen backend name for
+// the startup log too.
+func selectInferenceBackend() (inferFunc, string) {
+	backend := strings.ToLower(strings.TrimSpace(getEnv("AGENT_INFERENCE_BACKEND", "stub")))
+	if backend != "openai" {
+		return nil, "stub"
+	}
+	client := inference.New(
+		getEnv("AGENT_INFERENCE_BASE_URL", inference.DefaultBaseURL),
+		getEnv("AGENT_INFERENCE_API_KEY", ""),
+		getEnv("AGENT_INFERENCE_MODEL", inference.DefaultModel),
+	)
+	return client.Infer, "openai"
+}
+
 func main() {
 	listenAddr := getEnv("AGENT_LISTEN_ADDR", ":4317")
 	healthAddr := getEnv("AGENT_HEALTH_ADDR", ":13134")
@@ -408,11 +442,26 @@ func main() {
 	// inference.used (who #739 WILL call). Start() launches the background re-probe
 	// ticker (DefaultProbeInterval) and primes the cache in the background; it
 	// stops when ctx is cancelled at shutdown.
-	sharedResolver := decision.NewResolver(decision.DefaultChain(decision.Endpoints{
+	// Inference backend selection (#1048, per the #1046 design). ONE OpenAI-compatible
+	// client (or nil for the stub default) feeds BOTH the decision chain (here) AND the
+	// shadow-experiment proposer (below) — Go structural typing means a single Infer
+	// implementation satisfies decision.Backend and experiment.Backend. Default = stub
+	// → nil delegate → no behavior change (the chain keeps its not-implemented sentinel
+	// and degrades to rules; the proposer keeps proposeBackend{} and proposes nothing).
+	// AGENT_INFERENCE_BACKEND=openai points it at the host Ollama (or a gateway) for a
+	// real local inference path with no key.
+	inferDelegate, inferBackendName := selectInferenceBackend()
+	slog.Info("Inference backend selected (#1048)",
+		"backend", inferBackendName,
+		"base_url", getEnv("AGENT_INFERENCE_BASE_URL", inference.DefaultBaseURL),
+		"model", getEnv("AGENT_INFERENCE_MODEL", inference.DefaultModel),
+		"api_key_set", getEnv("AGENT_INFERENCE_API_KEY", "") != "",
+	)
+	sharedResolver := decision.NewResolver(decision.DefaultChainWithInfer(decision.Endpoints{
 		Cloud:     getEnv("AGENT_CLOUD_ENDPOINT", ""),                    // #742 credential-blocked: empty = permanently unreachable
 		Jetson:    getEnv("AGENT_JETSON_ENDPOINT", "jetson:11434"),       // #738 Ollama on the Jetson; unresolvable in dev
 		Localhost: getEnv("AGENT_LOCALHOST_ENDPOINT", "localhost:11434"), // #739 Ollama locally; unreachable unless running
-	}), decision.DefaultProbeInterval)
+	}, inferDelegate), decision.DefaultProbeInterval)
 	// The resolver's background probe ticker is started by run() (#923), which owns
 	// the agent's goroutine lifecycle, so it is stopped on ctx cancellation alongside
 	// every other runtime goroutine.
@@ -601,8 +650,13 @@ func main() {
 	// The vocab provider reads the LIVE game.json flag keys so the model is
 	// constrained to (and the decoder validates against) the actual flag surface.
 	experimentGate := experiment.NewGate(experiment.NewWriterFromEnv(logger), nil, logger)
+	// Feed the SAME inference backend (#1048) to the proposer that feeds the decision
+	// chain above: when AGENT_INFERENCE_BACKEND=openai, inferDelegate is the real
+	// OpenAI-compatible client and proposeBackendFor wraps it as an experiment.Backend;
+	// when nil (the stub default) it stays the inert proposeBackend{} so the propose
+	// path degrades to no-proposal exactly as before.
 	proposer := experiment.NewProposer(
-		proposeBackend{},
+		proposeBackendFor(inferDelegate),
 		experimentGate,
 		gameFlagVocab(getEnv("GAME_FLAG_PATH", experiment.DefaultGamePath)),
 		nil,
@@ -769,6 +823,29 @@ type proposeBackend struct{}
 
 func (proposeBackend) Infer(context.Context, llm.Prompt) (string, error) {
 	return "", errProposeBackendNotImplemented
+}
+
+// inferBackend adapts a bare inferFunc into an experiment.Backend (#1048). The
+// proposer takes a Backend (an interface with one Infer method); this lets the same
+// inference delegate that feeds the decision chain feed the proposer too, with no
+// second client instance — one OpenAIBackend, both seams.
+type inferBackend struct {
+	infer inferFunc
+}
+
+func (b inferBackend) Infer(ctx context.Context, prompt llm.Prompt) (string, error) {
+	return b.infer(ctx, prompt)
+}
+
+// proposeBackendFor selects the proposer's inference backend (#1048): the real
+// OpenAI-compatible client (wrapped as an experiment.Backend) when one was selected,
+// or the inert proposeBackend{} stub when delegate is nil (the default) — so the
+// propose path degrades to no-proposal exactly as before when inference is stubbed.
+func proposeBackendFor(delegate inferFunc) experiment.Backend {
+	if delegate == nil {
+		return proposeBackend{}
+	}
+	return inferBackend{infer: delegate}
 }
 
 // gameFlagVocab returns the live set of game.json flag keys at path — the


### PR DESCRIPTION
Implements the real LLM inference backend per the **#1046** design — the unblock that makes REAL inference flow through the proposer and the decision loop, pointed at the maintainer's host Ollama (`phi4-mini`), no key/gateway needed for the local path.

## What lands

**One `inference.OpenAIBackend{baseURL, apiKey, model, httpClient}`** implementing `Infer(ctx, llm.Prompt) (string, error)`. Per #1046 both seams share the IDENTICAL shape, so Go structural typing means this ONE implementation satisfies BOTH `experiment.Backend` (proposer) and `decision.Backend` (decision loop):
- POSTs `{model, messages:[{system},{user}], stream:false}` to `<baseURL>/chat/completions`, parses `choices[0].message.content` → raw text.
- `Authorization: Bearer <key>` **only when a key is set** (local Ollama needs none).
- Pure stdlib `net/http` + `encoding/json` — **no new deps, CGO-free**, alpine/ARM64-safe.
- ctx-aware with a 60s client backstop; 1 MiB response cap.

**Backend selection via env (config-time):**
| Env | Default |
|---|---|
| `AGENT_INFERENCE_BACKEND` | `stub` (`stub` \| `openai`) |
| `AGENT_INFERENCE_BASE_URL` | `http://host.docker.internal:11434/v1` |
| `AGENT_INFERENCE_MODEL` | `phi4-mini` |
| `AGENT_INFERENCE_API_KEY` | _(empty — local no-key path)_ |

**Default = stub → NO behavior change.** Unknown values fail safe to stub. When `openai` is selected, `main.go` builds ONE client and feeds it to the proposer (`proposeBackendFor`) AND every decision chain tier (`decision.DefaultChainWithInfer` + an injected `endpointBackend.infer` delegate).

**Graceful degradation (critical):** unreachable / non-2xx / timeout / malformed body / empty completion / error-envelope all return a CLEAN error. The proposer (`ProposeNoBackend`) and decision (rules fallback) paths already handle any `Infer` error — never panics, never crashes the loop.

**Container → host Ollama:** `extra_hosts: ["host.docker.internal:host-gateway"]` on the agent service + the `AGENT_INFERENCE_*` passthrough block (default stub / host Ollama).

## Tests
- Mock OpenAI server: request shape (POST, path, model, system+user messages), auth header **only when keyed**, content parse.
- Degradation matrix: 500 / connection-refused / ctx-timeout / malformed / empty-completion / 200-with-error-envelope → clean error, no panic.
- One-impl-feeds-both-seams integration: same backend → proposer writes a shadow Proposal AND the decision-shaped consumer gets usable text.
- Env selection (`stub`/unknown → nil delegate; `openai` → real) + `proposeBackendFor` forwarding.
- **Live Ollama smoke** (`AGENT_LIVE_OLLAMA=1`, self-skips when unreachable) — Ollama was **not reachable from the build sandbox** (connection refused), so it skipped cleanly; run the live path via `make dry-run` with `AGENT_INFERENCE_BACKEND=openai`.

`go test ./... -race`, `go vet`, `gofmt -l`, `make lint` all clean. No `go.mod`/`go.sum` change.

Subsumes the agent-side transport scope of **#738** (Ollama) and **#742** (cloud); unblocks **#964 / #965**.

Part of #1048

🤖 Generated with [Claude Code](https://claude.com/claude-code)