### PR TITLE
feat(agent): live-wire M7-7 validator to real shadow games + fitness telemetry (#965)

### DIFF
--- a/services/agent/experiment/fitness_store.go
+++ b/services/agent/experiment/fitness_store.go
@@ -1,0 +1,232 @@
+package experiment
+
+import (
+	"sort"
+	"sync"
+	"time"
+)
+
+// fitness_store.go is the FINALIZED-PER-GAME fitness store (#965, #1017): the
+// missing instrumentation seam that turns the M7-7 Validator's INJECTED fitness
+// reads (Baseline / FitnessMeasurer) into REAL ones.
+//
+// THE #1017 GAP, precisely: shadow and real games already emit the SAME fitness
+// inputs through the SAME code path, and decision.EvaluateFitness is
+// substrate-agnostic — so fitness is COMPUTABLE today; it is simply never STORED
+// for the validation path. The experiment loop already computes a per-game
+// fitness scalar at conclusion (defaultGameFitness → EvaluateFitness) but folds
+// it ONLY into the cohort journal for experiment-bound games and DROPS it for
+// everything else. This store is the rolling, in-memory, game_id-keyed sink that
+// captures that already-computed sample for BOTH:
+//
+//   - a SHADOW validation game (the SyntheticRunner spawns it; the FitnessMeasurer
+//     reads its finalized fitness back by game_id — the StoreMeasurer here), and
+//   - a REAL primary game (the StoreBaseline reads the mean of the last N real
+//     games as the validation baseline — the #965 Baseline.Fitness seam).
+//
+// FINALIZED, NOT A LIVE SCRAPE (#958 / #1017): Record is called from onGameEnd
+// AFTER the game has concluded and its duration has been recovered
+// (withEffectiveDuration), so a reader sees the SETTLED per-game fitness — it
+// never races the ~10s OTel span flush. This is the explicit requirement the
+// validate.go Baseline doc and the #958 strategy doc both call out.
+//
+// NO-PLAYER-IDENTITY (#23): a sample is keyed by game_id and carries only
+// per-game aggregates (the objective's fitness scalar, the resolved flag config,
+// the duration). It holds NOTHING per-person and is evicted by a bounded ring, so
+// it composes cleanly with controllers≠persons — no cross-session profile is ever
+// assembled here.
+
+// DefaultFitnessStoreCapacity bounds the store's ring. A few hundred finalized
+// samples is ample: the Baseline only ever reads the last N real games (N is a
+// handful), and a validation batch reads a handful of just-spawned shadow
+// game_ids, so the working set is tiny. The ring keeps the store O(1) in memory
+// regardless of how long the agent runs.
+const DefaultFitnessStoreCapacity = 512
+
+// GameKindReal (the game_kind label a live, player-facing game carries —
+// game_session.py:52-53) is defined in targeting.go. The Baseline reads only
+// samples with this kind so a shadow validation game can never pollute the
+// recent-real baseline.
+
+// FitnessSample is one finalized per-game fitness datapoint (#965). It is the unit
+// the store holds and both validation seams read.
+type FitnessSample struct {
+	// GameID is the coordinator-assigned game id this sample finalized for. It is
+	// the store key and the join key the FitnessMeasurer uses against a Run's ids.
+	GameID string
+	// Fitness is the game's finalized objective fitness scalar in [0,1] (higher =
+	// better) — the SAME defaultGameFitness → EvaluateFitness value the cohort
+	// journal folds, captured here for the validation path.
+	Fitness float64
+	// Objective is the fitness objective the Fitness scalar scored (endurance /
+	// balanced / accelerate). The Baseline filters recent-real samples by it so a
+	// baseline is per-objective (the #958 study is per-objective: only
+	// endurance/accelerate carry real signal today, #1015).
+	Objective string
+	// GameKind is "real" for a primary game or "shadow" for a validation/cohort
+	// game. The Baseline reads only GameKindReal; the FitnessMeasurer keys purely
+	// by game_id (a Run only ever holds shadow ids).
+	GameKind string
+	// DurationS is the game's recovered effective duration in seconds (#997), kept
+	// alongside the fitness for the audit trail / drift monitor (#1017 §4).
+	DurationS float64
+	// Config is the resolved per-game flag snapshot in effect for this game (the
+	// value(s) under experiment), so a paired (config → fitness) study can assemble
+	// observations (#1017 §3 item 3). Optional — nil when the loop has no resolved
+	// snapshot to attach. Copied on Record so a caller cannot mutate stored state.
+	Config map[string]any
+	// At is when the sample finalized (Record time), used for recency ordering in
+	// RecentReal.
+	At time.Time
+}
+
+// FitnessStore is a bounded, thread-safe, finalized-per-game fitness store keyed
+// by game_id (#965). It is the production backing for the StoreBaseline and
+// StoreMeasurer validation seams. Construct with NewFitnessStore; the experiment
+// loop's onGameEnd Records into it, and the Validator's seams read from it.
+type FitnessStore struct {
+	mu  sync.Mutex
+	cap int
+	// byKey is the authoritative finalized sample per (game_id, objective). A REAL
+	// game is scored against EVERY experimentable objective its signals support
+	// (#1017 §3 item 1) — so one game_id may hold several samples, one per objective.
+	// The composite key keeps them distinct (a single game_id key would clobber). A
+	// SHADOW game carries one objective, so it has exactly one entry. Last write wins
+	// per key (a defensive re-Record updates in place).
+	byKey map[string]FitnessSample
+	// order is the insertion order of keys for FIFO eviction once cap is exceeded. A
+	// key appears at most once (Record removes a stale dup before re-appending), so
+	// order and byKey stay in lockstep.
+	order []string
+}
+
+// NewFitnessStore builds a store with the given ring capacity. A non-positive
+// capacity falls back to DefaultFitnessStoreCapacity (a zero ring would evict
+// every sample immediately, defeating the store).
+func NewFitnessStore(capacity int) *FitnessStore {
+	if capacity <= 0 {
+		capacity = DefaultFitnessStoreCapacity
+	}
+	return &FitnessStore{
+		cap:   capacity,
+		byKey: make(map[string]FitnessSample, capacity),
+	}
+}
+
+// sampleKey composes the (game_id, objective) store key. A shadow game's objective
+// may be empty (the measurer reads it back by game_id regardless), which is fine —
+// the empty-objective key is still distinct per game_id.
+func sampleKey(gameID, objective string) string {
+	return gameID + "\x00" + objective
+}
+
+// Record finalizes one per-game fitness sample, keyed by sample.GameID. It is
+// called from onGameEnd after the game concluded and its duration was recovered,
+// so the stored value is SETTLED (no span-flush race). A sample with an empty
+// GameID is dropped (nothing can read it back). The ring evicts the oldest
+// sample(s) once capacity is exceeded.
+func (s *FitnessStore) Record(sample FitnessSample) {
+	if sample.GameID == "" {
+		return
+	}
+	if sample.At.IsZero() {
+		sample.At = time.Now().UTC()
+	}
+	// Defensive copy so a later mutation of the caller's map cannot reach in.
+	sample.Config = copyConfig(sample.Config)
+
+	key := sampleKey(sample.GameID, sample.Objective)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, exists := s.byKey[key]; exists {
+		// Re-Record (rare): update in place, keep its position in the order ring so a
+		// duplicate cannot grow order unbounded.
+		s.byKey[key] = sample
+		return
+	}
+	s.byKey[key] = sample
+	s.order = append(s.order, key)
+	s.evictLocked()
+}
+
+// Get returns a finalized sample for a game_id and whether one is present. The
+// FitnessMeasurer uses it to read a just-completed SHADOW game's fitness — a shadow
+// game holds exactly one (game_id, objective) sample, so Get returns it. For a game
+// id with several per-objective samples (a real game) Get returns an arbitrary one;
+// callers needing a specific objective use RecentReal, which filters by objective.
+func (s *FitnessStore) Get(gameID string) (FitnessSample, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, sample := range s.byKey {
+		if sample.GameID == gameID {
+			return sample, true
+		}
+	}
+	return FitnessSample{}, false
+}
+
+// RecentReal returns the most-recent (newest-first) finalized samples from REAL
+// (game_kind="real") games for the given objective, up to n. An empty objective
+// matches any objective (the caller filters). It is the read side of the
+// StoreBaseline: the validation baseline is the mean over what this returns.
+func (s *FitnessStore) RecentReal(objective string, n int) []FitnessSample {
+	if n <= 0 {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Collect matching real samples, then sort newest-first and take n. The ring is
+	// small (cap), so a full scan + sort is cheap and keeps ordering correct even
+	// across re-Records (which do not move the order entry).
+	matches := make([]FitnessSample, 0, len(s.byKey))
+	for _, sample := range s.byKey {
+		if sample.GameKind != GameKindReal {
+			continue
+		}
+		if objective != "" && sample.Objective != objective {
+			continue
+		}
+		matches = append(matches, sample)
+	}
+	sort.Slice(matches, func(i, j int) bool {
+		return matches[i].At.After(matches[j].At)
+	})
+	if len(matches) > n {
+		matches = matches[:n]
+	}
+	return matches
+}
+
+// Len returns the number of finalized samples currently held (test/observability).
+// A real game scored against multiple objectives counts once PER objective.
+func (s *FitnessStore) Len() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.byKey)
+}
+
+// evictLocked drops the oldest sample(s) until the ring is within capacity.
+// Assumes s.mu is held.
+func (s *FitnessStore) evictLocked() {
+	for len(s.order) > s.cap {
+		oldest := s.order[0]
+		s.order = s.order[1:]
+		delete(s.byKey, oldest)
+	}
+}
+
+// copyConfig deep-enough copies a resolved-config snapshot (a flat map of scalar
+// flag values) so the store owns its own copy. nil/empty maps return nil.
+func copyConfig(m map[string]any) map[string]any {
+	if len(m) == 0 {
+		return nil
+	}
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}

