### PR TITLE
feat(agent): LiteLLM gateway sidecar — OpenAI-compatible router (#1049)

### DIFF
--- a/docker-compose.gateway.yml
+++ b/docker-compose.gateway.yml
@@ -1,0 +1,44 @@
+# LiteLLM gateway override (#1049, per the #1046 design)
+#
+# Layer this ON TOP of the base compose to route the agent THROUGH the LiteLLM
+# gateway instead of talking to Ollama directly. The gateway itself lives in
+# docker-compose.yml behind the `gateway` profile; this file flips the agent's
+# inference env so it dials the gateway service name.
+#
+# Usage (the gateway is OPT-IN — a plain `up` does NOT load this file):
+#
+#   docker compose \
+#     -f docker-compose.yml \
+#     -f docker-compose.gateway.yml \
+#     --profile gateway up -d
+#
+# Set the OPTIONAL Anthropic cloud layer via the GATEWAY env only (a .env or an
+# export reaches the litellm service in docker-compose.yml — NEVER the agent):
+#
+#   ANTHROPIC_API_KEY=sk-ant-... docker compose -f docker-compose.yml \
+#     -f docker-compose.gateway.yml --profile gateway up -d
+#
+# Without a key the gateway runs Ollama-only and the `claude` route falls back
+# to the local model (see services/litellm/config.yaml fallbacks).
+#
+# This changes nothing about the DEFAULT stack: omit this file and the agent
+# keeps its stub/Ollama-direct default (docker-compose.yml).
+
+services:
+  agent:
+    environment:
+      # Route the agent's single OpenAI-compatible client at the gateway.
+      # The agent sends the agent.json `model` value as the OpenAI `model`
+      # param; the gateway resolves route -> provider (config.yaml model_list).
+      - AGENT_INFERENCE_BACKEND=openai
+      - AGENT_INFERENCE_BASE_URL=http://litellm:4000/v1
+      # The model the agent asks for by default. OpenFeature/agent.json `model`
+      # still owns selection at runtime; this is the env-level default the
+      # OpenAI client uses. Keep it a route the gateway defines (phi4-mini).
+      - AGENT_INFERENCE_MODEL=${AGENT_INFERENCE_MODEL:-phi4-mini}
+      # The proxy's optional master key. Only needed if LITELLM_MASTER_KEY is
+      # set on the gateway. Empty = unauthenticated on the internal network.
+      - AGENT_INFERENCE_API_KEY=${LITELLM_MASTER_KEY:-}
+    depends_on:
+      litellm:
+        condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -773,6 +773,63 @@ services:
           cpus: '0.5'
     logging: *default-logging
 
+  # LiteLLM gateway (#1049, per the #1046 design) — the OpenAI-compatible "tool
+  # in the middle". OPT-IN: behind the `gateway` profile, so a plain `up` runs
+  # WITHOUT it (the agent stays on its stub/Ollama-direct default, no behavior
+  # change). Enable with `--profile gateway` (see docs/agent-inference-gateway.md).
+  #
+  # When up, the agent points AGENT_INFERENCE_BASE_URL at http://litellm:4000/v1
+  # (set that + AGENT_INFERENCE_BACKEND=openai on the agent — see the runbook).
+  # Backend selection stays OpenFeature-driven (agent.json `model`); this gateway
+  # only resolves route -> provider and holds the keys (NEVER in the agent).
+  litellm:
+    image: ghcr.io/berriai/litellm:v1.88.2
+    container_name: joustmania-litellm
+    profiles:
+      - gateway
+    command: ["--config", "/etc/litellm/config.yaml", "--port", "4000"]
+    expose:
+      - "4000"
+    ports:
+      # Published so a host-side curl can smoke-test /v1/models and
+      # /v1/chat/completions. Drop this mapping on a hardened fleet host if the
+      # gateway should stay docker-network-internal only.
+      - "4000:4000"
+    environment:
+      # Free local default: where the gateway reaches Ollama. Defaults to the
+      # HOST machine's Ollama via host.docker.internal (extra_hosts below).
+      # Repoint to a LAN Jetson (#738) without editing config.yaml.
+      - OLLAMA_BASE_URL=${OLLAMA_BASE_URL:-http://host.docker.internal:11434}
+      # OPTIONAL cloud layer. Leave empty to run Ollama-only; the `claude` route
+      # then errors on use and falls back to local (config.yaml fallbacks). The
+      # key lives HERE in the gateway env ONLY — never in the agent container.
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
+      # Optional shared key for the proxy's own OpenAI-compatible API. Unset =
+      # open on the internal docker network. When set, the agent must send it via
+      # AGENT_INFERENCE_API_KEY.
+      - LITELLM_MASTER_KEY=${LITELLM_MASTER_KEY:-}
+    volumes:
+      - ./services/litellm/config.yaml:/etc/litellm/config.yaml:ro
+    # Reach the HOST machine's Ollama (same mechanism the agent uses, #1048).
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    networks:
+      - joustmania
+    restart: unless-stopped
+    healthcheck:
+      # LiteLLM exposes a liveness endpoint at /health/liveliness.
+      test: ["CMD", "curl", "-fsS", "http://localhost:4000/health/liveliness"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+      start_period: 20s
+    deploy:
+      resources:
+        limits:
+          memory: 512m
+          cpus: '1.0'
+    logging: *default-logging
+
   # Dashboard (Real-time controller visualization SPA)
   dashboard:
     image: ghcr.io/watchmejoustmyflags/joustmania/dashboard:${IMAGE_TAG:-latest}

--- a/docs/agent-inference-gateway.md
+++ b/docs/agent-inference-gateway.md
@@ -1,0 +1,155 @@
+# Agent inference gateway — LiteLLM "tool in the middle" (#1049)
+
+The agent talks to **one** OpenAI-compatible endpoint and lets a gateway decide
+which provider actually answers. This is the [#1046](https://github.com/WatchMeJoustMyFlags/JoustMania/issues/1046)
+recommendation: keep the Go agent clean (one base URL + one key) and move all
+provider swap / fallback / key custody into **config**, not Go code.
+
+It builds on [#1048](https://github.com/WatchMeJoustMyFlags/JoustMania/issues/1048):
+the agent already has an OpenAI-compatible `Backend.Infer` driven by
+`AGENT_INFERENCE_*` env (`services/agent/inference/openai.go`). The gateway just
+changes where `AGENT_INFERENCE_BASE_URL` points.
+
+## It is OPT-IN
+
+A plain `docker compose up` runs the stack **without** the gateway. The agent
+keeps its default inference backend (`stub`, or Ollama-direct when configured) —
+no behavior change. The gateway only exists when you activate the `gateway`
+compose profile.
+
+| State | Agent inference | Gateway container |
+|-------|-----------------|-------------------|
+| **Default** (`up`) | stub / Ollama-direct (`host.docker.internal:11434`) | absent |
+| **Gateway** (`--profile gateway` + override) | `openai` → `http://litellm:4000/v1` | running |
+
+## Enable it
+
+```bash
+# Ollama-only (free, local, no key):
+docker compose \
+  -f docker-compose.yml \
+  -f docker-compose.gateway.yml \
+  --profile gateway up -d
+
+# With the optional Anthropic cloud layer (key lives in the GATEWAY env only):
+ANTHROPIC_API_KEY=sk-ant-... docker compose \
+  -f docker-compose.yml \
+  -f docker-compose.gateway.yml \
+  --profile gateway up -d
+```
+
+- `docker-compose.yml` defines the `litellm` service behind the `gateway`
+  profile (on `:4000`).
+- `docker-compose.gateway.yml` flips the **agent's** env to route through it
+  (`AGENT_INFERENCE_BACKEND=openai`, `AGENT_INFERENCE_BASE_URL=http://litellm:4000/v1`)
+  and makes the agent wait for the gateway to be healthy.
+
+The default stack is untouched — omit the override file and the `--profile
+gateway` flag and nothing changes.
+
+## Routing & fallback (`services/litellm/config.yaml`)
+
+The gateway's `model_list` maps **route name → provider**. The route names are a
+superset of the `agent.json` `model` flag variants, so a flag flip always
+resolves to a real route:
+
+| Route (= agent.json `model`) | Provider | Notes |
+|------------------------------|----------|-------|
+| `phi4-mini` | host Ollama | **free local default** |
+| `gemma3:4b` | host Ollama (or LAN Jetson) | higher-quality local tier (#738) |
+| `claude` | Anthropic API | **optional** cloud top layer |
+| `copilot` | host Ollama (`phi4-mini`) | dropped in #1046; mapped to local so a stale flag still resolves |
+
+**Fallback chain** (`litellm_settings.fallbacks`): `claude → phi4-mini` and
+`gemma3:4b → phi4-mini`. A cloud outage (or an unset key) degrades to the local
+model rather than failing inference.
+
+```yaml
+litellm_settings:
+  fallbacks:
+    - claude: ["phi4-mini"]
+    - gemma3:4b: ["phi4-mini"]
+```
+
+Where the gateway reaches Ollama is `OLLAMA_BASE_URL` (default
+`http://host.docker.internal:11434`, the host machine's Ollama via
+`extra_hosts: host-gateway`). Repoint it at a LAN Jetson without editing
+`config.yaml`.
+
+## The Anthropic key — gateway-only, optional
+
+The Anthropic API key lives **only** in the gateway's env (`ANTHROPIC_API_KEY`
+on the `litellm` service). It is **never** mounted into or passed to the agent
+container — credentials are not OpenFeature flags. The key is **optional**: with
+no key set, the gateway runs Ollama-only and the `claude` route falls back to
+local. (Per the [#742](https://github.com/WatchMeJoustMyFlags/JoustMania/issues/742)
+spike, use the Anthropic **API key**, NOT Max OAuth — that path is ToS-barred.)
+
+Optionally set `LITELLM_MASTER_KEY` to require a shared key on the proxy's own
+API; the agent then sends it via `AGENT_INFERENCE_API_KEY` (wired automatically
+by the override from `LITELLM_MASTER_KEY`). Unset = open on the internal docker
+network only.
+
+## Control-plane boundary — OpenFeature stays in charge
+
+The gateway sits **below** the agent's control plane; it does not replace it
+(#1046):
+
+- **OpenFeature / `agent.json`** (human-owned, `:ro`) owns *selection* — the
+  `model`/route, `mode`, `enabled` kill-switch, etc. The agent sends the `model`
+  value as the OpenAI `model` param.
+- **Gateway config** (infra, NOT OpenFeature) owns route→provider mapping, API
+  keys, and fallback chains.
+
+Two invariants the gateway preserves:
+
+1. **Route-name contract** — `agent.json` `model` variants are a subset of the
+   gateway routes. An unknown/unreachable route degrades via the fallback chain,
+   it does not silently break.
+2. **Terminal fallback stays agent-side** — the rules engine "no backend
+   answered → rules" last rung lives in the **agent**, so a **gateway outage ≠
+   agent outage**. The gateway owns LLM fallback chains; the agent owns the
+   final no-cloud-dependency rung.
+
+## Edge / Pi note (not implemented here)
+
+LiteLLM is Python/FastAPI — the **heaviest** gateway option. On the Pi 5 (low
+RAM), prefer one of the lighter alternatives from the #1046 survey, keeping the
+no-cloud-dependency property:
+
+- **Bifrost** (Maxim AI) — a single static **Go** binary, Apache-2.0, ~50×
+  lighter than the Python proxy, with the same OpenAI-compatible surface and
+  Ollama + Anthropic fallback. Matches our Go/static-binary stack; preferred if
+  the Pi itself must host a router.
+- **Ollama-direct** — skip the gateway entirely and point the agent's
+  `AGENT_INFERENCE_BASE_URL` straight at Ollama's built-in `/v1/`
+  (`http://host.docker.internal:11434/v1`, the #1048 default). Local-only, no
+  cloud fallback, lowest footprint.
+
+Either way the agent's rules-engine terminal rung means the edge runs fully
+standalone with no cloud dependency.
+
+## Validate / smoke-test
+
+Static (config resolves, gateway is opt-in):
+
+```bash
+# gateway profile resolves cleanly (litellm + agent pointed at it):
+docker compose -f docker-compose.yml -f docker-compose.gateway.yml \
+  --profile gateway config >/dev/null && echo OK
+
+# default stack still excludes the gateway:
+docker compose -f docker-compose.yml config | grep -c joustmania-litellm  # -> 0
+```
+
+Live (needs the host Ollama running with `phi4-mini` pulled, e.g.
+`ollama pull phi4-mini`):
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.gateway.yml \
+  --profile gateway up -d litellm
+curl -s http://localhost:4000/v1/models
+curl -s http://localhost:4000/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"phi4-mini","messages":[{"role":"user","content":"ping"}]}'
+```

--- a/services/agent/README.md
+++ b/services/agent/README.md
@@ -752,6 +752,13 @@ a real model, copy `llm.prompt.system` / `llm.prompt.user` into two files and ru
 [docs/research/739-prompt-capture.md](../../docs/research/739-prompt-capture.md)
 for the response contract and the forward path (#741 backend, #742 auth).
 
+> **Real inference backend (#1048/#1049):** the OpenAI-compatible `Backend.Infer`
+> (`inference/openai.go`) is driven by `AGENT_INFERENCE_*` env. By default it is a
+> `stub` (or Ollama-direct). To route through the optional **LiteLLM gateway** —
+> one endpoint, Ollama default + optional Anthropic, with fallback chains and
+> gateway-side key custody — see
+> [docs/agent-inference-gateway.md](../../docs/agent-inference-gateway.md).
+
 #### Post-game retrospective capture (M4, #844)
 
 When a game **ends** (the `GameActive` true→false transition fires the store's

--- a/services/litellm/config.yaml
+++ b/services/litellm/config.yaml
@@ -1,0 +1,70 @@
+# LiteLLM gateway config (#1049, per the #1046 design)
+#
+# The "tool in the middle": the agent talks to ONE OpenAI-compatible endpoint
+# (this proxy on :4000) and backend selection + key custody + fallback chains
+# live HERE, in config — not in the agent's Go binary.
+#
+# Control-plane boundary (#1046): OpenFeature / agent.json stays the control
+# plane. The agent.json `model` flag (variants: phi4-mini | gemma3:4b | claude |
+# copilot) is sent verbatim as the OpenAI `model` param. The route NAMES below
+# MUST be a superset of those variants so a flag flip resolves to a real route.
+# This file only maps route -> provider; it does NOT decide WHICH route to use.
+#
+# Keys live ONLY in this gateway's env (ANTHROPIC_API_KEY), NEVER in the agent
+# container. The gateway works Ollama-only with NO key set — see fallbacks.
+
+model_list:
+  # ---- Free local default: host Ollama (no key, fully offline) ----
+  # api_base points at the HOST machine's Ollama; the compose service adds
+  # extra_hosts host.docker.internal:host-gateway so this resolves from the
+  # gateway container. OLLAMA_BASE_URL lets a deployment repoint it (e.g. a LAN
+  # Jetson) without editing this file.
+  - model_name: phi4-mini
+    litellm_params:
+      model: ollama_chat/phi4-mini
+      api_base: os.environ/OLLAMA_BASE_URL
+
+  # gemma3:4b — the higher-quality local tier (#738; typically the Jetson over
+  # the LAN). Same Ollama backend by default; repoint OLLAMA_BASE_URL per host.
+  - model_name: gemma3:4b
+    litellm_params:
+      model: ollama_chat/gemma3:4b
+      api_base: os.environ/OLLAMA_BASE_URL
+
+  # ---- Optional cloud top layer: Anthropic (API key, NOT Max OAuth) ----
+  # Reached only when ANTHROPIC_API_KEY is set in the GATEWAY env. The
+  # agent.json `model=claude` variant resolves here. Falls back to local on a
+  # cloud outage (see litellm_settings.fallbacks below).
+  - model_name: claude
+    litellm_params:
+      model: anthropic/claude-haiku-4-5
+      api_key: os.environ/ANTHROPIC_API_KEY
+
+  # `copilot` is an agent.json variant but has NO sanctioned standalone API
+  # (#1046 dropped it). Map it to the local default so a stale flag value still
+  # resolves (fail-soft) instead of returning an unknown-model error.
+  - model_name: copilot
+    litellm_params:
+      model: ollama_chat/phi4-mini
+      api_base: os.environ/OLLAMA_BASE_URL
+
+litellm_settings:
+  # Fallback chains (#1046): a cloud outage degrades to LOCAL, never to nothing.
+  # claude -> phi4-mini keeps inference answering on Anthropic failure/unset key.
+  # The local routes have no cloud fallback (they ARE the terminal LLM tier);
+  # the agent's rules engine remains the always-present last rung (gateway
+  # outage != agent outage — that terminal fallback stays agent-side, #1046).
+  fallbacks:
+    - claude: ["phi4-mini"]
+    - gemma3:4b: ["phi4-mini"]
+  # Keep latency bounded so a hung backend degrades to the fallback promptly.
+  request_timeout: 30
+  # Don't abort the proxy if ANTHROPIC_API_KEY is unset — the gateway must run
+  # Ollama-only. The claude route simply errors on use and falls back to local.
+  drop_params: true
+
+general_settings:
+  # Optional shared key for the proxy's OpenAI-compatible API. When set, the
+  # agent must send it as AGENT_INFERENCE_API_KEY. Unset (default) = open on the
+  # internal docker network only (the service is not published to the host).
+  master_key: os.environ/LITELLM_MASTER_KEY


### PR DESCRIPTION
Part of #1049 (per the #1046 design). Adds an **opt-in** LiteLLM proxy as the OpenAI-compatible "tool in the middle" so the agent talks to ONE endpoint and backends become gateway config. Builds on #1048 (the agent's OpenAI-compatible `Backend.Infer` + `AGENT_INFERENCE_*` env).

## What's here

- **`docker-compose.yml`** — `litellm` service on `:4000` behind the OPT-IN `gateway` profile. A plain `up` runs WITHOUT it (the agent keeps its stub / Ollama-direct default — no behavior change). Pinned `ghcr.io/berriai/litellm:v1.88.2`; `extra_hosts: host-gateway` to reach the host Ollama.
- **`services/litellm/config.yaml`** — `model_list` routing:
  - `phi4-mini` / `gemma3:4b` → host Ollama (**free local default**, `OLLAMA_BASE_URL`)
  - `claude` → Anthropic (**optional** cloud layer, `ANTHROPIC_API_KEY` from the **gateway** env only)
  - `copilot` → local (dropped in #1046; mapped so a stale flag still resolves)
  - **Fallback chain** `claude → phi4-mini` (and `gemma3:4b → phi4-mini`) so a cloud outage / unset key degrades to local.
  - Route names are a **superset** of the `agent.json` `model` flag variants (route-name contract).
- **`docker-compose.gateway.yml`** — opt-in override that points the agent at the gateway (`AGENT_INFERENCE_BACKEND=openai`, `AGENT_INFERENCE_BASE_URL=http://litellm:4000/v1`) and waits for it healthy. The default stack is untouched.
- **`docs/agent-inference-gateway.md`** + agent README link — how to enable, the Anthropic-key setup (gateway-only, optional), routing/fallback, the OpenFeature control-plane boundary, and the **Pi/Bifrost** edge note.

## Invariants preserved (#1046)

- **Keys gateway-only** — `ANTHROPIC_API_KEY` lives in the `litellm` env, NEVER in the agent container. Optional (gateway works Ollama-only).
- **OpenFeature stays the control plane** — `agent.json` `model` selects the route; the gateway only maps route → provider.
- **Terminal fallback stays agent-side** — "no backend → rules" remains in the agent; a gateway outage ≠ agent outage.

## Validation

- `docker compose -f docker-compose.yml -f docker-compose.gateway.yml --profile gateway config` resolves cleanly (litellm + agent pointed at it).
- Default stack **excludes** the gateway (`config | grep -c joustmania-litellm` → `0`); dry-run stack unaffected.
- `config.yaml` + `gateway.yml` parse; image tag `v1.88.2` verified present in the registry; `ollama_chat/` prefix + `api_base` confirmed against LiteLLM docs.
- `make lint` passes.
- **Live gateway smoke deferred** — no host Ollama running / image not cached in this context. Static config validated; live `curl /v1/models` + `/chat/completions` is a follow-up.

No service image source touched (compose + config + docs only) → no `ci-full` needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)