### PR TITLE
feat(agent): flow real LLM inference through the decision loop + proposer (#964)

### DIFF
--- a/services/agent/decision/decision.go
+++ b/services/agent/decision/decision.go
@@ -221,6 +221,15 @@ type Loop struct {
 	// a single budget. Nil until injected; a nil budget gates every llm attempt
 	// with llm_budget_exhausted (fail-closed: no shared cap means no llm).
 	budget *llmBudget
+	// budgetOverride, when > 0, replaces the per-cycle llm.max_requests_per_minute
+	// flag value as the budget cap (#964). It exists for LIVE inference operation
+	// (AGENT_LLM_MAX_REQUESTS_PER_MINUTE): under the eval-cycle rate the flag default
+	// (6/min) exhausts the budget almost immediately, gating the llm path with
+	// llm_budget_exhausted even when a backend is reachable. An operator can raise the
+	// cap for a live dry-run via one env knob without editing flagd. Zero (the default,
+	// and every existing test) means "no override" → the flag value governs exactly as
+	// before, so the default-off path is unchanged. Set at construction, before serving.
+	budgetOverride int
 
 	// resolver is the SHARED inference fallback-chain resolver (#741), injected via
 	// SetResolver from the one instance main.go constructs (one availability cache
@@ -321,6 +330,31 @@ func NewLoop(flagSource FlagSource, log *slog.Logger) *Loop {
 // collectively exceed llm.max_requests_per_minute. Not safe to call concurrently
 // with OnEvaluate — set it during construction, before the loop serves.
 func (l *Loop) SetLLMBudget(b *llmBudget) { l.budget = b }
+
+// SetLLMBudgetOverride sets a per-minute LLM request cap that REPLACES the live
+// llm.max_requests_per_minute flag value (#964). main.go passes
+// AGENT_LLM_MAX_REQUESTS_PER_MINUTE when an operator wants a higher live cap for a
+// real-inference dry-run (the flag default of 6/min exhausts under the eval-cycle
+// rate, gating the llm path with llm_budget_exhausted even with a reachable backend).
+// A non-positive value is ignored (the flag governs), so the default-off path is
+// unchanged. Set during construction, before the loop serves.
+func (l *Loop) SetLLMBudgetOverride(maxPerMinute int) {
+	if maxPerMinute > 0 {
+		l.budgetOverride = maxPerMinute
+	}
+}
+
+// budgetCap returns the per-minute LLM request cap to enforce this cycle: the
+// startup env override (#964) when one is set, else the live
+// llm.max_requests_per_minute flag value (#847). Keeping the flag as the default
+// preserves the never-cached, tune-live contract; the override is purely an
+// operator escape hatch for live inference and defaults to off.
+func (l *Loop) budgetCap(flagValue int) int {
+	if l.budgetOverride > 0 {
+		return l.budgetOverride
+	}
+	return flagValue
+}
 
 // SetResolver injects the SHARED inference fallback-chain resolver (#741). main.go
 // constructs ONE Resolver (one availability cache + one background probe ticker for
@@ -719,7 +753,7 @@ func (l *Loop) gateLLM(ctx context.Context, snapshot flags.Snapshot, c gameconte
 	// (never injected) fails closed — no shared cap means no llm. The budget is
 	// charged here, last, so an attempt blocked by cadence above never draws it
 	// down.
-	if l.budget == nil || !l.budget.allow(t, snapshot.LLMGate.MaxRequestsPerMinute) {
+	if l.budget == nil || !l.budget.allow(t, l.budgetCap(snapshot.LLMGate.MaxRequestsPerMinute)) {
 		l.recordGated(ctx, FallbackBudgetExhausted)
 		return FallbackBudgetExhausted
 	}

--- a/services/agent/decision/inference_flow_test.go
+++ b/services/agent/decision/inference_flow_test.go
@@ -1,0 +1,147 @@
+package decision
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"github.com/joustmania/agent/flags"
+	"github.com/joustmania/agent/gamecontext"
+	"github.com/joustmania/agent/llm"
+)
+
+// inference_flow_test.go is the #964 end-to-end proof: with a REAL inference backend
+// configured (NewInferenceResolver) and reachable, an llm-mode cycle reaches mode=llm —
+// the resolved inference tier is CALLED and its decision dispatched — even though the
+// agent.model flag is the default phi4-mini. The inference span's gen_ai.request.model
+// is the configured AGENT_INFERENCE_MODEL (single source of truth, gap 3), and an
+// unreachable backend degrades to rules unchanged (graceful degradation preserved).
+
+const flowModel = "gemma4:latest" // stands in for AGENT_INFERENCE_MODEL
+
+// flowResponse is a valid in-vocab decision the configured backend returns.
+const flowResponse = `{"intervention":"grant_shield","target_serial":"","value":"","reason":"llm decided","objective_served":"endurance"}`
+
+// flowSnapshot is an llm-mode snapshot whose gate always admits. The model flag is the
+// DEFAULT phi4-mini — the very value that, pre-#964, made the resolver start at the
+// unreachable localhost tier and degrade to rules. With the inference tier wired it must
+// no longer matter.
+func flowSnapshot() flags.Snapshot {
+	return flags.Snapshot{
+		Enabled:              true,
+		Mode:                 "llm",
+		Objectives:           map[string]float64{"endurance": 1.0},
+		Capability:           flags.Capability{Model: "phi4-mini", PromptVariant: "balanced"},
+		InterventionsAllowed: []string{"noop", "grant_shield"},
+		Policy:               flags.Policy{MaxInterventionsPerMinute: 100},
+		LLMGate: flags.LLMGate{
+			EligibleGameKinds:    []string{"real"},
+			MinDecisionInterval:  0,
+			MaxRequestsPerMinute: 100,
+		},
+	}
+}
+
+func flowLoop(t *testing.T, resolver *Resolver) (*Loop, *tracetest.SpanRecorder, *fakeSink) {
+	t.Helper()
+	sr := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+
+	sink := &fakeSink{}
+	l := NewLoop(&settableFlags{snap: flowSnapshot()}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	l.Tracer = tp.Tracer("test")
+	// Distinct rules output so a rules fallback is detectable by decision.reason.
+	// grant_shield is in the allow-list so a rules decision actually dispatches (lets the
+	// unreachable test assert the rules decision reached the sink); the LLM response uses a
+	// distinct reason so the two paths are still distinguishable.
+	l.Rules = fakeRules{out: []Decision{{Intervention: "grant_shield", Reason: "from rules"}}}
+	l.Actions = sink
+	l.SetLLMBudget(NewLLMBudget())
+	l.SetResolver(resolver)
+	return l, sr, sink
+}
+
+// TestInferenceFlow_ReachableBackendReachesModeLLM: the headline #964 acceptance — a
+// reachable configured backend means the decision loop CALLS it (mode=llm) and
+// dispatches the LLM's decision, with the configured model on the request span, despite
+// the default phi4-mini agent.model flag.
+func TestInferenceFlow_ReachableBackendReachesModeLLM(t *testing.T) {
+	addr, closeFn := listenLocal(t)
+	defer closeFn()
+
+	delegateCalls := 0
+	delegate := func(context.Context, llm.Prompt) (string, error) {
+		delegateCalls++
+		return flowResponse, nil
+	}
+	r := NewInferenceResolver(InferenceTier{Model: flowModel, Addr: addr, Infer: delegate},
+		Endpoints{}, 0)
+	r.Refresh(context.Background())
+
+	l, sr, sink := flowLoop(t, r)
+	l.OnEvaluate(context.Background(), gamecontext.GameContext{SessionID: "s1", GameKind: "real"}, testTrigger())
+
+	if delegateCalls != 1 {
+		t.Fatalf("configured-backend Infer calls = %d, want 1 (mode=llm, backend CALLED)", delegateCalls)
+	}
+	decs := spansByName(sr.Ended(), SpanDecision)
+	if len(decs) != 1 {
+		t.Fatalf("agent.decision spans = %d, want 1", len(decs))
+	}
+	if v, ok := attrValue(decs[0], AttrDecisionReason); !ok || v.AsString() != "llm decided" {
+		t.Errorf("decision.reason = %q, want the LLM's reason (mode=llm, not rules fallback)", v.AsString())
+	}
+	if v, ok := attrValue(decs[0], AttrInferenceUsed); !ok || v.AsString() != flowModel {
+		t.Errorf("inference.used = %q, want %q (the configured inference tier decided)", v.AsString(), flowModel)
+	}
+	if sink.calls.Load() != 1 {
+		t.Errorf("action sink calls = %d, want 1 (llm decision dispatched)", sink.calls.Load())
+	}
+	// Gap 3: the inference span's request model is the configured AGENT_INFERENCE_MODEL,
+	// not the agent.model flag (phi4-mini) — a single source of truth end to end.
+	inf := spansByName(sr.Ended(), SpanLLMInfer)
+	if len(inf) != 1 {
+		t.Fatalf("agent.llm.infer spans = %d, want 1", len(inf))
+	}
+	if v, ok := attrValue(inf[0], "gen_ai.request.model"); !ok || v.AsString() != flowModel {
+		t.Errorf("infer span gen_ai.request.model = %q, want %q (AGENT_INFERENCE_MODEL, not phi4-mini)", v.AsString(), flowModel)
+	}
+}
+
+// TestInferenceFlow_UnreachableBackendStaysRules: an unreachable configured backend (and
+// no legacy tier) degrades to rules — the dispatched decision is the rules engine's,
+// inference.used=rules, no_backend_available. Graceful degradation is unchanged.
+func TestInferenceFlow_UnreachableBackendStaysRules(t *testing.T) {
+	delegate := func(context.Context, llm.Prompt) (string, error) {
+		t.Fatal("delegate must not be called when the backend is unreachable")
+		return "", nil
+	}
+	r := NewInferenceResolver(InferenceTier{Model: flowModel, Addr: "127.0.0.1:1", Infer: delegate},
+		Endpoints{}, 0)
+	r.Refresh(context.Background())
+
+	l, sr, sink := flowLoop(t, r)
+	l.OnEvaluate(context.Background(), gamecontext.GameContext{SessionID: "s1", GameKind: "real"}, testTrigger())
+
+	decs := spansByName(sr.Ended(), SpanDecision)
+	if len(decs) != 1 {
+		t.Fatalf("agent.decision spans = %d, want 1 (rules decided)", len(decs))
+	}
+	if v, ok := attrValue(decs[0], AttrDecisionReason); !ok || v.AsString() != "from rules" {
+		t.Errorf("decision.reason = %q, want the rules fallback (mode=rules)", v.AsString())
+	}
+	if v, ok := attrValue(decs[0], AttrInferenceUsed); !ok || v.AsString() != InferenceRules {
+		t.Errorf("inference.used = %q, want %q (degraded to rules)", v.AsString(), InferenceRules)
+	}
+	if v, ok := attrValue(decs[0], AttrInferenceFallback); !ok || v.AsString() != FallbackNoBackend {
+		t.Errorf("inference.fallback_reason = %q, want %q", v.AsString(), FallbackNoBackend)
+	}
+	if sink.calls.Load() != 1 {
+		t.Errorf("action sink calls = %d, want 1 (rules decision dispatched)", sink.calls.Load())
+	}
+}

--- a/services/agent/decision/llm_budget_override_test.go
+++ b/services/agent/decision/llm_budget_override_test.go
@@ -1,0 +1,82 @@
+package decision
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/joustmania/agent/flags"
+	"github.com/joustmania/agent/gamecontext"
+)
+
+// llm_budget_override_test.go covers the #964 LLM budget override: an operator
+// startup knob (AGENT_LLM_MAX_REQUESTS_PER_MINUTE, wired in main.go via
+// SetLLMBudgetOverride) that REPLACES the live llm.max_requests_per_minute flag value
+// as the per-minute cap, so a real-inference dry-run is not gated by
+// llm_budget_exhausted under the eval-cycle rate. A non-positive override is ignored
+// (the flag governs) — the default-off path is unchanged.
+
+// TestBudgetOverride_RaisesCapAboveFlag: with a tiny flag budget (2) but an override
+// of 5, five attempts are admitted before the budget exhausts — the override governs,
+// not the flag. This is the live-inference fix: the loop reaches mode=llm instead of
+// gating after 2 cycles.
+func TestBudgetOverride_RaisesCapAboveFlag(t *testing.T) {
+	clock := time.Unix(1000, 0)
+	snap := gateSnapshot(flags.LLMGate{
+		EligibleGameKinds:    []string{"real"},
+		MinDecisionInterval:  0, // no cadence floor — isolate the budget layer
+		MaxRequestsPerMinute: 2, // the flag says only 2/min
+	})
+	l, _, reader := gateLoop(t, snap, NewLLMBudget(), &clock)
+	l.SetLLMBudgetOverride(5) // operator override: 5/min
+	ctx := gamecontext.GameContext{SessionID: "s1", GameKind: "real"}
+
+	for i := 0; i < 5; i++ {
+		l.OnEvaluate(context.Background(), ctx, testTrigger())
+	}
+	// Five admitted (override cap), none gated yet.
+	if got := gatedByReason(t, reader); got[FallbackBudgetExhausted] != 0 {
+		t.Errorf("after 5 cycles under override=5, budget-exhausted gated = %d, want 0", got[FallbackBudgetExhausted])
+	}
+	// The sixth exceeds the override cap.
+	l.OnEvaluate(context.Background(), ctx, testTrigger())
+	if got := gatedByReason(t, reader); got[FallbackBudgetExhausted] != 1 {
+		t.Errorf("6th cycle: budget-exhausted gated = %d, want 1 (override cap of 5 reached)", got[FallbackBudgetExhausted])
+	}
+}
+
+// TestBudgetOverride_ZeroIgnored_FlagGoverns: a non-positive override is ignored, so
+// the flag value (2) governs exactly as before — the default-off regression guard.
+func TestBudgetOverride_ZeroIgnored_FlagGoverns(t *testing.T) {
+	clock := time.Unix(1000, 0)
+	snap := gateSnapshot(flags.LLMGate{
+		EligibleGameKinds:    []string{"real"},
+		MinDecisionInterval:  0,
+		MaxRequestsPerMinute: 2,
+	})
+	l, _, reader := gateLoop(t, snap, NewLLMBudget(), &clock)
+	l.SetLLMBudgetOverride(0)  // ignored
+	l.SetLLMBudgetOverride(-3) // ignored
+	ctx := gamecontext.GameContext{SessionID: "s1", GameKind: "real"}
+
+	l.OnEvaluate(context.Background(), ctx, testTrigger()) // 1 admitted
+	l.OnEvaluate(context.Background(), ctx, testTrigger()) // 2 admitted
+	l.OnEvaluate(context.Background(), ctx, testTrigger()) // 3 -> exhausted (flag cap of 2)
+
+	if got := gatedByReason(t, reader); got[FallbackBudgetExhausted] != 1 {
+		t.Errorf("budget-exhausted gated = %d, want 1 (flag cap of 2 governs when override unset)", got[FallbackBudgetExhausted])
+	}
+}
+
+// TestBudgetCap_Unit: the cap selection helper directly — override wins when > 0, the
+// flag value governs otherwise.
+func TestBudgetCap_Unit(t *testing.T) {
+	l := &Loop{}
+	if got := l.budgetCap(6); got != 6 {
+		t.Errorf("no override: budgetCap(6) = %d, want 6 (flag governs)", got)
+	}
+	l.budgetOverride = 20
+	if got := l.budgetCap(6); got != 20 {
+		t.Errorf("override=20: budgetCap(6) = %d, want 20", got)
+	}
+}

--- a/services/agent/decision/resolver.go
+++ b/services/agent/decision/resolver.go
@@ -241,7 +241,19 @@ type InferenceTier struct {
 func NewInferenceResolver(tier InferenceTier, eps Endpoints, interval time.Duration) *Resolver {
 	chain := make([]Backend, 0, 4)
 	chain = append(chain, newEndpointBackendWithInfer(tier.Model, tier.Addr, tier.Infer))
-	chain = append(chain, DefaultChainWithInfer(eps, tier.Infer)...)
+	// Skip any legacy tier whose Name() duplicates the configured model. The
+	// availability map is keyed by Name() (see Refresh/resolve), so a duplicate
+	// (e.g. AGENT_INFERENCE_MODEL unset -> DefaultModel "phi4-mini" == TierPhi) would
+	// collide on one key and the legacy localhost probe — unreachable in the
+	// container — would clobber the configured tier's availability under last-write-
+	// wins, silently degrading a reachable backend to rules. The configured tier
+	// (probed at tier.Addr) supersedes the same-named legacy rung entirely.
+	for _, b := range DefaultChainWithInfer(eps, tier.Infer) {
+		if b.Name() == tier.Model {
+			continue
+		}
+		chain = append(chain, b)
+	}
 	r := NewResolver(chain, interval)
 	r.inferenceTier = tier.Model
 	return r

--- a/services/agent/decision/resolver.go
+++ b/services/agent/decision/resolver.go
@@ -2,6 +2,9 @@ package decision
 
 import (
 	"context"
+	"net"
+	"net/url"
+	"strings"
 	"sync"
 	"time"
 
@@ -129,6 +132,18 @@ type Resolver struct {
 	// index downward. The rules engine is the implicit terminal rung below it.
 	chain []Backend
 
+	// inferenceTier is the name of the configured-inference-backend tier (#964): when
+	// AGENT_INFERENCE_BACKEND=openai, main.go builds a Resolver whose chain TOP is a
+	// real OpenAI-compatible tier named after AGENT_INFERENCE_MODEL, probed at the
+	// host:port of AGENT_INFERENCE_BASE_URL and Infer-delegating to the same client
+	// the proposer uses. When this is non-empty resolve() ALWAYS starts the walk at
+	// this tier regardless of the agent.model flag, so the configured backend IS the
+	// inference path and a stale/default model flag (phi4-mini) can no longer skip
+	// past it down the chain — closing the #964 "resolver decoupled from
+	// AGENT_INFERENCE_BASE_URL" gap. Empty (the stub default) restores the pre-#964
+	// behavior: the walk starts at the tier the model flag selects (resolveTierFromModel).
+	inferenceTier string
+
 	// mu guards available. The decision hot path takes it for a cheap read; the
 	// background refresh takes it for the write. Held only around the map read and
 	// write, never across a probe (probes run before the lock is taken).
@@ -190,6 +205,74 @@ func DefaultChainWithInfer(eps Endpoints, inferFn func(ctx context.Context, prom
 	}
 }
 
+// InferenceTier describes the configured real inference backend as a resolver tier
+// (#964). When AGENT_INFERENCE_BACKEND=openai, main.go fills it from the SAME
+// AGENT_INFERENCE_* config that builds the OpenAIBackend, so the resolver's
+// availability probe targets the configured backend's host:port (Addr) and the tier
+// is named after the configured model (Model = AGENT_INFERENCE_MODEL). The zero value
+// (no real backend selected) yields no inference tier and the chain/resolver behave
+// exactly as before — the stub default is byte-identical.
+type InferenceTier struct {
+	// Model is the tier name, equal to AGENT_INFERENCE_MODEL. It becomes inference.used
+	// on the decision span and gen_ai.request.model on the inference span, so a single
+	// AGENT_INFERENCE_MODEL drives the backend request AND the decision-loop attribution
+	// (#964 gap 3: one source of truth, no more phi4-mini/AGENT_INFERENCE_MODEL drift).
+	Model string
+	// Addr is the host:port the availability probe TCP-dials, parsed from
+	// AGENT_INFERENCE_BASE_URL (see InferenceProbeAddr). Empty makes the tier
+	// permanently unreachable (the chain degrades exactly as today), so a
+	// mis-/un-parseable base URL fails SAFE to rules rather than to a broken tier.
+	Addr string
+	// Infer is the real OpenAI-compatible delegate (the SAME inference.OpenAIBackend
+	// the proposer uses). Non-nil on AGENT_INFERENCE_BACKEND=openai; a reachable tier
+	// then produces real model text instead of the not-implemented sentinel.
+	Infer func(ctx context.Context, prompt llm.Prompt) (string, error)
+}
+
+// NewInferenceResolver builds the production Resolver for the configured real
+// inference backend (#964). The configured-inference tier (named after the model) is
+// the chain TOP, probed at its own host:port, followed by the legacy cloud/jetson/
+// localhost tiers (still probed at their endpoints, still Infer-delegating to the
+// same client) so the existing fallback chain remains intact below the configured
+// backend. resolve() ALWAYS starts the walk at the configured-inference tier (it is
+// the canonical inference path), then degrades down the legacy chain and finally to
+// rules — graceful degradation is preserved end to end. interval is the background
+// re-probe cadence (DefaultProbeInterval when non-positive).
+func NewInferenceResolver(tier InferenceTier, eps Endpoints, interval time.Duration) *Resolver {
+	chain := make([]Backend, 0, 4)
+	chain = append(chain, newEndpointBackendWithInfer(tier.Model, tier.Addr, tier.Infer))
+	chain = append(chain, DefaultChainWithInfer(eps, tier.Infer)...)
+	r := NewResolver(chain, interval)
+	r.inferenceTier = tier.Model
+	return r
+}
+
+// InferenceProbeAddr derives the host:port a TCP availability probe should dial from
+// an OpenAI-compatible base URL (#964). It strips the scheme and any path (e.g.
+// "http://192.168.224.1:11434/v1" -> "192.168.224.1:11434"), and when the URL omits a
+// port it supplies the scheme default (443 for https, else 80) so the probe still has
+// a concrete dial target. An unparseable / host-less URL returns "" — the caller then
+// builds a permanently-unreachable tier (fail-safe to rules), never a panic.
+func InferenceProbeAddr(baseURL string) string {
+	u, err := url.Parse(strings.TrimSpace(baseURL))
+	if err != nil || u.Host == "" {
+		return ""
+	}
+	host := u.Hostname()
+	if host == "" {
+		return ""
+	}
+	port := u.Port()
+	if port == "" {
+		if u.Scheme == "https" {
+			port = "443"
+		} else {
+			port = "80"
+		}
+	}
+	return net.JoinHostPort(host, port)
+}
+
 // resolveTierFromModel maps the configured agent.model flag to the index of the
 // chain tier it selects as the TOP of the walk. claude/copilot -> the cloud tier
 // (index 0); gemma3:4b -> the Jetson tier; phi4-mini -> the localhost tier; any
@@ -197,6 +280,20 @@ func DefaultChainWithInfer(eps Endpoints, inferFn func(ctx context.Context, prom
 // and degrades through every rung rather than silently skipping the chain. It
 // returns the chain index to start resolving from.
 func (r *Resolver) resolveTierFromModel(model string) int {
+	// #964: when a real inference backend is configured (AGENT_INFERENCE_BACKEND=openai),
+	// it is the canonical inference path — ALWAYS start the walk at its tier, whatever
+	// the agent.model flag says. This is what wires the decision-loop resolver to
+	// AGENT_INFERENCE_BASE_URL/AGENT_INFERENCE_MODEL: the configured backend's tier is
+	// the chain top, so a reachable backend resolves to a non-nil Backend and decide()
+	// actually CALLS it (mode=llm) instead of degrading to rules because a default
+	// phi4-mini flag pointed at an unreachable localhost tier.
+	if r.inferenceTier != "" {
+		for i, b := range r.chain {
+			if b.Name() == r.inferenceTier {
+				return i
+			}
+		}
+	}
 	if _, isCloud := cloudModels[model]; isCloud {
 		return 0
 	}

--- a/services/agent/decision/resolver_inference_test.go
+++ b/services/agent/decision/resolver_inference_test.go
@@ -1,0 +1,161 @@
+package decision
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/joustmania/agent/llm"
+)
+
+// resolver_inference_test.go covers the #964 inference-backend resolver tier: when
+// AGENT_INFERENCE_BACKEND=openai, the resolver's chain TOP is the configured backend
+// (named after AGENT_INFERENCE_MODEL, probed at the AGENT_INFERENCE_BASE_URL host:port,
+// Infer-delegating to the real client). resolve() must START at that tier regardless of
+// the agent.model flag (so a default phi4-mini flag no longer skips it), report it as
+// inference.used when reachable, and degrade to rules when it (and the legacy chain) are
+// unreachable — graceful degradation unchanged. The stub default (no inference tier) is
+// covered for byte-identical behavior.
+
+// listenLocal opens a real loopback TCP listener and returns its host:port plus a
+// cleanup. The resolver's production endpointBackend probes reachability with a real
+// TCP dial, so an open listener is the dependency-free way to make a tier "reachable"
+// in a unit test (no mock dialer plumbing for endpointBackend).
+func listenLocal(t *testing.T) (addr string, closeFn func()) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	return ln.Addr().String(), func() { _ = ln.Close() }
+}
+
+// TestInferenceProbeAddr parses an OpenAI-compatible base URL down to the host:port a
+// TCP probe should dial (#964 gap 1), supplying the scheme default port when omitted
+// and returning "" (fail-safe) for an unusable URL.
+func TestInferenceProbeAddr(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"ollama lan with port and /v1", "http://192.168.224.1:11434/v1", "192.168.224.1:11434"},
+		{"host docker internal", "http://host.docker.internal:11434/v1", "host.docker.internal:11434"},
+		{"https default port", "https://api.example.com/v1", "api.example.com:443"},
+		{"http default port", "http://example.com/v1", "example.com:80"},
+		{"trailing space tolerated", "  http://h:9/v1  ", "h:9"},
+		{"empty -> empty", "", ""},
+		{"no scheme/host -> empty", "/v1", ""},
+		{"garbage -> empty", "::::", ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := InferenceProbeAddr(tc.in); got != tc.want {
+				t.Errorf("InferenceProbeAddr(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestInferenceResolver_ReachableStartsAtInferenceTier: with the inference backend
+// configured and reachable, resolve() returns the inference tier as inference.used and
+// a non-nil Backend that calls the real delegate — even though the agent.model flag is
+// the default phi4-mini (which previously selected the unreachable localhost tier and
+// degraded to rules). This is the #964 gaps 1+3 fix: the configured backend IS the
+// inference path, and AGENT_INFERENCE_MODEL is the single source of truth for the tier.
+func TestInferenceResolver_ReachableStartsAtInferenceTier(t *testing.T) {
+	addr, closeFn := listenLocal(t)
+	defer closeFn()
+
+	const model = "gemma4:latest"
+	called := false
+	delegate := func(context.Context, llm.Prompt) (string, error) {
+		called = true
+		return `{"intervention":"noop"}`, nil
+	}
+	// Legacy endpoints all unreachable (the dev default) — only the configured
+	// inference tier is up. resolve() must still pick it.
+	r := NewInferenceResolver(InferenceTier{Model: model, Addr: addr, Infer: delegate},
+		Endpoints{}, 0)
+	r.Refresh(context.Background())
+
+	// The default model flag is phi4-mini; the inference tier must win regardless.
+	res := r.resolve("phi4-mini")
+	if res.Used != model {
+		t.Fatalf("inference.used = %q, want %q (configured inference tier)", res.Used, model)
+	}
+	if res.FallbackReason != "" {
+		t.Errorf("fallback_reason = %q, want empty (configured tier reachable)", res.FallbackReason)
+	}
+	if res.Backend == nil {
+		t.Fatal("resolved Backend is nil; decide() would degrade to rules (mode=rules) — the #964 bug")
+	}
+	out, err := res.Backend.Infer(context.Background(), llm.Prompt{})
+	if err != nil || !called {
+		t.Errorf("resolved Backend.Infer did not reach the real delegate: out=%q err=%v called=%v", out, err, called)
+	}
+}
+
+// TestInferenceResolver_UnreachableDegradesToRules: when the configured inference tier
+// AND the legacy chain are unreachable, resolve() bottoms out at rules with
+// no_backend_available — the unchanged graceful-degradation path (mode=rules).
+func TestInferenceResolver_UnreachableDegradesToRules(t *testing.T) {
+	delegate := func(context.Context, llm.Prompt) (string, error) { return "", nil }
+	// An addr that nothing is listening on (port 1 on loopback) -> probe fails.
+	r := NewInferenceResolver(InferenceTier{Model: "gemma4:latest", Addr: "127.0.0.1:1", Infer: delegate},
+		Endpoints{}, 0)
+	r.Refresh(context.Background())
+
+	res := r.resolve("phi4-mini")
+	if res.Used != InferenceRules || res.FallbackReason != FallbackNoBackend {
+		t.Errorf("unreachable resolve = %+v, want rules/%s", res, FallbackNoBackend)
+	}
+	if res.Backend != nil {
+		t.Error("Backend should be nil when the whole chain is unreachable (degrade to rules)")
+	}
+}
+
+// TestInferenceResolver_DegradesToLegacyTier: with the configured inference tier down
+// but a legacy tier (localhost/phi) up, resolve() degrades down the chain rather than
+// straight to rules — the fallback chain below the configured backend stays intact.
+func TestInferenceResolver_DegradesToLegacyTier(t *testing.T) {
+	legacyAddr, closeFn := listenLocal(t)
+	defer closeFn()
+
+	delegate := func(context.Context, llm.Prompt) (string, error) { return "ok", nil }
+	r := NewInferenceResolver(
+		InferenceTier{Model: "gemma4:latest", Addr: "127.0.0.1:1", Infer: delegate}, // configured tier down
+		Endpoints{Localhost: legacyAddr},                                            // phi4-mini tier up
+		0)
+	r.Refresh(context.Background())
+
+	res := r.resolve("phi4-mini")
+	if res.Used != TierPhi {
+		t.Fatalf("inference.used = %q, want %q (degraded to reachable legacy tier)", res.Used, TierPhi)
+	}
+	if res.FallbackReason != FallbackEndpointUnreachable {
+		t.Errorf("fallback_reason = %q, want %q", res.FallbackReason, FallbackEndpointUnreachable)
+	}
+	if res.Backend == nil {
+		t.Error("resolved legacy Backend is nil")
+	}
+}
+
+// TestStubResolver_NoInferenceTier_Unchanged: the stub default (NewResolver, no
+// inference tier) selects the tier the agent.model flag names, exactly as before #964 —
+// the default-off path is byte-identical (regression guard for gap 1+3 not leaking into
+// the stub build).
+func TestStubResolver_NoInferenceTier_Unchanged(t *testing.T) {
+	r := NewResolver(DefaultChainWithInfer(Endpoints{}, nil), 0)
+	if r.inferenceTier != "" {
+		t.Fatalf("stub resolver inferenceTier = %q, want empty", r.inferenceTier)
+	}
+	// resolveTierFromModel must follow the model flag (phi4-mini -> the phi tier index 2),
+	// not jump to an inference tier.
+	if got := r.resolveTierFromModel("phi4-mini"); got != 2 {
+		t.Errorf("stub resolveTierFromModel(phi4-mini) = %d, want 2 (TierPhi)", got)
+	}
+	if got := r.resolveTierFromModel("claude"); got != 0 {
+		t.Errorf("stub resolveTierFromModel(claude) = %d, want 0 (TierCloud)", got)
+	}
+}

--- a/services/agent/decision/resolver_inference_test.go
+++ b/services/agent/decision/resolver_inference_test.go
@@ -141,6 +141,42 @@ func TestInferenceResolver_DegradesToLegacyTier(t *testing.T) {
 	}
 }
 
+// TestInferenceResolver_ModelNameCollidesWithLegacyTier: when AGENT_INFERENCE_MODEL
+// equals a legacy tier name (the default "phi4-mini" == TierPhi when the model is
+// unset), the configured tier and the legacy rung would share one availability-map
+// key. NewInferenceResolver must drop the same-named legacy rung so the reachable
+// configured tier is NOT clobbered by the unreachable legacy localhost probe. Without
+// the fix this resolves to rules (no_backend_available) despite a reachable backend.
+func TestInferenceResolver_ModelNameCollidesWithLegacyTier(t *testing.T) {
+	addr, closeFn := listenLocal(t)
+	defer closeFn()
+
+	called := false
+	delegate := func(context.Context, llm.Prompt) (string, error) {
+		called = true
+		return `{"intervention":"noop"}`, nil
+	}
+	// Configured model name == TierPhi. Legacy localhost points at an unreachable
+	// port (the container/dev reality) — last-write-wins would otherwise clobber the
+	// configured tier's availability under the shared "phi4-mini" key.
+	r := NewInferenceResolver(
+		InferenceTier{Model: TierPhi, Addr: addr, Infer: delegate},
+		Endpoints{Localhost: "127.0.0.1:1"},
+		0)
+	r.Refresh(context.Background())
+
+	res := r.resolve(TierPhi)
+	if res.Backend == nil {
+		t.Fatal("Backend nil: same-named legacy tier clobbered the reachable configured tier (the #964 collision bug)")
+	}
+	if res.Used != TierPhi || res.FallbackReason != "" {
+		t.Errorf("resolve = %+v, want %s with empty fallback (configured tier reachable)", res, TierPhi)
+	}
+	if _, err := res.Backend.Infer(context.Background(), llm.Prompt{}); err != nil || !called {
+		t.Errorf("resolved Backend did not reach the configured delegate: err=%v called=%v", err, called)
+	}
+}
+
 // TestStubResolver_NoInferenceTier_Unchanged: the stub default (NewResolver, no
 // inference tier) selects the tier the agent.model flag names, exactly as before #964 —
 // the default-off path is byte-identical (regression guard for gap 1+3 not leaking into

--- a/services/agent/llm_budget_override_main_test.go
+++ b/services/agent/llm_budget_override_main_test.go
@@ -1,0 +1,37 @@
+package main
+
+import "testing"
+
+// llm_budget_override_main_test.go covers the #964 AGENT_LLM_MAX_REQUESTS_PER_MINUTE
+// env parsing in main: a positive value overrides the flag-derived budget cap; an
+// unset/empty/invalid/non-positive value returns 0 ("no override", the flag governs),
+// keeping the default-off path unchanged.
+func TestLLMBudgetOverride(t *testing.T) {
+	tests := []struct {
+		name string
+		set  bool
+		val  string
+		want int
+	}{
+		{"unset -> no override", false, "", 0},
+		{"empty -> no override", true, "", 0},
+		{"positive -> override", true, "20", 20},
+		{"zero -> no override", true, "0", 0},
+		{"negative -> no override", true, "-5", 0},
+		{"garbage -> no override", true, "lots", 0},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.set {
+				t.Setenv("AGENT_LLM_MAX_REQUESTS_PER_MINUTE", tc.val)
+			} else {
+				// Ensure the var is unset for this case (t.Setenv restores afterward,
+				// but a prior process env could leak in — explicitly clear it).
+				t.Setenv("AGENT_LLM_MAX_REQUESTS_PER_MINUTE", "")
+			}
+			if got := llmBudgetOverride(); got != tc.want {
+				t.Errorf("llmBudgetOverride() = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}

--- a/services/agent/main.go
+++ b/services/agent/main.go
@@ -275,6 +275,27 @@ func rolloutCooldown() time.Duration {
 	return secondsEnv("AGENT_ROLLOUT_COOLDOWN_SECONDS", decision.DefaultRolloutCooldown)
 }
 
+// llmBudgetOverride reads the LIVE LLM per-minute request cap override from
+// AGENT_LLM_MAX_REQUESTS_PER_MINUTE (#964). The decision loop normally reads the cap
+// from the llm.max_requests_per_minute flag (default 6), which under the eval-cycle
+// rate exhausts the budget almost immediately and gates the llm path with
+// llm_budget_exhausted even when a backend is reachable. This env override lets an
+// operator raise the cap for a real-inference dry-run without editing flagd. An
+// unset/empty/invalid/non-positive value returns 0 = "no override" (the flag
+// governs), so the default-off path is unchanged.
+func llmBudgetOverride() int {
+	s := strings.TrimSpace(os.Getenv("AGENT_LLM_MAX_REQUESTS_PER_MINUTE"))
+	if s == "" {
+		return 0
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil || n <= 0 {
+		slog.Warn("AGENT_LLM_MAX_REQUESTS_PER_MINUTE invalid; ignoring (flag governs) (#964)", "value", s)
+		return 0
+	}
+	return n
+}
+
 // secondsEnv parses a positive integer "seconds" env var into a Duration,
 // returning fallback on an empty/invalid/non-positive value.
 func secondsEnv(key string, fallback time.Duration) time.Duration {
@@ -431,6 +452,15 @@ func main() {
 	// per-game cadence + eligibility layers live on each Loop; only the budget is
 	// shared across loops.
 	sharedLLMBudget := decision.NewLLMBudget()
+	// LIVE LLM budget override (#964): AGENT_LLM_MAX_REQUESTS_PER_MINUTE raises the
+	// per-minute LLM request cap above the llm.max_requests_per_minute flag default
+	// (6/min, which exhausts under the eval-cycle rate). 0 = no override (the flag
+	// governs), so the default-off path is unchanged. Read once at startup and applied
+	// to every per-game loop below, mirroring the shared budget instance itself.
+	llmBudgetCapOverride := llmBudgetOverride()
+	if llmBudgetCapOverride > 0 {
+		slog.Info("LLM request budget override enabled (#964)", "max_per_minute", llmBudgetCapOverride)
+	}
 	// Startup self-heal (#924): when the real action sink is enabled, validate the
 	// interventions file and repair a poisoned (unparseable) one to the neutral
 	// document before the first decision cycle. A corrupt file would otherwise make
@@ -461,17 +491,44 @@ func main() {
 	// AGENT_INFERENCE_BACKEND=openai points it at the host Ollama (or a gateway) for a
 	// real local inference path with no key.
 	inferDelegate, inferBackendName := selectInferenceBackend()
+	inferBaseURL := getEnv("AGENT_INFERENCE_BASE_URL", inference.DefaultBaseURL)
+	inferModel := getEnv("AGENT_INFERENCE_MODEL", inference.DefaultModel)
 	slog.Info("Inference backend selected (#1048)",
 		"backend", inferBackendName,
-		"base_url", getEnv("AGENT_INFERENCE_BASE_URL", inference.DefaultBaseURL),
-		"model", getEnv("AGENT_INFERENCE_MODEL", inference.DefaultModel),
+		"base_url", inferBaseURL,
+		"model", inferModel,
 		"api_key_set", getEnv("AGENT_INFERENCE_API_KEY", "") != "",
 	)
-	sharedResolver := decision.NewResolver(decision.DefaultChainWithInfer(decision.Endpoints{
+	legacyEndpoints := decision.Endpoints{
 		Cloud:     getEnv("AGENT_CLOUD_ENDPOINT", ""),                    // #742 credential-blocked: empty = permanently unreachable
 		Jetson:    getEnv("AGENT_JETSON_ENDPOINT", "jetson:11434"),       // #738 Ollama on the Jetson; unresolvable in dev
 		Localhost: getEnv("AGENT_LOCALHOST_ENDPOINT", "localhost:11434"), // #739 Ollama locally; unreachable unless running
-	}, inferDelegate), decision.DefaultProbeInterval)
+	}
+	// #964: when a REAL inference backend is configured (AGENT_INFERENCE_BACKEND=openai),
+	// build a Resolver whose chain TOP is the configured backend itself — named after
+	// AGENT_INFERENCE_MODEL, probed at the host:port parsed from AGENT_INFERENCE_BASE_URL,
+	// Infer-delegating to the SAME client the proposer uses. resolve() always starts at
+	// that tier, so a reachable backend yields a non-nil Backend and the decision loop
+	// reaches mode=llm instead of degrading to rules because the default phi4-mini model
+	// flag pointed at an unreachable localhost tier. A single AGENT_INFERENCE_* config now
+	// drives the backend request, the resolver's availability probe, AND the inference.used
+	// attribution. When inferDelegate is nil (the stub DEFAULT) the legacy DefaultChainWithInfer
+	// resolver is built unchanged — byte-identical degrade-to-rules behavior.
+	var sharedResolver *decision.Resolver
+	if inferDelegate != nil {
+		probeAddr := decision.InferenceProbeAddr(inferBaseURL)
+		slog.Info("Inference-backend resolver tier wired (#964)",
+			"model", inferModel, "probe_addr", probeAddr)
+		sharedResolver = decision.NewInferenceResolver(decision.InferenceTier{
+			Model: inferModel,
+			Addr:  probeAddr,
+			Infer: inferDelegate,
+		}, legacyEndpoints, decision.DefaultProbeInterval)
+	} else {
+		sharedResolver = decision.NewResolver(
+			decision.DefaultChainWithInfer(legacyEndpoints, inferDelegate),
+			decision.DefaultProbeInterval)
+	}
 	// The resolver's background probe ticker is started by run() (#923), which owns
 	// the agent's goroutine lifecycle, so it is stopped on ctx cancellation alongside
 	// every other runtime goroutine.
@@ -515,6 +572,11 @@ func main() {
 		// references the same instance: the gate's eligibility + cadence layers are
 		// per-loop, but the budget layer is one global cap across all games.
 		loop.SetLLMBudget(sharedLLMBudget)
+		// Apply the LIVE budget override (#964): when AGENT_LLM_MAX_REQUESTS_PER_MINUTE is
+		// set it replaces the llm.max_requests_per_minute flag value as the per-minute cap,
+		// so a real-inference dry-run is not gated by llm_budget_exhausted under the eval
+		// rate. 0 (unset) is ignored — the flag governs, default-off path unchanged.
+		loop.SetLLMBudgetOverride(llmBudgetCapOverride)
 		// Inject the SHARED inference resolver (#741): every per-game loop resolves the
 		// fallback chain against the same availability cache, so a gate-admitted llm
 		// cycle reports the honest inference.used tier and any degradation reason.


### PR DESCRIPTION
## Summary

First layer of #964: make REAL LLM inference actually FLOW through the agent's decision loop + proposer. Previously, with `AGENT_INFERENCE_BACKEND=openai` and a reachable Ollama, the #1048 backend was SELECTED but NEVER CALLED — the loop stayed `mode=rules` with `no_backend_available` + `llm_budget_exhausted`. This wires the three gaps from the 2026-06-15 live dry-run so a reachable backend reaches `mode=llm` and the proposer produces a real Proposal.

Scoped to "inference flows" — the validate→promote orchestration (#965 Validator + #1065 reverter) is a separate follow-up layer.

## The three gaps

**Gap 1 — resolver tier-endpoint decoupled from `AGENT_INFERENCE_BASE_URL`.** The decision-loop resolver probed its own tier endpoints (cloud/jetson/localhost), none of which pointed at the inference backend, so `resolve()` returned a nil Backend → `endpointBackend.infer` (the #1048 seam) was never invoked → `mode=rules`. Added a configured-inference resolver tier (`NewInferenceResolver` / `InferenceTier`): when a real backend is selected, the resolver's chain TOP IS the backend — named after `AGENT_INFERENCE_MODEL`, availability-probed at the host:port parsed from `AGENT_INFERENCE_BASE_URL` (`InferenceProbeAddr`), Infer-delegating to the same client the proposer uses. The legacy cloud/jetson/localhost chain stays intact below it for graceful degradation.

**Gap 2 — LLM budget exhausts under the eval rate.** Added an `AGENT_LLM_MAX_REQUESTS_PER_MINUTE` startup override (`SetLLMBudgetOverride`) that replaces the `llm.max_requests_per_minute` flag value as the per-minute cap for a live dry-run, without editing flagd. A non-positive/unset value is ignored — the flag governs, default-off unchanged.

**Gap 3 — model drift (`phi4-mini` vs `AGENT_INFERENCE_MODEL`).** `resolve()` always starts the walk at the configured inference tier, so a default `phi4-mini` `agent.model` flag no longer skips past it down the chain. The tier name (and thus `inference.used` + `gen_ai.request.model`) is `AGENT_INFERENCE_MODEL` — a single source of truth end to end. The proposer already wraps the same delegate (`proposeBackendFor`), so its backend is invoked with the same model.

## Safety (unchanged, default-off)

- Kill-switch, `interventions_allowed`, battery, weighted rate-limit gates, shadow-scoping, and the fail-closed promotion safety net (#1016) are all untouched.
- The proposer's output still goes through the existing shadow-scoped Gate (game.json-only).
- An unreachable backend degrades to rules exactly as before.
- The stub default (no `AGENT_INFERENCE_BACKEND`) builds the legacy resolver and the `proposeBackend{}` stub — byte-identical `mode=rules`.

## Tests

- Resolver: inference tier reachable → `mode=llm` + backend called; unreachable → rules (graceful degradation unchanged); degrade-to-legacy-tier; probe-addr parsing; stub resolver follows the model flag (regression guard).
- Budget: override raises the cap above the flag; zero/negative ignored (flag governs); env parsing.
- End-to-end flow through `decide()`: reachable → `mode=llm` with `gen_ai.request.model = AGENT_INFERENCE_MODEL`; unreachable → rules.
- `go test ./... -race`, `go vet`, `gofmt -l` all clean. No new deps (stdlib `net`/`net/url`).

## Live validation (maintainer)

Build is shaped for: `AGENT_INFERENCE_BACKEND=openai AGENT_INFERENCE_BASE_URL=http://192.168.224.1:11434/v1 AGENT_INFERENCE_MODEL=gemma4:latest` → expect `mode=llm` + real completions. Raise the budget for the run with `AGENT_LLM_MAX_REQUESTS_PER_MINUTE`.

Part of #964

🤖 Generated with [Claude Code](https://claude.com/claude-code)