--- a/services/agent/experiment/fitness_store_test.go
+++ b/services/agent/experiment/fitness_store_test.go
@@ -1,0 +1,133 @@
+package experiment
+
+import (
+	"testing"
+	"time"
+)
+
+// fitness_store_test.go covers the #965 finalized-per-game fitness store: the
+// instrumentation that turns the Validator's injected fitness reads into real ones.
+
+// TestFitnessStore_RecordAndGet: a recorded sample is read back by game_id.
+func TestFitnessStore_RecordAndGet(t *testing.T) {
+	s := NewFitnessStore(0) // default capacity
+	s.Record(FitnessSample{GameID: "game_aaa", Fitness: 0.7, Objective: "endurance", GameKind: "shadow"})
+
+	got, ok := s.Get("game_aaa")
+	if !ok {
+		t.Fatalf("Get(game_aaa) not found after Record")
+	}
+	if got.Fitness != 0.7 {
+		t.Errorf("fitness = %v, want 0.7", got.Fitness)
+	}
+	if _, ok := s.Get("game_missing"); ok {
+		t.Errorf("Get(game_missing) should be absent")
+	}
+}
+
+// TestFitnessStore_EmptyGameIDDropped: a sample with no game_id is not stored
+// (nothing could ever read it back).
+func TestFitnessStore_EmptyGameIDDropped(t *testing.T) {
+	s := NewFitnessStore(0)
+	s.Record(FitnessSample{GameID: "", Fitness: 0.5, GameKind: "real"})
+	if s.Len() != 0 {
+		t.Fatalf("empty-game-id sample should be dropped, len = %d", s.Len())
+	}
+}
+
+// TestFitnessStore_RingEviction: the ring evicts the oldest sample once capacity is
+// exceeded, keeping memory bounded.
+func TestFitnessStore_RingEviction(t *testing.T) {
+	s := NewFitnessStore(2)
+	s.Record(FitnessSample{GameID: "g1", Fitness: 0.1, GameKind: "real"})
+	s.Record(FitnessSample{GameID: "g2", Fitness: 0.2, GameKind: "real"})
+	s.Record(FitnessSample{GameID: "g3", Fitness: 0.3, GameKind: "real"}) // evicts g1
+
+	if s.Len() != 2 {
+		t.Fatalf("len = %d, want 2 (ring capacity)", s.Len())
+	}
+	if _, ok := s.Get("g1"); ok {
+		t.Errorf("g1 should have been evicted (oldest)")
+	}
+	if _, ok := s.Get("g3"); !ok {
+		t.Errorf("g3 (newest) should be present")
+	}
+}
+
+// TestFitnessStore_ReRecordKeepsBounded: re-Recording the same game_id updates in
+// place without growing the order ring (so a duplicate cannot evict live samples).
+func TestFitnessStore_ReRecordKeepsBounded(t *testing.T) {
+	s := NewFitnessStore(2)
+	s.Record(FitnessSample{GameID: "g1", Fitness: 0.1, GameKind: "real"})
+	s.Record(FitnessSample{GameID: "g2", Fitness: 0.2, GameKind: "real"})
+	s.Record(FitnessSample{GameID: "g1", Fitness: 0.9, GameKind: "real"}) // update, not new
+
+	if s.Len() != 2 {
+		t.Fatalf("len = %d, want 2 after re-record", s.Len())
+	}
+	got, _ := s.Get("g1")
+	if got.Fitness != 0.9 {
+		t.Errorf("re-record fitness = %v, want 0.9", got.Fitness)
+	}
+	if _, ok := s.Get("g2"); !ok {
+		t.Errorf("g2 must not be evicted by a re-record of g1")
+	}
+}
+
+// TestFitnessStore_RecentRealFiltersKindAndObjective: RecentReal returns only
+// game_kind="real" samples for the requested objective, newest-first, up to n.
+func TestFitnessStore_RecentRealFiltersKindAndObjective(t *testing.T) {
+	s := NewFitnessStore(0)
+	base := time.Now()
+	// Two real endurance samples, one real balanced, one shadow endurance.
+	s.Record(FitnessSample{GameID: "r1", Fitness: 0.4, Objective: "endurance", GameKind: "real", At: base})
+	s.Record(FitnessSample{GameID: "r2", Fitness: 0.6, Objective: "endurance", GameKind: "real", At: base.Add(time.Second)})
+	s.Record(FitnessSample{GameID: "rb", Fitness: 0.9, Objective: "balanced", GameKind: "real", At: base.Add(2 * time.Second)})
+	s.Record(FitnessSample{GameID: "sh", Fitness: 0.99, Objective: "endurance", GameKind: "shadow", At: base.Add(3 * time.Second)})
+
+	got := s.RecentReal("endurance", 10)
+	if len(got) != 2 {
+		t.Fatalf("RecentReal(endurance) returned %d samples, want 2 (real endurance only)", len(got))
+	}
+	// Newest-first: r2 then r1.
+	if got[0].GameID != "r2" || got[1].GameID != "r1" {
+		t.Errorf("RecentReal order = [%s,%s], want [r2,r1] (newest-first)", got[0].GameID, got[1].GameID)
+	}
+}
+
+// TestFitnessStore_RecentRealRespectsN: RecentReal caps the result at n.
+func TestFitnessStore_RecentRealRespectsN(t *testing.T) {
+	s := NewFitnessStore(0)
+	base := time.Now()
+	for i := 0; i < 5; i++ {
+		s.Record(FitnessSample{
+			GameID: "r" + string(rune('0'+i)), Fitness: 0.5, Objective: "endurance",
+			GameKind: "real", At: base.Add(time.Duration(i) * time.Second),
+		})
+	}
+	if got := s.RecentReal("endurance", 3); len(got) != 3 {
+		t.Fatalf("RecentReal(n=3) returned %d, want 3", len(got))
+	}
+}
+
+// TestRunGameIDsRoundTrip: NewRun encodes game_ids into Run.ID and RunGameIDs
+// decodes them, dropping empty fragments.
+func TestRunGameIDsRoundTrip(t *testing.T) {
+	ids := []string{"game_aaa", "game_bbb", "game_ccc"}
+	run := NewRun(ids)
+	if run.Games != 3 {
+		t.Errorf("run.Games = %d, want 3", run.Games)
+	}
+	got := RunGameIDs(run)
+	if len(got) != 3 || got[0] != "game_aaa" || got[2] != "game_ccc" {
+		t.Errorf("RunGameIDs = %v, want %v", got, ids)
+	}
+	// Empty run → no ids.
+	if got := RunGameIDs(Run{}); got != nil {
+		t.Errorf("RunGameIDs(empty) = %v, want nil", got)
+	}
+	// Stray separators are dropped.
+	if got := RunGameIDs(Run{ID: "game_x,,game_y,"}); len(got) != 2 {
+		t.Errorf("RunGameIDs with stray seps = %v, want 2 ids", got)
+	}
+}

--- a/services/agent/experiment/validate.go
+++ b/services/agent/experiment/validate.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -167,6 +168,37 @@ type Run struct {
 	// Games is the number of games the runner actually completed, echoed back so
 	// the measurer and the span agree on the realized sample size.
 	Games int
+}
+
+// runIDSep joins shadow game_ids into the Run.ID. The live SyntheticRunner
+// (shadow_validation_runner.go) encodes the batch's shadow game_ids as a
+// comma-joined Run.ID; the StoreMeasurer (validate_seams.go) decodes them with
+// RunGameIDs to read each game's finalized fitness back from the store. A coordinator
+// game_id is "game_<hex>" and never contains a comma, so the split is unambiguous.
+const runIDSep = ","
+
+// NewRun builds a Run handle from a batch of shadow game_ids, encoding them into the
+// Run.ID so the FitnessMeasurer can recover them. Games is set to len(ids) — the
+// realized sample size the Validator records and the measurer averages over.
+func NewRun(gameIDs []string) Run {
+	return Run{ID: strings.Join(gameIDs, runIDSep), Games: len(gameIDs)}
+}
+
+// RunGameIDs decodes the shadow game_ids a Run carries (the inverse of NewRun).
+// An empty ID yields no ids; empty fragments (a stray separator) are dropped so a
+// malformed id list never produces phantom empty game_ids the measurer would miss.
+func RunGameIDs(run Run) []string {
+	if run.ID == "" {
+		return nil
+	}
+	parts := strings.Split(run.ID, runIDSep)
+	ids := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			ids = append(ids, p)
+		}
+	}
+	return ids
 }
 
 // FitnessMeasurer reads the aggregate fitness of a completed synthetic Run. It is

