### PR TITLE
feat(agent): recent-real fitness baseline as secondary verdict anchor (#992)

### DIFF
--- a/services/agent/experiment/journal/journal.go
+++ b/services/agent/experiment/journal/journal.go
@@ -448,6 +448,10 @@ func (j *Journal) Summary() Summary {
 // copySummaryLocked deep-copies the rolling summary. Assumes j.mu is held.
 func (j *Journal) copySummaryLocked() Summary {
 	out := j.summary
+	// Objective is a derived VIEW field (#992): always sourced from the immutable
+	// intent, never folded onto the persisted summary, so it survives a rehydrate
+	// (intent.json is authoritative) without summary-schema migration.
+	out.Objective = j.intent.Objective
 	out.Arms = make(map[string]*ArmStat, len(j.summary.Arms))
 	for name, stat := range j.summary.Arms {
 		s := *stat

--- a/services/agent/experiment/journal/journal_test.go
+++ b/services/agent/experiment/journal/journal_test.go
@@ -210,6 +210,29 @@ func TestRehydrate_SurvivesRestart(t *testing.T) {
 	}
 }
 
+// TestSummary_ObjectiveFromIntent: Summary().Objective is a derived view field
+// (#992) always sourced from the immutable intent, so it is present on a fresh
+// journal AND survives a rehydrate from disk (intent.json is authoritative) — the
+// #992 recent-real anchor reads it to key the per-objective baseline.
+func TestSummary_ObjectiveFromIntent(t *testing.T) {
+	dir := t.TempDir()
+	j, err := Create(dir, testIntent())
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if got := j.Summary().Objective; got != "engagement_balanced" {
+		t.Fatalf("fresh Summary().Objective = %q, want %q", got, "engagement_balanced")
+	}
+
+	reloaded, err := Load(dir, "exp_a1b2c3d4e5f6")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got := reloaded.Summary().Objective; got != "engagement_balanced" {
+		t.Fatalf("rehydrated Summary().Objective = %q, want %q", got, "engagement_balanced")
+	}
+}
+
 // TestRehydrate_RecomputesFromLogNotSummaryCache: the event log is the source of
 // truth. A corrupted summary.json on disk must NOT influence Load — the rebuilt
 // summary comes purely from intent + events.

--- a/services/agent/experiment/journal/record.go
+++ b/services/agent/experiment/journal/record.go
@@ -209,6 +209,15 @@ type Summary struct {
 	SchemaVersion int `json:"schema_version"`
 	// ExperimentID joins the summary to its intent and events.
 	ExperimentID string `json:"experiment_id"`
+	// Objective is the experiment's fitness objective (endurance/balanced/accelerate),
+	// copied from Intent.Objective onto every Summary the journal hands out (#992). It
+	// lets the CohortVerdict seam read the objective WITHOUT widening Evaluate's
+	// signature — the recent-real baseline anchor (#992) is per-objective, so the
+	// verdict needs the objective to look up the right baseline. It is a derived VIEW
+	// field sourced from the immutable intent on every Summary() call, not folded from
+	// the event stream, so it is always correct after a rehydrate (intent.json is
+	// authoritative). omitempty so the empty-objective case adds no bytes.
+	Objective string `json:"objective,omitempty"`
 	// Status is the experiment lifecycle status ("running", "concluded", ...). It is
 	// set from decision/outcome events; defaults to "running" at Create.
 	Status string `json:"status"`

--- a/services/agent/experiment/verdict.go
+++ b/services/agent/experiment/verdict.go
@@ -32,12 +32,17 @@ import (
 //
 // CONTROL ARM is the PRIMARY decision basis (decision 5): the within-experiment
 // shadow control arm is differenced against the experimental arm here. The
-// recent-real baseline (the M7-7 validate.Baseline seam) is a SECONDARY sanity
-// anchor; it is NOT wired through this seam because CohortVerdict.Evaluate is
-// handed only a Summary (no ctx / Proposal to call Baseline.Fitness against) — see
-// the wiring note at the bottom of this file. Shipping the within-experiment
-// comparison (the primary basis) and deferring the baseline cross-check is the
-// path the issue authorizes.
+// recent-real baseline is a SECONDARY substrate-validity anchor (#992, relates
+// #1017): when recent REAL play exists for the experiment's objective, a PROMOTE
+// must additionally hold up against it (the experimental arm must not REGRESS below
+// the recent-real baseline beyond a margin) or it is downgraded to inconclusive.
+// The anchor only ever GATES a promote — it never forces one, and discard /
+// inconclusive verdicts are unaffected. It FAILS OPEN: with no real-game data (the
+// mock/shadow-only reality) the anchor is skipped and the within-experiment verdict
+// stands. The baseline is read via an injected, nil-safe RecentRealBaseline accessor
+// (wired with WithRecentRealBaseline); the objective is carried on the Summary
+// (journal.Summary.Objective), so the CohortVerdict.Evaluate seam signature is
+// UNCHANGED — see applyRecentRealAnchor and the wiring note at the bottom.
 
 // Default gate thresholds. Tuned conservative: a verdict needs a non-trivial
 // sample per arm and a medium standardized effect before it commits.
@@ -99,7 +104,31 @@ const (
 	minPairsEnv  = "AGENT_VERDICT_MIN_PAIRS"
 	minRawEffEnv = "AGENT_VERDICT_MIN_RAW_EFFECT"
 	sdFloorEnv   = "AGENT_VERDICT_SD_FLOOR"
+	// anchorMarginEnv tunes the recent-real regression margin (#992). Falls back to
+	// DefaultAnchorMargin (which mirrors the #1042 raw-effect floor).
+	anchorMarginEnv = "AGENT_VERDICT_ANCHOR_MARGIN"
 )
+
+// DefaultAnchorMargin is the recent-real regression margin (#992): a PROMOTE
+// verdict is downgraded only when the experimental arm mean falls BELOW the
+// recent-real baseline by MORE than this margin. It mirrors DefaultMinRawEffect
+// (the #1042 practical-significance floor) on purpose — the same "don't act on a
+// fitness change smaller than ~2% of the [0,1] range" don't-care band applies to
+// the secondary cross-check, so a shadow-winner that is within noise of recent
+// real play is NOT treated as a regression. Tune via AGENT_VERDICT_ANCHOR_MARGIN.
+const DefaultAnchorMargin = DefaultMinRawEffect
+
+// RecentRealBaseline is the injected secondary-anchor accessor (#992): given the
+// experiment's fitness objective it returns the mean finalized fitness of the last
+// N REAL (game_kind="real") games for that objective and whether such a baseline
+// is AVAILABLE (ok=false ⇒ no/insufficient real samples — the mock/shadow-only
+// reality). It is the read seam over the #965 FitnessStore's RecentReal, adapted
+// to the (objective)→(mean, ok) shape the verdict needs WITHOUT importing the
+// store. A nil accessor (the default) means the anchor is entirely absent; ok=false
+// means the anchor is SKIPPED for this evaluation. Both fail OPEN — absence of real
+// data must never block the within-experiment verdict (the demo/shadow loop runs
+// with no real games today).
+type RecentRealBaseline func(objective string) (mean float64, ok bool)
 
 // CohortStat is the swappable arm-comparison strategy (design §8.3). Given the two
 // arms' raw running statistics it returns a standardized effect size (experimental
@@ -192,6 +221,34 @@ type Verdict struct {
 	sdFloor float64
 	// stat is the swappable comparison strategy (default effectSizeGate).
 	stat CohortStat
+	// recentRealBaseline is the SECONDARY-ANCHOR accessor (#992): the recent-real
+	// fitness baseline for an objective. nil ⇒ the anchor is absent (the verdict is
+	// the pure within-experiment comparison). When non-nil it GATES (never forces) a
+	// PROMOTE: a shadow-winner that would regress vs recent real play is downgraded to
+	// INCONCLUSIVE. Construction-immutable; wired via WithRecentRealBaseline.
+	recentRealBaseline RecentRealBaseline
+	// anchorMargin is the recent-real regression margin (#992). Construction-immutable.
+	anchorMargin float64
+}
+
+// WithRecentRealBaseline wires the SECONDARY recent-real anchor (#992) onto the
+// verdict and returns the same *Verdict for chaining. The accessor is nil-safe at
+// every use site (a nil accessor leaves the verdict the pure within-experiment
+// comparison), so callers that have no FitnessStore simply never call this. A
+// non-positive margin falls back to DefaultAnchorMargin.
+//
+// It is a post-construction wiring step (not a constructor parameter) deliberately:
+// every existing NewVerdict* call site stays unchanged, and the registry can build
+// the verdict, then attach the baseline once the FitnessStore exists — keeping the
+// seam one-directional (the verdict reads the baseline; it never reaches into the
+// store). Call once at construction, before the verdict is handed to the registry.
+func (v *Verdict) WithRecentRealBaseline(accessor RecentRealBaseline, margin float64) *Verdict {
+	if margin <= 0 {
+		margin = DefaultAnchorMargin
+	}
+	v.recentRealBaseline = accessor
+	v.anchorMargin = margin
+	return v
 }
 
 // SetThresholds live-updates the min-N and min-pairs gates (#1044) so a hot-reload
@@ -367,7 +424,16 @@ func (v *Verdict) Evaluate(s journal.Summary) (journal.Verdict, bool) {
 	// whenever at least one pair has completed; otherwise we fall through to the
 	// two-arm path so legacy/unpaired experiments are unaffected (the fallback).
 	if s.PairDiff != nil && s.PairDiff.Count > 0 {
-		return v.evaluatePaired(*s.PairDiff, minPairs)
+		// The experimental arm mean (the value a promote would make the real default)
+		// for the #992 recent-real anchor. The two-arm Welford accumulators are folded
+		// alongside the paired diffs, so the experimental arm's running mean is present
+		// even on the paired path; default to the per-pair mean when the arm is absent
+		// (legacy/degenerate) so the anchor still has a sensible experimental value.
+		expMean := s.PairDiff.Mean
+		if a, ok := s.Arms[ArmExperimental]; ok && a != nil {
+			expMean = a.Welford.Mean
+		}
+		return v.evaluatePaired(*s.PairDiff, minPairs, s.Objective, expMean)
 	}
 
 	expStat, expOK := s.Arms[ArmExperimental]
@@ -422,13 +488,15 @@ func (v *Verdict) Evaluate(s journal.Summary) (journal.Verdict, bool) {
 
 	switch {
 	case effect >= v.effectThreshold:
-		return journal.Verdict{
+		promote := journal.Verdict{
 			Outcome:     CohortOutcomePromote,
 			Delta:       delta,
 			Significant: true,
 			Reason: fmt.Sprintf("experimental better: effect=%.3f >= threshold=%.2f, |delta|=%.4f >= min_raw=%.4f (n=%d/%d)",
 				effect, v.effectThreshold, math.Abs(delta), v.minRawEffect, exp.Count, ctl.Count),
-		}, true
+		}
+		// SECONDARY anchor (#992): gate the promote against recent real play.
+		return v.applyRecentRealAnchor(promote, s.Objective, exp.Mean), true
 	case effect <= -v.effectThreshold:
 		return journal.Verdict{
 			Outcome:     CohortOutcomeDiscard,
@@ -448,6 +516,63 @@ func (v *Verdict) Evaluate(s journal.Summary) (journal.Verdict, bool) {
 	}
 }
 
+// applyRecentRealAnchor is the SECONDARY substrate-validity guard (#992, relates
+// #1017): it cross-checks a PROMOTE verdict against recent REAL play. The within-
+// experiment (shadow) arm comparison is the PRIMARY decision (above); this anchor
+// only ever GATES a promote — it never forces one, and it leaves discard /
+// inconclusive verdicts untouched.
+//
+// Behaviour (a secondary anchor that fails OPEN on missing real data):
+//
+//   - The verdict is not a PROMOTE ⇒ returned UNCHANGED (the anchor only gates
+//     promotion). Discard / inconclusive are never affected.
+//   - No accessor wired (recentRealBaseline == nil) OR the accessor reports no
+//     recent-real data (ok == false — the mock/shadow-only reality with no real
+//     games) ⇒ the anchor is SKIPPED and the PROMOTE stands UNCHANGED. This is the
+//     explicit fail-OPEN: absence of real data must not block the demo/shadow loop.
+//   - Recent-real data IS available AND the experimental value would REGRESS below
+//     the baseline by more than anchorMargin ⇒ the PROMOTE is DOWNGRADED to
+//     INCONCLUSIVE (the within-experiment shadow winner is worse than recent real
+//     play, so it is not a trustworthy real-default change), with a reason that names
+//     the regression. Significant is cleared.
+//   - Recent-real data available AND the experimental value holds up (≥ baseline −
+//     margin) ⇒ the PROMOTE stands; the reason is annotated with the cleared anchor.
+//
+// experimentalValue is the experimental arm's mean fitness (the value a promotion
+// would make the real default) — exp.Mean in the two-arm path, the experimental
+// arm mean in the paired path. objective selects the per-objective baseline.
+func (v *Verdict) applyRecentRealAnchor(verdict journal.Verdict, objective string, experimentalValue float64) journal.Verdict {
+	if verdict.Outcome != CohortOutcomePromote {
+		return verdict // anchor gates promotion only; discard/inconclusive unaffected.
+	}
+	if v.recentRealBaseline == nil {
+		return verdict // anchor absent — pure within-experiment verdict stands.
+	}
+	baseline, ok := v.recentRealBaseline(objective)
+	if !ok {
+		// No / insufficient recent-real data (the mock/shadow-only reality). FAIL OPEN:
+		// the within-experiment verdict stands so the demo/shadow loop is never blocked.
+		verdict.Reason += " | recent-real anchor: skipped (no real-game baseline)"
+		return verdict
+	}
+	// Regression test: the experimental value must not fall below recent real play by
+	// more than the margin. margin mirrors the #1042 practical-significance floor, so a
+	// shadow winner within noise of recent real play is NOT treated as a regression.
+	if experimentalValue < baseline-v.anchorMargin {
+		return journal.Verdict{
+			Outcome:     OutcomeInconclusive,
+			Delta:       verdict.Delta,
+			Significant: false,
+			Reason: fmt.Sprintf("promote gated by recent-real regression: experimental=%.4f < recent_real=%.4f - margin=%.4f (objective=%q); %s",
+				experimentalValue, baseline, v.anchorMargin, objective, verdict.Reason),
+		}
+	}
+	// Anchor cleared — annotate the promote reason so the cross-check is observable.
+	verdict.Reason += fmt.Sprintf(" | recent-real anchor: held (experimental=%.4f >= recent_real=%.4f - margin=%.4f)",
+		experimentalValue, baseline, v.anchorMargin)
+	return verdict
+}
+
 // evaluatePaired computes the verdict from the per-PAIR difference accumulator
 // (#1004). The statistic is the standardized paired effect d_z = mean(d) / sd(d),
 // where d_i = f_experimental_i − f_control_i and sd(d) is the UNBIASED sample
@@ -465,7 +590,7 @@ func (v *Verdict) Evaluate(s journal.Summary) (journal.Verdict, bool) {
 // Delta carries mean(d) (the average per-pair fitness improvement) for the audit
 // trail. The bool is always true: a non-nil non-empty PairDiff is a meaningful
 // (possibly interim) verdict the registry should record.
-func (v *Verdict) evaluatePaired(pd journal.Welford, minPairs int) (journal.Verdict, bool) {
+func (v *Verdict) evaluatePaired(pd journal.Welford, minPairs int, objective string, experimentalMean float64) (journal.Verdict, bool) {
 	meanD := pd.Mean
 
 	if pd.Count < minPairs {
@@ -529,13 +654,15 @@ func (v *Verdict) evaluatePaired(pd journal.Welford, minPairs int) (journal.Verd
 
 	switch {
 	case dz >= v.effectThreshold:
-		return journal.Verdict{
+		promote := journal.Verdict{
 			Outcome:     CohortOutcomePromote,
 			Delta:       meanD,
 			Significant: true,
 			Reason: fmt.Sprintf("paired: experimental better: d_z=%.3f >= threshold=%.2f, |mean_d|=%.4f >= min_raw=%.4f (pairs=%d)",
 				dz, v.effectThreshold, math.Abs(meanD), v.minRawEffect, pd.Count),
-		}, true
+		}
+		// SECONDARY anchor (#992): gate the paired promote against recent real play.
+		return v.applyRecentRealAnchor(promote, objective, experimentalMean), true
 	case dz <= -v.effectThreshold:
 		return journal.Verdict{
 			Outcome:     CohortOutcomeDiscard,
@@ -555,16 +682,22 @@ func (v *Verdict) evaluatePaired(pd journal.Welford, minPairs int) (journal.Verd
 	}
 }
 
-// Wiring note (recent-real baseline, design §8.3 secondary anchor — DEFERRED):
+// Wiring note (recent-real baseline, design §8.3 secondary anchor — IMPLEMENTED #992):
 //
-// The within-experiment control arm is the PRIMARY decision basis and is fully
-// implemented above. The recent-real baseline (validate.Baseline.Fitness) is the
-// design's SECONDARY sanity cross-check. It is NOT wired here because the
-// CohortVerdict seam (registry_seams.go) deliberately passes only a
-// journal.Summary — there is no ctx / Proposal in Evaluate's signature to call
-// Baseline.Fitness(ctx, p) against, and the registry's ConcludeGame call site does
-// not thread one through. Plumbing it would mean widening the seam (and the
-// registry call sites), which is out of scope for this issue. Follow-up: either
-// fold a recent-real baseline sample into a third pseudo-arm on the Summary at
-// game-end, or annotate the Verdict.Reason with a baseline cross-check after the
-// registry gains access to Baseline. Tracked as a follow-up on epic #982.
+// The within-experiment control arm is the PRIMARY decision basis (the paired d_z /
+// two-arm Cohen's d above). The recent-real baseline is the design's SECONDARY
+// substrate-validity cross-check, now wired WITHOUT widening the CohortVerdict seam:
+//
+//   - The objective the baseline is keyed by is carried on journal.Summary.Objective
+//     (a derived view field the journal copies from the immutable Intent on every
+//     Summary() call), so Evaluate's signature stays Evaluate(s journal.Summary).
+//   - The baseline itself is read via the injected RecentRealBaseline accessor
+//     (WithRecentRealBaseline), a nil-safe func(objective)→(mean, ok) over the #965
+//     FitnessStore.RecentReal. The verdict reads the baseline; it never imports or
+//     reaches into the store (the seam stays one-directional).
+//   - applyRecentRealAnchor gates ONLY a PROMOTE and fails OPEN (nil accessor or
+//     ok=false ⇒ promote stands), so the mock/shadow-only loop is never blocked.
+//
+// The registry builds the verdict and attaches the baseline in experiment_loop.go
+// once the FitnessStore exists. Tracked on epic #982; relates #1017 (the offline
+// validity study that makes this anchor's threshold meaningful).

--- a/services/agent/experiment/verdict_anchor_test.go
+++ b/services/agent/experiment/verdict_anchor_test.go
@@ -1,0 +1,229 @@
+package experiment
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/joustmania/agent/experiment/journal"
+)
+
+// verdict_anchor_test.go covers the recent-real SECONDARY substrate-validity anchor
+// (#992, relates #1017): a PROMOTE verdict must also hold up against recent REAL
+// play, the anchor fails OPEN when no real data exists, and it never touches
+// discard / inconclusive verdicts.
+
+// fixedBaseline returns a RecentRealBaseline accessor that always reports the given
+// mean as AVAILABLE (ok=true) for any objective — the "recent real data exists"
+// case.
+func fixedBaseline(mean float64) RecentRealBaseline {
+	return func(_ string) (float64, bool) { return mean, true }
+}
+
+// noBaseline returns a RecentRealBaseline accessor that always reports NO data
+// (ok=false) — the mock/shadow-only reality with no real games.
+func noBaseline() RecentRealBaseline {
+	return func(_ string) (float64, bool) { return 0, false }
+}
+
+// summaryWithObjective is summaryWith plus the per-objective view field the anchor
+// reads (journal.Summary.Objective).
+func summaryWithObjective(objective string, exp, ctl *journal.ArmStat) journal.Summary {
+	s := summaryWith(exp, ctl)
+	s.Objective = objective
+	return s
+}
+
+// clearWinArms are a clean two-arm PROMOTE: experimental mean 0.80, control 0.50,
+// tight spread ⇒ large positive Cohen's d. Reused across the anchor cases so only
+// the baseline varies.
+func clearWinArms() (*journal.ArmStat, *journal.ArmStat) {
+	return armFrom(spread(10, 0.80, 0.02)...), armFrom(spread(10, 0.50, 0.02)...)
+}
+
+func TestVerdict_Anchor_RecentRealAtOrBelowExperimental_PromoteStands(t *testing.T) {
+	// Recent-real baseline 0.50 < experimental 0.80 ⇒ no regression ⇒ promote stands.
+	v := NewVerdict(8, 0.5, nil).WithRecentRealBaseline(fixedBaseline(0.50), DefaultAnchorMargin)
+	exp, ctl := clearWinArms()
+
+	got, ok := v.Evaluate(summaryWithObjective("endurance", exp, ctl))
+	if !ok {
+		t.Fatalf("expected ok=true")
+	}
+	if got.Outcome != CohortOutcomePromote || !got.Significant {
+		t.Fatalf("verdict = %+v, want PROMOTE significant (anchor should hold)", got)
+	}
+	if !strings.Contains(got.Reason, "recent-real anchor: held") {
+		t.Errorf("reason should annotate the cleared anchor, got %q", got.Reason)
+	}
+}
+
+func TestVerdict_Anchor_ExperimentalRegressesVsRecentReal_DowngradedToInconclusive(t *testing.T) {
+	// Recent-real baseline 0.95 >> experimental 0.80 (by far more than the margin) ⇒
+	// the shadow winner is WORSE than recent real play ⇒ PROMOTE is downgraded.
+	v := NewVerdict(8, 0.5, nil).WithRecentRealBaseline(fixedBaseline(0.95), DefaultAnchorMargin)
+	exp, ctl := clearWinArms()
+
+	got, ok := v.Evaluate(summaryWithObjective("endurance", exp, ctl))
+	if !ok {
+		t.Fatalf("expected ok=true")
+	}
+	if got.Outcome != OutcomeInconclusive {
+		t.Fatalf("verdict = %q (reason %q), want INCONCLUSIVE (anchor bites)", got.Outcome, got.Reason)
+	}
+	if got.Significant {
+		t.Errorf("a gated promote must not stay significant, got %+v", got)
+	}
+	if !strings.Contains(got.Reason, "promote gated by recent-real regression") {
+		t.Errorf("reason should name the regression, got %q", got.Reason)
+	}
+}
+
+func TestVerdict_Anchor_WithinMargin_PromoteStands(t *testing.T) {
+	// Recent-real baseline 0.81 is just ABOVE experimental 0.80, but within the
+	// default margin (~0.02) ⇒ NOT a regression ⇒ promote stands. Guards against the
+	// anchor biting on noise.
+	v := NewVerdict(8, 0.5, nil).WithRecentRealBaseline(fixedBaseline(0.81), DefaultAnchorMargin)
+	exp, ctl := clearWinArms()
+
+	got, ok := v.Evaluate(summaryWithObjective("endurance", exp, ctl))
+	if !ok {
+		t.Fatalf("expected ok=true")
+	}
+	if got.Outcome != CohortOutcomePromote {
+		t.Fatalf("verdict = %q (reason %q), want PROMOTE (within margin, not a regression)", got.Outcome, got.Reason)
+	}
+}
+
+func TestVerdict_Anchor_NoRecentRealData_PromoteStandsUnchanged(t *testing.T) {
+	// ok=false (the mock/shadow-only reality) ⇒ anchor SKIPPED, fail OPEN. The
+	// within-experiment promote must stand so the demo/shadow loop is never blocked.
+	v := NewVerdict(8, 0.5, nil).WithRecentRealBaseline(noBaseline(), DefaultAnchorMargin)
+	exp, ctl := clearWinArms()
+
+	got, ok := v.Evaluate(summaryWithObjective("endurance", exp, ctl))
+	if !ok {
+		t.Fatalf("expected ok=true")
+	}
+	if got.Outcome != CohortOutcomePromote || !got.Significant {
+		t.Fatalf("verdict = %+v, want PROMOTE significant (anchor skipped, fail open)", got)
+	}
+	if !strings.Contains(got.Reason, "recent-real anchor: skipped") {
+		t.Errorf("reason should note the skipped anchor, got %q", got.Reason)
+	}
+}
+
+func TestVerdict_Anchor_NilAccessor_PromoteStandsUnchanged(t *testing.T) {
+	// No accessor wired at all ⇒ pure within-experiment verdict, anchor absent.
+	v := NewVerdict(8, 0.5, nil) // no WithRecentRealBaseline
+	exp, ctl := clearWinArms()
+
+	got, ok := v.Evaluate(summaryWithObjective("endurance", exp, ctl))
+	if !ok {
+		t.Fatalf("expected ok=true")
+	}
+	if got.Outcome != CohortOutcomePromote || !got.Significant {
+		t.Fatalf("verdict = %+v, want PROMOTE significant (nil anchor)", got)
+	}
+	if strings.Contains(got.Reason, "recent-real anchor") {
+		t.Errorf("nil anchor should not annotate the reason, got %q", got.Reason)
+	}
+}
+
+func TestVerdict_Anchor_DiscardUnaffected(t *testing.T) {
+	// Even a baseline that would "regress" must NOT touch a DISCARD — the anchor only
+	// gates promotion. Experimental 0.30 < control 0.70 ⇒ DISCARD; baseline 0.95 is
+	// irrelevant.
+	v := NewVerdict(8, 0.5, nil).WithRecentRealBaseline(fixedBaseline(0.95), DefaultAnchorMargin)
+	exp := armFrom(spread(10, 0.30, 0.02)...)
+	ctl := armFrom(spread(10, 0.70, 0.02)...)
+
+	got, ok := v.Evaluate(summaryWithObjective("endurance", exp, ctl))
+	if !ok {
+		t.Fatalf("expected ok=true")
+	}
+	if got.Outcome != CohortOutcomeDiscard || !got.Significant {
+		t.Fatalf("verdict = %+v, want DISCARD significant (anchor must not touch discard)", got)
+	}
+	if strings.Contains(got.Reason, "recent-real anchor") {
+		t.Errorf("discard reason should carry no anchor annotation, got %q", got.Reason)
+	}
+}
+
+func TestVerdict_Anchor_InconclusiveUnaffected(t *testing.T) {
+	// A within-noise INCONCLUSIVE must be returned untouched by the anchor regardless
+	// of the baseline.
+	v := NewVerdict(8, 0.5, nil).WithRecentRealBaseline(fixedBaseline(0.95), DefaultAnchorMargin)
+	exp := armFrom(spread(10, 0.50, 0.30)...) // huge spread ⇒ tiny effect ⇒ inconclusive
+	ctl := armFrom(spread(10, 0.50, 0.30)...)
+
+	got, ok := v.Evaluate(summaryWithObjective("endurance", exp, ctl))
+	if !ok {
+		t.Fatalf("expected ok=true")
+	}
+	if got.Outcome != OutcomeInconclusive {
+		t.Fatalf("verdict = %q (reason %q), want INCONCLUSIVE", got.Outcome, got.Reason)
+	}
+	if strings.Contains(got.Reason, "recent-real anchor") {
+		t.Errorf("inconclusive reason should carry no anchor annotation, got %q", got.Reason)
+	}
+}
+
+// --- paired (CRN) path ---
+
+func TestVerdict_Anchor_Paired_RegressionDowngrades(t *testing.T) {
+	// Paired promote (mean(d)=0.30, tight spread ⇒ large d_z). The experimental ARM
+	// mean (0.80) is carried on the Summary's arms; baseline 0.95 >> 0.80 ⇒ regression
+	// ⇒ the paired promote is downgraded.
+	v := NewVerdictWithPairs(8, 5, 0.5, nil).WithRecentRealBaseline(fixedBaseline(0.95), DefaultAnchorMargin)
+	pd := pairDiffFrom(0.28, 0.32, 0.29, 0.31, 0.30, 0.30)
+	s := journal.Summary{
+		ExperimentID: "exp_paired",
+		Objective:    "endurance",
+		Arms: map[string]*journal.ArmStat{
+			ArmExperimental: armFrom(spread(6, 0.80, 0.02)...),
+			ArmControl:      armFrom(spread(6, 0.50, 0.02)...),
+		},
+		PairDiff: pd,
+	}
+
+	got, ok := v.Evaluate(s)
+	if !ok {
+		t.Fatalf("expected ok=true")
+	}
+	if got.Outcome != OutcomeInconclusive || got.Significant {
+		t.Fatalf("verdict = %+v, want INCONCLUSIVE (paired anchor bites)", got)
+	}
+	if !strings.Contains(got.Reason, "promote gated by recent-real regression") {
+		t.Errorf("reason should name the regression, got %q", got.Reason)
+	}
+}
+
+func TestVerdict_Anchor_Paired_NoRealData_PromoteStands(t *testing.T) {
+	// Same paired promote, but no real data ⇒ anchor skipped ⇒ promote stands.
+	v := NewVerdictWithPairs(8, 5, 0.5, nil).WithRecentRealBaseline(noBaseline(), DefaultAnchorMargin)
+	pd := pairDiffFrom(0.28, 0.32, 0.29, 0.31, 0.30, 0.30)
+	s := journal.Summary{
+		ExperimentID: "exp_paired",
+		Objective:    "endurance",
+		Arms: map[string]*journal.ArmStat{
+			ArmExperimental: armFrom(spread(6, 0.80, 0.02)...),
+			ArmControl:      armFrom(spread(6, 0.50, 0.02)...),
+		},
+		PairDiff: pd,
+	}
+
+	got, ok := v.Evaluate(s)
+	if !ok {
+		t.Fatalf("expected ok=true")
+	}
+	if got.Outcome != CohortOutcomePromote || !got.Significant {
+		t.Fatalf("verdict = %+v, want PROMOTE significant (paired anchor skipped)", got)
+	}
+}
+
+func TestVerdict_WithRecentRealBaseline_NonPositiveMarginDefaults(t *testing.T) {
+	v := NewVerdict(8, 0.5, nil).WithRecentRealBaseline(fixedBaseline(0.50), 0)
+	if v.anchorMargin != DefaultAnchorMargin {
+		t.Fatalf("non-positive margin should fall back to DefaultAnchorMargin=%v, got %v", DefaultAnchorMargin, v.anchorMargin)
+	}
+}

--- a/services/agent/experiment_loop.go
+++ b/services/agent/experiment_loop.go
@@ -256,19 +256,31 @@ func buildExperimentLoop(
 	// ShadowSpawner (#976): the real outbound game-coordinator client.
 	spawner := newShadowSpawner(gamerunner.ConfigFromEnv(), logger)
 
+	// FitnessStore (#965/#1017): the finalized-per-game fitness store onGameEnd
+	// Records into and the M7-7 validation seams read from. It is the instrumentation
+	// that turns the Validator's injected fitness reads into REAL ones. Built BEFORE
+	// the verdict so the #992 recent-real anchor can read it.
+	fitnessStore := experiment.NewFitnessStore(fitnessStoreCapacity())
+
+	// CohortVerdict (#979) + recent-real SECONDARY anchor (#992): the within-experiment
+	// comparison gated by recent REAL play. The anchor reads the FitnessStore's
+	// RecentReal mean for the experiment's objective via a nil-safe accessor; it fails
+	// OPEN when no real-game baseline exists (the current mock/shadow-only reality), so
+	// it never blocks the shadow loop. recentN/minSamples reuse the validation-baseline
+	// knobs so the anchor and the M7-7 Validator agree on what "enough real data" means.
+	verdict := experiment.NewVerdictFromEnv().WithRecentRealBaseline(
+		recentRealBaselineAccessor(fitnessStore, validationBaselineRecentN(), validationBaselineMinSamples()),
+		experiment.DefaultAnchorMargin,
+	)
+
 	registry := experiment.NewRegistry(experiment.RegistryConfig{
 		Root:      journal.DirFromEnv(),
 		Spawner:   spawner,
-		Verdict:   experiment.NewVerdictFromEnv(),
+		Verdict:   verdict,
 		Promoter:  promo,
 		Targeting: targeting,
 		Log:       logger,
 	})
-
-	// FitnessStore (#965/#1017): the finalized-per-game fitness store onGameEnd
-	// Records into and the M7-7 validation seams read from. It is the instrumentation
-	// that turns the Validator's injected fitness reads into REAL ones.
-	fitnessStore := experiment.NewFitnessStore(fitnessStoreCapacity())
 
 	loop := &experimentLoop{
 		registry:       registry,
@@ -1061,6 +1073,36 @@ func validationGameTimeout() time.Duration {
 		}
 	}
 	return DefaultValidationGameTimeout
+}
+
+// recentRealBaselineAccessor adapts the #965 FitnessStore into the verdict's #992
+// RecentRealBaseline seam: given an objective it returns the mean finalized fitness
+// of the last recentN REAL games and whether a TRUSTWORTHY baseline exists (>=
+// minSamples real samples). It returns ok=false (anchor SKIPPED — fail open) when
+// the store is unwired or too few real samples exist, mirroring StoreBaseline's
+// fail-closed-for-promotion threshold but expressed as the anchor's fail-OPEN bool.
+// store may be nil ⇒ the accessor always reports ok=false (anchor disabled).
+func recentRealBaselineAccessor(store *experiment.FitnessStore, recentN, minSamples int) experiment.RecentRealBaseline {
+	if recentN < 1 {
+		recentN = 1
+	}
+	if minSamples < 1 {
+		minSamples = 1
+	}
+	return func(objective string) (float64, bool) {
+		if store == nil {
+			return 0, false
+		}
+		samples := store.RecentReal(objective, recentN)
+		if len(samples) < minSamples {
+			return 0, false
+		}
+		var sum float64
+		for _, s := range samples {
+			sum += s.Fitness
+		}
+		return sum / float64(len(samples)), true
+	}
 }
 
 // validationBaselineRecentN resolves how many recent real games the baseline


### PR DESCRIPTION
Part of #992 (relates #1017).

Wires the recent-real-game fitness baseline as a **secondary anchor** on the cohort verdict: a promotion must now not only win the within-experiment (shadow) arm comparison (the PRIMARY decision, #979) but also hold up against recent REAL play — the verdict-time substrate-validity guard.

## How the anchor gates promotion
- `applyRecentRealAnchor` runs only on a **PROMOTE** verdict. Discard / inconclusive are returned untouched (a secondary anchor only GATES promotion, never forces one).
- When recent-real data IS available for the experiment's objective and the **experimental arm mean regresses below the baseline by more than `DefaultAnchorMargin`** (`= DefaultMinRawEffect`, the #1042 practical-significance floor, so a shadow winner within noise of real play is not a regression), the promote is **downgraded to INCONCLUSIVE** with reason `promote gated by recent-real regression: …`. `Significant` is cleared.
- When the experimental value holds up (≥ baseline − margin) the promote stands, annotated `recent-real anchor: held (…)`.

## Fail-OPEN on no real data
- A nil accessor, or `ok=false` (no/insufficient real samples — the current mock/shadow-only reality), **skips** the anchor and leaves the within-experiment verdict unchanged (annotated `recent-real anchor: skipped (no real-game baseline)`). Absence of real data never blocks the demo/shadow loop. Explicitly tested for both two-arm and paired paths.

## The seam (nil-safe, one-directional)
- New `RecentRealBaseline func(objective string) (mean float64, ok bool)`, wired via `Verdict.WithRecentRealBaseline(accessor, margin)` — every existing `NewVerdict*` call site is unchanged.
- The objective is carried on `journal.Summary.Objective`, a derived view field sourced from the immutable Intent on every `Summary()` call (survives rehydrate), so the `CohortVerdict.Evaluate(s journal.Summary)` signature is **unchanged** — no call-site / fake churn.
- `experiment_loop.go` builds the `FitnessStore` before the verdict and attaches `recentRealBaselineAccessor` (reusing the validation-baseline `recentN` / `minSamples` knobs over `FitnessStore.RecentReal`). The verdict reads the baseline; it never imports or reaches into the store.
- Covers both the two-arm Cohen's d and the paired CRN (`d_z`) promote branches (the paired path passes the experimental ARM mean).

## Telemetry / observability
The cross-check is surfaced in `Verdict.Reason` (held / skipped / gated-regression), which is recorded on the interim/outcome journal events.

## Tests
`go test ./... -race` green. New `verdict_anchor_test.go`: anchor holds (≥ baseline), bites (regression → inconclusive), within-margin no-bite, no-real-data skip (nil + ok=false), discard + inconclusive unaffected, paired regression + paired skip, margin defaulting. New journal test: `Summary().Objective` present fresh and after `Load`. Existing verdict tests unchanged and passing. `go vet` + `gofmt -l` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)