### PR TITLE
feat(dashboard): Agent tab — decision feed, flag panel, intervention overlay (#792)

### DIFF
--- a/services/dashboard/src/__tests__/agent.test.ts
+++ b/services/dashboard/src/__tests__/agent.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Unit tests for the pure parse + fold in agent.ts (issue #792).
+ *
+ * Exercise aggregateAgentLogs (decision feed + flag panel + Loki-derived blocked
+ * tallies) and parseAppliedCounts (VictoriaMetrics applied count) in isolation —
+ * no Loki / VM / DOM. Covers the agent.* log shapes the agent really emits
+ * (services/agent/decision/decision.go, async_apply.go):
+ *   - agent.evaluate feeds the flag panel (newest wins) and never floods the feed
+ *   - agent.decision_blocked folds into blocked-by-action and blocked-by-reason
+ *   - agent.llm.discarded and agent.rollout_* appear in the feed but don't count
+ *     as blocked
+ *   - the feed is newest-first
+ *   - VM applied-count summing across namespaced jobs, and the empty/unavailable
+ *     path returning nulls
+ */
+import { describe, it, expect } from "vitest";
+import { aggregateAgentLogs, parseAppliedCounts } from "../agent.js";
+import type { VmQueryResponse } from "../agent.js";
+
+/** Build a synthetic slog TextHandler line from key→value pairs. */
+function logfmt(fields: Record<string, string>): string {
+  return Object.entries(fields)
+    .map(([k, v]) => (/[\s"]/.test(v) ? `${k}=${JSON.stringify(v)}` : `${k}=${v}`))
+    .join(" ");
+}
+
+let ts = 1_700_000_000_000;
+function nextTs(): number {
+  ts += 1000;
+  return ts;
+}
+
+function line(fields: Record<string, string>, tsMs = nextTs()) {
+  return { line: logfmt({ level: "INFO", ...fields }), tsMs };
+}
+
+describe("aggregateAgentLogs — flag panel", () => {
+  it("takes the resolved values from the newest agent.evaluate line", () => {
+    const out = aggregateAgentLogs([
+      line({
+        msg: "agent.evaluate",
+        session_id: "game_aaa",
+        mode: "rules",
+        model: "none",
+        prompt_variant: "v1",
+        battery_threshold: "20",
+        variance_window: "5",
+        max_per_minute: "12",
+        game_mode: "JoustFFA",
+      }),
+      line({
+        msg: "agent.evaluate",
+        session_id: "game_aaa",
+        mode: "llm",
+        model: "claude",
+        prompt_variant: "v2",
+        battery_threshold: "30",
+        variance_window: "8",
+        max_per_minute: "20",
+        game_mode: "Zombies",
+      }),
+    ]);
+    expect(out.flags).not.toBeNull();
+    // Newest (second) line wins.
+    expect(out.flags?.mode).toBe("llm");
+    expect(out.flags?.model).toBe("claude");
+    expect(out.flags?.maxPerMinute).toBe("20");
+    expect(out.flags?.gameMode).toBe("Zombies");
+  });
+
+  it("newest wins regardless of input order", () => {
+    const newer = line({ msg: "agent.evaluate", mode: "llm" }, 2000);
+    const older = line({ msg: "agent.evaluate", mode: "rules" }, 1000);
+    // Feed older AFTER newer to prove it's ts-driven, not order-driven.
+    expect(aggregateAgentLogs([newer, older]).flags?.mode).toBe("llm");
+  });
+
+  it("agent.evaluate never appears in the decision feed", () => {
+    const out = aggregateAgentLogs([
+      line({ msg: "agent.evaluate", mode: "rules" }),
+      line({ msg: "agent.evaluate", mode: "rules" }),
+    ]);
+    expect(out.feed).toHaveLength(0);
+    expect(out.flags).not.toBeNull();
+  });
+
+  it("is null when no agent.evaluate line is present", () => {
+    const out = aggregateAgentLogs([
+      line({ msg: "agent.decision_blocked", intervention: "grant_shield", reason: "rate_limit" }),
+    ]);
+    expect(out.flags).toBeNull();
+  });
+});
+
+describe("aggregateAgentLogs — blocked tallies", () => {
+  it("folds blocked decisions by action and by reason", () => {
+    const out = aggregateAgentLogs([
+      line({ msg: "agent.decision_blocked", intervention: "grant_shield", reason: "rate_limit" }),
+      line({ msg: "agent.decision_blocked", intervention: "grant_shield", reason: "battery_threshold" }),
+      line({ msg: "agent.decision_blocked", intervention: "raise_demand", reason: "rate_limit" }),
+    ]);
+    expect(out.overlay.totalBlocked).toBe(3);
+    // Most-blocked action first.
+    expect(out.overlay.blockedByAction[0]).toEqual({ action: "grant_shield", blocked: 2 });
+    expect(out.overlay.blockedByAction).toContainEqual({ action: "raise_demand", blocked: 1 });
+    // Reasons descending: rate_limit (2) before battery_threshold (1).
+    expect(out.overlay.blockedByReason[0]).toEqual({ reason: "rate_limit", count: 2 });
+  });
+
+  it("is order-independent (additive)", () => {
+    const a = line({ msg: "agent.decision_blocked", intervention: "x", reason: "r1" }, 1000);
+    const b = line({ msg: "agent.decision_blocked", intervention: "x", reason: "r1" }, 2000);
+    const fwd = aggregateAgentLogs([a, b]);
+    const rev = aggregateAgentLogs([b, a]);
+    expect(fwd.overlay.totalBlocked).toBe(rev.overlay.totalBlocked);
+    expect(fwd.overlay.blockedByAction).toEqual(rev.overlay.blockedByAction);
+  });
+
+  it("discarded and rollout lines are NOT counted as blocked", () => {
+    const out = aggregateAgentLogs([
+      line({ msg: "agent.llm.discarded", session_id: "game_a", reason: "timeout" }),
+      line({ msg: "agent.rollout_expand", reason: "stable" }),
+    ]);
+    expect(out.overlay.totalBlocked).toBe(0);
+    expect(out.feed).toHaveLength(2);
+  });
+});
+
+describe("aggregateAgentLogs — decision feed", () => {
+  it("includes blocked / discarded / rollout rows with the right kind", () => {
+    const out = aggregateAgentLogs([
+      line({ msg: "agent.decision_blocked", intervention: "grant_shield", reason: "rate_limit", session_id: "game_z" }),
+      line({ msg: "agent.llm.discarded", reason: "stale_context" }),
+      line({ msg: "agent.rollout_rollback", reason: "regression" }),
+    ]);
+    const kinds = out.feed.map((r) => r.kind).sort();
+    expect(kinds).toEqual(["blocked", "discarded", "rollout"]);
+    const blocked = out.feed.find((r) => r.kind === "blocked");
+    expect(blocked?.blocked).toBe(true);
+    expect(blocked?.action).toBe("grant_shield");
+    expect(blocked?.reason).toBe("rate_limit");
+    expect(blocked?.sessionId).toBe("game_z");
+  });
+
+  it("is sorted newest-first", () => {
+    const out = aggregateAgentLogs([
+      line({ msg: "agent.decision_blocked", intervention: "a", reason: "r" }, 1000),
+      line({ msg: "agent.decision_blocked", intervention: "b", reason: "r" }, 3000),
+      line({ msg: "agent.decision_blocked", intervention: "c", reason: "r" }, 2000),
+    ]);
+    expect(out.feed.map((r) => r.tsMs)).toEqual([3000, 2000, 1000]);
+  });
+
+  it("ignores unrelated agent.* messages", () => {
+    const out = aggregateAgentLogs([
+      line({ msg: "agent.game.summary_written", session_id: "game_a" }),
+      line({ msg: "agent.llm.prompt_captured" }),
+    ]);
+    expect(out.feed).toHaveLength(0);
+    expect(out.overlay.totalBlocked).toBe(0);
+  });
+});
+
+describe("parseAppliedCounts", () => {
+  it("sums result series across namespaced jobs", () => {
+    const body: VmQueryResponse = {
+      status: "success",
+      data: {
+        resultType: "vector",
+        result: [
+          { metric: { result: "ok", job: "infrastructure/agent-service" }, value: [1700, "7"] as [number, string] },
+          { metric: { result: "ok", job: "other/agent" }, value: [1700, "3"] as [number, string] },
+          { metric: { result: "error" }, value: [1700, "2"] as [number, string] },
+        ],
+      },
+    };
+    expect(parseAppliedCounts(body)).toEqual({ appliedOk: 10, appliedError: 2 });
+  });
+
+  it("returns nulls when VM has no samples", () => {
+    expect(parseAppliedCounts({ status: "success", data: { resultType: "vector", result: [] } }))
+      .toEqual({ appliedOk: null, appliedError: null });
+  });
+
+  it("returns nulls on a malformed body", () => {
+    expect(parseAppliedCounts({ status: "error" })).toEqual({ appliedOk: null, appliedError: null });
+  });
+
+  it("skips non-finite values", () => {
+    const body: VmQueryResponse = {
+      status: "success",
+      data: {
+        resultType: "vector",
+        result: [{ metric: { result: "ok" }, value: [1700, "NaN"] as [number, string] }],
+      },
+    };
+    // The one ok series had a non-finite value, so ok stays null.
+    expect(parseAppliedCounts(body)).toEqual({ appliedOk: null, appliedError: null });
+  });
+});

--- a/services/dashboard/src/agent.ts
+++ b/services/dashboard/src/agent.ts
@@ -1,0 +1,404 @@
+/**
+ * Agent data source (issue #792).
+ *
+ * The "Agent" tab is the demo's observability focus screen: it shows what the
+ * in-game agent is doing live — the decisions it evaluates, the effective flag
+ * values it resolved, and the interventions it applied vs blocked.
+ *
+ * TRANSPORT — reuse the experiments-tab path, don't invent a new one
+ * -----------------------------------------------------------------
+ * The experiments tab (#981) established the dashboard's read-only telemetry
+ * path: query the Loki HTTP API at `/loki/...` through envoy and fold the agent's
+ * raw slog lines client-side. This module reuses that exact path for the decision
+ * feed and the intervention "blocked" counts, and adds ONE more already-routed
+ * datasource — VictoriaMetrics at `/victoria-metrics/...` (envoy.yaml) — for the
+ * applied-intervention count, which is only emitted as a metric (see below).
+ *
+ * LOKI LABEL CONTRACT — `service_name="agent"`
+ * --------------------------------------------
+ * Identical to ../experiments.ts: this view is empty unless the agent's container
+ * logs arrive in Loki under the stream label `service_name="agent"`, produced by
+ * the compose-label -> OTEL `service.name` -> Loki `service_name` chain documented
+ * in services/otel-collector/config.yaml (`transform/docker_logs`). If that chain
+ * changes the selector below silently returns zero streams and the view goes blank
+ * with no error.
+ *
+ * WHAT THE AGENT EMITS (and where)
+ * --------------------------------
+ * The agent's full per-decision audit trail lives on OTEL *spans*
+ * (agent.signal_received -> agent.decision -> agent.action, see
+ * services/agent/decision/telemetry.go) — that is where decision.action /
+ * decision.objective_served on the ALLOWED path are recorded. Those are NOT in
+ * Loki. The agent DOES emit a useful subset as slog lines we can fold here:
+ *
+ *   agent.evaluate         one per evaluated cycle — carries the RESOLVED effective
+ *                          flag values (mode, model, prompt_variant, and the three
+ *                          policy numbers). This is our flag-panel source.
+ *   agent.decision_blocked blocked decision — intervention, target_serial, reason
+ *                          (the BlockReason), decision_reason, allowed.
+ *   agent.llm.discarded    async LLM result dropped at apply time — reason, tier.
+ *   agent.rollout_expand / agent.rollout_rollback(_recommended) — rollout activity.
+ *
+ * GAP (documented, not faked): the allowed-path decision detail (action +
+ * objective_served) and the boolean agent.json flags (enabled,
+ * experiments_enabled, experiment_dynamic_enabled, interventions_allowed list,
+ * verdict_*) are span-only / flagd-only and not present in the agent's stdout
+ * logs. The decision feed therefore renders the blocked decisions and discards
+ * with full detail and the allowed cycles as liveness, and deep-links to Jaeger
+ * for the full per-decision audit. The flag panel surfaces the resolved values the
+ * agent.evaluate line DOES carry, and links to Jaeger/Grafana for the rest. When a
+ * flag-state read endpoint or a flagd evaluation route lands (#505), the flag panel
+ * can be upgraded to the full effective set.
+ */
+
+import { parseLogfmt } from "./experiments.js";
+
+const BASE_URL = import.meta.env.DEV ? "" : globalThis.location.origin;
+
+/**
+ * Loki LogQL selector for the agent's decision/flag activity log lines.
+ *
+ * `service_name="agent"` is a load-bearing contract — see the LOKI LABEL CONTRACT
+ * note in the module header before changing it. The `|~` line filter narrows to
+ * the agent.* messages this view folds, so a busy run's experiment.* lines (folded
+ * by the experiments tab) don't crowd out the limit.
+ */
+const AGENT_LOG_QUERY =
+  '{service_name="agent"} |~ "agent\\\\.(evaluate|decision_blocked|llm\\\\.discarded|rollout_)"';
+
+/** How far back to look for agent activity (decision feed window). */
+const LOOKBACK_SECONDS = 10 * 60; // 10 minutes
+
+/** Max log lines Loki returns per query. */
+const QUERY_LIMIT = 2000;
+
+/** Max decision-feed rows kept after folding (newest first). */
+const MAX_FEED_ROWS = 80;
+
+/**
+ * VictoriaMetrics instant-query for the count of applied interventions, by result.
+ *
+ * `agent_intervention_writes_total{result="ok"|"error"}` is the ActionSink's
+ * flag-file write counter (services/agent/actions/writer.go). It is the only
+ * signal for the APPLIED count (the dispatched path is not logged to stdout). VM
+ * receives the metric under the namespaced job (see MEMORY: prometheusremotewrite
+ * maps service.name -> job, prefixed by service.namespace), so we sum across jobs
+ * rather than pinning one. This is a best-effort secondary source: if VM is
+ * unreachable the overlay still renders the Loki-derived blocked counts.
+ */
+const APPLIED_QUERY = 'sum(agent_intervention_writes_total) by (result)';
+
+/** One row in the rolling decision feed. */
+export interface DecisionFeedRow {
+  /** Epoch ms of the log line. */
+  tsMs: number;
+  /** "evaluate" | "blocked" | "discarded" | "rollout" — drives the row style. */
+  kind: "evaluate" | "blocked" | "discarded" | "rollout";
+  /** The raw agent.* message (e.g. "agent.decision_blocked"). */
+  msg: string;
+  /** Short human label for the signal/cycle. */
+  signal: string;
+  /** The action/intervention this row is about, when known ("" otherwise). */
+  action: string;
+  /** Whether this decision was blocked. */
+  blocked: boolean;
+  /** Block/discard reason, when known. */
+  reason: string;
+  /** Game/session id this row belongs to, when known. */
+  sessionId: string;
+}
+
+/** The resolved effective flag/policy values from the latest agent.evaluate line. */
+export interface FlagPanel {
+  /** Epoch ms of the agent.evaluate line these values came from. */
+  tsMs: number;
+  /** Inference mode: "rules" | "llm". */
+  mode: string;
+  model: string;
+  promptVariant: string;
+  batteryThreshold: string;
+  varianceWindow: string;
+  maxPerMinute: string;
+  gameMode: string;
+}
+
+/** A single action's applied/blocked tallies for the intervention overlay. */
+export interface InterventionTally {
+  action: string;
+  blocked: number;
+}
+
+/** Folded intervention overlay state. */
+export interface InterventionOverlay {
+  /** Per-action blocked counts, folded from the Loki window (descending). */
+  blockedByAction: InterventionTally[];
+  /** Blocked counts grouped by reason (descending). */
+  blockedByReason: { reason: string; count: number }[];
+  /** Total blocked decisions in the window. */
+  totalBlocked: number;
+  /**
+   * Applied-intervention count from VictoriaMetrics (writes result="ok"), or null
+   * when VM was unreachable / had no samples. A counter total, not windowed.
+   */
+  appliedOk: number | null;
+  /** Failed flag-file writes (writes result="error"), or null when unavailable. */
+  appliedError: number | null;
+}
+
+/** The full folded state the Agent tab renders. */
+export interface AgentView {
+  feed: DecisionFeedRow[];
+  flags: FlagPanel | null;
+  overlay: InterventionOverlay;
+}
+
+interface LokiStreamResult {
+  stream: Record<string, string>;
+  values: [string, string][];
+}
+
+interface LokiQueryResponse {
+  status: string;
+  data: { resultType: string; result: LokiStreamResult[] };
+}
+
+export interface VmQueryResponse {
+  status: string;
+  data?: {
+    resultType: string;
+    result: { metric: Record<string, string>; value: [number, string] }[];
+  };
+}
+
+/** Classify an agent.* message into a feed row kind (null = ignore). */
+function classify(msg: string): DecisionFeedRow["kind"] | null {
+  if (msg === "agent.evaluate") return "evaluate";
+  if (msg === "agent.decision_blocked") return "blocked";
+  if (msg === "agent.llm.discarded") return "discarded";
+  if (msg.startsWith("agent.rollout_")) return "rollout";
+  return null;
+}
+
+/**
+ * Fold a batch of agent log lines into the decision feed, flag panel, and the
+ * Loki-derived half of the intervention overlay.
+ *
+ * Pure and order-independent for the aggregates (blocked tallies are additive).
+ * The feed itself is sorted newest-first and capped; the flag panel takes the
+ * single newest agent.evaluate line.
+ *
+ * Each entry is { line, tsMs }.
+ */
+export function aggregateAgentLogs(
+  lines: { line: string; tsMs: number }[],
+): Omit<AgentView, "overlay"> & {
+  overlay: Omit<InterventionOverlay, "appliedOk" | "appliedError">;
+} {
+  const feed: DecisionFeedRow[] = [];
+  let flags: FlagPanel | null = null;
+  const blockedByAction = new Map<string, number>();
+  const blockedByReason = new Map<string, number>();
+  let totalBlocked = 0;
+
+  for (const { line, tsMs } of lines) {
+    const fields = parseLogfmt(line);
+    const msg = fields["msg"];
+    if (!msg) continue;
+    const kind = classify(msg);
+    if (!kind) continue;
+
+    const sessionId = fields["session_id"] ?? "";
+
+    if (kind === "evaluate") {
+      // Keep the newest agent.evaluate as the flag-panel snapshot.
+      if (!flags || tsMs >= flags.tsMs) {
+        flags = {
+          tsMs,
+          mode: fields["mode"] ?? "",
+          model: fields["model"] ?? "",
+          promptVariant: fields["prompt_variant"] ?? "",
+          batteryThreshold: fields["battery_threshold"] ?? "",
+          varianceWindow: fields["variance_window"] ?? "",
+          maxPerMinute: fields["max_per_minute"] ?? "",
+          gameMode: fields["game_mode"] ?? "",
+        };
+      }
+      // agent.evaluate is a high-volume liveness line; don't flood the feed with
+      // it. It feeds the flag panel only.
+      continue;
+    }
+
+    let action = "";
+    let reason = "";
+    let blocked = false;
+
+    if (kind === "blocked") {
+      action = fields["intervention"] ?? "";
+      reason = fields["reason"] ?? "";
+      blocked = true;
+      totalBlocked += 1;
+      if (action) blockedByAction.set(action, (blockedByAction.get(action) ?? 0) + 1);
+      if (reason) blockedByReason.set(reason, (blockedByReason.get(reason) ?? 0) + 1);
+    } else if (kind === "discarded") {
+      // Async LLM result dropped at apply time — a different kind of "not applied".
+      reason = fields["reason"] ?? "";
+    } else if (kind === "rollout") {
+      reason = fields["reason"] ?? "";
+    }
+
+    feed.push({
+      tsMs,
+      kind,
+      msg,
+      signal: feedSignal(msg),
+      action,
+      blocked,
+      reason,
+      sessionId,
+    });
+  }
+
+  feed.sort((a, b) => b.tsMs - a.tsMs);
+
+  return {
+    feed: feed.slice(0, MAX_FEED_ROWS),
+    flags,
+    overlay: {
+      blockedByAction: toSortedTallies(blockedByAction),
+      blockedByReason: toSortedReasons(blockedByReason),
+      totalBlocked,
+    },
+  };
+}
+
+/** Short, readable signal label for a feed row. */
+function feedSignal(msg: string): string {
+  switch (msg) {
+    case "agent.decision_blocked":
+      return "decision blocked";
+    case "agent.llm.discarded":
+      return "llm result discarded";
+    case "agent.rollout_expand":
+      return "rollout expand";
+    case "agent.rollout_rollback":
+      return "rollout rollback";
+    case "agent.rollout_rollback_recommended":
+      return "rollback recommended";
+    default:
+      return msg.replace(/^agent\./, "").replace(/_/g, " ");
+  }
+}
+
+function toSortedTallies(m: Map<string, number>): InterventionTally[] {
+  return Array.from(m.entries())
+    .map(([action, blocked]) => ({ action, blocked }))
+    .sort((a, b) => b.blocked - a.blocked || a.action.localeCompare(b.action));
+}
+
+function toSortedReasons(m: Map<string, number>): { reason: string; count: number }[] {
+  return Array.from(m.entries())
+    .map(([reason, count]) => ({ reason, count }))
+    .sort((a, b) => b.count - a.count || a.reason.localeCompare(b.reason));
+}
+
+/**
+ * Parse a VictoriaMetrics instant-query response into the applied/error counts.
+ * Sums across all `result` series (the metric may arrive under several namespaced
+ * jobs). Returns nulls when the response is empty/malformed so the overlay can show
+ * "unavailable" without throwing.
+ */
+export function parseAppliedCounts(body: VmQueryResponse): {
+  appliedOk: number | null;
+  appliedError: number | null;
+} {
+  const results = body.data?.result;
+  if (!results || results.length === 0) {
+    return { appliedOk: null, appliedError: null };
+  }
+  let ok: number | null = null;
+  let err: number | null = null;
+  for (const series of results) {
+    const result = series.metric["result"];
+    const v = Number.parseFloat(series.value?.[1] ?? "");
+    if (!Number.isFinite(v)) continue;
+    if (result === "ok") ok = (ok ?? 0) + v;
+    else if (result === "error") err = (err ?? 0) + v;
+  }
+  return { appliedOk: ok, appliedError: err };
+}
+
+/** Query Loki for the agent's recent decision/flag log lines. */
+async function fetchAgentLogs(): Promise<{ line: string; tsMs: number }[]> {
+  const endNs = BigInt(Date.now()) * 1_000_000n;
+  const startNs = endNs - BigInt(LOOKBACK_SECONDS) * 1_000_000_000n;
+
+  const params = new URLSearchParams({
+    query: AGENT_LOG_QUERY,
+    start: startNs.toString(),
+    end: endNs.toString(),
+    limit: String(QUERY_LIMIT),
+    // backward = newest-first: the decision feed is a rolling tail, so when the
+    // window is truncated we want the most RECENT lines, not the oldest. (The
+    // experiments tab uses forward because its aggregates need the complete
+    // lifecycle prefix; this view's feed is the opposite need.)
+    direction: "backward",
+  });
+
+  const url = `${BASE_URL}/loki/loki/api/v1/query_range?${params.toString()}`;
+  const response = await fetch(url, { headers: { Accept: "application/json" } });
+  if (!response.ok) {
+    throw new Error(`Loki query failed: ${response.status} ${response.statusText}`);
+  }
+
+  const body = (await response.json()) as LokiQueryResponse;
+  const lines: { line: string; tsMs: number }[] = [];
+  for (const stream of body.data?.result ?? []) {
+    for (const [tsNs, line] of stream.values) {
+      const tsMs = Number(BigInt(tsNs) / 1_000_000n);
+      lines.push({ line, tsMs });
+    }
+  }
+  return lines;
+}
+
+/**
+ * Best-effort query of VictoriaMetrics for the applied-intervention counter.
+ * Returns nulls (never throws) on any failure so it can't break the Loki-backed
+ * panels — the overlay degrades to showing only blocked counts.
+ */
+async function fetchAppliedCounts(): Promise<{
+  appliedOk: number | null;
+  appliedError: number | null;
+}> {
+  try {
+    const params = new URLSearchParams({ query: APPLIED_QUERY });
+    const url = `${BASE_URL}/victoria-metrics/api/v1/query?${params.toString()}`;
+    const response = await fetch(url, { headers: { Accept: "application/json" } });
+    if (!response.ok) return { appliedOk: null, appliedError: null };
+    const body = (await response.json()) as VmQueryResponse;
+    return parseAppliedCounts(body);
+  } catch {
+    return { appliedOk: null, appliedError: null };
+  }
+}
+
+/**
+ * Fetch and fold the full Agent view. Throws only if the PRIMARY (Loki) source is
+ * unreachable; the VictoriaMetrics applied-count is best-effort and never throws.
+ */
+export async function fetchAgentView(): Promise<AgentView> {
+  const [lines, applied] = await Promise.all([
+    fetchAgentLogs(),
+    fetchAppliedCounts(),
+  ]);
+  const folded = aggregateAgentLogs(lines);
+  return {
+    feed: folded.feed,
+    flags: folded.flags,
+    overlay: {
+      ...folded.overlay,
+      appliedOk: applied.appliedOk,
+      appliedError: applied.appliedError,
+    },
+  };
+}

--- a/services/dashboard/src/components/AgentView.ts
+++ b/services/dashboard/src/components/AgentView.ts
@@ -1,0 +1,251 @@
+/**
+ * Agent View Component (issue #792).
+ *
+ * The demo's agent focus screen. Three panels, all fed from the agent's live
+ * telemetry (see ../agent.ts):
+ *
+ *   1. Decision feed     — a rolling tail of the agent's recent decisions
+ *                          (blocked decisions + discarded LLM results + rollout
+ *                          activity), allowed-vs-blocked at a glance.
+ *   2. Flag panel        — the resolved effective mode/model/policy values the
+ *                          agent last evaluated against.
+ *   3. Intervention      — applied vs blocked tallies (blocked by action and by
+ *      overlay             reason from Loki, applied from VictoriaMetrics).
+ *
+ * Mirrors ExperimentsView's lifecycle exactly: setError / markStale /
+ * updateFreshness / rendered, with the same STALE_AFTER_MS staleness model so the
+ * operator is never fooled by frozen numbers when a poll is failing.
+ */
+import type {
+  AgentView as AgentViewData,
+  DecisionFeedRow,
+  FlagPanel,
+  InterventionOverlay,
+} from "../agent.js";
+
+/**
+ * After this many ms without a successful poll, a kept-on-screen view is flagged
+ * "stale". Set above the poll cadence so a single missed tick doesn't cry wolf.
+ */
+const STALE_AFTER_MS = 12_000;
+
+export class AgentView {
+  private readonly feedEl: HTMLElement;
+  private readonly flagsEl: HTMLElement;
+  private readonly overlayEl: HTMLElement;
+  private readonly freshnessEl: HTMLElement | null;
+  private hasRendered = false;
+  private lastUpdatedMs: number | null = null;
+
+  constructor(
+    feedId: string,
+    flagsId: string,
+    overlayId: string,
+    freshnessId?: string,
+  ) {
+    this.feedEl = requireEl(feedId);
+    this.flagsEl = requireEl(flagsId);
+    this.overlayEl = requireEl(overlayId);
+    this.freshnessEl = freshnessId ? document.getElementById(freshnessId) : null;
+  }
+
+  setError(message: string) {
+    const html = `<div class="loading">${escapeHtml(message)}</div>`;
+    this.feedEl.innerHTML = html;
+    this.flagsEl.innerHTML = html;
+    this.overlayEl.innerHTML = html;
+    this.hasRendered = true;
+  }
+
+  /** A poll just failed; keep the last good render and let the hint go stale. */
+  markStale() {
+    this.updateFreshness();
+  }
+
+  updateFreshness() {
+    const el = this.freshnessEl;
+    if (!el || this.lastUpdatedMs === null) return;
+    const ageMs = Date.now() - this.lastUpdatedMs;
+    const ageSec = Math.max(0, Math.round(ageMs / 1000));
+    const stale = ageMs >= STALE_AFTER_MS;
+    el.textContent = stale
+      ? `stale — last updated ${ageSec}s ago`
+      : `updated ${ageSec}s ago`;
+    el.classList.toggle("stale", stale);
+    el.hidden = false;
+  }
+
+  get rendered(): boolean {
+    return this.hasRendered;
+  }
+
+  render(view: AgentViewData) {
+    this.hasRendered = true;
+    this.lastUpdatedMs = Date.now();
+    this.updateFreshness();
+
+    this.renderFeed(view.feed);
+    this.renderFlags(view.flags);
+    this.renderOverlay(view.overlay);
+  }
+
+  private renderFeed(feed: DecisionFeedRow[]) {
+    if (feed.length === 0) {
+      this.feedEl.innerHTML =
+        '<div class="loading">No agent decisions in the last 10 minutes. ' +
+        "Allowed decisions appear in the Jaeger trace (link above); this feed shows " +
+        "blocked decisions, discarded LLM results, and rollout activity.</div>";
+      return;
+    }
+    this.feedEl.innerHTML = feed.map((row) => this.renderFeedRow(row)).join("");
+  }
+
+  private renderFeedRow(row: DecisionFeedRow): string {
+    const time = formatTime(row.tsMs);
+    const session = row.sessionId
+      ? `<span class="agent-feed-session" title="${escapeHtml(row.sessionId)}">${escapeHtml(shortId(row.sessionId))}</span>`
+      : "";
+    const action = row.action
+      ? `<span class="agent-feed-action">${escapeHtml(row.action)}</span>`
+      : "";
+    const reason = row.reason
+      ? `<span class="agent-feed-reason" title="${escapeHtml(row.reason)}">${escapeHtml(row.reason)}</span>`
+      : "";
+    const badge = row.blocked
+      ? '<span class="agent-badge agent-badge-blocked">blocked</span>'
+      : `<span class="agent-badge agent-badge-${row.kind}">${escapeHtml(row.kind)}</span>`;
+    return `
+      <div class="agent-feed-row agent-feed-${row.kind}">
+        <span class="agent-feed-time">${time}</span>
+        ${badge}
+        <span class="agent-feed-signal">${escapeHtml(row.signal)}</span>
+        ${action}
+        ${session}
+        ${reason}
+      </div>
+    `;
+  }
+
+  private renderFlags(flags: FlagPanel | null) {
+    if (!flags) {
+      this.flagsEl.innerHTML =
+        '<div class="loading">No agent.evaluate cycle observed yet. ' +
+        "Effective mode/model/policy values appear here once the agent evaluates a game.</div>";
+      return;
+    }
+    const rows: [string, string][] = [
+      ["mode", flags.mode || "—"],
+      ["model", flags.model || "—"],
+      ["prompt variant", flags.promptVariant || "—"],
+      ["battery threshold", flags.batteryThreshold || "—"],
+      ["variance window", flags.varianceWindow || "—"],
+      ["max interventions/min", flags.maxPerMinute || "—"],
+      ["game mode", flags.gameMode || "—"],
+    ];
+    const body = rows
+      .map(
+        ([k, v]) => `
+        <div class="agent-flag">
+          <span class="agent-flag-key">${escapeHtml(k)}</span>
+          <span class="agent-flag-val">${escapeHtml(v)}</span>
+        </div>`,
+      )
+      .join("");
+    this.flagsEl.innerHTML = `
+      <div class="agent-flags-grid">${body}</div>
+      <div class="agent-flags-note">
+        Resolved effective values from the latest <code>agent.evaluate</code> cycle.
+        Boolean kill-switch flags (enabled, experiments_enabled, interventions_allowed)
+        live in flagd and are not yet exposed to the dashboard &mdash; see
+        <a href="/jaeger/search?service=agent" target="_blank" rel="noreferrer">Jaeger</a>
+        for the per-decision flag attribution.
+      </div>
+    `;
+  }
+
+  private renderOverlay(overlay: InterventionOverlay) {
+    const applied =
+      overlay.appliedOk === null
+        ? '<span class="agent-stat-val agent-stat-na" title="VictoriaMetrics unreachable">n/a</span>'
+        : `<span class="agent-stat-val agent-stat-applied">${overlay.appliedOk}</span>`;
+    const appliedErr =
+      overlay.appliedError && overlay.appliedError > 0
+        ? `<span class="agent-stat-sub" title="failed flag-file writes">(${overlay.appliedError} failed)</span>`
+        : "";
+
+    const byAction =
+      overlay.blockedByAction.length > 0
+        ? overlay.blockedByAction
+            .map(
+              (t) => `
+              <div class="agent-tally">
+                <span class="agent-tally-label">${escapeHtml(t.action || "(unknown)")}</span>
+                <span class="agent-tally-count agent-tally-blocked">${t.blocked}</span>
+              </div>`,
+            )
+            .join("")
+        : '<div class="agent-tally-empty">none blocked</div>';
+
+    const byReason =
+      overlay.blockedByReason.length > 0
+        ? overlay.blockedByReason
+            .map(
+              (r) => `
+              <div class="agent-tally">
+                <span class="agent-tally-label">${escapeHtml(r.reason)}</span>
+                <span class="agent-tally-count">${r.count}</span>
+              </div>`,
+            )
+            .join("")
+        : '<div class="agent-tally-empty">&mdash;</div>';
+
+    this.overlayEl.innerHTML = `
+      <div class="agent-overlay-stats">
+        <div class="agent-stat">
+          <span class="agent-stat-label">applied</span>
+          ${applied} ${appliedErr}
+        </div>
+        <div class="agent-stat">
+          <span class="agent-stat-label">blocked (10m)</span>
+          <span class="agent-stat-val agent-stat-blocked">${overlay.totalBlocked}</span>
+        </div>
+      </div>
+      <div class="agent-overlay-cols">
+        <div class="agent-overlay-col">
+          <h4>Blocked by action</h4>
+          ${byAction}
+        </div>
+        <div class="agent-overlay-col">
+          <h4>Blocked by reason</h4>
+          ${byReason}
+        </div>
+      </div>
+    `;
+  }
+}
+
+function requireEl(id: string): HTMLElement {
+  const el = document.getElementById(id);
+  if (!el) throw new Error(`Container element not found: ${id}`);
+  return el;
+}
+
+/** epoch ms -> HH:MM:SS local time. */
+function formatTime(tsMs: number): string {
+  const d = new Date(tsMs);
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+}
+
+/** Trim a long game/session id to a readable tail. */
+function shortId(id: string): string {
+  return id.length > 12 ? `…${id.slice(-10)}` : id;
+}
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}

--- a/services/dashboard/src/index.html
+++ b/services/dashboard/src/index.html
@@ -42,6 +42,9 @@
         <button class="tab-btn active" data-tab="controllers">
           <span class="tab-icon">&#127918;</span> Controllers
         </button>
+        <button class="tab-btn" data-tab="agent">
+          <span class="tab-icon">&#129302;</span> Agent
+        </button>
         <button class="tab-btn" data-tab="experiments">
           <span class="tab-icon">&#129514;</span> Experiments
         </button>
@@ -59,6 +62,37 @@
           <div id="controller-grid" class="controller-grid">
             <!-- Controller cards will be rendered here -->
             <div class="loading">Connecting to controller manager...</div>
+          </div>
+        </div>
+
+        <!-- Agent Tab (decision feed, flag panel, intervention overlay, #792) -->
+        <div id="tab-agent" class="tab-panel">
+          <div class="embed-header agent-header">
+            <h3>Agent <span class="agent-subtitle">live decisions &amp; interventions</span></h3>
+            <span id="agent-freshness" class="experiments-freshness" hidden></span>
+            <a href="/jaeger/search?service=agent&operation=agent.decision&limit=50" target="_blank" rel="noreferrer" class="external-link">Full decision trace in Jaeger &#8599;</a>
+          </div>
+          <div class="agent-layout">
+            <section class="agent-panel agent-panel-feed">
+              <h4 class="agent-panel-title">Decision feed</h4>
+              <div id="agent-feed" class="agent-feed">
+                <div class="loading">Loading agent activity&hellip;</div>
+              </div>
+            </section>
+            <aside class="agent-side">
+              <section class="agent-panel">
+                <h4 class="agent-panel-title">Effective flags</h4>
+                <div id="agent-flags" class="agent-flags">
+                  <div class="loading">Loading&hellip;</div>
+                </div>
+              </section>
+              <section class="agent-panel">
+                <h4 class="agent-panel-title">Interventions</h4>
+                <div id="agent-overlay" class="agent-overlay">
+                  <div class="loading">Loading&hellip;</div>
+                </div>
+              </section>
+            </aside>
           </div>
         </div>
 

--- a/services/dashboard/src/main.ts
+++ b/services/dashboard/src/main.ts
@@ -9,12 +9,20 @@ import { GameStatus } from "./components/GameStatus.js";
 import { Controls } from "./components/Controls.js";
 import { ExperimentsView } from "./components/ExperimentsView.js";
 import { fetchExperiments } from "./experiments.js";
+import { AgentView } from "./components/AgentView.js";
+import { fetchAgentView } from "./agent.js";
 import type { GameplayData } from "./gen/controller_manager_pb.js";
 
 // Poll cadence for the agent experiment view (Loki query). Matches the slow,
 // human-readable refresh rate of the embedded observability panels rather than
 // the 30Hz controller stream — experiment state moves on the order of games.
 const EXPERIMENTS_POLL_MS = 5000;
+
+// Poll cadence for the agent decision/flag/intervention view (Loki + VM query).
+// Faster than the experiment view (state moves per decision, not per game) but
+// still well under the agent's signal rate — this is an observability tail, not
+// a live stream.
+const AGENT_POLL_MS = 2000;
 
 // State
 interface AppState {
@@ -40,6 +48,7 @@ let controllerGrid: ControllerGrid;
 let gameStatus: GameStatus;
 let controls: Controls;
 let experimentsView: ExperimentsView;
+let agentView: AgentView;
 
 // Initialize the dashboard
 async function init() {
@@ -54,6 +63,7 @@ async function init() {
     onModeChange: handleModeChange,
   });
   experimentsView = new ExperimentsView("experiments-grid", "experiments-freshness");
+  agentView = new AgentView("agent-feed", "agent-flags", "agent-overlay", "agent-freshness");
 
   // Set up tab navigation
   setupTabs();
@@ -66,6 +76,9 @@ async function init() {
 
   // Start polling the agent experiment telemetry (Loki)
   startExperimentsPolling();
+
+  // Start polling the agent decision/flag/intervention telemetry (Loki + VM)
+  startAgentPolling();
 
   console.log("Dashboard initialized");
 }
@@ -192,6 +205,49 @@ function startExperimentsPolling() {
       }
     } else if (experimentsPollTimer === null) {
       // Resume: poll immediately so the operator sees fresh data on return.
+      tick();
+    }
+  });
+
+  tick();
+}
+
+// Poll the agent's decision/flag/intervention telemetry and refresh the view.
+// Same self-rescheduling + tab-hidden-pause + staleness model as the experiments
+// poller (#1047): a slow query can't stack, a hidden tab burns no queries, and a
+// failed poll keeps the last good render on screen flagged stale.
+let agentPollTimer: ReturnType<typeof setTimeout> | null = null;
+
+function startAgentPolling() {
+  const tick = async () => {
+    agentPollTimer = null;
+    if (document.hidden) return;
+    try {
+      const view = await fetchAgentView();
+      agentView.render(view);
+    } catch (error) {
+      console.error("Agent poll error:", error);
+      if (agentView.rendered) {
+        agentView.markStale();
+      } else {
+        agentView.setError("Could not reach Loki for agent telemetry.");
+      }
+    } finally {
+      if (!document.hidden) {
+        agentPollTimer = setTimeout(tick, AGENT_POLL_MS);
+      }
+    }
+  };
+
+  setInterval(() => agentView.updateFreshness(), 1000);
+
+  document.addEventListener("visibilitychange", () => {
+    if (document.hidden) {
+      if (agentPollTimer !== null) {
+        clearTimeout(agentPollTimer);
+        agentPollTimer = null;
+      }
+    } else if (agentPollTimer === null) {
       tick();
     }
   });

--- a/services/dashboard/src/style.css
+++ b/services/dashboard/src/style.css
@@ -642,3 +642,275 @@ body {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+
+/* ===== Agent tab (#792) ===== */
+
+.agent-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  padding: 12px 4px;
+}
+
+.agent-header h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.agent-subtitle {
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  font-weight: normal;
+  margin-left: 8px;
+}
+
+/* Two columns: a wide decision feed and a narrow side stack. */
+.agent-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) minmax(280px, 1fr);
+  gap: 16px;
+  padding: 4px;
+  align-items: start;
+}
+
+@media (max-width: 900px) {
+  .agent-layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+.agent-side {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.agent-panel {
+  background: var(--bg-card);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: var(--border-radius);
+  padding: 12px 14px;
+}
+
+.agent-panel-title {
+  margin: 0 0 10px;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-secondary);
+}
+
+/* Decision feed: a scrollable rolling tail. */
+.agent-feed {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-height: 60vh;
+  overflow-y: auto;
+}
+
+.agent-feed-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  border-radius: 6px;
+  font-size: 0.82rem;
+  background: rgba(255, 255, 255, 0.03);
+  border-left: 3px solid transparent;
+}
+
+.agent-feed-blocked {
+  border-left-color: var(--accent-primary);
+}
+
+.agent-feed-discarded {
+  border-left-color: var(--accent-warning);
+}
+
+.agent-feed-rollout {
+  border-left-color: var(--accent-info);
+}
+
+.agent-feed-time {
+  font-variant-numeric: tabular-nums;
+  color: var(--text-secondary);
+  font-size: 0.75rem;
+  white-space: nowrap;
+}
+
+.agent-badge {
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  padding: 1px 6px;
+  border-radius: 10px;
+  white-space: nowrap;
+}
+
+.agent-badge-blocked {
+  background: rgba(233, 69, 96, 0.2);
+  color: var(--accent-primary);
+}
+
+.agent-badge-discarded {
+  background: rgba(255, 152, 0, 0.2);
+  color: var(--accent-warning);
+}
+
+.agent-badge-rollout {
+  background: rgba(33, 150, 243, 0.2);
+  color: var(--accent-info);
+}
+
+.agent-feed-signal {
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.agent-feed-action {
+  font-family: monospace;
+  font-size: 0.78rem;
+  color: var(--text-primary);
+}
+
+.agent-feed-session {
+  font-family: monospace;
+  font-size: 0.72rem;
+  color: var(--text-secondary);
+}
+
+.agent-feed-reason {
+  margin-left: auto;
+  color: var(--text-secondary);
+  font-size: 0.76rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Flag panel. */
+.agent-flags-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.agent-flag {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  font-size: 0.82rem;
+  padding: 3px 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.agent-flag-key {
+  color: var(--text-secondary);
+}
+
+.agent-flag-val {
+  font-family: monospace;
+  color: var(--text-primary);
+}
+
+.agent-flags-note {
+  margin-top: 10px;
+  font-size: 0.72rem;
+  color: var(--text-secondary);
+  line-height: 1.4;
+}
+
+.agent-flags-note a {
+  color: var(--accent-info);
+}
+
+/* Intervention overlay. */
+.agent-overlay-stats {
+  display: flex;
+  gap: 20px;
+  margin-bottom: 12px;
+}
+
+.agent-stat {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.agent-stat-label {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: var(--text-secondary);
+}
+
+.agent-stat-val {
+  font-size: 1.4rem;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+
+.agent-stat-applied {
+  color: var(--accent-success);
+}
+
+.agent-stat-blocked {
+  color: var(--accent-primary);
+}
+
+.agent-stat-na {
+  color: var(--text-secondary);
+  font-size: 1rem;
+}
+
+.agent-stat-sub {
+  font-size: 0.72rem;
+  color: var(--accent-warning);
+}
+
+.agent-overlay-cols {
+  display: flex;
+  gap: 16px;
+}
+
+.agent-overlay-col {
+  flex: 1;
+  min-width: 0;
+}
+
+.agent-overlay-col h4 {
+  margin: 0 0 6px;
+  font-size: 0.74rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: var(--text-secondary);
+}
+
+.agent-tally {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  font-size: 0.8rem;
+  padding: 3px 0;
+}
+
+.agent-tally-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.agent-tally-count {
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+}
+
+.agent-tally-blocked {
+  color: var(--accent-primary);
+}
+
+.agent-tally-empty {
+  font-size: 0.78rem;
+  color: var(--text-secondary);
+}

--- a/services/dashboard/vite.config.ts
+++ b/services/dashboard/vite.config.ts
@@ -23,6 +23,14 @@ export default defineConfig({
         target: 'http://localhost:80',
         changeOrigin: true,
       },
+      // Proxy VictoriaMetrics queries (agent applied-intervention count, #792)
+      // through envoy, which routes /victoria-metrics/* to the VM HTTP API. As
+      // with /loki, this only matters for `vite dev`; in production the dashboard
+      // is served behind the same envoy.
+      '/victoria-metrics': {
+        target: 'http://localhost:80',
+        changeOrigin: true,
+      },
     },
   },
 })


### PR DESCRIPTION
## What

Adds a live **Agent** tab to the dashboard SPA (`services/dashboard/`) so an operator running the real stack can see what the in-game agent is doing — the observability half of real-stack gap-finding. Part of #789 / M5 Demo Polish.

Three panels, all fed from live telemetry:

| Panel | Source |
|-------|--------|
| **Decision feed** | Loki `{service_name="agent"}` — `agent.decision_blocked` / `agent.llm.discarded` / `agent.rollout_*` slog lines, folded newest-first (time · badge · signal · action · session · reason) |
| **Flag panel** | Resolved effective values from the latest `agent.evaluate` line (mode, model, prompt_variant, battery_threshold, variance_window, max_per_minute, game_mode) |
| **Intervention overlay** | Blocked-by-action + blocked-by-reason from Loki; **applied** count from `agent_intervention_writes_total{result}` via VictoriaMetrics (best-effort, degrades gracefully) |

## Pattern reuse

Mirrors the experiments tab (#981/#1045/#1047) exactly:
- pure parse/fold module `agent.ts` (reuses `parseLogfmt` from `experiments.ts`)
- view component `components/AgentView.ts` with the same `setError`/`markStale`/`updateFreshness`/`rendered` lifecycle and `STALE_AFTER_MS` model
- self-rescheduling poller in `main.ts` with the **tab-hidden-pause** + staleness patterns (#1047), 2s cadence
- reuses the envoy-routed Loki transport (`/loki/*`); adds the already-routed `/victoria-metrics/*` datasource for the applied count (vite dev proxy added to match)

## Documented data-source gap

The allowed-path decision detail (`decision.action` / `decision.objective_served`) and the boolean `agent.json` flags (`enabled`, `experiments_enabled`, `interventions_allowed` list, `verdict_*`) live on **OTEL spans** (`agent.decision`) / in **flagd**, not in the agent's stdout logs. So the feed renders blocked decisions + discards + rollout with full detail and deep-links to **Jaeger** (`service=agent`) for the full per-decision audit; the flag panel surfaces the resolved values `agent.evaluate` *does* carry and links out for the rest. The panel can be upgraded when a flagd evaluation route / flag-state endpoint lands (#505).

> Note: the issue speculated `game_interventions_total{blocked}` and `service=joustmania-agent`; neither exists. The real signals are `agent_intervention_writes_total{result}` + Loki blocked lines, and the agent's Jaeger service name is `agent`.

## Validate

`npm ci && npx tsc --noEmit && npx vite build` — clean. `npx vitest run` — 36 passed (14 new in `agent.test.ts` covering the fold + VM parse). Live verification against a running stack is a follow-up smoke-test; built against the real telemetry shapes + fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)