--- a/services/agent/experiment/validate_seams.go
+++ b/services/agent/experiment/validate_seams.go
@@ -1,0 +1,145 @@
+package experiment
+
+import (
+	"context"
+	"fmt"
+)
+
+// validate_seams.go provides the PRODUCTION implementations of the M7-7 Validator's
+// fitness-reading seams (#965), backed by the finalized-per-game FitnessStore
+// (fitness_store.go). They replace the validate_test.go fakes for the live wiring:
+//
+//   - StoreBaseline   → Baseline.Fitness: the mean fitness of the last N REAL
+//     (game_kind="real") games for the proposal's objective. This is the #965
+//     "baseline established from the last N real games" seam, reading FINALIZED
+//     samples (never a live scrape that races the span flush, per #958/#1017).
+//   - StoreMeasurer   → FitnessMeasurer.Measure: the mean finalized fitness of the
+//     shadow games a Run produced, read back by their game_ids.
+//   - WriterReverter  → Reverter.Revert: strips the experiment's shadow targeting
+//     branch via the #977 Writer (the inverse of the Gate's Apply).
+//
+// The SyntheticRunner is the one seam that lives in package main (shadow_validation_runner.go):
+// it drives real shadow games via the agent's gamerunner/registry, which package
+// experiment cannot import. The runner returns a Run whose ID carries the spawned
+// shadow game_ids; the StoreMeasurer joins those ids against this store.
+
+// ObjectiveResolver maps a Proposal to the fitness objective its experiment
+// optimizes. A Proposal carries only {flag, value, rationale}; the objective lives
+// on the experiment Intent (registry CompactView keyed by ExperimentID). Injecting
+// it as a func keeps StoreBaseline free of a registry dependency and unit-testable.
+// An empty objective ("") means "any objective" — the baseline then folds whatever
+// real-game samples exist (the loop's defaultGameFitness already maps an empty
+// objective to balanced, so a real sample always carries a concrete objective).
+type ObjectiveResolver func(p Proposal) string
+
+// StoreBaseline implements Baseline over a FitnessStore: the validation baseline is
+// the mean finalized fitness of the last N REAL games for the proposal's objective.
+type StoreBaseline struct {
+	store      *FitnessStore
+	objective  ObjectiveResolver
+	recentN    int
+	minSamples int
+}
+
+// NewStoreBaseline builds the store-backed baseline. recentN is how many recent
+// real games to average (clamped to >= 1). minSamples is the minimum real samples
+// required before a baseline is trustworthy; below it Fitness FAILS CLOSED (returns
+// an error) so the Validator never promotes against a baseline of too-few real
+// games (epic #982: fitness is observed, never assumed). objective may be nil ⇒ the
+// baseline folds any-objective real samples.
+func NewStoreBaseline(store *FitnessStore, objective ObjectiveResolver, recentN, minSamples int) *StoreBaseline {
+	if recentN < 1 {
+		recentN = 1
+	}
+	if minSamples < 1 {
+		minSamples = 1
+	}
+	return &StoreBaseline{store: store, objective: objective, recentN: recentN, minSamples: minSamples}
+}
+
+// Fitness returns the mean finalized fitness of the last recentN real games for
+// p's objective. It FAILS CLOSED (error) when the store is unwired or fewer than
+// minSamples real samples exist — without a trustworthy baseline there is nothing
+// to compare an experiment against, so the cycle must not promote.
+func (b *StoreBaseline) Fitness(_ context.Context, p Proposal) (float64, error) {
+	if b.store == nil {
+		return 0, fmt.Errorf("baseline: fitness store not wired")
+	}
+	objective := ""
+	if b.objective != nil {
+		objective = b.objective(p)
+	}
+	samples := b.store.RecentReal(objective, b.recentN)
+	if len(samples) < b.minSamples {
+		return 0, fmt.Errorf("baseline: only %d real-game fitness samples for objective %q, need >= %d",
+			len(samples), objective, b.minSamples)
+	}
+	var sum float64
+	for _, s := range samples {
+		sum += s.Fitness
+	}
+	return sum / float64(len(samples)), nil
+}
+
+// StoreMeasurer implements FitnessMeasurer over a FitnessStore: the synthetic Run's
+// fitness is the mean of its shadow games' finalized fitness, read back by game_id.
+type StoreMeasurer struct {
+	store *FitnessStore
+}
+
+// NewStoreMeasurer builds the store-backed measurer.
+func NewStoreMeasurer(store *FitnessStore) *StoreMeasurer {
+	return &StoreMeasurer{store: store}
+}
+
+// Measure returns the mean finalized fitness of the Run's shadow games. The Run's
+// ID is the comma-joined shadow game_ids (RunGameIDs decodes them). It FAILS CLOSED
+// when the store is unwired or NONE of the run's games has a finalized sample (an
+// unmeasurable run must never promote). Games that are missing a sample (e.g. a
+// shadow game that errored without folding fitness) are skipped; the mean is over
+// the games that did finalize, so a partial batch still measures honestly.
+func (m *StoreMeasurer) Measure(_ context.Context, run Run) (float64, error) {
+	if m.store == nil {
+		return 0, fmt.Errorf("measure: fitness store not wired")
+	}
+	ids := RunGameIDs(run)
+	if len(ids) == 0 {
+		return 0, fmt.Errorf("measure: run %q carries no shadow game ids", run.ID)
+	}
+	var sum float64
+	found := 0
+	for _, id := range ids {
+		if s, ok := m.store.Get(id); ok {
+			sum += s.Fitness
+			found++
+		}
+	}
+	if found == 0 {
+		return 0, fmt.Errorf("measure: none of run %q's %d shadow games has a finalized fitness sample", run.ID, len(ids))
+	}
+	return sum / float64(found), nil
+}
+
+// WriterReverter implements Reverter over the #977 Writer: a degradation rollback
+// strips the experiment's shadow targeting branch (the inverse of the Gate's
+// Apply). Removing a shadow branch only ever restores a strictly-more-real-
+// protective rule, so it needs no invariant gate (design §10) — straight to the
+// Writer's Strip, mirroring GateTargetingWriter.Strip.
+type WriterReverter struct {
+	writer *Writer
+}
+
+// NewWriterReverter builds the Writer-backed reverter. writer MUST be the same one
+// the experiment's targeting was written through so Strip finds the branch.
+func NewWriterReverter(writer *Writer) *WriterReverter {
+	return &WriterReverter{writer: writer}
+}
+
+// Revert strips p's experiment-scoped shadow targeting branch + reserved variant.
+// A missing branch is a no-op (idempotent). It satisfies Reverter.
+func (r *WriterReverter) Revert(_ context.Context, p Proposal) error {
+	if r.writer == nil {
+		return fmt.Errorf("revert: writer not wired")
+	}
+	return r.writer.Strip(p.FlagKey, p.ExperimentID)
+}

