### PR TITLE
fix(agent): practical-significance floor for experiment verdict (#1042)

### DIFF
--- a/services/agent/README.md
+++ b/services/agent/README.md
@@ -933,6 +933,8 @@ All configuration is via environment variables:
 | `AGENT_EXPERIMENT_DIR` | `/var/lib/joustmania/agent/experiments` | Durable experiment journal root (intent/events/summary per experiment); the registry rehydrates from it on startup |
 | `AGENT_VERDICT_MIN_N` | `8` | #979 min games per arm before a conclusive verdict (else inconclusive) |
 | `AGENT_VERDICT_EFFECT_THRESHOLD` | `0.5` | #979 minimum \|Cohen's d\| for a promote/discard verdict |
+| `AGENT_VERDICT_MIN_RAW_EFFECT` | `0.02` | #1042 practical-significance floor: minimum RAW effect (\|mean_d\| paired / \|mean_exp − mean_ctl\| two-arm) for a promote/discard. Below it ⇒ inconclusive regardless of how large the standardized d_z / Cohen's d is — stops near-deterministic shadow games promoting on a trivially-tiny but perfectly-consistent delta. 0.02 = 2% of the ~0..1 fitness range |
+| `AGENT_VERDICT_SD_FLOOR` | `0.0001` | #1042 minimum-SD floor (defense in depth): floors the d_z / Cohen's d denominator so the standardized stat stays finite when the spread collapses toward 0 (sd→0). 1e-4 is two orders below any real-play spread, so it never distorts a real-noise verdict |
 | `AGENT_EXPERIMENT_SEED_FLAG` | _unset_ | When set (and the loop is enabled), declares ONE env-seeded experiment at startup on this game.json flag — the simplest declaration trigger for the demo. Paired with `AGENT_EXPERIMENT_SEED_VALUE` / `_OBJECTIVE` / `_TARGET_N` / `_HYPOTHESIS` |
 | `AGENT_EXPERIMENT_SEED_VALUE` | _unset_ | The seed experiment's experimental value. Parsed as a number when it parses as a float, else bool for `true`/`false`, else the raw string. Its JSON kind must match the flag's existing variants (the Gate's type guard rejects a mistyped seed at the targeting write) |
 | `AGENT_EXPERIMENT_SEED_OBJECTIVE` | `balanced` | The seed experiment's fitness objective (`endurance` / `balanced` / `accelerate` / `chaos`) |
@@ -974,8 +976,9 @@ All configuration is via environment variables:
 > declarer knobs `AGENT_EXPERIMENT_DYNAMIC_CANDIDATES` / `_DENYLIST` — a top-level
 > flagd **LIST** flag hits a `get_object_value` `TYPE_MISMATCH` (only the in-process
 > resolver reads list flags; the agent uses the RPC resolver), so a list flag here
-> would be silently broken. `AGENT_VERDICT_EFFECT_THRESHOLD` also stays env for now
-> (it ties to the #1042 practical-significance floor; not part of this migration).
+> would be silently broken. `AGENT_VERDICT_EFFECT_THRESHOLD` and the #1042
+> practical-significance floors (`AGENT_VERDICT_MIN_RAW_EFFECT`,
+> `AGENT_VERDICT_SD_FLOOR`) also stay env for now (not part of this migration).
 
 > The Go agent uses the flagd **RPC** resolver (gRPC evaluation port `8013`),
 > not the in-process sync port `8015` that the Python services use.

--- a/services/agent/experiment/verdict.go
+++ b/services/agent/experiment/verdict.go
@@ -62,12 +62,43 @@ const (
 	// Below it the paired path is under-powered and the verdict falls back / stays
 	// inconclusive. Tune via AGENT_VERDICT_MIN_PAIRS.
 	DefaultMinPairs = 5
+
+	// DefaultMinRawEffect is the PRACTICAL-significance floor (#1042): the minimum RAW
+	// effect magnitude — |mean_d| (paired) or |mean_exp − mean_ctl| (two-arm) — a
+	// promote/discard verdict requires, regardless of how large the STANDARDIZED effect
+	// (d_z / Cohen's d) is. Below it the verdict is INCONCLUSIVE.
+	//
+	// WHY: on near-deterministic shadow games the per-pair difference is tiny but
+	// perfectly consistent, so sd(d)→0 and d_z = mean_d/sd(d) explodes (the dry-run saw
+	// d_z=-34 on a ~0.0004 fitness delta). Statistical significance ≠ practical
+	// significance: a tiny-but-consistent delta is not worth promoting/discarding on.
+	//
+	// VALUE 0.02 = 2% of the ~0..1 fitness range. Rationale: a fitness change smaller
+	// than 2% of the achievable range is below what we'd act on for a party game — it is
+	// in the don't-care band — while every genuinely meaningful effect in practice (and
+	// in the test suite, deltas ≥0.05) clears it comfortably. Tune via
+	// AGENT_VERDICT_MIN_RAW_EFFECT.
+	DefaultMinRawEffect = 0.02
+
+	// DefaultSDFloor is the minimum-standard-deviation floor (#1042, defense in depth):
+	// the denominator of d_z / Cohen's d is floored at this value so the standardized
+	// statistic stays finite and meaningful when the observed spread collapses toward 0
+	// (near-deterministic games). It does NOT replace the raw-effect floor above — it
+	// keeps d_z from reporting an absurd magnitude in the audit trail / logs.
+	//
+	// VALUE 1e-4: two orders of magnitude below any real-play spread (real per-game
+	// fitness noise is ~0.01+), so it never distorts a real-noise verdict — it only bites
+	// in the degenerate sd→0 regime, where the raw-effect floor is the real gate anyway.
+	// Tune via AGENT_VERDICT_SD_FLOOR.
+	DefaultSDFloor = 1e-4
 )
 
 const (
-	minNEnv     = "AGENT_VERDICT_MIN_N"
-	effectEnv   = "AGENT_VERDICT_EFFECT_THRESHOLD"
-	minPairsEnv = "AGENT_VERDICT_MIN_PAIRS"
+	minNEnv      = "AGENT_VERDICT_MIN_N"
+	effectEnv    = "AGENT_VERDICT_EFFECT_THRESHOLD"
+	minPairsEnv  = "AGENT_VERDICT_MIN_PAIRS"
+	minRawEffEnv = "AGENT_VERDICT_MIN_RAW_EFFECT"
+	sdFloorEnv   = "AGENT_VERDICT_SD_FLOOR"
 )
 
 // CohortStat is the swappable arm-comparison strategy (design §8.3). Given the two
@@ -90,14 +121,22 @@ type CohortStat interface {
 // POPULATION variance M2/Count). Population variance would under-state spread at
 // small N and inflate the effect size toward a premature verdict; the sample
 // (n−1) form is the conservative, correct choice here.
-type effectSizeGate struct{}
+type effectSizeGate struct {
+	// sdFloor floors the pooled SD denominator (#1042) so Cohen's d stays finite and
+	// bounded when the pooled spread collapses toward 0 (near-deterministic arms). A
+	// non-positive value means "no floor" (legacy behaviour — divide-by-zero is then
+	// guarded by the pooledSD==0 ⇒ ok=false branch).
+	sdFloor float64
+}
 
 // Effect computes Cohen's d = (mean_exp − mean_control) / pooledSD, using the
-// pooled UNBIASED sample variance. It returns ok=false when either arm has fewer
-// than 2 samples (sample variance undefined) or the pooled SD is zero (no spread —
-// the standardized effect is undefined / infinite, which the min-N gate handles
-// separately so we never divide by zero).
-func (effectSizeGate) Effect(experimental, control journal.Welford) (float64, bool) {
+// pooled UNBIASED sample variance. The pooled SD denominator is floored at sdFloor
+// (#1042) so a near-deterministic pair can't produce an absurd Cohen's d. It returns
+// ok=false only when either arm has fewer than 2 samples (sample variance undefined)
+// or the floored denominator is still zero (sdFloor not set AND pooled SD is exactly
+// 0 — no spread, the standardized effect is undefined, which the min-N gate and the
+// raw-effect floor handle separately so we never divide by zero).
+func (g effectSizeGate) Effect(experimental, control journal.Welford) (float64, bool) {
 	if experimental.Count < 2 || control.Count < 2 {
 		return 0, false
 	}
@@ -110,6 +149,10 @@ func (effectSizeGate) Effect(experimental, control journal.Welford) (float64, bo
 	dfCtl := float64(control.Count - 1)
 	pooledVar := (dfExp*varExp + dfCtl*varCtl) / (dfExp + dfCtl)
 	pooledSD := math.Sqrt(pooledVar)
+	// Floor the denominator (#1042) so Cohen's d can't explode when pooledSD→0.
+	if g.sdFloor > 0 && pooledSD < g.sdFloor {
+		pooledSD = g.sdFloor
+	}
 	if pooledSD == 0 {
 		return 0, false
 	}
@@ -138,6 +181,15 @@ type Verdict struct {
 	// effectThreshold is the minimum |effect| for a promote/discard verdict. It gates
 	// both the two-arm Cohen's d and the paired d_z (both are standardized effects).
 	effectThreshold float64
+	// minRawEffect is the PRACTICAL-significance floor (#1042): the minimum RAW effect
+	// magnitude (|mean_d| paired / |mean_exp − mean_ctl| two-arm) a promote/discard
+	// requires, on top of the standardized effectThreshold. Below it ⇒ INCONCLUSIVE no
+	// matter how large the standardized effect is. Construction-immutable.
+	minRawEffect float64
+	// sdFloor is the minimum-SD floor (#1042) applied to the d_z denominator in the
+	// paired path (the two-arm path's floor lives in effectSizeGate.sdFloor).
+	// Construction-immutable.
+	sdFloor float64
 	// stat is the swappable comparison strategy (default effectSizeGate).
 	stat CohortStat
 }
@@ -179,6 +231,20 @@ func NewVerdict(minN int, effectThreshold float64, stat CohortStat) *Verdict {
 // effectThreshold falls back to DefaultEffectThreshold; a nil stat falls back to the
 // default Cohen's d gate.
 func NewVerdictWithPairs(minN, minPairs int, effectThreshold float64, stat CohortStat) *Verdict {
+	return NewVerdictWithFloors(minN, minPairs, effectThreshold, DefaultMinRawEffect, DefaultSDFloor, stat)
+}
+
+// NewVerdictWithFloors is the full constructor (#1042): it adds the practical-
+// significance floors (minRawEffect, sdFloor) to the min-N / min-pairs / effect-
+// threshold gates. A non-positive minN/minPairs/effectThreshold falls back to its
+// default. A non-positive minRawEffect/sdFloor falls back to its default
+// (DefaultMinRawEffect / DefaultSDFloor) — pass the default explicitly to disable a
+// floor only by setting the env knob, never via a silent 0.
+//
+// When stat is nil the default Cohen's d gate is built WITH the resolved sdFloor so
+// the two-arm path is floored too; a caller-supplied stat is used verbatim (it owns
+// its own denominator handling).
+func NewVerdictWithFloors(minN, minPairs int, effectThreshold, minRawEffect, sdFloor float64, stat CohortStat) *Verdict {
 	if minN <= 0 {
 		minN = DefaultMinNPerArm
 	}
@@ -188,10 +254,23 @@ func NewVerdictWithPairs(minN, minPairs int, effectThreshold float64, stat Cohor
 	if effectThreshold <= 0 {
 		effectThreshold = DefaultEffectThreshold
 	}
-	if stat == nil {
-		stat = effectSizeGate{}
+	if minRawEffect <= 0 {
+		minRawEffect = DefaultMinRawEffect
 	}
-	return &Verdict{minN: minN, minPairs: minPairs, effectThreshold: effectThreshold, stat: stat}
+	if sdFloor <= 0 {
+		sdFloor = DefaultSDFloor
+	}
+	if stat == nil {
+		stat = effectSizeGate{sdFloor: sdFloor}
+	}
+	return &Verdict{
+		minN:            minN,
+		minPairs:        minPairs,
+		effectThreshold: effectThreshold,
+		minRawEffect:    minRawEffect,
+		sdFloor:         sdFloor,
+		stat:            stat,
+	}
 }
 
 // MinNFromEnv resolves the verdict min-N-per-arm gate from AGENT_VERDICT_MIN_N,
@@ -230,13 +309,23 @@ func MinPairsFromEnv() int {
 func NewVerdictFromEnv() *Verdict {
 	minN := MinNFromEnv()
 	minPairs := MinPairsFromEnv()
-	threshold := DefaultEffectThreshold
-	if v := strings.TrimSpace(os.Getenv(effectEnv)); v != "" {
+	threshold := floatFromEnv(effectEnv, DefaultEffectThreshold)
+	minRawEffect := floatFromEnv(minRawEffEnv, DefaultMinRawEffect)
+	sdFloor := floatFromEnv(sdFloorEnv, DefaultSDFloor)
+	// stat=nil so NewVerdictWithFloors builds the default gate WITH the resolved sdFloor.
+	return NewVerdictWithFloors(minN, minPairs, threshold, minRawEffect, sdFloor, nil)
+}
+
+// floatFromEnv resolves a positive float knob from env, falling back to def on an
+// unset, empty, non-numeric, or non-positive value (the same fail-safe convention
+// MinNFromEnv / the effectThreshold parse use).
+func floatFromEnv(key string, def float64) float64 {
+	if v := strings.TrimSpace(os.Getenv(key)); v != "" {
 		if f, err := strconv.ParseFloat(v, 64); err == nil && f > 0 {
-			threshold = f
+			return f
 		}
 	}
-	return NewVerdictWithPairs(minN, minPairs, threshold, effectSizeGate{})
+	return def
 }
 
 // Evaluate computes the current verdict for an experiment from its rolling
@@ -318,22 +407,35 @@ func (v *Verdict) Evaluate(s journal.Summary) (journal.Verdict, bool) {
 		}, true
 	}
 
+	// PRACTICAL-significance floor (#1042): even a large standardized effect must be
+	// backed by a raw mean difference worth acting on. A tiny-but-consistent delta
+	// (near-deterministic arms ⇒ huge Cohen's d on a meaningless gap) is INCONCLUSIVE.
+	if math.Abs(effect) >= v.effectThreshold && math.Abs(delta) < v.minRawEffect {
+		return journal.Verdict{
+			Outcome:     OutcomeInconclusive,
+			Delta:       delta,
+			Significant: false,
+			Reason: fmt.Sprintf("not practically significant: |delta|=%.4f < min_raw_effect=%.4f (effect=%.3f, n=%d/%d)",
+				math.Abs(delta), v.minRawEffect, effect, exp.Count, ctl.Count),
+		}, true
+	}
+
 	switch {
 	case effect >= v.effectThreshold:
 		return journal.Verdict{
 			Outcome:     CohortOutcomePromote,
 			Delta:       delta,
 			Significant: true,
-			Reason: fmt.Sprintf("experimental better: effect=%.3f >= threshold=%.2f (n=%d/%d)",
-				effect, v.effectThreshold, exp.Count, ctl.Count),
+			Reason: fmt.Sprintf("experimental better: effect=%.3f >= threshold=%.2f, |delta|=%.4f >= min_raw=%.4f (n=%d/%d)",
+				effect, v.effectThreshold, math.Abs(delta), v.minRawEffect, exp.Count, ctl.Count),
 		}, true
 	case effect <= -v.effectThreshold:
 		return journal.Verdict{
 			Outcome:     CohortOutcomeDiscard,
 			Delta:       delta,
 			Significant: true,
-			Reason: fmt.Sprintf("experimental worse: effect=%.3f <= -threshold=%.2f (n=%d/%d)",
-				effect, v.effectThreshold, exp.Count, ctl.Count),
+			Reason: fmt.Sprintf("experimental worse: effect=%.3f <= -threshold=%.2f, |delta|=%.4f >= min_raw=%.4f (n=%d/%d)",
+				effect, v.effectThreshold, math.Abs(delta), v.minRawEffect, exp.Count, ctl.Count),
 		}, true
 	default:
 		return journal.Verdict{
@@ -388,10 +490,18 @@ func (v *Verdict) evaluatePaired(pd journal.Welford, minPairs int) (journal.Verd
 		}, true
 	}
 	sdD := math.Sqrt(pd.M2 / float64(pd.Count-1))
+	// Minimum-SD floor (#1042, defense in depth): floor the d_z denominator so a
+	// near-deterministic pair set (sd→0) can't produce an absurd standardized effect.
+	// At sd=0 exactly this also replaces the old "zero spread ⇒ undefined" bail-out:
+	// the raw-effect floor below is now the gate that keeps a zero-spread no-op
+	// inconclusive, so a zero-spread set with a meaningful meanD can legitimately
+	// conclude (floored d_z is large AND |meanD| clears the practical floor).
+	if v.sdFloor > 0 && sdD < v.sdFloor {
+		sdD = v.sdFloor
+	}
 	if sdD == 0 {
-		// Zero spread across pairs — the per-pair difference is a constant. The
-		// standardized effect is undefined (the magnitude is in meanD, but with no
-		// spread there is no scale to standardize against), so treat it as no signal.
+		// Only reachable if the SD floor was disabled (sdFloor<=0) AND the spread is
+		// exactly 0. The standardized effect is undefined; treat as no signal.
 		return journal.Verdict{
 			Outcome:     OutcomeInconclusive,
 			Delta:       meanD,
@@ -402,22 +512,37 @@ func (v *Verdict) evaluatePaired(pd journal.Welford, minPairs int) (journal.Verd
 	}
 
 	dz := meanD / sdD
+
+	// PRACTICAL-significance floor (#1042): a tiny-but-consistent per-pair delta yields
+	// a huge d_z on near-deterministic shadow games (the dry-run's d_z=-34 on a ~0.0004
+	// fitness gap). Require |meanD| to clear the minimum meaningful delta before
+	// promote/discard, regardless of d_z magnitude — otherwise INCONCLUSIVE.
+	if math.Abs(dz) >= v.effectThreshold && math.Abs(meanD) < v.minRawEffect {
+		return journal.Verdict{
+			Outcome:     OutcomeInconclusive,
+			Delta:       meanD,
+			Significant: false,
+			Reason: fmt.Sprintf("paired not practically significant: |mean_d|=%.4f < min_raw_effect=%.4f (d_z=%.3f, pairs=%d)",
+				math.Abs(meanD), v.minRawEffect, dz, pd.Count),
+		}, true
+	}
+
 	switch {
 	case dz >= v.effectThreshold:
 		return journal.Verdict{
 			Outcome:     CohortOutcomePromote,
 			Delta:       meanD,
 			Significant: true,
-			Reason: fmt.Sprintf("paired: experimental better: d_z=%.3f >= threshold=%.2f (pairs=%d)",
-				dz, v.effectThreshold, pd.Count),
+			Reason: fmt.Sprintf("paired: experimental better: d_z=%.3f >= threshold=%.2f, |mean_d|=%.4f >= min_raw=%.4f (pairs=%d)",
+				dz, v.effectThreshold, math.Abs(meanD), v.minRawEffect, pd.Count),
 		}, true
 	case dz <= -v.effectThreshold:
 		return journal.Verdict{
 			Outcome:     CohortOutcomeDiscard,
 			Delta:       meanD,
 			Significant: true,
-			Reason: fmt.Sprintf("paired: experimental worse: d_z=%.3f <= -threshold=%.2f (pairs=%d)",
-				dz, v.effectThreshold, pd.Count),
+			Reason: fmt.Sprintf("paired: experimental worse: d_z=%.3f <= -threshold=%.2f, |mean_d|=%.4f >= min_raw=%.4f (pairs=%d)",
+				dz, v.effectThreshold, math.Abs(meanD), v.minRawEffect, pd.Count),
 		}, true
 	default:
 		return journal.Verdict{

--- a/services/agent/experiment/verdict_paired_test.go
+++ b/services/agent/experiment/verdict_paired_test.go
@@ -88,17 +88,54 @@ func TestPairedVerdict_NoOpFlagWithinNoise(t *testing.T) {
 	}
 }
 
-func TestPairedVerdict_ZeroSpreadUndefined(t *testing.T) {
+// TestPairedVerdict_ZeroSpreadMeaningfulDelta_SDFloor (#1042): every pair identical
+// (zero spread) but with a MEANINGFUL per-pair delta (0.20, well above the raw-effect
+// floor). The minimum-SD floor caps the denominator so d_z is large-but-finite (not
+// NaN/Inf), and because the raw effect clears the practical floor this is a legitimate
+// PROMOTE — the SD floor turns the old "undefined ⇒ inconclusive" bail-out into a sane
+// conclusion when the delta actually matters.
+func TestPairedVerdict_ZeroSpreadMeaningfulDelta_SDFloor(t *testing.T) {
 	v := NewVerdictWithPairs(8, 5, 0.5, nil)
-	// Every pair identical (zero spread): paired SD = 0 ⇒ effect undefined ⇒
-	// INCONCLUSIVE (no false promote despite a non-zero mean).
 	pd := pairDiffFrom(0.20, 0.20, 0.20, 0.20, 0.20, 0.20)
 	got, ok := v.Evaluate(pairedSummary(pd))
 	if !ok {
 		t.Fatalf("expected ok=true")
 	}
+	if got.Outcome != CohortOutcomePromote || !got.Significant {
+		t.Fatalf("verdict = %+v, want PROMOTE (meaningful delta, SD floored)", got)
+	}
+}
+
+// TestPairedVerdict_TinyConsistentDelta_NotPractical (#1042) is the EXACT dry-run
+// scenario: a tiny per-pair delta (~ -0.0005) that is perfectly consistent across
+// pairs. The SD collapses toward 0 so the standardized d_z is enormous (would be the
+// dry-run's d_z=-34), but |mean_d| is FAR below the practical-significance floor →
+// INCONCLUSIVE, NOT discard. This is the core bug fix.
+func TestPairedVerdict_TinyConsistentDelta_NotPractical(t *testing.T) {
+	v := NewVerdictWithPairs(8, 5, 0.5, nil)
+	// exp ~0.0496..0.0506 vs ctl ~0.0500..0.0510 ⇒ d_i ≈ -0.0004..-0.0006, tiny + consistent.
+	pd := pairDiffFrom(-0.0004, -0.0005, -0.0006, -0.0005, -0.0004, -0.0005)
+	got, ok := v.Evaluate(pairedSummary(pd))
+	if !ok {
+		t.Fatalf("expected ok=true")
+	}
 	if got.Outcome != OutcomeInconclusive || got.Significant {
-		t.Fatalf("verdict = %+v, want zero-spread INCONCLUSIVE", got)
+		t.Fatalf("verdict = %+v, want INCONCLUSIVE (tiny delta below raw-effect floor); the dry-run bug would DISCARD here", got)
+	}
+}
+
+// TestPairedVerdict_NoOpFlag_ZeroDelta_Inconclusive (#1042): a true no-op flag with
+// IDENTICAL fitness per pair ⇒ mean_d == 0 and zero spread. SD floored, but mean_d=0
+// is below the raw-effect floor ⇒ INCONCLUSIVE (never a false promote/discard).
+func TestPairedVerdict_NoOpFlag_ZeroDelta_Inconclusive(t *testing.T) {
+	v := NewVerdictWithPairs(8, 5, 0.5, nil)
+	pd := pairDiffFrom(0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+	got, ok := v.Evaluate(pairedSummary(pd))
+	if !ok {
+		t.Fatalf("expected ok=true")
+	}
+	if got.Outcome != OutcomeInconclusive || got.Significant {
+		t.Fatalf("verdict = %+v, want no-op INCONCLUSIVE", got)
 	}
 }
 

--- a/services/agent/experiment/verdict_test.go
+++ b/services/agent/experiment/verdict_test.go
@@ -271,13 +271,124 @@ func TestVerdictFromEnv(t *testing.T) {
 	}
 }
 
+// TestVerdictFromEnv_Floors (#1042): the practical-significance floor and SD floor are
+// configurable via AGENT_VERDICT_MIN_RAW_EFFECT / AGENT_VERDICT_SD_FLOOR, with
+// fallback to defaults on unset/invalid values.
+func TestVerdictFromEnv_Floors(t *testing.T) {
+	t.Setenv(minRawEffEnv, "0.05")
+	t.Setenv(sdFloorEnv, "0.001")
+	v := NewVerdictFromEnv()
+	if v.minRawEffect != 0.05 {
+		t.Fatalf("env minRawEffect = %v, want 0.05", v.minRawEffect)
+	}
+	if v.sdFloor != 0.001 {
+		t.Fatalf("env sdFloor = %v, want 0.001", v.sdFloor)
+	}
+	// The default gate must be built WITH the resolved sdFloor so the two-arm path is
+	// floored too.
+	g, ok := v.stat.(effectSizeGate)
+	if !ok {
+		t.Fatalf("default stat should be effectSizeGate, got %T", v.stat)
+	}
+	if g.sdFloor != 0.001 {
+		t.Fatalf("two-arm gate sdFloor = %v, want 0.001 (must inherit the env SD floor)", g.sdFloor)
+	}
+
+	// Invalid / non-positive fall back to defaults.
+	t.Setenv(minRawEffEnv, "garbage")
+	t.Setenv(sdFloorEnv, "-1")
+	v2 := NewVerdictFromEnv()
+	if v2.minRawEffect != DefaultMinRawEffect || v2.sdFloor != DefaultSDFloor {
+		t.Fatalf("invalid floor env should fall back to defaults, got rawEffect=%v sdFloor=%v",
+			v2.minRawEffect, v2.sdFloor)
+	}
+}
+
+// TestVerdict_TwoArm_TinyDelta_NotPractical (#1042) is the two-arm analog of the
+// dry-run bug: N met, a large standardized Cohen's d (tight spread), but a raw mean
+// delta FAR below the practical-significance floor ⇒ INCONCLUSIVE, not promote.
+func TestVerdict_TwoArm_TinyDelta_NotPractical(t *testing.T) {
+	v := NewVerdict(8, 0.5, nil)
+	// Means differ by only 0.005 (< 0.02 floor) but the spread is tiny (±0.0005), so
+	// Cohen's d is huge — exactly the trap the floor must catch.
+	exp := armFrom(spread(12, 0.5050, 0.0005)...)
+	ctl := armFrom(spread(12, 0.5000, 0.0005)...)
+
+	got, ok := v.Evaluate(summaryWith(exp, ctl))
+	if !ok {
+		t.Fatalf("expected ok=true")
+	}
+	if got.Outcome != OutcomeInconclusive || got.Significant {
+		t.Fatalf("two-arm tiny-delta verdict = %+v, want INCONCLUSIVE (raw-effect floor)", got)
+	}
+}
+
+// TestVerdict_TwoArm_MeaningfulDelta_TightSpread_Promote (#1042): a delta ABOVE the
+// raw-effect floor with a clear direction still promotes — the floor ADDS to, doesn't
+// replace, the effect-size test.
+func TestVerdict_TwoArm_MeaningfulDelta_TightSpread_Promote(t *testing.T) {
+	v := NewVerdict(8, 0.5, nil)
+	// Delta 0.10 (>> 0.02 floor), tight spread ⇒ large Cohen's d ⇒ PROMOTE.
+	exp := armFrom(spread(12, 0.60, 0.01)...)
+	ctl := armFrom(spread(12, 0.50, 0.01)...)
+
+	got, ok := v.Evaluate(summaryWith(exp, ctl))
+	if !ok {
+		t.Fatalf("expected ok=true")
+	}
+	if got.Outcome != CohortOutcomePromote || !got.Significant {
+		t.Fatalf("meaningful-delta verdict = %+v, want PROMOTE", got)
+	}
+}
+
+// TestVerdict_TwoArm_SDFloor_CapsCohenD (#1042): with the SD floor active, even a
+// pooled SD near 0 yields a finite Cohen's d (no Inf/NaN). The default gate inherits
+// DefaultSDFloor.
+func TestVerdict_TwoArm_SDFloor_CapsCohenD(t *testing.T) {
+	g := effectSizeGate{sdFloor: DefaultSDFloor}
+	// Near-zero spread, meaningful mean gap: without a floor Cohen's d would blow up.
+	exp := journal.Welford{}
+	ctl := journal.Welford{}
+	for _, s := range spread(10, 0.50, 1e-12) {
+		exp.Add(s)
+	}
+	for _, s := range spread(10, 0.40, 1e-12) {
+		ctl.Add(s)
+	}
+	effect, ok := g.Effect(exp, ctl)
+	if !ok {
+		t.Fatalf("expected ok=true with SD floor active")
+	}
+	if math.IsInf(effect, 0) || math.IsNaN(effect) {
+		t.Fatalf("Cohen's d = %v, want finite (SD floor must cap it)", effect)
+	}
+	// delta 0.10 / sdFloor 1e-4 = 1000 — large but finite.
+	if effect < 100 {
+		t.Fatalf("expected a large (floored) effect, got %v", effect)
+	}
+}
+
+// TestVerdict_DefaultsIncludeFloors (#1042): the default constructor wires the floors.
+func TestVerdict_DefaultsIncludeFloors(t *testing.T) {
+	v := NewVerdict(8, 0.5, nil)
+	if v.minRawEffect != DefaultMinRawEffect {
+		t.Fatalf("minRawEffect = %v, want default %v", v.minRawEffect, DefaultMinRawEffect)
+	}
+	if v.sdFloor != DefaultSDFloor {
+		t.Fatalf("sdFloor = %v, want default %v", v.sdFloor, DefaultSDFloor)
+	}
+}
+
 // TestVerdict_SwappableStrategy verifies a custom CohortStat replaces the gate
 // without touching the seam — the design's swappability requirement (§8.3).
 func TestVerdict_SwappableStrategy(t *testing.T) {
 	// A stub strategy that always reports a large positive effect, ignoring the
 	// actual stats — stands in for a future Welch / non-parametric test.
 	v := NewVerdict(2, 0.5, constantStat{effect: 5.0, ok: true})
-	exp := armFrom(0.5, 0.5, 0.5) // identical samples — default gate would be inconclusive
+	// The arms carry a clear raw mean difference (0.8 vs 0.5) so the #1042 practical-
+	// significance floor passes; the point is that the SWAPPABLE strategy's reported
+	// effect (5.0) — not the default Cohen's d — drives the promote.
+	exp := armFrom(0.8, 0.8, 0.8)
 	ctl := armFrom(0.5, 0.5, 0.5)
 
 	got, ok := v.Evaluate(summaryWith(exp, ctl))


### PR DESCRIPTION
## What

Adds a **practical-significance floor** to the experiment verdict so it stops declaring trivially-tiny effects "hugely significant" on near-deterministic shadow games.

### The bug (2026-06-14 dry-run)
A seeded endurance experiment concluded `discard (paired: experimental worse: d_z=-34.495 <= -threshold=0.50 (pairs=5))` on fitnesses all ~0.050 (exp ~0.0496–0.0506 vs ctl ~0.0500–0.0510). The direction was right but `d_z=-34` is absurd: mock shadow games are near-deterministic, so the per-pair difference is tiny **and perfectly consistent** → `sd(d)→0` → `d_z = mean(d)/sd(d)` explodes. Statistical significance ≠ practical significance.

## Fix

Two floors, applied to **both** the paired (`d_z`) and two-arm (Cohen's d) decision paths:

1. **Minimum raw effect** (`AGENT_VERDICT_MIN_RAW_EFFECT`, default **0.02**): a promote/discard requires the RAW effect magnitude — `|mean_d|` (paired) / `|mean_exp − mean_ctl|` (two-arm) — to exceed the floor, regardless of how large the standardized effect is. Below it → INCONCLUSIVE. Default 0.02 = 2% of the ~0..1 fitness range — below this we genuinely don't care for a party game, and every meaningful effect in practice (and in the suite, deltas ≥0.05) clears it comfortably.
2. **Minimum-SD floor** (`AGENT_VERDICT_SD_FLOOR`, default **1e-4**, defense in depth): floors the `d_z` / Cohen's d denominator so the standardized stat stays finite when `sd→0`. 1e-4 is two orders below any real-play spread (~0.01+), so it never distorts a real-noise verdict.

Both knobs are env-configurable, mirroring `AGENT_VERDICT_EFFECT_THRESHOLD`. The existing min-N / min-pairs gating + direction logic are unchanged — the floor **adds** to the effect-size test. The default two-arm Cohen's d gate inherits the SD floor.

## Tests

- Tiny-but-consistent delta (huge `d_z`, `|mean_d|` below the floor) → INCONCLUSIVE — the exact dry-run scenario (paired + two-arm).
- Meaningful delta with clear direction → promote/discard.
- `sd≈0` capped → finite `d_z`, no Inf/NaN; no-op flag (identical fitness) → inconclusive.
- New env-floor configurability + default-wiring tests.
- Updated two now-intentionally-flipped tests: the obsolete zero-spread-"undefined" paired test (a zero-spread set with a *meaningful* delta now legitimately concludes via the SD floor), and the swappable-strategy test (gave it a real raw delta so the floor passes — strategy swap still verified).

`go test ./... -race`, `go vet ./...`, `gofmt -l .`, `make lint` all green.

Part of #1042

🤖 Generated with [Claude Code](https://claude.com/claude-code)