### PR TITLE
feat(agent): signal-agnostic root span + eval-cycle counter (#1053)

### DIFF
--- a/docs/agent-act-runbook.md
+++ b/docs/agent-act-runbook.md
@@ -38,7 +38,7 @@ With `docker compose up`, the agent:
   `GameContext`, gates on whether a game is live with fresh data.
 - **Decides**: runs the objective-weighted rules engine each gated cycle,
   evaluating all four flag layers from flagd live.
-- **Traces**: emits the `agent.span_received → agent.decision → agent.action`
+- **Traces**: emits the `agent.signal_received → agent.decision → agent.action`
   audit trace whenever the engine returns ≥ 1 decision (idle cycles cost no
   spans).
 - **Dispatches nothing**: the action sink is `NoopActions`
@@ -193,7 +193,7 @@ can verify the trace pipeline without a live game. See the agent README →
 
 - **Default variant**: `noop` is in no standard allow-list, so probe decisions
   are **blocked by design** (`decision.block_reason=not_allowed`). The
-  `agent.span_received → agent.decision` spans still emit — OBSERVE→DECIDE and the
+  `agent.signal_received → agent.decision` spans still emit — OBSERVE→DECIDE and the
   span schema are fully exercised; only `agent.action` is withheld.
 - **Full path**: flip `interventions_allowed` to the **`probe`** variant
   (`["noop"]`) in `agent.json`, plus `AGENT_INTERVENTIONS_ENABLED=true` and
@@ -239,7 +239,7 @@ not at normal play.
 
 | Tool | Path | Use |
 |------|------|-----|
-| **Jaeger** | `http://localhost:8080/jaeger/` | Decision audit traces: `agent.span_received → agent.decision → agent.action`, and `agent.disabled` kill-switch traces. Service: `agent` |
+| **Jaeger** | `http://localhost:8080/jaeger/` | Decision audit traces: `agent.signal_received → agent.decision → agent.action`, and `agent.disabled` kill-switch traces. Service: `agent` |
 | **Grafana** | `http://localhost:8080/grafana/` | Dashboards in `services/grafana/dashboards/` |
 | **Prometheus** | `http://localhost:8080/prometheus/` | `game_interventions_total`, agent process metrics |
 | **agent logs** | `docker compose logs -f agent` | Sink-enabled warning, flag evaluation, block reasons |

--- a/services/agent/README.md
+++ b/services/agent/README.md
@@ -115,7 +115,7 @@ grace.
 ### Span attribution
 
 Decision spans are independently attributable per game. The root
-`agent.span_received` span carries both `session.id` and the `game.id` alias
+`agent.signal_received` span carries both `session.id` and the `game.id` alias
 (`session.id` **is** the real `game_id` since PR A's early adoption); the
 decision / `agent.disabled` / `agent.llm.prompt` spans carry `game.kind` (and the
 prompt-capture span carries `game.id` too). So a Jaeger query by `game.id` is
@@ -644,13 +644,20 @@ Every evaluation that produces decisions emits one trace (hierarchy always
 parent → child):
 
 ```
-agent.span_received          one per triggering OTLP Export (backdated to arrival)
+agent.signal_received          one per triggering OTLP Export (backdated to arrival)
   └─ agent.decision          one per Decision the rules engine returns
        └─ agent.action       one per decision, wrapping the ActionSink call
 ```
 
+The root span is **signal-agnostic** (#1053): a metric-triggered cycle and a
+trace-triggered cycle both emit `agent.signal_received`, distinguished only by
+`otlp.signal` (`metrics`|`traces`) + `rpc.service` — the name never implies
+spans-only activity (metrics are in fact the primary trigger; see *Signal
+timing*).
+
 **Traces are emitted only when the rules engine returns ≥ 1 decision** —
-including decisions that end up *blocked*. Idle evaluations cost no spans.
+including decisions that end up *blocked*. Idle evaluations cost no spans (they
+are instead counted by `agent_evaluations_total{outcome="idle"}`, #1053).
 Blocked actions are recorded (`decision.blocked = true` on both the decision
 and action spans, ActionSink **not** called), never silently dropped.
 
@@ -701,7 +708,7 @@ path-agnostic — it works for the LLM path automatically once M4 lands.
 
 When the existence layer reports the agent **off** (`enabled=false`) the loop
 short-circuits before any rules run, but still emits a **throttled** kill-switch
-trace so "agent off" is visible in Jaeger: a root `agent.span_received` with a
+trace so "agent off" is visible in Jaeger: a root `agent.signal_received` with a
 single `agent.disabled` child (no `agent.action` child — nothing was decided)
 carrying the same cycle-level flag attribution above (`agent.enabled=false`, the
 capability and permission flags that were in effect). Throttled to one per second
@@ -848,6 +855,17 @@ fitness → rollback); the game path had nothing. #918 closes the **measurement*
    the #844 retro prompt reads per-intervention effect evidence; both consume this
    span + metric.
 
+**Eval-cycle liveness (#1053):** the audit trace is emitted **only** when a rule
+fires, so idle cycles (signal arrives, nothing decided) are span-silent. To keep
+signal arrival observable without a span per idle cycle, **every** enabled eval
+cycle increments the metric `agent_evaluations_total` (`Int64Counter`), labeled
+`signal` (`metrics`|`traces`) and `outcome` (`decided`|`idle`). The labels are
+deliberately tiny (4 series max) — no per-game/per-serial dimensions. Because
+metrics are the agent's primary (~100 ms–1 s) trigger, `rate(agent_evaluations_total{signal="metrics"}[1m])`
+answers "is the agent receiving metrics?" directly, and the `outcome` split
+distinguishes "metrics arrive but trigger nothing" from "metrics aren't arriving"
+— the exact ambiguity that made the metric-driven loop look span-driven.
+
 **Lifecycle safety (#923 goleak):** each follow-up runs in a goroutine tracked on a
 `WaitGroup` (joined by `AwaitInflight` at shutdown) and bounded by the agent root
 context. It selects on the follow-up timer **and** `rootCtx.Done()`: on shutdown it
@@ -862,7 +880,7 @@ are used wherever one honestly applies:
 
 | Where | Convention |
 |-------|-----------|
-| `agent.span_received` | `rpc.system=grpc`, `rpc.service` (OTLP `TraceService`/`MetricsService`), `rpc.method=Export`; span kind `SERVER` |
+| `agent.signal_received` | `rpc.system=grpc`, `rpc.service` (OTLP `TraceService`/`MetricsService`), `rpc.method=Export`; span kind `SERVER` |
 | `agent.decision` | `gen_ai.agent.name` identity (the full [GenAI agent conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-agent-spans/) apply once an LLM inference path exists — `gen_ai.provider.name` etc. land as a `gen_ai.*` child span in llm mode) |
 | `agent.decision` event | `feature_flag` span event (`feature_flag.key=interventions.allowed`, `feature_flag.provider.name`, `feature_flag.result.variant`) — same shape the openfeature OTel hooks emit in the Python services; provider is `"stub"` until flagd (#725) |
 | `agent.action` failures | `span.RecordError` + `error.type` + status `ERROR` |
@@ -984,7 +1002,7 @@ change:
 
 `AGENT_PROBE_DECISIONS=true` swaps the rules engine for `ProbeRules`, which emits
 one synthetic `noop` decision at most every 5 s. Its only purpose is to drive a
-**full audit trace** (`agent.span_received → agent.decision → agent.action`)
+**full audit trace** (`agent.signal_received → agent.decision → agent.action`)
 without waiting for a live game to trigger the real rules — invaluable for
 verifying the trace pipeline end to end.
 
@@ -992,7 +1010,7 @@ verifying the trace pipeline end to end.
 by design.** `noop` is not in the `ambient`/`standard`/`full` allow-lists, so the
 permission layer blocks every probe decision with `decision.blocked=true`,
 `decision.block_reason=not_allowed`. This is still useful: the
-`agent.span_received → agent.decision` spans are emitted (a blocked decision is
+`agent.signal_received → agent.decision` spans are emitted (a blocked decision is
 traced, not dropped), so the OBSERVE→DECIDE path and the span schema are fully
 exercised — only the `agent.action` dispatch is withheld.
 

--- a/services/agent/decision/attribution_test.go
+++ b/services/agent/decision/attribution_test.go
@@ -138,7 +138,7 @@ func TestDisabledSpan_EmittedWithFlagAttribution(t *testing.T) {
 	l.OnEvaluate(context.Background(), gamecontext.GameContext{SessionID: "s1"}, testTrigger())
 
 	ended := sr.Ended()
-	roots := spansByName(ended, SpanReceived)
+	roots := spansByName(ended, SignalReceived)
 	disabled := spansByName(ended, SpanDisabled)
 	if len(roots) != 1 || len(disabled) != 1 {
 		t.Fatalf("spans = %d root + %d disabled, want 1/1 (no action span)", len(roots), len(disabled))
@@ -157,7 +157,7 @@ func TestDisabledSpan_EmittedWithFlagAttribution(t *testing.T) {
 		t.Errorf("policy.battery_threshold = %d, want 20", v.AsInt64())
 	}
 	if d.Parent().SpanID() != roots[0].SpanContext().SpanID() {
-		t.Error("disabled span must be a child of agent.span_received")
+		t.Error("disabled span must be a child of agent.signal_received")
 	}
 }
 

--- a/services/agent/decision/decision.go
+++ b/services/agent/decision/decision.go
@@ -1,6 +1,6 @@
 // Package decision holds the agent's decision loop: a gated, throttled hook that
 // turns a GameContext snapshot into interventions via a pluggable rules engine
-// and action sink, and emits the agent.span_received -> agent.decision ->
+// and action sink, and emits the agent.signal_received -> agent.decision ->
 // agent.action audit trace for every evaluation that produces decisions
 // (issue #724). ObjectiveRules (#726) is the objective-weighted rules engine;
 // the action sink stays a no-op until the intervention API (#730).
@@ -147,7 +147,7 @@ type fitnessReader interface {
 }
 
 // EvalTrigger describes the OTLP Export that triggered an evaluation, used to
-// annotate the agent.span_received root span with rpc.* semconv attributes and
+// annotate the agent.signal_received root span with rpc.* semconv attributes and
 // backdate it to the moment the Export arrived.
 type EvalTrigger struct {
 	// Signal is the OTLP signal type: "traces" or "metrics".
@@ -235,6 +235,12 @@ type Loop struct {
 	// to a no-op so a Loop built without metrics wiring still works.
 	llmGated otelmetric.Int64Counter
 
+	// evaluations counts EVERY eval cycle (agent_evaluations_total{signal,outcome},
+	// #1053), so signal arrival is observable even on idle cycles where no rule fires
+	// and no audit span is emitted. Defaults to a no-op so a Loop built without metrics
+	// wiring still works.
+	evaluations otelmetric.Int64Counter
+
 	// asyncInferState is the per-Loop async-inference machinery (#917): the pile-up
 	// guard, the in-flight wait group, this loop's game id, the re-validation context
 	// provider, and the agent root context. Embedded so the async surface lives in one
@@ -294,14 +300,15 @@ func NewLoop(flagSource FlagSource, log *slog.Logger) *Loop {
 		flagSource = disabledFlags{}
 	}
 	return &Loop{
-		Flags:    flagSource,
-		Rules:    NoopRules{},
-		Actions:  NoopActions{},
-		Log:      log,
-		Tracer:   otel.Tracer(instrumentationName),
-		now:      time.Now,
-		throttle: DefaultThrottleInterval,
-		llmGated: defaultLLMGatedCounter(),
+		Flags:       flagSource,
+		Rules:       NoopRules{},
+		Actions:     NoopActions{},
+		Log:         log,
+		Tracer:      otel.Tracer(instrumentationName),
+		now:         time.Now,
+		throttle:    DefaultThrottleInterval,
+		llmGated:    defaultLLMGatedCounter(),
+		evaluations: defaultEvaluationsCounter(),
 		effectSampler: effectSampler{
 			effectDelta: defaultEffectDeltaHistogram(),
 		},
@@ -358,6 +365,20 @@ func (l *Loop) recordIntervention(intervention, serial string, blocked bool) {
 		return
 	}
 	l.interventionRecorder(intervention, serial, blocked)
+}
+
+// recordEvaluation bumps agent_evaluations_total for one eval cycle (#1053). It
+// is called on EVERY enabled cycle — idle or not — so signal arrival is queryable
+// even when no rule fires. signal is the triggering OTLP signal (metrics|traces),
+// outcome is decided|idle. Labels are kept to these two low-cardinality dimensions
+// (4 series max) on purpose: no per-game/per-serial labels. The counter is never
+// nil (NewLoop seeds a no-op), so this is safe from the concurrent Export-handler
+// goroutines that drive OnEvaluate.
+func (l *Loop) recordEvaluation(ctx context.Context, signal, outcome string) {
+	l.evaluations.Add(ctx, 1, otelmetric.WithAttributes(
+		attribute.String("signal", signal),
+		attribute.String("outcome", outcome),
+	))
 }
 
 // SetThrottle overrides the log/span throttle interval. It is read once at
@@ -473,10 +494,17 @@ func (l *Loop) OnEvaluate(ctx context.Context, c gamecontext.GameContext, trig E
 		}
 	}
 
+	// Bump the per-cycle liveness counter BEFORE the lazy-trace branch so an idle
+	// cycle (no rule fired, hence no span) is still counted (#1053). outcome=idle
+	// on a zero-decision cycle, decided otherwise; signal is the OTLP signal that
+	// triggered this cycle (metrics|traces). This is what makes "metrics are
+	// arriving but nothing fires" distinguishable from "metrics aren't arriving".
 	if len(decisions) == 0 {
+		l.recordEvaluation(ctx, trig.Signal, "idle")
 		l.setLastLayer(state) // no decision, no trace
 		return state
 	}
+	l.recordEvaluation(ctx, trig.Signal, "decided")
 
 	// The root span wraps the inbound OTLP Export with rpc.* semconv attrs and
 	// kind SERVER. There is no otelgrpc interceptor on this server today, so
@@ -484,7 +512,7 @@ func (l *Loop) OnEvaluate(ctx context.Context, c gamecontext.GameContext, trig E
 	// otelgrpc.NewServerHandler is ever added to the agent's gRPC server,
 	// demote this span to SpanKindInternal and drop the rpc.* attributes to
 	// avoid a duplicate server span for the same RPC.
-	rootCtx, root := l.Tracer.Start(ctx, SpanReceived,
+	rootCtx, root := l.Tracer.Start(ctx, SignalReceived,
 		trace.WithTimestamp(trig.T0),
 		trace.WithSpanKind(trace.SpanKindServer),
 		trace.WithAttributes(
@@ -865,7 +893,7 @@ func (l *Loop) runDecision(ctx context.Context, snapshot flags.Snapshot, c gamec
 }
 
 // emitDisabledSpan emits the kill-switch trace for a cycle where the existence
-// layer reported the agent off (enabled=false): a root agent.span_received with
+// layer reported the agent off (enabled=false): a root agent.signal_received with
 // a single agent.decision child (no action child — nothing was decided) carrying
 // the existence + capability + permission attribution lifted from the disabled
 // LayerState. This makes "agent off, here are the flags that were in effect"
@@ -876,7 +904,7 @@ func (l *Loop) emitDisabledSpan(ctx context.Context, snapshot flags.Snapshot, c 
 	if !l.shouldLog() {
 		return
 	}
-	rootCtx, root := l.Tracer.Start(ctx, SpanReceived,
+	rootCtx, root := l.Tracer.Start(ctx, SignalReceived,
 		trace.WithTimestamp(trig.T0),
 		trace.WithSpanKind(trace.SpanKindServer),
 		trace.WithAttributes(

--- a/services/agent/decision/loop_test.go
+++ b/services/agent/decision/loop_test.go
@@ -115,7 +115,7 @@ func TestOnEvaluate_EmitsFullHierarchy(t *testing.T) {
 	if len(ended) != 3 {
 		t.Fatalf("spans = %d, want 3", len(ended))
 	}
-	roots := spansByName(ended, SpanReceived)
+	roots := spansByName(ended, SignalReceived)
 	decisions := spansByName(ended, SpanDecision)
 	actions := spansByName(ended, SpanAction)
 	if len(roots) != 1 || len(decisions) != 1 || len(actions) != 1 {
@@ -124,10 +124,10 @@ func TestOnEvaluate_EmitsFullHierarchy(t *testing.T) {
 
 	root, dec, act := roots[0], decisions[0], actions[0]
 	if root.Parent().IsValid() {
-		t.Error("span_received must be the root span")
+		t.Error("signal_received must be the root span")
 	}
 	if dec.Parent().SpanID() != root.SpanContext().SpanID() {
-		t.Error("agent.decision must be a child of agent.span_received")
+		t.Error("agent.decision must be a child of agent.signal_received")
 	}
 	if act.Parent().SpanID() != dec.SpanContext().SpanID() {
 		t.Error("agent.action must be a child of agent.decision")
@@ -228,7 +228,7 @@ func TestOnEvaluate_MultipleDecisions(t *testing.T) {
 	l.OnEvaluate(context.Background(), gamecontext.GameContext{}, testTrigger())
 
 	ended := sr.Ended()
-	if len(spansByName(ended, SpanReceived)) != 1 ||
+	if len(spansByName(ended, SignalReceived)) != 1 ||
 		len(spansByName(ended, SpanDecision)) != 2 ||
 		len(spansByName(ended, SpanAction)) != 2 {
 		t.Fatalf("spans = %d, want 1 root + 2 decisions + 2 actions", len(ended))
@@ -320,7 +320,7 @@ func TestOnEvaluate_ConcurrentExportHandlers(t *testing.T) {
 	}
 	wg.Wait()
 
-	if got := len(spansByName(sr.Ended(), SpanReceived)); got != 50 {
+	if got := len(spansByName(sr.Ended(), SignalReceived)); got != 50 {
 		t.Fatalf("root spans = %d, want 50", got)
 	}
 }

--- a/services/agent/decision/loopset_test.go
+++ b/services/agent/decision/loopset_test.go
@@ -328,7 +328,7 @@ func TestLoopSet_ShadowVsRealAttribution(t *testing.T) {
 			t.Errorf("%s decision span game.kind=%q, want %q", id, got, wantKind)
 		}
 		// game.id alias must equal the partition's game id on the root span.
-		roots := spansByName(recorders[id].Ended(), SpanReceived)
+		roots := spansByName(recorders[id].Ended(), SignalReceived)
 		if len(roots) != 1 {
 			t.Fatalf("%s emitted %d root spans, want 1", id, len(roots))
 		}

--- a/services/agent/decision/metrics.go
+++ b/services/agent/decision/metrics.go
@@ -39,6 +39,34 @@ func defaultLLMGatedCounter() otelmetric.Int64Counter {
 	return newLLMGatedCounter(otel.GetMeterProvider())
 }
 
+// newEvaluationsCounter builds the agent_evaluations_total counter from the given
+// meter provider (#1053). Unlike the audit trace — which is emitted ONLY when the
+// rules engine returns ≥1 decision — this counter is incremented on EVERY eval
+// cycle, so metric arrival is observable even on idle cycles where no rule fires.
+// It closes the "are signals even arriving?" blind spot WITHOUT a span per idle
+// cycle. Labels are deliberately tiny — signal=metrics|traces and outcome=
+// decided|idle (4 series max). NO per-game/per-serial labels: this is a liveness
+// pulse, not per-game attribution (that lives on the trace). An instrument-creation
+// error yields a no-op counter so the Loop always has a usable instrument and tests
+// that never wire a real meter provider still work — mirrors newLLMGatedCounter.
+func newEvaluationsCounter(mp otelmetric.MeterProvider) otelmetric.Int64Counter {
+	c, err := mp.Meter(decisionMeterName).Int64Counter(
+		"agent_evaluations_total",
+		otelmetric.WithDescription("Total agent evaluation cycles, labeled by signal (metrics|traces) and outcome (decided|idle); incremented on every cycle including idle ones so signal arrival is observable (#1053)"),
+	)
+	if err != nil {
+		c, _ = metricnoop.NewMeterProvider().Meter(decisionMeterName).Int64Counter("agent_evaluations_total")
+	}
+	return c
+}
+
+// defaultEvaluationsCounter is the no-op fallback counter a Loop uses until one is
+// injected (NewLoop wires the global meter provider; tests may leave it). It keeps
+// the per-cycle increment path nil-safe without every test having to set a counter.
+func defaultEvaluationsCounter() otelmetric.Int64Counter {
+	return newEvaluationsCounter(otel.GetMeterProvider())
+}
+
 // newEffectDeltaHistogram builds the agent_intervention_effect_delta histogram from
 // the given meter provider (#918). It records the follow_up-baseline change in a
 // game's fitness/objective signal a follow-up window after an intervention was

--- a/services/agent/decision/signal_telemetry_test.go
+++ b/services/agent/decision/signal_telemetry_test.go
@@ -1,0 +1,154 @@
+package decision
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	"go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"github.com/joustmania/agent/flags"
+	"github.com/joustmania/agent/gamecontext"
+)
+
+// meteredTestLoop builds an enabled, permissive Loop wired with BOTH a recording
+// tracer and a metered agent_evaluations_total counter, so a single OnEvaluate can
+// be asserted against the span name AND the eval-cycle counter (#1053).
+func meteredTestLoop(t *testing.T) (*Loop, *tracetest.SpanRecorder, *metric.ManualReader) {
+	t.Helper()
+	sr := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+
+	reader := metric.NewManualReader()
+	mp := metric.NewMeterProvider(metric.WithReader(reader))
+
+	fl := &settableFlags{snap: flags.Snapshot{
+		Enabled:              true,
+		Mode:                 "rules",
+		InterventionsAllowed: []string{"noop", "grant_shield"},
+		Policy:               flags.Policy{MaxInterventionsPerMinute: 100},
+	}}
+	l := NewLoop(fl, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	l.Tracer = tp.Tracer("test")
+	l.evaluations = newEvaluationsCounter(mp)
+	return l, sr, reader
+}
+
+// evaluationsBySignalOutcome collects agent_evaluations_total into a
+// "<signal>/<outcome>" -> count map.
+func evaluationsBySignalOutcome(t *testing.T, reader *metric.ManualReader) map[string]int64 {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("collect metrics: %v", err)
+	}
+	out := map[string]int64{}
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != "agent_evaluations_total" {
+				continue
+			}
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			if !ok {
+				t.Fatalf("expected Sum[int64], got %T", m.Data)
+			}
+			for _, dp := range sum.DataPoints {
+				signal, _ := dp.Attributes.Value("signal")
+				outcome, _ := dp.Attributes.Value("outcome")
+				out[signal.AsString()+"/"+outcome.AsString()] = dp.Value
+			}
+		}
+	}
+	return out
+}
+
+// traceTrigger mirrors testTrigger but for a trace-signal-driven cycle (#1053):
+// the root span must be signal-agnostic, so a trace-triggered cycle emits the same
+// agent.signal_received name, discriminated only by otlp.signal=traces.
+func traceTrigger() EvalTrigger {
+	t := testTrigger()
+	t.Signal = "traces"
+	t.RPCService = "opentelemetry.proto.collector.trace.v1.TraceService"
+	return t
+}
+
+// TestSignalReceived_NameIsSignalAgnostic asserts the root span is now named
+// agent.signal_received (NOT agent.span_received) for BOTH a metric-triggered and a
+// trace-triggered eval that decides, with the correct otlp.signal discriminator.
+func TestSignalReceived_NameIsSignalAgnostic(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		trig   EvalTrigger
+		signal string
+	}{
+		{"metrics", testTrigger(), "metrics"},
+		{"traces", traceTrigger(), "traces"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			l, sr, _ := meteredTestLoop(t)
+			l.Rules = fakeRules{out: []Decision{{Intervention: "noop", Reason: "x"}}}
+			l.Actions = &fakeSink{}
+
+			l.OnEvaluate(context.Background(), gamecontext.GameContext{SessionID: "s"}, tc.trig)
+
+			roots := spansByName(sr.Ended(), SignalReceived)
+			if len(roots) != 1 {
+				t.Fatalf("agent.signal_received spans = %d, want 1", len(roots))
+			}
+			if got := roots[0].Name(); got != "agent.signal_received" {
+				t.Errorf("root span name = %q, want agent.signal_received", got)
+			}
+			if old := spansByName(sr.Ended(), "agent.span_received"); len(old) != 0 {
+				t.Errorf("found %d stale agent.span_received spans, want 0", len(old))
+			}
+			v, ok := attrValue(roots[0], "otlp.signal")
+			if !ok || v.AsString() != tc.signal {
+				t.Errorf("otlp.signal = %q (present=%v), want %q", v.AsString(), ok, tc.signal)
+			}
+		})
+	}
+}
+
+// TestEvaluationsCounter_DecidedAndIdle asserts the per-cycle counter (#1053)
+// increments {signal=metrics,outcome=decided} on a metric cycle that fires a rule,
+// {signal=metrics,outcome=idle} on a metric cycle that fires NOTHING, and
+// {signal=traces,outcome=decided} on a trace cycle — proving signal arrival is
+// observable even on idle cycles where no audit span emits.
+func TestEvaluationsCounter_DecidedAndIdle(t *testing.T) {
+	l, sr, reader := meteredTestLoop(t)
+
+	// 1. Metric-triggered cycle that DECIDES.
+	l.Rules = fakeRules{out: []Decision{{Intervention: "noop", Reason: "x"}}}
+	l.Actions = &fakeSink{}
+	l.OnEvaluate(context.Background(), gamecontext.GameContext{SessionID: "s"}, testTrigger())
+
+	// 2. Metric-triggered cycle that fires NO rule (idle). No span must emit for it.
+	l.Rules = fakeRules{out: nil}
+	l.OnEvaluate(context.Background(), gamecontext.GameContext{SessionID: "s"}, testTrigger())
+
+	// 3. Trace-triggered cycle that DECIDES.
+	l.Rules = fakeRules{out: []Decision{{Intervention: "noop", Reason: "x"}}}
+	l.OnEvaluate(context.Background(), gamecontext.GameContext{SessionID: "s"}, traceTrigger())
+
+	counts := evaluationsBySignalOutcome(t, reader)
+	for key, want := range map[string]int64{
+		"metrics/decided": 1,
+		"metrics/idle":    1,
+		"traces/decided":  1,
+	} {
+		if counts[key] != want {
+			t.Errorf("agent_evaluations_total{%s} = %d, want %d (all: %v)", key, counts[key], want, counts)
+		}
+	}
+
+	// The idle cycle must NOT have emitted any span — the counter is the only
+	// record of it (the whole point of #1053).
+	if idleRoots := len(spansByName(sr.Ended(), SignalReceived)); idleRoots != 2 {
+		t.Errorf("agent.signal_received spans = %d, want 2 (idle cycle emits none)", idleRoots)
+	}
+}

--- a/services/agent/decision/telemetry.go
+++ b/services/agent/decision/telemetry.go
@@ -3,16 +3,25 @@ package decision
 // Span names for the agent's decision audit trail (issue #724). The hierarchy
 // is always parent -> child:
 //
-//	agent.span_received          one per triggering OTLP Export
+//	agent.signal_received        one per triggering OTLP Export (metrics OR traces)
 //	  └─ agent.decision          one per Decision the rules engine returns
 //	       └─ agent.action       one per decision, wrapping the ActionSink call
 //
+// The root span is signal-AGNOSTIC (#1053): a metric-triggered cycle and a
+// trace-triggered cycle both emit agent.signal_received, distinguished by the
+// otlp.signal (metrics|traces) + rpc.service attributes — NOT by the span name.
+// Metrics are the agent's PRIMARY (~100ms-1s) trigger; the old "span_received"
+// name implied trace-only activity and misled readers into thinking metrics
+// were not wired (they are — see receiver.go ApplyMetrics -> OnEvaluate).
+//
 // Traces are only emitted when the rules engine returns at least one decision
 // (including decisions that end up blocked) — the trace IS the audit log of
-// agent activity, not of agent idle time.
+// agent activity, not of agent idle time. Idle cycles (signal arrives, no rule
+// fires) are instead made observable via the agent_evaluations_total counter
+// (#1053), so "are signals arriving?" is answerable without a span per cycle.
 //
 // Where OpenTelemetry semantic conventions exist they are used (semconv
-// v1.34.0): rpc.* on agent.span_received (it wraps an inbound OTLP gRPC
+// v1.34.0): rpc.* on agent.signal_received (it wraps an inbound OTLP gRPC
 // Export), gen_ai.agent.name as the agent identity on agent.decision (the full
 // GenAI agent conventions apply once an LLM inference path exists — its
 // requireds, e.g. gen_ai.provider.name, are only honest in llm mode), a
@@ -22,9 +31,9 @@ package decision
 // fitness.*, agent.mode, agent.objectives and interventions.allowed attributes
 // have no semantic convention and are custom to this project.
 const (
-	SpanReceived = "agent.span_received"
-	SpanDecision = "agent.decision"
-	SpanAction   = "agent.action"
+	SignalReceived = "agent.signal_received"
+	SpanDecision   = "agent.decision"
+	SpanAction     = "agent.action"
 )
 
 // SpanDisabled is the kill-switch trace emitted when the existence layer reports
@@ -47,7 +56,7 @@ const SpanLLMPrompt = "agent.llm.prompt"
 
 // SpanLLMInfer is the actual-inference span (#739): emitted when the llm path
 // calls a resolved backend's Infer (NOT the capture path, which only renders the
-// prompt). It is a child of agent.span_received and a SIBLING of the resulting
+// prompt). It is a child of agent.signal_received and a SIBLING of the resulting
 // agent.decision span, carrying the GenAI request attribution and — on a parsed
 // response — the model's reasoning + chosen objective + action. On an Infer error
 // or an unparseable response it carries AttrLLMInferError and the cycle falls back
@@ -56,7 +65,7 @@ const SpanLLMInfer = "agent.llm.infer"
 
 // SpanLLMApply is the ASYNC-application audit root (#917): emitted when an
 // async inference RESULT lands, seconds after the cycle that fired it, carrying
-// the whole re-validation outcome. Because the firing cycle's agent.span_received
+// the whole re-validation outcome. Because the firing cycle's agent.signal_received
 // has long since ended (the loop never blocks on Infer), the async result cannot
 // hang off it — so the apply path opens its OWN root span backdated to the moment
 // inference completed. It parents the agent.llm.infer call span and, when the
@@ -320,7 +329,7 @@ const (
 // loop — the infra path already has fitness->rollback, the game path had nothing
 // (#918). It is MEASUREMENT ONLY: it never reverts the intervention.
 //
-// Because the dispatch cycle's agent.span_received root has long since ended (the
+// Because the dispatch cycle's agent.signal_received root has long since ended (the
 // follow-up window is seconds later), the effect cannot hang off it — so the sampler
 // opens its OWN root span backdated to dispatch time, parenting an
 // agent.intervention.effect span per evaluated objective, so a Jaeger trace shows the

--- a/services/agent/receiver.go
+++ b/services/agent/receiver.go
@@ -14,7 +14,7 @@ import (
 )
 
 // Full OTLP gRPC service names, recorded as rpc.service (semconv) on the
-// agent.span_received root span.
+// agent.signal_received root span.
 const (
 	otlpTraceService   = "opentelemetry.proto.collector.trace.v1.TraceService"
 	otlpMetricsService = "opentelemetry.proto.collector.metrics.v1.MetricsService"


### PR DESCRIPTION
Part of #1053.

Fixes two agent decision-telemetry defects that made a **metric-driven** loop look **span-driven** (and hid idle cycles).

## Ask 1 — signal-agnostic root span
Renamed the root audit span `agent.span_received` → **`agent.signal_received`**. A metric-triggered and a trace-triggered cycle now share one name, discriminated only by the existing `otlp.signal` (`metrics`|`traces`) + `rpc.service` attributes. The old name implied trace-only activity even though metrics are the primary (~100 ms–1 s) trigger.

Every reference updated — no dangling `span_received`:
- `decision/telemetry.go` — const `SpanReceived` → `SignalReceived` + name + comments
- `decision/decision.go` — both `Tracer.Start` call sites (decided path + disabled-span path) + comments
- `receiver.go` — comment
- `decision/{loop,loopset,attribution}_test.go` — assertions
- `services/agent/README.md`, `docs/agent-act-runbook.md`

Grafana dashboards, Prometheus/alerts, and the #792 dashboard app were checked — **none** reference the span name, so nothing to migrate there.

## Ask 2 — eval-cycle counter (visible on idle cycles)
Added `agent_evaluations_total` (`Int64Counter`) labeled `signal` (`metrics`|`traces`) and `outcome` (`decided`|`idle`), incremented on **every** enabled eval cycle in `OnEvaluate` — `decided` when ≥1 decision fired, `idle` otherwise. So signal arrival is observable even when no rule fires, without a span per idle cycle. Cardinality is tiny (signal × outcome = 4 series, no per-game/per-serial labels). No-op default instrument so `rate()` works from zero and metric-free tests still pass — mirrors the existing `agent_llm_gated_total` wiring.

## Tests
New `decision/signal_telemetry_test.go`:
- root span is `agent.signal_received` for **both** a metric- and a trace-triggered eval, with the correct `otlp.signal`, and zero stale `agent.span_received`
- counter increments `{metrics,decided}`, `{metrics,idle}` (no-rule cycle), `{traces,decided}`; idle cycle confirmed to emit no span

`go test ./... -race`, `go vet ./...`, `gofmt -l .` all clean; existing decision/telemetry tests updated and passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)