--- a/services/agent/experiment/validate_seams_test.go
+++ b/services/agent/experiment/validate_seams_test.go
@@ -1,0 +1,167 @@
+package experiment
+
+import (
+	"context"
+	"testing"
+)
+
+// validate_seams_test.go covers the #965 store-backed Validator seams: the
+// StoreBaseline (recent-real baseline), StoreMeasurer (synthetic-run fitness), and
+// WriterReverter (degradation rollback).
+
+// TestStoreBaseline_MeanOfRecentReal: the baseline is the mean of the last N real
+// games for the proposal's objective.
+func TestStoreBaseline_MeanOfRecentReal(t *testing.T) {
+	store := NewFitnessStore(0)
+	store.Record(FitnessSample{GameID: "r1", Fitness: 0.4, Objective: "endurance", GameKind: GameKindReal})
+	store.Record(FitnessSample{GameID: "r2", Fitness: 0.6, Objective: "endurance", GameKind: GameKindReal})
+	// A shadow + a different-objective sample must NOT affect the endurance baseline.
+	store.Record(FitnessSample{GameID: "sh", Fitness: 0.99, Objective: "endurance", GameKind: "shadow"})
+	store.Record(FitnessSample{GameID: "rb", Fitness: 0.1, Objective: "balanced", GameKind: GameKindReal})
+
+	objResolver := func(Proposal) string { return "endurance" }
+	b := NewStoreBaseline(store, objResolver, 8, 2)
+
+	got, err := b.Fitness(context.Background(), Proposal{ExperimentID: "exp_1"})
+	if err != nil {
+		t.Fatalf("Fitness: %v", err)
+	}
+	if got < 0.49 || got > 0.51 {
+		t.Errorf("baseline = %v, want ~0.5 (mean of 0.4,0.6)", got)
+	}
+}
+
+// TestStoreBaseline_FailsClosedBelowMinSamples: with fewer than minSamples real
+// games the baseline fails closed (the Validator must not promote against it).
+func TestStoreBaseline_FailsClosedBelowMinSamples(t *testing.T) {
+	store := NewFitnessStore(0)
+	store.Record(FitnessSample{GameID: "r1", Fitness: 0.4, Objective: "endurance", GameKind: GameKindReal})
+
+	b := NewStoreBaseline(store, func(Proposal) string { return "endurance" }, 8, 3)
+	if _, err := b.Fitness(context.Background(), Proposal{}); err == nil {
+		t.Fatalf("expected fail-closed error with only 1 real sample (min 3)")
+	}
+}
+
+// TestStoreBaseline_NilStoreFailsClosed: a nil store fails closed.
+func TestStoreBaseline_NilStoreFailsClosed(t *testing.T) {
+	b := NewStoreBaseline(nil, nil, 8, 1)
+	if _, err := b.Fitness(context.Background(), Proposal{}); err == nil {
+		t.Fatalf("expected fail-closed error with nil store")
+	}
+}
+
+// TestStoreMeasurer_MeanOfRunGames: the measurer averages the run's shadow games'
+// finalized fitness, read back by game_id.
+func TestStoreMeasurer_MeanOfRunGames(t *testing.T) {
+	store := NewFitnessStore(0)
+	store.Record(FitnessSample{GameID: "game_a", Fitness: 0.5, GameKind: "shadow"})
+	store.Record(FitnessSample{GameID: "game_b", Fitness: 0.7, GameKind: "shadow"})
+
+	m := NewStoreMeasurer(store)
+	got, err := m.Measure(context.Background(), NewRun([]string{"game_a", "game_b"}))
+	if err != nil {
+		t.Fatalf("Measure: %v", err)
+	}
+	if got < 0.59 || got > 0.61 {
+		t.Errorf("measured fitness = %v, want ~0.6", got)
+	}
+}
+
+// TestStoreMeasurer_PartialBatch: a run whose games partially finalized still
+// measures over the games that DID finalize (a smaller honest sample).
+func TestStoreMeasurer_PartialBatch(t *testing.T) {
+	store := NewFitnessStore(0)
+	store.Record(FitnessSample{GameID: "game_a", Fitness: 0.8, GameKind: "shadow"})
+	// game_b never finalized.
+
+	m := NewStoreMeasurer(store)
+	got, err := m.Measure(context.Background(), NewRun([]string{"game_a", "game_b"}))
+	if err != nil {
+		t.Fatalf("Measure: %v", err)
+	}
+	if got != 0.8 {
+		t.Errorf("measured fitness = %v, want 0.8 (only game_a finalized)", got)
+	}
+}
+
+// TestStoreMeasurer_FailsClosedNoneFinalized: a run whose games none finalized
+// fails closed (an unmeasurable run never promotes).
+func TestStoreMeasurer_FailsClosedNoneFinalized(t *testing.T) {
+	m := NewStoreMeasurer(NewFitnessStore(0))
+	if _, err := m.Measure(context.Background(), NewRun([]string{"game_x", "game_y"})); err == nil {
+		t.Fatalf("expected fail-closed error when no run game finalized")
+	}
+	// And an empty run.
+	if _, err := m.Measure(context.Background(), Run{}); err == nil {
+		t.Fatalf("expected fail-closed error on an empty run")
+	}
+}
+
+// TestWriterReverter_StripsTargeting: Revert strips the experiment's shadow
+// targeting branch via the Writer (the inverse of the Gate's Apply).
+func TestWriterReverter_StripsTargeting(t *testing.T) {
+	path := newGameFile(t)
+	w := NewWriter(path, discardLogger())
+
+	const flag = "invincibility_seconds"
+	const expID = "exp_revert1234"
+	if err := w.Apply(Proposal{FlagKey: flag, ExperimentID: expID, ExperimentalValue: 6.0}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if _, ok := flagVariants(t, path, flag)[experimentVariantName(expID)]; !ok {
+		t.Fatalf("precondition: experiment variant should exist after apply")
+	}
+
+	rev := NewWriterReverter(w)
+	if err := rev.Revert(context.Background(), Proposal{FlagKey: flag, ExperimentID: expID}); err != nil {
+		t.Fatalf("Revert: %v", err)
+	}
+	if _, ok := flagVariants(t, path, flag)[experimentVariantName(expID)]; ok {
+		t.Fatalf("after Revert: experiment variant should be stripped")
+	}
+}
+
+// TestValidatorEndToEndOverStoreSeams: the M7-7 Validator over the LIVE store seams
+// (Baseline + Measurer fed from the store) reaches a PROMOTE verdict when the shadow
+// run's fitness beats the recent-real baseline past the threshold — the #965
+// end-to-end "validate verdict on real shadow fitness" path with NO fakes for the
+// fitness reads.
+func TestValidatorEndToEndOverStoreSeams(t *testing.T) {
+	store := NewFitnessStore(0)
+	// Recent-real baseline ≈ 0.40.
+	store.Record(FitnessSample{GameID: "r1", Fitness: 0.40, Objective: "endurance", GameKind: GameKindReal})
+	store.Record(FitnessSample{GameID: "r2", Fitness: 0.40, Objective: "endurance", GameKind: GameKindReal})
+	store.Record(FitnessSample{GameID: "r3", Fitness: 0.40, Objective: "endurance", GameKind: GameKindReal})
+	// The shadow validation batch finalized ≈ 0.70 (a real improvement).
+	store.Record(FitnessSample{GameID: "game_s1", Fitness: 0.70, GameKind: "shadow"})
+	store.Record(FitnessSample{GameID: "game_s2", Fitness: 0.70, GameKind: "shadow"})
+
+	// A runner that "spawned" the two shadow games (returns their pre-recorded ids).
+	runner := stubRunner{run: NewRun([]string{"game_s1", "game_s2"})}
+	baseline := NewStoreBaseline(store, func(Proposal) string { return "endurance" }, 8, 3)
+	measurer := NewStoreMeasurer(store)
+
+	v, _ := validatorWithRecorder(t, baseline, runner, measurer, nil)
+	dec := v.Validate(context.Background(), Proposal{FlagKey: "x", ExperimentID: "exp_e2e"}, defaultCfg())
+
+	if dec.Err != nil {
+		t.Fatalf("unexpected err: %v", dec.Err)
+	}
+	if dec.Outcome != OutcomePromote {
+		t.Fatalf("outcome = %q, want promote (0.70 vs 0.40 baseline)", dec.Outcome)
+	}
+	if dec.FitnessBefore < 0.39 || dec.FitnessBefore > 0.41 {
+		t.Errorf("fitness_before = %v, want ~0.40 (recent-real baseline)", dec.FitnessBefore)
+	}
+	if dec.FitnessAfter < 0.69 || dec.FitnessAfter > 0.71 {
+		t.Errorf("fitness_after = %v, want ~0.70 (shadow run mean)", dec.FitnessAfter)
+	}
+}
+
+// stubRunner is a SyntheticRunner that returns a pre-built Run (the shadow game_ids
+// the store already holds), so the end-to-end test exercises the REAL Baseline +
+// Measurer over the store without spinning a game stack.
+type stubRunner struct{ run Run }
+
+func (s stubRunner) Run(context.Context, Proposal, int) (Run, error) { return s.run, nil }

--- a/services/agent/experiment_fitness_store_test.go
+++ b/services/agent/experiment_fitness_store_test.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/joustmania/agent/decision"
+	"github.com/joustmania/agent/experiment"
+	"github.com/joustmania/agent/gamecontext"
+)
+
+// experiment_fitness_store_test.go covers the #965/#1017 instrumentation: onGameEnd
+// recording finalized per-game fitness into the store for BOTH real and shadow
+// games (the previously-DROPPED real-game fitness the Validator's Baseline needs).
+
+// loopWithStore builds a minimal experimentLoop with a real fitness store and the
+// default fitness func, for exercising the onGameEnd recording paths in isolation.
+// It has NO registry, so the experiment-game branch's ConcludeGame is not driven
+// here — these tests assert only the STORE recording, which happens before
+// ConcludeGame. (The full conclude pipeline is covered by experiment_loop_test.go.)
+func loopWithStore(store *experiment.FitnessStore) *experimentLoop {
+	return &experimentLoop{
+		log:          testLogger(),
+		fitness:      defaultGameFitness,
+		fitnessStore: store,
+	}
+}
+
+// realEnduranceGC builds a finished REAL game whose endurance fitness is evaluable
+// (it carries a recovered duration via a start→end timeline). durationS controls the
+// session length so the endurance progress is predictable.
+func realEnduranceGC(gameID string, durationS float64) gamecontext.GameContext {
+	start := time.Unix(1_000, 0)
+	return gamecontext.GameContext{
+		SessionID: gameID,
+		GameKind:  experiment.GameKindReal,
+		Timeline: []gamecontext.TimelineEvent{
+			{At: start, Kind: gamecontext.EventPhase, Detail: "start"},
+			{At: start.Add(time.Duration(durationS) * time.Second), Kind: gamecontext.EventPhase, Detail: "end"},
+		},
+	}
+}
+
+// TestOnGameEnd_RecordsRealGameFitness: a finished REAL game's fitness is now
+// stored, keyed by game_id, for every experimentable objective it evaluated — the
+// #1017 gap (previously dropped). The recorded sample is readable as a recent-real
+// baseline input.
+func TestOnGameEnd_RecordsRealGameFitness(t *testing.T) {
+	store := experiment.NewFitnessStore(0)
+	loop := loopWithStore(store)
+
+	// A long real game → high endurance progress.
+	loop.onGameEnd(realEnduranceGC("game_real1", 600))
+
+	sample, ok := store.Get("game_real1")
+	if !ok {
+		t.Fatalf("real game fitness not recorded in the store (#1017 gap)")
+	}
+	if sample.GameKind != experiment.GameKindReal {
+		t.Errorf("recorded game_kind = %q, want real", sample.GameKind)
+	}
+	// The store must surface it as a recent-real sample for the endurance baseline.
+	recent := store.RecentReal(decision.ObjectiveEndurance, 8)
+	found := false
+	for _, s := range recent {
+		if s.GameID == "game_real1" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("recorded real game not returned by RecentReal(endurance)")
+	}
+}
+
+// TestOnGameEnd_ShadowWithoutExperimentNotInRealBaseline: a game labeled shadow but
+// carrying no ExperimentID must NOT pollute the recent-real baseline (only real
+// games seed it).
+func TestOnGameEnd_ShadowWithoutExperimentNotInRealBaseline(t *testing.T) {
+	store := experiment.NewFitnessStore(0)
+	loop := loopWithStore(store)
+
+	gc := realEnduranceGC("game_shadowish", 600)
+	gc.GameKind = "shadow" // labeled shadow, no ExperimentID
+	loop.onGameEnd(gc)
+
+	if got := store.RecentReal(decision.ObjectiveEndurance, 8); len(got) != 0 {
+		t.Fatalf("a shadow-labeled game must not seed the real baseline, got %d samples", len(got))
+	}
+}
+
+// TestRecordFinalizedRealFitness_SkipsMissingSignalObjective: a real game whose
+// signals don't support an objective (e.g. no duration → endurance skipped) does NOT
+// fabricate a sample for it (the #731 honesty contract).
+func TestRecordFinalizedRealFitness_SkipsMissingSignalObjective(t *testing.T) {
+	store := experiment.NewFitnessStore(0)
+	loop := loopWithStore(store)
+
+	// No duration, no timeline → endurance/accelerate skip; no players → balanced skips.
+	gc := gamecontext.GameContext{SessionID: "game_signalless", GameKind: experiment.GameKindReal}
+	loop.onGameEnd(gc)
+
+	if store.Len() != 0 {
+		t.Fatalf("a signal-less real game must not fabricate a fitness sample, got %d", store.Len())
+	}
+}

