### PR TITLE
feat(agent): wire autonomous-promotion safety net (watch real games -> auto-revert on degradation) (#1016)

### DIFF
--- a/services/agent/experiment_loop_test.go
+++ b/services/agent/experiment_loop_test.go
@@ -100,6 +100,14 @@ func (r *recordingRealDefault) count() int {
 	return len(r.calls)
 }
 
+// loopWatcher is a non-degrading autonomous safety-net Watcher (#1016): autonomous
+// now FAILS CLOSED without a Watcher wired, so these end-to-end loop tests must wire
+// one for the real-default write path to be reachable. It reports "not degraded" so
+// a promoted change is kept (the gating-and-keep path these tests assert).
+type loopWatcher struct{}
+
+func (loopWatcher) Degraded(context.Context, string, float64) (bool, error) { return false, nil }
+
 // recordingGitHub records OpenIssue/OpenPR so a test can assert the safe (issue)
 // path was taken instead of a real-default mutation.
 type recordingGitHub struct {
@@ -166,7 +174,9 @@ func buildLoopForTest(
 	gate := experiment.NewGate(writer, nil, log)
 	targeting := experiment.NewGateTargetingWriter(gate, writer)
 
-	base := promote.NewPromoter(github, nil, realDef, nil, nil, promote.RepoRef{}, nil, log)
+	// #1016: autonomous fails closed without a Watcher, so wire a non-degrading one
+	// (the safety net) for the real-default write path to be reachable in these tests.
+	base := promote.NewPromoter(github, nil, realDef, loopWatcher{}, nil, promote.RepoRef{}, nil, log)
 	promo := promote.NewExperimentPromoter(base, resolveConfig)
 
 	// Low min-N so a handful of conclusions reaches a conclusive verdict; effect

--- a/services/agent/main.go
+++ b/services/agent/main.go
@@ -187,8 +187,16 @@ func rolloutActuator(logger *slog.Logger) decision.RolloutActuator {
 // Promote on a validated experiment is the documented follow-up (the proposer is
 // #931, parallel; the SyntheticRunner/Watcher live wiring reuses M7-7's seams where
 // merged). buildPromoter wires the env-gated promotion SURFACE; the autonomous
-// watch+revert seams (Watcher/RealDefaultReverter) are nil until that live
-// measurement is wired, so autonomous applies-and-records without a watch for now.
+// watch+revert seams (Watcher/RealDefaultReverter) are nil until the live real-game
+// fitness source (promote.RealGameFitness, reading the #731 evaluator / gamewindow)
+// is wired.
+//
+// FAIL-CLOSED (#1016): with the Watcher nil, autonomous now REFUSES to apply to the
+// real default (a hard stop), rather than applying without a safety net. So an
+// operator who flips mode=autonomous before the live watch is wired gets a recorded
+// no-op (OutcomeDiscarded), NOT an unguarded real-default change. Building the
+// real RealGameFitness source + NewFitnessWatcher here is the live-verify follow-up;
+// the watch→degradation→revert WIRING + decision logic ships + is unit-tested now.
 func buildPromoter(logger *slog.Logger) *promote.Promoter {
 	// Resolve the target for client construction from the ENV (AGENT_CODE_IMPROVEMENT_TARGET),
 	// distinct from the LIVE flag (code_improvement.target) that Promote dispatches on.
@@ -238,8 +246,10 @@ func buildPromoter(logger *slog.Logger) *promote.Promoter {
 		Base:  getEnv("GITHUB_BASE_BRANCH", "main"),
 	}
 	// Watcher + RealDefaultReverter (autonomous live watch+revert) reuse M7-7's
-	// fitness measurement seams; they are nil until that live wiring lands, so
-	// autonomous applies+records without a watch (documented follow-up).
+	// fitness measurement seams; they are nil until the live real-game fitness source
+	// is wired. Per #1016 a nil Watcher makes autonomous FAIL CLOSED (refuse to apply
+	// to the real default), so this is safe: autonomous degrades to a recorded no-op
+	// rather than an unguarded real change until the safety net is connected.
 	return promote.NewPromoter(ghIface, gitIface, realDefIface, nil, nil, repo, nil, logger)
 }
 

--- a/services/agent/promote/actions.go
+++ b/services/agent/promote/actions.go
@@ -90,10 +90,15 @@ func (pr *Promoter) promotePR(ctx context.Context, p experiment.Proposal, ev Evi
 //     RealDefaultWriter — explicitly NOT the shadow experiment.Writer (which is
 //     structurally shadow-only). A nil RealDefaultWriter (real path not wired) → a
 //     recorded no-op; the shadow Writer is never reused to sneak a real change.
-//   - WATCH + REVERT: after applying, the Watcher observes real games; on
-//     degradation the RealDefaultReverter rolls the real default back (reusing M7-7's
-//     watch/revert seams where wired). A nil Watcher means no live watch is wired yet
-//     (documented follow-up) — applied without a watch.
+//   - WATCH + REVERT: after applying, the Watcher observes real-game fitness for a
+//     window; on degradation vs the pre-promotion baseline the RealDefaultReverter
+//     rolls the real default back (the OutcomeRevert path, reusing M7-7's
+//     watch/revert seams).
+//   - FAIL CLOSED WITHOUT A WATCH (#1016): a nil Watcher is a HARD STOP, NOT an
+//     apply-without-watch. An unguarded autonomous promotion (apply to real players
+//     with no auto-revert) is the unacceptable state, so we REFUSE to apply when no
+//     Watcher is wired — checked BEFORE the real-default write, so nothing is ever
+//     written without a connected safety net.
 func (pr *Promoter) promoteAutonomous(ctx context.Context, p experiment.Proposal, cfg Config, ev Evidence, res *Result) {
 	if !cfg.Enabled {
 		res.Outcome = OutcomeDiscarded
@@ -105,6 +110,14 @@ func (pr *Promoter) promoteAutonomous(ctx context.Context, p experiment.Proposal
 		res.Reason = "autonomous requested but no real-default writer wired; real default not changed"
 		return
 	}
+	// FAIL CLOSED (#1016): no safety net → refuse to apply. Checked BEFORE the write
+	// so an autonomous promotion can NEVER touch the real default without a
+	// watch→auto-revert loop connected behind it.
+	if pr.watcher == nil {
+		res.Outcome = OutcomeDiscarded
+		res.Reason = "autonomous requested but no watch/auto-revert wired; refusing to apply to real default without a safety net (#1016)"
+		return
+	}
 
 	// The one sanctioned real-player-affecting write, through the gated seam.
 	if err := pr.realDef.SetRealDefault(ctx, p.FlagKey, ev.RealDefaultValue); err != nil {
@@ -114,13 +127,9 @@ func (pr *Promoter) promoteAutonomous(ctx context.Context, p experiment.Proposal
 	}
 	res.Outcome = OutcomeApplied
 
-	// No live watch wired yet: apply and record. The watch+revert wiring reuses
-	// M7-7's Validator/Reverter seams and is the documented follow-up (main.go).
-	if pr.watcher == nil {
-		return
-	}
-
-	degraded, err := pr.watcher.Degraded(ctx, p.FlagKey)
+	// Watch real-game fitness for the promoted flag's objective and auto-revert on
+	// degradation vs the pre-promotion baseline (Evidence.FitnessBefore).
+	degraded, err := pr.watcher.Degraded(ctx, p.FlagKey, ev.FitnessBefore)
 	// An error means we cannot CONFIRM the change is healthy; fail safe by treating
 	// it as a degradation so a real-player change is rolled back rather than left
 	// unverified.

--- a/services/agent/promote/promote.go
+++ b/services/agent/promote/promote.go
@@ -235,15 +235,22 @@ type RealDefaultWriter interface {
 }
 
 // Watcher observes real games after an autonomous real-default change and reports
-// whether fitness DEGRADED (so the change should be reverted). It reuses M7-7's
-// fitness measurement seam where wired; a nil Watcher means "no live watch wired
-// yet" — autonomous applies and records OutcomeApplied without a watch (the live
-// watch+revert wiring is the documented follow-up; see main.go).
+// whether fitness DEGRADED vs the pre-promotion baseline (so the change should be
+// reverted). It reuses M7-7's fitness measurement seam where wired.
+//
+// FAIL-CLOSED CONTRACT (#1016): a nil Watcher is NOT "apply without a watch" — it
+// is a HARD STOP. An autonomous real-default change with no safety net wired is the
+// single most dangerous state in the loop (apply to real players with no
+// auto-revert), so promoteAutonomous REFUSES to apply when the Watcher is nil
+// rather than applying unguarded. A safety net that is not connected blocks the
+// action; it is never silently skipped.
 type Watcher interface {
-	// Degraded reports whether real-game fitness degraded after the change (true →
-	// the Promoter reverts via RealDefaultReverter). An error is treated as "cannot
-	// confirm healthy" → fail-safe revert.
-	Degraded(ctx context.Context, flagKey string) (bool, error)
+	// Degraded reports whether real-game fitness degraded vs baseline after the
+	// change (true → the Promoter reverts via RealDefaultReverter). baseline is the
+	// pre-promotion real-game fitness (Evidence.FitnessBefore) the recent window is
+	// compared against. An error is treated as "cannot confirm healthy" → fail-safe
+	// revert.
+	Degraded(ctx context.Context, flagKey string, baseline float64) (bool, error)
 }
 
 // RealDefaultReverter rolls back an autonomous real-default change on degradation.
@@ -263,7 +270,7 @@ type Promoter struct {
 	github   GitHubClient        // wire boundary; recording fake in tests, env-gated real client in main.go
 	git      GitClient           // local-target commit; temp git repo in tests
 	realDef  RealDefaultWriter   // autonomous real-default mutation (nil = not wired)
-	watcher  Watcher             // autonomous live watch (nil = not wired; applies without watch)
+	watcher  Watcher             // autonomous live watch (nil = HARD STOP: autonomous refuses to apply, #1016)
 	reverter RealDefaultReverter // autonomous degradation rollback (nil = not wired)
 	repo     RepoRef             // owner/name/base used to build issue/PR/commit requests
 	tracer   trace.Tracer

--- a/services/agent/promote/promote_test.go
+++ b/services/agent/promote/promote_test.go
@@ -79,7 +79,26 @@ type fakeWatcher struct {
 	err      error
 }
 
-func (w fakeWatcher) Degraded(context.Context, string) (bool, error) { return w.degraded, w.err }
+func (w fakeWatcher) Degraded(context.Context, string, float64) (bool, error) {
+	return w.degraded, w.err
+}
+
+// baselineRecordingWatcher records the baseline + flag it was asked to judge, so a
+// test can assert the Promoter threads Evidence.FitnessBefore through to the watch.
+type baselineRecordingWatcher struct {
+	calls        int
+	lastBaseline float64
+	lastFlag     string
+	degraded     bool
+	err          error
+}
+
+func (w *baselineRecordingWatcher) Degraded(_ context.Context, flag string, baseline float64) (bool, error) {
+	w.calls++
+	w.lastFlag = flag
+	w.lastBaseline = baseline
+	return w.degraded, w.err
+}
 
 // recordingReverter records real-default reverts.
 type recordingReverter struct {
@@ -264,10 +283,12 @@ func TestPromotePRModeLocal(t *testing.T) {
 }
 
 // --- mode=autonomous: applies to the REAL default (separate writer), outcome
-// applied; a degradation reverts. ---
+// applied when the watch holds (no degradation); a degradation reverts. A Watcher
+// MUST be wired (the safety net) — see TestPromoteAutonomousFailsClosedWithoutWatcher. ---
 func TestPromoteAutonomousApplied(t *testing.T) {
 	realDef := &recordingRealDefault{}
-	p, rec := promoterWithRecorder(t, &recordingGitHub{}, &recordingGit{}, realDef, nil, nil)
+	// A wired, non-degrading watcher is the safety net that lets the apply stand.
+	p, rec := promoterWithRecorder(t, &recordingGitHub{}, &recordingGit{}, realDef, fakeWatcher{degraded: false}, &recordingReverter{})
 
 	res := p.Promote(context.Background(), promoteProposal, promoteVerdict,
 		Config{Mode: ModeAutonomous, Target: TargetLocal, Enabled: true}, testEvidence())
@@ -320,6 +341,57 @@ func TestPromoteAutonomousRevertsOnUnconfirmableWatch(t *testing.T) {
 	}
 	if rev.calls != 1 {
 		t.Errorf("RevertRealDefault calls = %d, want 1", rev.calls)
+	}
+}
+
+// --- FAIL CLOSED (#1016): autonomous with NO Watcher REFUSES to apply. This is the
+// key safety assertion: an unguarded autonomous promotion (apply to real players
+// with no auto-revert) is the unacceptable state, so a nil Watcher is a HARD STOP —
+// nothing is written to the real default. This test would FAIL if the apply path
+// reverted to the old "apply without a watch" behaviour. ---
+func TestPromoteAutonomousFailsClosedWithoutWatcher(t *testing.T) {
+	realDef := &recordingRealDefault{}
+	rev := &recordingReverter{}
+	// realDef + reverter wired, but NO Watcher (the safety net is not connected).
+	p, _ := promoterWithRecorder(t, &recordingGitHub{}, &recordingGit{}, realDef, nil, rev)
+
+	res := p.Promote(context.Background(), promoteProposal, promoteVerdict,
+		Config{Mode: ModeAutonomous, Target: TargetLocal, Enabled: true}, testEvidence())
+
+	if res.Outcome != OutcomeDiscarded {
+		t.Fatalf("outcome = %q, want discarded (no watcher → fail closed)", res.Outcome)
+	}
+	if len(realDef.calls) != 0 {
+		t.Fatalf("SAFETY: autonomous applied to the real default %d time(s) with NO watch wired", len(realDef.calls))
+	}
+	if rev.calls != 0 {
+		t.Errorf("nothing was applied, so nothing should be reverted: revert calls = %d", rev.calls)
+	}
+	if !strings.Contains(res.Reason, "safety net") {
+		t.Errorf("reason = %q, want it to name the missing safety net", res.Reason)
+	}
+}
+
+// --- the watcher receives the pre-promotion baseline (Evidence.FitnessBefore) so it
+// can compare recent real-game fitness against what the promotion was justified by. ---
+func TestPromoteAutonomousPassesBaselineToWatcher(t *testing.T) {
+	realDef := &recordingRealDefault{}
+	bw := &baselineRecordingWatcher{}
+	p, _ := promoterWithRecorder(t, &recordingGitHub{}, &recordingGit{}, realDef, bw, &recordingReverter{})
+
+	ev := testEvidence()
+	ev.FitnessBefore = 0.61
+	p.Promote(context.Background(), promoteProposal, promoteVerdict,
+		Config{Mode: ModeAutonomous, Target: TargetLocal, Enabled: true}, ev)
+
+	if bw.calls != 1 {
+		t.Fatalf("watcher Degraded calls = %d, want 1", bw.calls)
+	}
+	if bw.lastBaseline != 0.61 {
+		t.Errorf("watcher baseline = %v, want 0.61 (Evidence.FitnessBefore)", bw.lastBaseline)
+	}
+	if bw.lastFlag != promoteProposal.FlagKey {
+		t.Errorf("watcher flag = %q, want %q", bw.lastFlag, promoteProposal.FlagKey)
 	}
 }
 

--- a/services/agent/promote/watcher.go
+++ b/services/agent/promote/watcher.go
@@ -1,0 +1,203 @@
+package promote
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+)
+
+// watcher.go is the autonomous-promotion SAFETY NET (#1016): after promoteAutonomous
+// applies a validated change to the REAL default, the fitnessWatcher observes
+// real-game fitness for a window and reports DEGRADATION vs the pre-promotion
+// baseline, so the Promoter can auto-revert (the OutcomeRevert path) before a
+// regression rides on real players for long.
+//
+// WHY THIS IS THE CRITICAL GATE (#1016): promoting to real players with no
+// auto-revert is the single most dangerous gap in the loop. Today it is masked only
+// because autonomous is default-off, env-gated, kill-switched, and a human merges —
+// none of which survive going lights-out. This watcher is what makes an autonomous
+// apply self-correcting: it watches the SAME real-game fitness signal the agent
+// already aggregates (#731 / gamewindow), compares a recent window to the baseline
+// the promotion was justified against, and trips the revert when fitness drops below
+// baseline by a margin over a minimum number of real games (so one unlucky game
+// never reverts a good change).
+//
+// SEAM SPLIT (mirrors the Validator / RealDefaultWriter): the watcher owns ONLY the
+// degradation-decision logic. Reading real-game fitness is the injected
+// RealGameFitness seam — a fake in tests (no real games exist there), the #731
+// evaluator / gamewindow in production (a documented follow-up to wire; see
+// RealGameFitness). The promote package stays free of an OpenFeature / coordinator
+// dependency.
+
+// WatchPolicy is the degradation policy the fitnessWatcher judges by. All thresholds
+// are configurable; DefaultWatchPolicy supplies sane defaults so a fully-wired
+// autonomous path has a safety net without per-call tuning.
+type WatchPolicy struct {
+	// MinGames is the minimum number of real-game fitness samples that must be
+	// observed before any degradation verdict is rendered. Below this, the watcher
+	// has too little evidence to revert on — it must NOT revert a good change on one
+	// unlucky game. Default DefaultMinGames. Clamped to >= 1 by the watcher.
+	MinGames int
+	// DegradationMargin is how far recent real-game fitness must fall BELOW the
+	// pre-promotion baseline (baseline - recentMean > margin) to count as a
+	// degradation. A small positive margin absorbs ordinary game-to-game noise so the
+	// watcher reverts on a genuine regression, not on jitter at the baseline. Default
+	// DefaultDegradationMargin.
+	DegradationMargin float64
+	// WindowGames is how many of the MOST RECENT real-game fitness samples the recent
+	// mean is computed over (the observation window). The watcher asks the
+	// RealGameFitness seam for up to this many samples. Default DefaultWindowGames.
+	// Clamped to >= MinGames by the watcher (the window can never be smaller than the
+	// evidence floor).
+	WindowGames int
+}
+
+// Degradation policy defaults (#1016). Conservative: require several real games and
+// a clear margin below baseline before reverting, so the safety net trips on a real
+// regression rather than on noise, while still catching a degradation within a small
+// number of real games rather than letting it ride.
+const (
+	// DefaultMinGames is the default minimum real games before a verdict: enough that
+	// one unlucky game cannot trigger a revert.
+	DefaultMinGames = 3
+	// DefaultDegradationMargin is the default fitness drop (in the 0..1 fitness space
+	// the #731 evaluator produces) below baseline that counts as degradation. 0.05 is
+	// a clear, beyond-noise regression while staying sensitive.
+	DefaultDegradationMargin = 0.05
+	// DefaultWindowGames is the default observation window: the most recent real games
+	// the recent mean is averaged over.
+	DefaultWindowGames = 5
+)
+
+// normalize fills zero/invalid fields with the defaults and enforces the invariants
+// (MinGames >= 1, WindowGames >= MinGames, margin >= 0). Returns a sanitized copy so
+// the watcher always judges by a coherent policy even from a partially-set struct.
+func (p WatchPolicy) normalize() WatchPolicy {
+	if p.MinGames <= 0 {
+		p.MinGames = DefaultMinGames
+	}
+	if p.DegradationMargin < 0 {
+		p.DegradationMargin = DefaultDegradationMargin
+	}
+	if p.DegradationMargin == 0 {
+		// A zero margin is almost certainly an unset field, not a deliberate
+		// "revert on any drop below baseline"; use the noise-absorbing default.
+		p.DegradationMargin = DefaultDegradationMargin
+	}
+	if p.WindowGames < p.MinGames {
+		p.WindowGames = p.MinGames
+	}
+	if p.WindowGames < DefaultWindowGames {
+		// Keep the window at least the default unless explicitly larger via MinGames.
+		if DefaultWindowGames >= p.MinGames {
+			p.WindowGames = DefaultWindowGames
+		}
+	}
+	return p
+}
+
+// RealGameFitness reads recent REAL-game fitness for the promoted flag's objective —
+// the signal the watcher judges degradation against. It is injected so the watcher's
+// degradation logic is unit-testable with fixed samples (no real games exist in a
+// test).
+//
+// PRODUCTION FOLLOW-UP (not built here, #1016 notes live-verify as a follow-up): the
+// real implementation reads the fitness of recent REAL (game_kind == "real") games
+// AFTER the promotion from the #731 fitness evaluator / the gamewindow rolling
+// window — the same recent-real-game fitness the agent already aggregates — filtered
+// to the objective(s) the promoted flag serves, newest-first or newest-last is fine
+// (the watcher only averages). An error fails the watch closed (treated as "cannot
+// confirm healthy" → revert).
+type RealGameFitness interface {
+	// Recent returns up to n most-recent REAL-game fitness samples observed AFTER the
+	// promotion for flagKey's objective. Fewer than n is allowed (the window has not
+	// filled yet); the watcher applies the MinGames floor. An error fails closed.
+	Recent(ctx context.Context, flagKey string, n int) ([]float64, error)
+}
+
+// fitnessWatcher is the concrete Watcher: it pulls recent real-game fitness via the
+// RealGameFitness seam and decides degradation by the WatchPolicy against the
+// pre-promotion baseline.
+type fitnessWatcher struct {
+	fitness RealGameFitness
+	policy  WatchPolicy
+	log     *slog.Logger
+}
+
+// NewFitnessWatcher builds the autonomous safety-net Watcher over a RealGameFitness
+// source and a degradation policy. A zero-value policy yields the defaults
+// (DefaultWatchPolicy). fitness MUST be non-nil — a watcher with no fitness source
+// could not observe real games, which would defeat the whole point of the fail-closed
+// guard; the caller (main.go) builds the real source behind the env gate or wires no
+// Watcher at all (then autonomous fails closed and refuses to apply). log nil uses
+// slog.Default().
+func NewFitnessWatcher(fitness RealGameFitness, policy WatchPolicy, log *slog.Logger) *fitnessWatcher {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &fitnessWatcher{fitness: fitness, policy: policy.normalize(), log: log}
+}
+
+// DefaultWatchPolicy returns the default degradation policy (#1016 sane defaults).
+func DefaultWatchPolicy() WatchPolicy {
+	return WatchPolicy{
+		MinGames:          DefaultMinGames,
+		DegradationMargin: DefaultDegradationMargin,
+		WindowGames:       DefaultWindowGames,
+	}
+}
+
+// Degraded reports whether real-game fitness degraded vs baseline after the
+// autonomous apply. The decision:
+//
+//  1. read up to WindowGames recent real-game fitness samples (seam error → fail
+//     closed: treat as degraded so an unconfirmable change is reverted);
+//  2. require at least MinGames samples — fewer is INSUFFICIENT EVIDENCE, so we
+//     return (false, nil): NOT a revert, but also not a confirmed-healthy keep on
+//     too little data. (The Promoter keeps the apply in that case; a real follow-up
+//     re-watches as more games complete. We do not revert a change on one unlucky
+//     game.);
+//  3. compute the recent mean and declare degradation when
+//     baseline - recentMean > DegradationMargin.
+func (w *fitnessWatcher) Degraded(ctx context.Context, flagKey string, baseline float64) (bool, error) {
+	samples, err := w.fitness.Recent(ctx, flagKey, w.policy.WindowGames)
+	if err != nil {
+		// Cannot read real-game fitness → cannot confirm healthy. Surface the error so
+		// the Promoter's fail-safe revert fires (it treats err != nil as a revert).
+		return false, fmt.Errorf("read recent real-game fitness for %q: %w", flagKey, err)
+	}
+	if len(samples) < w.policy.MinGames {
+		// Not enough real games yet to judge. Do NOT revert (one/few games is not
+		// evidence of degradation), and do NOT error (the read succeeded). The apply
+		// stands; degradation can only be CONFIRMED with MinGames of evidence.
+		w.log.Info("autonomous watch: insufficient real games to judge degradation",
+			"flag", flagKey, "samples", len(samples), "min_games", w.policy.MinGames)
+		return false, nil
+	}
+
+	recent := mean(samples)
+	drop := baseline - recent
+	degraded := drop > w.policy.DegradationMargin
+	w.log.Info("autonomous watch: real-game fitness judged",
+		"flag", flagKey,
+		"baseline", baseline,
+		"recent_mean", recent,
+		"drop", drop,
+		"margin", w.policy.DegradationMargin,
+		"games", len(samples),
+		"degraded", degraded)
+	return degraded, nil
+}
+
+// mean returns the arithmetic mean of a non-empty slice (callers guard len via
+// MinGames, but guard against an empty slice to avoid a divide-by-zero).
+func mean(xs []float64) float64 {
+	if len(xs) == 0 {
+		return 0
+	}
+	var sum float64
+	for _, x := range xs {
+		sum += x
+	}
+	return sum / float64(len(xs))
+}

--- a/services/agent/promote/watcher_test.go
+++ b/services/agent/promote/watcher_test.go
@@ -1,0 +1,162 @@
+package promote
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/joustmania/agent/experiment"
+)
+
+// watcher_test.go proves the autonomous safety net's decision logic (#1016): given
+// FAKE real-game telemetry (no real games exist in a unit test), the fitnessWatcher
+// declares degradation per the WatchPolicy, and the Promoter auto-reverts a
+// regressing autonomous promotion (OutcomeRevert) while keeping one that holds.
+
+// fakeRealGameFitness returns canned recent real-game fitness samples (or an error)
+// for the watcher to judge — the unit-test stand-in for the #731 evaluator /
+// gamewindow source.
+type fakeRealGameFitness struct {
+	samples []float64
+	err     error
+}
+
+func (f fakeRealGameFitness) Recent(_ context.Context, _ string, n int) ([]float64, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	if n < len(f.samples) {
+		return f.samples[:n], nil
+	}
+	return f.samples, nil
+}
+
+func TestFitnessWatcherDegradationVerdict(t *testing.T) {
+	policy := WatchPolicy{MinGames: 3, DegradationMargin: 0.05, WindowGames: 5}
+	const baseline = 0.70
+
+	cases := []struct {
+		name    string
+		samples []float64
+		fitErr  error
+		wantDeg bool
+		wantErr bool
+	}{
+		{
+			name:    "clear regression below baseline-margin reverts",
+			samples: []float64{0.50, 0.52, 0.48, 0.51}, // mean ~0.5025, drop ~0.20 > 0.05
+			wantDeg: true,
+		},
+		{
+			name:    "fitness holds at baseline is kept",
+			samples: []float64{0.70, 0.71, 0.69, 0.70},
+			wantDeg: false,
+		},
+		{
+			name:    "fitness improves is kept",
+			samples: []float64{0.80, 0.82, 0.78},
+			wantDeg: false,
+		},
+		{
+			name:    "drop within margin (noise) is kept",
+			samples: []float64{0.68, 0.67, 0.69}, // mean ~0.68, drop ~0.02 <= 0.05
+			wantDeg: false,
+		},
+		{
+			name:    "insufficient games does not revert (no false positive on one unlucky game)",
+			samples: []float64{0.10, 0.10}, // terrible but only 2 < MinGames(3)
+			wantDeg: false,
+		},
+		{
+			name:    "telemetry error fails closed (error surfaced for fail-safe revert)",
+			fitErr:  errors.New("telemetry unreachable"),
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := NewFitnessWatcher(fakeRealGameFitness{samples: tc.samples, err: tc.fitErr}, policy, discardLogger())
+			deg, err := w.Degraded(context.Background(), "death_grace_period_ms", baseline)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("Degraded err = nil, want an error (fail closed)")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Degraded err = %v, want nil", err)
+			}
+			if deg != tc.wantDeg {
+				t.Errorf("Degraded = %v, want %v", deg, tc.wantDeg)
+			}
+		})
+	}
+}
+
+func TestWatchPolicyNormalizeDefaults(t *testing.T) {
+	got := WatchPolicy{}.normalize()
+	want := DefaultWatchPolicy()
+	if got.MinGames != want.MinGames || got.DegradationMargin != want.DegradationMargin || got.WindowGames != want.WindowGames {
+		t.Errorf("zero policy normalized to %+v, want defaults %+v", got, want)
+	}
+
+	// WindowGames is never smaller than MinGames.
+	p := WatchPolicy{MinGames: 8, DegradationMargin: 0.1, WindowGames: 2}.normalize()
+	if p.WindowGames < p.MinGames {
+		t.Errorf("WindowGames %d < MinGames %d after normalize", p.WindowGames, p.MinGames)
+	}
+}
+
+// --- END-TO-END watch→revert: a Promoter wired with the concrete fitnessWatcher
+// over FAKE real-game telemetry auto-reverts a regressing autonomous promotion and
+// records outcome=reverted (the #1016 / #936 AC). ---
+func TestPromoteAutonomousAutoRevertsViaFitnessWatcher(t *testing.T) {
+	realDef := &recordingRealDefault{}
+	rev := &recordingReverter{}
+	// Real-game fitness collapses well below the baseline (0.50 in testEvidence).
+	regressing := fakeRealGameFitness{samples: []float64{0.20, 0.18, 0.22, 0.19}}
+	watcher := NewFitnessWatcher(regressing, DefaultWatchPolicy(), discardLogger())
+	p, rec := promoterWithRecorder(t, &recordingGitHub{}, &recordingGit{}, realDef, watcher, rev)
+
+	res := p.Promote(context.Background(), promoteProposal, promoteVerdict,
+		Config{Mode: ModeAutonomous, Target: TargetLocal, Enabled: true}, testEvidence())
+
+	if res.Outcome != OutcomeReverted {
+		t.Fatalf("outcome = %q, want reverted", res.Outcome)
+	}
+	if len(realDef.calls) != 1 {
+		t.Errorf("SetRealDefault calls = %d, want 1 (applied then reverted)", len(realDef.calls))
+	}
+	if rev.calls != 1 {
+		t.Errorf("RevertRealDefault calls = %d, want 1", rev.calls)
+	}
+	// The #936/#1016 AC: outcome=reverted is visible on the promote span.
+	span := spanByName(t, rec, SpanPromote)
+	if got := stringAttr(span, AttrOutcome); got != string(OutcomeReverted) {
+		t.Errorf("span outcome attr = %q, want reverted", got)
+	}
+}
+
+// --- END-TO-END: a holding/improving real-game fitness keeps the promotion. ---
+func TestPromoteAutonomousKeepsWhenFitnessHolds(t *testing.T) {
+	realDef := &recordingRealDefault{}
+	rev := &recordingReverter{}
+	// Baseline in testEvidence is 0.50; real games hold above it.
+	holding := fakeRealGameFitness{samples: []float64{0.55, 0.58, 0.60, 0.57}}
+	watcher := NewFitnessWatcher(holding, DefaultWatchPolicy(), discardLogger())
+	p, _ := promoterWithRecorder(t, &recordingGitHub{}, &recordingGit{}, realDef, watcher, rev)
+
+	res := p.Promote(context.Background(), promoteProposal, promoteVerdict,
+		Config{Mode: ModeAutonomous, Target: TargetLocal, Enabled: true}, testEvidence())
+
+	if res.Outcome != OutcomeApplied {
+		t.Fatalf("outcome = %q, want applied (fitness held)", res.Outcome)
+	}
+	if rev.calls != 0 {
+		t.Errorf("RevertRealDefault calls = %d, want 0 (no degradation)", rev.calls)
+	}
+}
+
+// keep the experiment import meaningful if a future edit drops the only use.
+var _ = experiment.OutcomePromote


### PR DESCRIPTION
Part of #1016.

## What

Wires the autonomous-promotion safety net so a promotion to the **real** default is self-correcting, and makes a missing safety net a **hard stop** rather than a silent apply.

### 1. Wire watch -> degradation -> revert
- New `promote.fitnessWatcher` (`promote/watcher.go`) implements `Watcher.Degraded`: it reads a recent real-game fitness window via an injected `RealGameFitness` seam, compares the recent mean to the **pre-promotion baseline** (`Evidence.FitnessBefore`), and trips a revert when fitness drops below baseline by `DegradationMargin` over at least `MinGames` real games.
- On degradation (or an unconfirmable watch error) the existing `RealDefaultReverter` rolls the real default back -> `OutcomeReverted`, visible on the `code_improvement.promote` span.
- `Watcher.Degraded` now receives the baseline so it can compare against what the promotion was justified by; the Promoter threads `Evidence.FitnessBefore` through.

### 2. Fail closed without a Watcher (the key safety change)
`promoteAutonomous` now **refuses to apply** to the real default when no `Watcher` is wired — checked **before** the real-default write, so an autonomous promotion can never touch real players without a connected watch->auto-revert loop. The old `nil Watcher` => "apply without a watch" path is gone. A nil Watcher => `OutcomeDiscarded`, zero real-default writes.

### 3. Gates unchanged
`AGENT_CODE_IMPROVEMENT_ENABLED` + `AGENT_AUTONOMOUS_ENABLED` + the kill-switch (`Config.Enabled`) are untouched; only the apply path is made safe.

## Degradation policy (configurable, sane defaults)
`WatchPolicy{ MinGames, DegradationMargin, WindowGames }`, defaults `MinGames=3`, `DegradationMargin=0.05` (in the 0..1 #731 fitness space), `WindowGames=5`. Conservative enough that one unlucky game never reverts a good change, sensitive enough to catch a real regression within a few real games.

## Tests
- `fitnessWatcher` verdict table: clear regression -> revert; hold/improve -> keep; drop-within-margin (noise) -> keep; insufficient games -> no revert; telemetry error -> fail closed.
- End-to-end watch->revert and watch->keep via the concrete watcher over **fake** real-game telemetry, asserting `outcome=reverted` on the span.
- **Fail-closed assertion**: autonomous with `nil` Watcher refuses to apply (would fail under the old apply-without-watch behaviour).
- Existing promote/validate/loop tests updated + green.

`go test ./... -race`, `go vet ./...`, `gofmt -l .` all clean.

## Follow-up
Live verification against actual real games needs the real-game flow + the LLM backend; the production `RealGameFitness` source (reading the #731 evaluator / gamewindow) + `NewFitnessWatcher` wiring in `main.go` is the live-verify follow-up. The **wiring + decision logic** ship and are unit-tested here. Until that source is wired, `main.go` passes a nil Watcher, so autonomous fail-closes (recorded no-op) rather than applying unguarded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)