--- a/services/agent/experiment_loop.go
+++ b/services/agent/experiment_loop.go
@@ -109,6 +109,23 @@ type experimentLoop struct {
 	flags    *flags.Flags
 	log      *slog.Logger
 
+	// fitnessStore is the finalized-per-game fitness store (#965/#1017): onGameEnd
+	// records every concluded game's settled fitness here, keyed by game_id, for
+	// BOTH a shadow validation game (read back by the M7-7 StoreMeasurer) and a real
+	// primary game (averaged by the StoreBaseline). It is the instrumentation the
+	// Validator's Baseline/FitnessMeasurer seams read. nil ⇒ recording is skipped
+	// (test wiring that does not exercise the validation path).
+	fitnessStore *experiment.FitnessStore
+
+	// validator is the M7-7 synthetic-validation gate (#935) wired over the LIVE #965
+	// seams: it runs a candidate Proposal through real shadow games (the
+	// shadowValidationRunner), measures their finalized fitness against the recent-real
+	// baseline (the StoreMeasurer + StoreBaseline), and returns a promote/discard/revert
+	// Decision. It is invoked ONLY from the gated, fail-closed (#1016)
+	// autonomous-promotion path; merely holding it is inert. nil in test wiring that
+	// does not exercise validation.
+	validator *experiment.Validator
+
 	// expDefaults are the BOOTSTRAP defaults for the migrated runtime knobs (#1044):
 	// the values resolved ONCE at startup from the AGENT_EXPERIMENT_* env vars. Each
 	// tick's live config(ctx) read falls back to these when the matching agent.json
@@ -248,17 +265,35 @@ func buildExperimentLoop(
 		Log:       logger,
 	})
 
+	// FitnessStore (#965/#1017): the finalized-per-game fitness store onGameEnd
+	// Records into and the M7-7 validation seams read from. It is the instrumentation
+	// that turns the Validator's injected fitness reads into REAL ones.
+	fitnessStore := experiment.NewFitnessStore(fitnessStoreCapacity())
+
 	loop := &experimentLoop{
 		registry:       registry,
 		spawner:        spawner,
 		flags:          flagsClient,
 		log:            logger,
+		fitnessStore:   fitnessStore,
 		expDefaults:    expDefaults,
 		seed:           seedIntentFromEnv(),
 		fitness:        defaultGameFitness,
 		completedGrace: completedGrace(),
 		dynamic:        newDynamicDeclarerFromEnv(gameFlagPath, nil),
 	}
+	// Build the M7-7 Validator (#935) over the LIVE seams (#965): the shadow
+	// SyntheticRunner drives real shadow games via the spawner; the FitnessMeasurer +
+	// Baseline read the finalized store; the Reverter strips shadow targeting via the
+	// #977 Writer. It is stored on the loop for the (gated, fail-closed #1016)
+	// autonomous-promotion path to invoke; merely building it is inert.
+	loop.validator = experiment.NewValidator(
+		experiment.NewStoreBaseline(fitnessStore, validatorObjectiveResolver(registry), validationBaselineRecentN(), validationBaselineMinSamples()),
+		newShadowValidationRunner(spawner, fitnessStore, validationGameTimeout(), logger),
+		experiment.NewStoreMeasurer(fitnessStore),
+		experiment.NewWriterReverter(writer),
+		nil, logger,
+	)
 	logger.Info("Dynamic experiment declarer constructed (#995/#1044) — gated LIVE by agent.json experiment_dynamic_enabled",
 		"env_dynamic_default", expDefaults.DynamicEnabled,
 		"candidates", os.Getenv(envDynamicCandidates))
@@ -587,27 +622,44 @@ func (e *experimentLoop) declareAndStart(ctx context.Context, in experiment.Inte
 // existing per-game retro/summary path. After a conclusion it nudges
 // AllocateAndSpawn so the freed slot is refilled promptly (capacity churn).
 func (e *experimentLoop) onGameEnd(gc gamecontext.GameContext) {
-	if gc.ExperimentID == "" {
-		return // not an experiment game.
-	}
-	objective := ""
-	if cv, ok := e.registry.CompactView(gc.ExperimentID); ok {
-		objective = cv.Intent.Objective
-	}
 	// The coordinator emits game_duration_seconds ONLY at game end (one gauge set in
 	// the session teardown), so for an agent-spawned shadow game it routinely loses
 	// the race against the game_active=0 datapoint that fires THIS hook — leaving
 	// gc.Session.DurationSeconds nil at conclusion. That nil made every
 	// duration-based objective (endurance/accelerate) skip its fitness function and
 	// fold the worst-case 0 (#997). Recover the real elapsed time from the partition's
-	// own start→end phase timeline so a concluded shadow game carries a meaningful,
-	// objective-relevant duration even when the end-only gauge has not arrived.
+	// own start→end phase timeline so a concluded game carries a meaningful,
+	// objective-relevant duration even when the end-only gauge has not arrived. This
+	// recovery now applies to REAL games too (#1017 §3 item 2) so a dropped end gauge
+	// cannot poison the recent-real baseline with a worst-case 0.
 	gc = withEffectiveDuration(gc)
-	fitness := e.fitness(gc, objective)
 	duration := 0.0
 	if gc.Session.DurationSeconds != nil {
 		duration = *gc.Session.DurationSeconds
 	}
+
+	if gc.ExperimentID == "" {
+		// Not an experiment game. Pre-#965 this returned immediately and the game's
+		// fitness was dropped. The #1017 instrumentation gap: a REAL primary game's
+		// fitness is COMPUTABLE today (same EvaluateFitness, substrate-agnostic) but is
+		// never stored — leaving the Validator's Baseline seam with no real-game signal.
+		// Record it into the finalized-per-game store (keyed by game_id) so the
+		// StoreBaseline can read the mean of the last N real games. This is a pure ADD:
+		// a non-experiment game still does nothing else (no cohort fold, no allocate).
+		e.recordFinalizedRealFitness(gc, duration)
+		return
+	}
+
+	objective := ""
+	if cv, ok := e.registry.CompactView(gc.ExperimentID); ok {
+		objective = cv.Intent.Objective
+	}
+	fitness := e.fitness(gc, objective)
+	// Record the SHADOW game's finalized fitness keyed by game_id (#965) so the M7-7
+	// StoreMeasurer can read a validation batch's fitness back. This is the same
+	// scalar ConcludeGame folds into the cohort journal — captured for the validation
+	// path too.
+	e.recordFinalizedFitness(gc, objective, fitness, duration)
 	status, err := e.registry.ConcludeGame(context.Background(), gc.SessionID, fitness, duration)
 	if err != nil {
 		e.log.Warn("experiment: conclude game failed", "game_id", gc.SessionID, "error", err)
@@ -617,6 +669,75 @@ func (e *experimentLoop) onGameEnd(gc gamecontext.GameContext) {
 		// A freed in-flight slot; refill it (respecting the kill-switch).
 		e.allocateIfEnabled(context.Background())
 	}
+}
+
+// recordFinalizedFitness writes one finalized SHADOW-game fitness sample into the
+// store keyed by game_id (#965). It is the capture side the StoreMeasurer reads:
+// the same defaultGameFitness scalar ConcludeGame folds into the cohort journal,
+// settled (post-withEffectiveDuration), available to the validation path. A nil
+// store (test wiring) is a no-op.
+func (e *experimentLoop) recordFinalizedFitness(gc gamecontext.GameContext, objective string, fitness, duration float64) {
+	if e.fitnessStore == nil {
+		return
+	}
+	if objective == "" {
+		objective = decision.ObjectiveBalanced
+	}
+	e.fitnessStore.Record(experiment.FitnessSample{
+		GameID:    gc.SessionID,
+		Fitness:   fitness,
+		Objective: objective,
+		GameKind:  gameKindOrDefault(gc),
+		DurationS: duration,
+	})
+}
+
+// recordFinalizedRealFitness writes a REAL primary game's finalized fitness into
+// the store (#1017 §3 item 1) — the previously-DROPPED real-game fitness the
+// Validator's Baseline needs. A real game is not bound to one objective, so it is
+// scored against EVERY experimentable objective its GameContext can evaluate and a
+// per-objective sample is recorded; the StoreBaseline then filters by the
+// experiment-under-validation's objective. Only objectives the fitness function
+// actually evaluated (signals present) are recorded — a missing-signal objective is
+// never fabricated (#731 honesty). A nil store or a non-real game_kind is skipped
+// (only real games seed the baseline). A nil store (test wiring) is a no-op.
+func (e *experimentLoop) recordFinalizedRealFitness(gc gamecontext.GameContext, duration float64) {
+	if e.fitnessStore == nil {
+		return
+	}
+	// Guard the baseline against shadow/unknown-kind games: only a game explicitly
+	// labeled real may seed the recent-real baseline. An agent-spawned shadow game
+	// never reaches here (it carries an ExperimentID), but a defensively-labeled
+	// shadow game with no ExperimentID must not pollute the real baseline.
+	if gameKindOrDefault(gc) != experiment.GameKindReal {
+		return
+	}
+	eval := decision.EvaluateFitness(gc, decision.DefaultStaticConfig().FitnessThresholds)
+	for objective, r := range eval.Results {
+		if !r.Evaluated || !decision.IsExperimentable(objective) {
+			continue
+		}
+		e.fitnessStore.Record(experiment.FitnessSample{
+			GameID:    gc.SessionID,
+			Fitness:   r.Progress,
+			Objective: objective,
+			GameKind:  experiment.GameKindReal,
+			DurationS: duration,
+		})
+	}
+}
+
+// gameKindOrDefault returns the game's kind label, defaulting an empty label to
+// "real": the coordinator labels a player-facing game "real" but an older/edge
+// datapoint may omit the label, and the conservative default for the baseline is to
+// treat an unlabeled, non-experiment game as real (it has no ExperimentID and was
+// not agent-spawned). An agent shadow game ALWAYS carries an ExperimentID, so it is
+// never mislabeled real by this default.
+func gameKindOrDefault(gc gamecontext.GameContext) string {
+	if gc.GameKind == "" {
+		return experiment.GameKindReal
+	}
+	return gc.GameKind
 }
 
 // onGameTerminal is the #1014 terminal-outcome backstop, invoked by a spawned
@@ -894,6 +1015,92 @@ func dynamicMaxConcurrent() int {
 		}
 	}
 	return defaultDynamicMaxConcurrent
+}
+
+// M7-7 validation seam env knobs (#965). These tune the LIVE Validator wiring; all
+// have safe defaults so the validation path is wired even with none set. They are
+// distinct from the cohort knobs (#1044) because the synthetic-validation gate is a
+// separate, gated path (the autonomous-promotion #1016 surface).
+const (
+	// envFitnessStoreCapacity overrides the finalized-fitness ring size.
+	envFitnessStoreCapacity = "AGENT_FITNESS_STORE_CAPACITY"
+	// envValidationGameTimeout overrides the per-cycle await for shadow games' fitness.
+	envValidationGameTimeout = "AGENT_VALIDATION_GAME_TIMEOUT_SECONDS"
+	// envValidationBaselineRecentN overrides how many recent real games the baseline averages.
+	envValidationBaselineRecentN = "AGENT_VALIDATION_BASELINE_RECENT_N"
+	// envValidationBaselineMinSamples overrides the minimum real samples a baseline needs.
+	envValidationBaselineMinSamples = "AGENT_VALIDATION_BASELINE_MIN_SAMPLES"
+)
+
+// defaultValidationBaselineRecentN is the default number of recent real games the
+// StoreBaseline averages. It mirrors the verdict's DefaultMinNPerArm (8) so the
+// baseline rests on a comparable sample to what the cohort verdict already trusts
+// (#1017 §2).
+const defaultValidationBaselineRecentN = 8
+
+// defaultValidationBaselineMinSamples is the default minimum real samples before a
+// baseline is trusted. Below it the Validator FAILS CLOSED (no promotion against a
+// baseline of too-few real games). A conservative floor of 3 means a baseline is
+// never a single-game fluke.
+const defaultValidationBaselineMinSamples = 3
+
+// fitnessStoreCapacity resolves the finalized-fitness ring size from
+// AGENT_FITNESS_STORE_CAPACITY, falling back to the package default on an
+// unset/invalid/non-positive value.
+func fitnessStoreCapacity() int {
+	return positiveIntEnv(envFitnessStoreCapacity, experiment.DefaultFitnessStoreCapacity)
+}
+
+// validationGameTimeout resolves the per-cycle await timeout from
+// AGENT_VALIDATION_GAME_TIMEOUT_SECONDS (seconds), falling back to
+// DefaultValidationGameTimeout on an unset/invalid/non-positive value.
+func validationGameTimeout() time.Duration {
+	if v := strings.TrimSpace(os.Getenv(envValidationGameTimeout)); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return time.Duration(n) * time.Second
+		}
+	}
+	return DefaultValidationGameTimeout
+}
+
+// validationBaselineRecentN resolves how many recent real games the baseline
+// averages from AGENT_VALIDATION_BASELINE_RECENT_N.
+func validationBaselineRecentN() int {
+	return positiveIntEnv(envValidationBaselineRecentN, defaultValidationBaselineRecentN)
+}
+
+// validationBaselineMinSamples resolves the minimum real samples a baseline needs
+// from AGENT_VALIDATION_BASELINE_MIN_SAMPLES.
+func validationBaselineMinSamples() int {
+	return positiveIntEnv(envValidationBaselineMinSamples, defaultValidationBaselineMinSamples)
+}
+
+// positiveIntEnv parses a positive integer env var, returning fallback on an
+// unset/invalid/non-positive value.
+func positiveIntEnv(key string, fallback int) int {
+	if v := strings.TrimSpace(os.Getenv(key)); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return fallback
+}
+
+// validatorObjectiveResolver maps a Proposal to its experiment's fitness objective
+// by reading the registry's CompactView keyed by the proposal's ExperimentID. The
+// objective is what the StoreBaseline filters recent-real samples by, so the
+// baseline is per-objective (#1017 §3 item 4). An unknown experiment id yields ""
+// (any-objective), the safe degrade.
+func validatorObjectiveResolver(reg *experiment.Registry) experiment.ObjectiveResolver {
+	return func(p experiment.Proposal) string {
+		if reg == nil || p.ExperimentID == "" {
+			return ""
+		}
+		if cv, ok := reg.CompactView(p.ExperimentID); ok {
+			return cv.Intent.Objective
+		}
+		return ""
+	}
 }
 
 // seedIntentFromEnv builds the single seed experiment Intent from the

--- a/services/agent/shadow_validation_runner.go
+++ b/services/agent/shadow_validation_runner.go
@@ -1,0 +1,200 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/joustmania/agent/experiment"
+)
+
+// shadow_validation_runner.go is the REAL SyntheticRunner seam (#965) the M7-7
+// Validator (experiment/validate.go) injects — the production replacement for the
+// validate_test.go fakeRunner.
+//
+// WHAT IT DOES (the #965 live wiring): given a validated Proposal whose experiment
+// is ALREADY written shadow-scoped (the Gate accepted it — the Validator's
+// precondition), it drives `games` REAL shadow games on the live stack through the
+// agent's existing shadow-game machinery (the #778 gamerunner via the #976
+// shadowSpawner), bound to the proposal's experiment_id + the EXPERIMENTAL arm so
+// each game resolves the candidate variant (the targeting #977 routes it). It then
+// AWAITS each game's finalized fitness in the #965 FitnessStore and returns a Run
+// whose ID carries the spawned game_ids — which the StoreMeasurer reads back.
+//
+// HOW IT REUSES THE SESSION'S SHADOW MACHINERY:
+//   - shadowSpawner.Spawn starts ONE experiment-bound shadow game and returns its
+//     coordinator game_id promptly; the game then plays to completion in a
+//     background goroutine and its fitness flows through telemetry → onGameEnd, the
+//     SAME path every cohort game uses. The runner does NOT re-implement game
+//     driving — it reuses the spawner verbatim.
+//   - onGameEnd Records the finalized per-game fitness into the FitnessStore keyed
+//     by game_id (the #1017 instrumentation). The runner waits for those records to
+//     appear, so "synthetic run + measure" is the spawner + the store, end to end.
+//
+// SCOPED vs DEFERRED (#965): the runner spawns + awaits REAL shadow games and reads
+// REAL computed fitness — the substrate the issue asks for. It is invoked ONLY from
+// the autonomous-promotion path, which is itself gated and currently FAIL-CLOSED
+// (#1016), so wiring it adds no new privilege. Driving real PRIMARY games / the live
+// LLM proposer is #992 / the live loop's territory, NOT here.
+
+// DefaultValidationGameTimeout bounds how long the runner waits for ALL spawned
+// shadow games to finalize their fitness in the store before giving up on the
+// stragglers. Shadow games are minutes-long and run sequentially under the
+// single-game coordinator, so the budget must comfortably exceed games ×
+// per-game-duration; it is generous but bounded so a stuck game can never wedge the
+// validation cycle. Tunable via AGENT_VALIDATION_GAME_TIMEOUT_SECONDS.
+const DefaultValidationGameTimeout = 10 * time.Minute
+
+// DefaultValidationPollInterval is how often the runner re-checks the store for a
+// spawned game's finalized fitness while awaiting completion.
+const DefaultValidationPollInterval = 500 * time.Millisecond
+
+// shadowValidationRunner is the SyntheticRunner backed by the real shadow spawner +
+// the finalized-per-game fitness store. It depends on the experiment.ShadowSpawner
+// INTERFACE (which the production shadowSpawner satisfies) so it is unit-testable
+// with a recording fake spawner.
+type shadowValidationRunner struct {
+	spawner experiment.ShadowSpawner
+	store   *experiment.FitnessStore
+	log     *slog.Logger
+
+	// gameTimeout bounds the await for all spawned games' fitness; pollInterval is
+	// the store re-check cadence. Injected so tests drive completion without real
+	// sleeps.
+	gameTimeout  time.Duration
+	pollInterval time.Duration
+
+	// now/sleep are injected for deterministic tests; production uses the wall clock.
+	now   func() time.Time
+	sleep func(context.Context, time.Duration) error
+}
+
+// newShadowValidationRunner builds the runner over the shared shadow spawner and
+// fitness store. log nil ⇒ slog.Default().
+func newShadowValidationRunner(spawner experiment.ShadowSpawner, store *experiment.FitnessStore, gameTimeout time.Duration, log *slog.Logger) *shadowValidationRunner {
+	if log == nil {
+		log = slog.Default()
+	}
+	if gameTimeout <= 0 {
+		gameTimeout = DefaultValidationGameTimeout
+	}
+	return &shadowValidationRunner{
+		spawner:      spawner,
+		store:        store,
+		log:          log,
+		gameTimeout:  gameTimeout,
+		pollInterval: DefaultValidationPollInterval,
+		now:          func() time.Time { return time.Now() },
+		sleep:        sleepCtx,
+	}
+}
+
+// Run spawns `games` experimental-arm shadow games for p's experiment, awaits their
+// finalized fitness in the store, and returns a Run carrying the spawned game_ids.
+// It satisfies experiment.SyntheticRunner.
+//
+// FAIL CLOSED: if NO game can be spawned at all, Run errors so the Validator
+// discards (never promotes on no evidence). If SOME games spawn but not all
+// finalize within the timeout, the Run still returns the ids that DID finalize — a
+// smaller-but-valid sample the Validator records as the realized game count; the
+// StoreMeasurer averages only the games that produced a sample.
+func (r *shadowValidationRunner) Run(ctx context.Context, p experiment.Proposal, games int) (experiment.Run, error) {
+	if r.spawner == nil {
+		return experiment.Run{}, fmt.Errorf("synthetic run: shadow spawner not wired")
+	}
+	if r.store == nil {
+		return experiment.Run{}, fmt.Errorf("synthetic run: fitness store not wired")
+	}
+	if p.ExperimentID == "" {
+		// Without an experiment id the spawned games carry no experimental-arm binding,
+		// so the targeting (#977) would resolve the DEFAULT variant and the "after"
+		// fitness would not reflect the candidate at all. Refuse rather than measure a
+		// non-experimental run.
+		return experiment.Run{}, fmt.Errorf("synthetic run: proposal has no experiment id (cannot bind experimental arm)")
+	}
+	if games < 1 {
+		games = 1
+	}
+
+	spawned := make([]string, 0, games)
+	for i := 0; i < games; i++ {
+		// seed 0 = entropy: the validation batch is not a CRN-paired cohort (it measures
+		// the experimental arm against the recent-real baseline, not a within-batch
+		// control), so each game gets independent entropy.
+		gameID, err := r.spawner.Spawn(ctx, p.ExperimentID, experiment.ArmExperimental, 0)
+		if err != nil {
+			if errors.Is(err, experiment.ErrSpawnBackpressure) {
+				// Coordinator at capacity: not a failure. Wait a beat and retry the SAME
+				// slot so the batch still reaches `games` games rather than under-sampling.
+				r.log.Debug("synthetic run: spawn backpressure, retrying",
+					"experiment_id", p.ExperimentID, "spawned_so_far", len(spawned))
+				if werr := r.sleep(ctx, r.pollInterval); werr != nil {
+					break // ctx cancelled while waiting on backpressure.
+				}
+				i--
+				continue
+			}
+			r.log.Warn("synthetic run: shadow game spawn failed",
+				"experiment_id", p.ExperimentID, "spawned_so_far", len(spawned), "error", err)
+			break
+		}
+		spawned = append(spawned, gameID)
+	}
+
+	if len(spawned) == 0 {
+		return experiment.Run{}, fmt.Errorf("synthetic run: no shadow game could be spawned for experiment %s", p.ExperimentID)
+	}
+
+	// Await each spawned game's finalized fitness in the store (the #965/#1017
+	// settled-sample contract). Games that never finalize within the timeout are
+	// dropped from the returned ids so the measurer never blocks on a stuck game.
+	finalized := r.awaitFinalized(ctx, spawned)
+	if len(finalized) == 0 {
+		return experiment.Run{}, fmt.Errorf("synthetic run: none of %d spawned shadow games finalized fitness within %s",
+			len(spawned), r.gameTimeout)
+	}
+	r.log.Info("synthetic run: shadow validation batch complete",
+		"experiment_id", p.ExperimentID, "spawned", len(spawned), "finalized", len(finalized))
+	return experiment.NewRun(finalized), nil
+}
+
+// awaitFinalized polls the store until every spawned game has a finalized fitness
+// sample or the game timeout elapses, returning the ids that finalized. It returns
+// promptly once all games are in; the timeout only bites on a stuck/errored game.
+func (r *shadowValidationRunner) awaitFinalized(ctx context.Context, spawned []string) []string {
+	deadline := r.now().Add(r.gameTimeout)
+	for {
+		done := make([]string, 0, len(spawned))
+		for _, id := range spawned {
+			if _, ok := r.store.Get(id); ok {
+				done = append(done, id)
+			}
+		}
+		if len(done) == len(spawned) {
+			return done // all finalized.
+		}
+		if !r.now().Before(deadline) {
+			r.log.Warn("synthetic run: validation timed out awaiting fitness; using games finalized so far",
+				"spawned", len(spawned), "finalized", len(done), "timeout", r.gameTimeout)
+			return done
+		}
+		if err := r.sleep(ctx, r.pollInterval); err != nil {
+			// ctx cancelled (agent shutdown): return whatever finalized so far.
+			return done
+		}
+	}
+}
+
+// sleepCtx sleeps for d or returns early with ctx.Err() if ctx is cancelled first.
+func sleepCtx(ctx context.Context, d time.Duration) error {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-t.C:
+		return nil
+	}
+}

--- a/services/agent/shadow_validation_runner_test.go
+++ b/services/agent/shadow_validation_runner_test.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/joustmania/agent/experiment"
+)
+
+// shadow_validation_runner_test.go covers the #965 live SyntheticRunner: it spawns
+// real shadow games via the spawner seam and awaits their finalized fitness in the
+// store. The spawner is a recording fake (the real shadowSpawner needs a game
+// stack); the store is real.
+
+// validationSpawner is a fake experiment.ShadowSpawner for the runner tests: it
+// mints sequential game_ids and records the (experimentID, arm) of each call. Named
+// distinctly from the experiment_loop_test recordingSpawner to avoid a redeclare.
+type validationSpawner struct {
+	calls          int
+	ids            []string
+	gotExperiments []string
+	gotArms        []string
+}
+
+func (s *validationSpawner) Spawn(_ context.Context, experimentID, arm string, _ uint64) (string, error) {
+	s.calls++
+	s.gotExperiments = append(s.gotExperiments, experimentID)
+	s.gotArms = append(s.gotArms, arm)
+	id := "game_s" + string(rune('0'+len(s.ids)))
+	s.ids = append(s.ids, id)
+	return id, nil
+}
+
+// alwaysErrSpawner errors on every Spawn (no game ever starts).
+type alwaysErrSpawner struct{}
+
+func (alwaysErrSpawner) Spawn(context.Context, string, string, uint64) (string, error) {
+	return "", errors.New("coordinator unreachable")
+}
+
+// newTestRunner builds a runner with a fake spawner + a real store and a fast,
+// no-real-sleep poll so the await loop turns quickly in tests.
+func newTestRunner(spawner experiment.ShadowSpawner, store *experiment.FitnessStore) *shadowValidationRunner {
+	r := newShadowValidationRunner(spawner, store, 2*time.Second, discardLogger())
+	r.pollInterval = time.Millisecond
+	r.sleep = func(ctx context.Context, _ time.Duration) error {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			return nil
+		}
+	}
+	return r
+}
+
+// TestRunner_SpawnsExperimentalArmAndReturnsFinalizedIDs: the runner spawns N games
+// bound to the proposal's experiment + the EXPERIMENTAL arm and returns a Run with
+// the game_ids whose fitness finalized in the store.
+func TestRunner_SpawnsExperimentalArmAndReturnsFinalizedIDs(t *testing.T) {
+	spawner := &validationSpawner{}
+	store := experiment.NewFitnessStore(0)
+	r := newTestRunner(spawner, store)
+
+	// Pre-seed the store so the spawned games (game_s0, game_s1) are "already
+	// finalized" the moment the runner awaits.
+	store.Record(experiment.FitnessSample{GameID: "game_s0", Fitness: 0.6, GameKind: "shadow"})
+	store.Record(experiment.FitnessSample{GameID: "game_s1", Fitness: 0.6, GameKind: "shadow"})
+
+	run, err := r.Run(context.Background(), experiment.Proposal{ExperimentID: "exp_1"}, 2)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if spawner.calls != 2 {
+		t.Errorf("spawner called %d times, want 2", spawner.calls)
+	}
+	for _, arm := range spawner.gotArms {
+		if arm != experiment.ArmExperimental {
+			t.Errorf("spawned arm = %q, want experimental", arm)
+		}
+	}
+	for _, exp := range spawner.gotExperiments {
+		if exp != "exp_1" {
+			t.Errorf("spawned experiment = %q, want exp_1", exp)
+		}
+	}
+	if ids := experiment.RunGameIDs(run); len(ids) != 2 {
+		t.Fatalf("run returned %d game ids, want 2", len(ids))
+	}
+}
+
+// TestRunner_FailsClosedWithoutExperimentID: a proposal with no experiment id is
+// refused (the spawned games would resolve the default variant, not the candidate).
+func TestRunner_FailsClosedWithoutExperimentID(t *testing.T) {
+	r := newTestRunner(&validationSpawner{}, experiment.NewFitnessStore(0))
+	if _, err := r.Run(context.Background(), experiment.Proposal{}, 2); err == nil {
+		t.Fatalf("expected error for a proposal with no experiment id")
+	}
+}
+
+// TestRunner_FailsClosedWhenNoGameSpawns: when the spawner cannot start any game,
+// Run errors (no evidence → the Validator discards).
+func TestRunner_FailsClosedWhenNoGameSpawns(t *testing.T) {
+	r := newTestRunner(alwaysErrSpawner{}, experiment.NewFitnessStore(0))
+	if _, err := r.Run(context.Background(), experiment.Proposal{ExperimentID: "exp_1"}, 2); err == nil {
+		t.Fatalf("expected error when no shadow game could be spawned")
+	}
+}
+
+// TestRunner_TimeoutReturnsFinalizedSoFar: when some spawned games never finalize,
+// the runner returns the ids that DID finalize once the timeout elapses (a smaller
+// but valid sample), rather than blocking forever.
+func TestRunner_TimeoutReturnsFinalizedSoFar(t *testing.T) {
+	spawner := &validationSpawner{}
+	store := experiment.NewFitnessStore(0)
+	r := newTestRunner(spawner, store)
+	// Only game_s0 ever finalizes; drive now() past the deadline after a couple polls.
+	store.Record(experiment.FitnessSample{GameID: "game_s0", Fitness: 0.5, GameKind: "shadow"})
+	calls := 0
+	start := time.Now()
+	r.now = func() time.Time {
+		calls++
+		if calls > 2 {
+			return start.Add(time.Hour)
+		}
+		return start
+	}
+
+	run, err := r.Run(context.Background(), experiment.Proposal{ExperimentID: "exp_1"}, 2)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	ids := experiment.RunGameIDs(run)
+	if len(ids) != 1 || ids[0] != "game_s0" {
+		t.Fatalf("run ids = %v, want [game_s0] (only finalized game)", ids)
+	}
+}


### PR DESCRIPTION
## What & why

The M7-7 `experiment.Validator` (#935, PR #956) was built with **injectable** fitness seams (`SyntheticRunner` / `FitnessMeasurer` / `Baseline` / `Reverter`) and was never constructed in production. This PR wires those seams to the **real shadow-game machinery** and a **finalized-per-game fitness store**, so the Validator validates a candidate against ACTUAL shadow games + computed fitness instead of injected fakes.

Per the #1017 methodology: real and shadow games already emit the **same fitness inputs through the same substrate-agnostic** `decision.EvaluateFitness`, so fitness is COMPUTABLE today — it was simply never **stored** for the validation path. The single gap was a finalized-per-game fitness store keyed by `game_id` (the `Baseline.Fitness` seam). This PR closes it.

## Seams wired

- **`SyntheticRunner`** (`shadow_validation_runner.go`) — spawns N experimental-arm shadow games for a candidate `Proposal` via the existing #976 `shadowSpawner` (reusing the #778 `gamerunner`/`StartExperimentGame` drive path verbatim), then awaits each game's finalized fitness in the store and returns a `Run` carrying the spawned `game_id`s.
- **`FitnessMeasurer` → `StoreMeasurer`** (`experiment/validate_seams.go`) — the mean finalized fitness of a `Run`'s shadow games, read back by `game_id` from the store. Fails closed when none finalized.
- **`Baseline` → `StoreBaseline`** — the mean of the last N **real** (`game_kind="real"`) games for the experiment's objective; fails closed below a minimum sample count.
- **`Reverter` → `WriterReverter`** — strips the experiment's shadow targeting branch via the #977 `Writer` (the inverse of the Gate's Apply).
- **The #1017 store gap** (`experiment/fitness_store.go`) — a bounded, thread-safe, finalized-per-`(game_id, objective)` fitness store. `onGameEnd` now Records into it for **both** shadow validation games **and** real primary games (the previously-dropped real fitness), using the same `defaultGameFitness`→`EvaluateFitness` scalar the cohort journal already folds. Samples are **settled** (post-`withEffectiveDuration`), never racing the span flush (#958/#1017). The #997 duration recovery now applies to real games too, so a dropped end-gauge can't poison the baseline.
- **Validator construction** wired into `buildExperimentLoop` over the LIVE seams.

## Scope / deferred

- This is the **shadow** validation substrate. Real-primary-game fitness for the runtime cross-check baseline is **#992's** territory; the live LLM proposer loop is the live loop's.
- The Validator is invoked **only** from the gated, **fail-closed (#1016)** autonomous-promotion path — merely building/holding it is inert, so this adds no new privilege.

## Tests

`FitnessStore` (record/get/ring eviction/recent-real filtering), the three store seams + a Validator end-to-end over the wired store seams (real PROMOTE verdict on shadow fitness vs recent-real baseline), the runner (experimental-arm spawn, fail-closed paths, timeout-returns-finalized-so-far), and `onGameEnd` real-game recording (incl. missing-signal honesty + shadow-not-in-baseline guard). `go test ./... -race`, `go vet`, `gofmt -l` all clean; existing validate/experiment tests unchanged and green.

Part of #965

🤖 Generated with [Claude Code](https://claude.com/claude-code)