### PR TITLE
feat(agent): live-wire the autonomous promotion safety net

### DIFF
--- a/services/agent/experiment_loop.go
+++ b/services/agent/experiment_loop.go
@@ -219,6 +219,7 @@ type gameFitnessFunc func(gc gamecontext.GameContext, objective string) float64
 func buildExperimentLoop(
 	flagsClient *flags.Flags,
 	promoter *promote.Promoter,
+	fitnessStore *experiment.FitnessStore,
 	gameFlagPath string,
 	logger *slog.Logger,
 ) *experimentLoop {
@@ -258,9 +259,13 @@ func buildExperimentLoop(
 
 	// FitnessStore (#965/#1017): the finalized-per-game fitness store onGameEnd
 	// Records into and the M7-7 validation seams read from. It is the instrumentation
-	// that turns the Validator's injected fitness reads into REAL ones. Built BEFORE
-	// the verdict so the #992 recent-real anchor can read it.
-	fitnessStore := experiment.NewFitnessStore(fitnessStoreCapacity())
+	// that turns the Validator's injected fitness reads into REAL ones. It is now built
+	// by the CALLER (main.go) and passed in so the SAME store also backs the autonomous
+	// Watcher's real-game fitness source (#1057). A nil store (a test or a caller that
+	// did not build one) falls back to a fresh local store so the loop is still valid.
+	if fitnessStore == nil {
+		fitnessStore = experiment.NewFitnessStore(fitnessStoreCapacity())
+	}
 
 	// CohortVerdict (#979) + recent-real SECONDARY anchor (#992): the within-experiment
 	// comparison gated by recent REAL play. The anchor reads the FitnessStore's

--- a/services/agent/experiment_loop_test.go
+++ b/services/agent/experiment_loop_test.go
@@ -819,7 +819,7 @@ func newRegistryConcurrency1(t *testing.T, spawner experiment.ShadowSpawner, res
 func TestBuildExperimentLoop_DisabledByDefault(t *testing.T) {
 	// Ensure the opt-in env is unset (the default).
 	t.Setenv(envExperimentsEnabled, "")
-	loop := buildExperimentLoop(nil, nil, "/nonexistent/game.json", testLogger())
+	loop := buildExperimentLoop(nil, nil, nil, "/nonexistent/game.json", testLogger())
 	if loop == nil {
 		t.Fatalf("buildExperimentLoop must ALWAYS build the loop now (#1044); gating is the live flag, not a nil return")
 	}
@@ -838,7 +838,7 @@ func TestBuildExperimentLoop_DisabledByDefault(t *testing.T) {
 
 	// Explicit "false" is also off.
 	t.Setenv(envExperimentsEnabled, "false")
-	loop2 := buildExperimentLoop(nil, nil, "/nonexistent/game.json", testLogger())
+	loop2 := buildExperimentLoop(nil, nil, nil, "/nonexistent/game.json", testLogger())
 	if loop2 == nil || loop2.expDefaults.Enabled {
 		t.Fatalf("AGENT_EXPERIMENTS_ENABLED=false must build a loop with the disabled bootstrap default")
 	}

--- a/services/agent/main.go
+++ b/services/agent/main.go
@@ -191,13 +191,22 @@ func rolloutActuator(logger *slog.Logger) decision.RolloutActuator {
 // fitness source (promote.RealGameFitness, reading the #731 evaluator / gamewindow)
 // is wired.
 //
-// FAIL-CLOSED (#1016): with the Watcher nil, autonomous now REFUSES to apply to the
-// real default (a hard stop), rather than applying without a safety net. So an
-// operator who flips mode=autonomous before the live watch is wired gets a recorded
-// no-op (OutcomeDiscarded), NOT an unguarded real-default change. Building the
-// real RealGameFitness source + NewFitnessWatcher here is the live-verify follow-up;
-// the watch→degradation→revert WIRING + decision logic ships + is unit-tested now.
-func buildPromoter(logger *slog.Logger) *promote.Promoter {
+// FAIL-CLOSED (#1016/#1057): the autonomous Watcher + RealDefaultReverter are now
+// LIVE-WIRED, but only when autonomous is safely enabled (the same env gate the
+// real-default writer uses) AND a real fitness source is available. When the gate is
+// off — the default — the Watcher stays nil, so autonomous REFUSES to apply (a hard
+// stop), NOT an unguarded real-default change. The live wiring:
+//   - RealGameFitness: reads recent REAL-game fitness from the #965 FitnessStore (the
+//     same finalized-per-game real fitness the recent-real baseline reads). Until real
+//     games populate the store it returns 0 samples ⇒ INSUFFICIENT ⇒ apply stays
+//     unverified + re-watched, never a false healthy keep.
+//   - RealDefaultReverter: the SAME concrete fileRealDefaultWriter, which snapshots the
+//     pre-promotion {defaultVariant + value} at write time and restores it exactly on
+//     revert (#1065).
+//   - Rewatcher: a background poller that re-observes an insufficient-games apply as
+//     more real games complete (#1065 item 4).
+//   - Cooldown: a post-revert cooldown suppresses re-promotion thrash (#1065 item 3).
+func buildPromoter(rootCtx context.Context, store *experiment.FitnessStore, objResolver *promote.LateObjectiveResolver, logger *slog.Logger) *promote.Promoter {
 	// Resolve the target for client construction from the ENV (AGENT_CODE_IMPROVEMENT_TARGET),
 	// distinct from the LIVE flag (code_improvement.target) that Promote dispatches on.
 	// This is a deliberate DOUBLE gate and is STRICTER than a single switch: opening a
@@ -235,9 +244,13 @@ func buildPromoter(logger *slog.Logger) *promote.Promoter {
 	if git != nil {
 		gitIface = git
 	}
+	// The real-default writer is ALSO the reverter (it snapshots prior state at write
+	// time, #1065). Keep a concrete handle so the same instance backs both seams.
 	var realDefIface promote.RealDefaultWriter
+	var reverterIface promote.RealDefaultReverter
 	if realDef != nil {
 		realDefIface = realDef
+		reverterIface = realDef
 	}
 
 	repo := promote.RepoRef{
@@ -245,12 +258,30 @@ func buildPromoter(logger *slog.Logger) *promote.Promoter {
 		Name:  firstField(getEnv("GITHUB_REPOSITORY", ""), 1),
 		Base:  getEnv("GITHUB_BASE_BRANCH", "main"),
 	}
-	// Watcher + RealDefaultReverter (autonomous live watch+revert) reuse M7-7's
-	// fitness measurement seams; they are nil until the live real-game fitness source
-	// is wired. Per #1016 a nil Watcher makes autonomous FAIL CLOSED (refuse to apply
-	// to the real default), so this is safe: autonomous degrades to a recorded no-op
-	// rather than an unguarded real change until the safety net is connected.
-	return promote.NewPromoter(ghIface, gitIface, realDefIface, nil, nil, repo, nil, logger)
+
+	// LIVE WATCH (#1057/#1065): build the Watcher over the real fitness source ONLY
+	// when the real-default writer is present (the autonomous env gate is satisfied AND
+	// a real-default path exists) AND a FitnessStore is available to read real-game
+	// fitness from. Otherwise leave the Watcher nil so autonomous FAILS CLOSED (refuses
+	// to apply) — never an unguarded real-default change.
+	var watcherIface promote.Watcher
+	var rewatcher promote.Rewatcher
+	if realDef != nil && store != nil {
+		fitnessSource := promote.NewStoreRealGameFitness(store, objResolver.Resolve)
+		watcher := promote.NewFitnessWatcher(fitnessSource, promote.DefaultWatchPolicy(), logger)
+		watcherIface = watcher
+		rewatcher = promote.NewPollingRewatcher(rootCtx, rewatchInterval(), rewatchTimeout(), logger)
+		logger.Warn("code_improvement AUTONOMOUS watch+revert LIVE-WIRED (#1057/#1065): autonomous promotions are now a closed apply→watch→keep-or-revert loop")
+	} else {
+		logger.Info("code_improvement autonomous watch NOT wired (autonomous env gate off or no fitness store); autonomous fails closed (#1016)")
+	}
+
+	p := promote.NewPromoter(ghIface, gitIface, realDefIface, watcherIface, reverterIface, repo, nil, logger)
+	p.SetCooldown(revertCooldown())
+	if rewatcher != nil {
+		p.SetRewatcher(rewatcher)
+	}
+	return p
 }
 
 // firstField splits an "owner/repo" string and returns the owner (i==0) or repo
@@ -259,6 +290,25 @@ func firstField(repo string, i int) string {
 	parts := strings.SplitN(repo, "/", 2)
 	if i < len(parts) {
 		return parts[i]
+	}
+	return ""
+}
+
+// objectiveForFlag resolves the fitness objective a promoted flag's experiment
+// serves by scanning the registry's LIVE experiments for one whose intent targets
+// flagKey (#1057). The autonomous Watcher uses this to read the right per-objective
+// recent-real fitness from the FitnessStore. Best-effort: a concluded/torn-down
+// experiment is gone from Live(), so this returns "" (any-objective) — a safe
+// degrade, since the watcher still observes a recent-real fitness trend, just
+// unfiltered by objective.
+func objectiveForFlag(reg *experiment.Registry, flagKey string) string {
+	if reg == nil || flagKey == "" {
+		return ""
+	}
+	for _, id := range reg.Live() {
+		if cv, ok := reg.CompactView(id); ok && cv.Intent.FlagKey == flagKey {
+			return cv.Intent.Objective
+		}
 	}
 	return ""
 }
@@ -294,6 +344,24 @@ func llmBudgetOverride() int {
 		return 0
 	}
 	return n
+}
+
+// revertCooldown reads the autonomous post-revert re-promotion cooldown (#1065
+// item 3) from AGENT_AUTONOMOUS_REVERT_COOLDOWN_SECONDS, else the package default.
+func revertCooldown() time.Duration {
+	return secondsEnv("AGENT_AUTONOMOUS_REVERT_COOLDOWN_SECONDS", promote.DefaultRevertCooldown)
+}
+
+// rewatchInterval reads the background re-watch poll interval (#1065 item 4) from
+// AGENT_AUTONOMOUS_REWATCH_INTERVAL_SECONDS, else the package default.
+func rewatchInterval() time.Duration {
+	return secondsEnv("AGENT_AUTONOMOUS_REWATCH_INTERVAL_SECONDS", promote.DefaultRewatchInterval)
+}
+
+// rewatchTimeout reads how long a background re-watch waits for enough real games
+// (#1065 item 4) from AGENT_AUTONOMOUS_REWATCH_TIMEOUT_SECONDS, else the default.
+func rewatchTimeout() time.Duration {
+	return secondsEnv("AGENT_AUTONOMOUS_REWATCH_TIMEOUT_SECONDS", promote.DefaultRewatchTimeout)
 }
 
 // secondsEnv parses a positive integer "seconds" env var into a Duration,
@@ -766,7 +834,19 @@ func main() {
 	// proposer is #931; the autonomous watch+revert reuses M7-7's seams); here the
 	// gated promotion surface is constructed and held so the wiring + the env gate
 	// are in place and observable.
-	promoter := buildPromoter(logger)
+	// FitnessStore (#965/#1017): the finalized-per-game fitness store. It is built HERE
+	// (hoisted out of buildExperimentLoop) so it can back BOTH the experiment loop's
+	// validation/anchor seams AND the autonomous Watcher's real-game fitness source
+	// (#1057). The experiment loop's onGameEnd Records into it; the Watcher reads
+	// recent REAL samples out of it.
+	fitnessStore := experiment.NewFitnessStore(fitnessStoreCapacity())
+	// objResolver maps a promoted flag → its experiment's objective for the Watcher's
+	// store reads. It is late-bound: the registry that knows the mapping is built inside
+	// buildExperimentLoop (below), so the resolver is SET there once the registry exists.
+	// Until then it resolves to "" (any-objective) — safe, just unfiltered.
+	objResolver := &promote.LateObjectiveResolver{}
+
+	promoter := buildPromoter(ctx, fitnessStore, objResolver, logger)
 	slog.Info("Code-improvement promotion surface enabled (#936, M7-8)",
 		"code_improvement_enabled", getEnv("AGENT_CODE_IMPROVEMENT_ENABLED", "false"),
 		"target", getEnv("AGENT_CODE_IMPROVEMENT_TARGET", string(promote.TargetLocal)),
@@ -784,11 +864,20 @@ func main() {
 	// starts it with no restart. The real-default promotion path stays
 	// behind ALL of #961's gates (the promoter built above + the kill-switch via the
 	// ConfigResolver).
-	expLoop := buildExperimentLoop(agentFlags, promoter, getEnv("GAME_FLAG_PATH", experiment.DefaultGamePath), logger)
+	expLoop := buildExperimentLoop(agentFlags, promoter, fitnessStore, getEnv("GAME_FLAG_PATH", experiment.DefaultGamePath), logger)
 	if expLoop != nil {
 		// Bind the spawner's background game-drive goroutines to the agent's root
 		// context so shutdown cancels in-flight shadow games (no goroutine leak).
 		expLoop.spawner.SetRootContext(ctx)
+		// Now the registry exists: install the flag→objective resolver the autonomous
+		// Watcher uses to read the right per-objective recent-real fitness (#1057). Until
+		// this point it resolved to "" (any-objective); from here it is precise.
+		if expLoop.registry != nil {
+			reg := expLoop.registry
+			objResolver.Set(func(flagKey string) string {
+				return objectiveForFlag(reg, flagKey)
+			})
+		}
 	}
 
 	// GameContext multiplexer (#845 PR B): one Store partition per game_id, plus the

--- a/services/agent/promote/actions.go
+++ b/services/agent/promote/actions.go
@@ -3,6 +3,7 @@ package promote
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/joustmania/agent/experiment"
 )
@@ -119,6 +120,16 @@ func (pr *Promoter) promoteAutonomous(ctx context.Context, p experiment.Proposal
 		return
 	}
 
+	// COOLDOWN (#1065 item 3): if this flag was reverted recently, refuse to re-apply
+	// until the cooldown elapses. This is checked BEFORE the write so a thrash loop
+	// (err→revert→re-promote→err→revert) cannot run hot — a reverted flag is parked
+	// for the cooldown rather than immediately re-promoted into the same failure.
+	if remaining, cooling := pr.cooldownRemaining(p.FlagKey); cooling {
+		res.Outcome = OutcomeDiscarded
+		res.Reason = fmt.Sprintf("autonomous re-promotion of %q suppressed: %s remaining in post-revert cooldown (#1065)", p.FlagKey, remaining.Round(time.Second))
+		return
+	}
+
 	// The one sanctioned real-player-affecting write, through the gated seam.
 	if err := pr.realDef.SetRealDefault(ctx, p.FlagKey, ev.RealDefaultValue); err != nil {
 		res.Outcome = OutcomeDiscarded
@@ -127,22 +138,119 @@ func (pr *Promoter) promoteAutonomous(ctx context.Context, p experiment.Proposal
 	}
 	res.Outcome = OutcomeApplied
 
-	// Watch real-game fitness for the promoted flag's objective and auto-revert on
-	// degradation vs the pre-promotion baseline (Evidence.FitnessBefore).
-	degraded, err := pr.watcher.Degraded(ctx, p.FlagKey, ev.FitnessBefore)
-	// An error means we cannot CONFIRM the change is healthy; fail safe by treating
-	// it as a degradation so a real-player change is rolled back rather than left
-	// unverified.
-	if err != nil || degraded {
-		pr.revertReal(ctx, p, res, err, degraded)
+	// Watch real-game fitness for the promoted flag's objective and act on the verdict.
+	// Use the tri-state Observe when the watcher supports it so an INSUFFICIENT-games
+	// result schedules a re-watch (#1065 item 4) instead of silently keeping an
+	// unverified change; otherwise fall back to the boolean Degraded.
+	verdict, err := pr.observe(ctx, p.FlagKey, ev.FitnessBefore)
+	switch {
+	case err != nil:
+		// Cannot CONFIRM healthy — fail safe by reverting rather than leaving a
+		// real-player change unverified.
+		pr.revertReal(ctx, p, res, err)
+	case verdict == VerdictDegraded:
+		pr.revertReal(ctx, p, res, nil)
+	case verdict == VerdictInsufficient:
+		// Apply stands, but unverified. Schedule a background re-watch (if wired) that
+		// reverts later if degradation is confirmed as more real games complete.
+		pr.scheduleRewatch(ctx, p, ev)
+	default: // VerdictHealthy — confirmed keep, nothing to do.
 	}
+}
+
+// observe runs the watcher and returns a tri-state verdict. When the wired Watcher
+// implements the richer Observer (the production fitnessWatcher does), its Observe is
+// used so INSUFFICIENT evidence is distinguishable from a confirmed healthy keep.
+// Otherwise it adapts the boolean Degraded (degraded→VerdictDegraded, else
+// VerdictHealthy — a boolean-only watcher cannot signal insufficiency, so no re-watch
+// is scheduled, matching the prior behavior).
+func (pr *Promoter) observe(ctx context.Context, flagKey string, baseline float64) (WatchVerdict, error) {
+	if obs, ok := pr.watcher.(Observer); ok {
+		return obs.Observe(ctx, flagKey, baseline)
+	}
+	degraded, err := pr.watcher.Degraded(ctx, flagKey, baseline)
+	if err != nil {
+		return VerdictInsufficient, err
+	}
+	if degraded {
+		return VerdictDegraded, nil
+	}
+	return VerdictHealthy, nil
+}
+
+// Observer is the tri-state watch interface (#1065 item 4). The production
+// fitnessWatcher implements it; the Promoter type-asserts for it so a boolean-only
+// Watcher still works (it just cannot trigger a re-watch).
+type Observer interface {
+	Observe(ctx context.Context, flagKey string, baseline float64) (WatchVerdict, error)
+}
+
+// scheduleRewatch hands an insufficient-games apply to the background re-watcher
+// (#1065 item 4) so it is re-observed as more real games complete. nil rewatcher →
+// the apply stands unverified (prior behavior). The revert closure performs a gated,
+// recorded fail-safe revert with its own Result so the journal/span reflects the
+// later auto-revert.
+func (pr *Promoter) scheduleRewatch(ctx context.Context, p experiment.Proposal, ev Evidence) {
+	if pr.rewatcher == nil {
+		pr.log.Info("autonomous watch: insufficient real games and no re-watcher wired; apply stands unverified",
+			"flag", p.FlagKey)
+		return
+	}
+	pr.log.Info("autonomous watch: insufficient real games; scheduling background re-watch (#1065)",
+		"flag", p.FlagKey)
+	revert := func(rctx context.Context) {
+		var rres Result
+		pr.revertReal(rctx, p, &rres, nil)
+		pr.log.Warn("autonomous re-watch confirmed degradation; reverted real default (#1065)",
+			"flag", p.FlagKey, "outcome", string(rres.Outcome), "reason", rres.Reason)
+	}
+	pr.rewatcher.Schedule(ctx, p.FlagKey, ev.FitnessBefore, pr.watcher, revert)
+}
+
+// cooldownRemaining reports the time left in flagKey's post-revert cooldown, and
+// whether it is still cooling. Outside the cooldown (or never reverted) it returns
+// (0, false). Guarded by mu.
+func (pr *Promoter) cooldownRemaining(flagKey string) (time.Duration, bool) {
+	if pr.cooldown <= 0 {
+		return 0, false
+	}
+	pr.mu.Lock()
+	defer pr.mu.Unlock()
+	last, ok := pr.lastRevert[flagKey]
+	if !ok {
+		return 0, false
+	}
+	elapsed := pr.clock().Sub(last)
+	if elapsed >= pr.cooldown {
+		return 0, false
+	}
+	return pr.cooldown - elapsed, true
+}
+
+// markReverted stamps flagKey's last-revert time so the cooldown gate can suppress an
+// immediate re-promotion. Guarded by mu.
+func (pr *Promoter) markReverted(flagKey string) {
+	pr.mu.Lock()
+	defer pr.mu.Unlock()
+	if pr.lastRevert == nil {
+		pr.lastRevert = map[string]time.Time{}
+	}
+	pr.lastRevert[flagKey] = pr.clock()
+}
+
+// clock returns the (possibly faked) time source; defaults to time.Now if unset.
+func (pr *Promoter) clock() time.Time {
+	if pr.now != nil {
+		return pr.now()
+	}
+	return time.Now()
 }
 
 // revertReal rolls the autonomous real-default change back on a degradation (or an
 // unconfirmable watch). A nil RealDefaultReverter (no rollback wired) records the
 // degradation but cannot undo it — logged + reasoned so it is visible, never
 // silent. On a successful revert the outcome becomes OutcomeReverted.
-func (pr *Promoter) revertReal(ctx context.Context, p experiment.Proposal, res *Result, watchErr error, degraded bool) {
+func (pr *Promoter) revertReal(ctx context.Context, p experiment.Proposal, res *Result, watchErr error) {
 	reason := "real-game fitness degraded after autonomous change"
 	if watchErr != nil {
 		reason = fmt.Sprintf("could not confirm real-game fitness healthy (%v); reverting fail-safe", watchErr)
@@ -156,7 +264,10 @@ func (pr *Promoter) revertReal(ctx context.Context, p experiment.Proposal, res *
 		res.Reason = fmt.Sprintf("%s; revert failed: %v", reason, err)
 		return
 	}
+	// Start the post-revert cooldown so a re-promotion of this flag cannot immediately
+	// re-trigger the same failure (#1065 item 3). Marked only on a SUCCESSFUL revert —
+	// a failed revert (above) leaves no cooldown, surfacing the unrolled-back state.
+	pr.markReverted(p.FlagKey)
 	res.Outcome = OutcomeReverted
 	res.Reason = reason
-	_ = degraded
 }

--- a/services/agent/promote/live.go
+++ b/services/agent/promote/live.go
@@ -1,0 +1,187 @@
+package promote
+
+import (
+	"context"
+	"log/slog"
+	"sync/atomic"
+	"time"
+
+	"github.com/joustmania/agent/experiment"
+)
+
+// live.go holds the PRODUCTION wiring of the autonomous safety net's two live seams
+// (#1057/#1065): the RealGameFitness source that reads recent REAL-game fitness from
+// the #965 FitnessStore, and the polling Rewatcher that re-observes an
+// insufficient-games apply as more real games complete. Both are constructed only in
+// main.go behind the autonomous env gate — a nil source/rewatcher keeps the loop
+// fail-closed (autonomous refuses to apply, #1016).
+
+// ObjectiveForFlag resolves the fitness objective a promoted flag's experiment serves
+// (so the FitnessStore can be queried per-objective, exactly the key the recent-real
+// baseline already uses). It is injected because the flag→objective mapping lives in
+// the experiment registry, which the promote package does not (and should not)
+// import. An empty objective means "any real game" — RecentReal then matches every
+// objective, which is still correct (the watcher only needs a recent-real fitness
+// trend) but less precise; the resolver should return the experiment's objective when
+// known.
+type ObjectiveForFlag func(flagKey string) string
+
+// LateObjectiveResolver is a goroutine-safe, settable ObjectiveForFlag. main.go
+// builds the FitnessWatcher (and thus the fitness source) BEFORE the experiment
+// registry that knows the flag→objective mapping exists; this holder lets the
+// registry-backed resolver be SET later (once the loop is built) without rebuilding
+// the watcher. Until set, it resolves to "" (any-objective), which is safe — the
+// watcher still observes a recent-real fitness trend, just not objective-filtered.
+type LateObjectiveResolver struct {
+	fn atomic.Pointer[ObjectiveForFlag]
+}
+
+// Set installs the resolver (called once the registry exists). A nil fn is ignored.
+func (l *LateObjectiveResolver) Set(fn ObjectiveForFlag) {
+	if fn != nil {
+		l.fn.Store(&fn)
+	}
+}
+
+// Resolve implements the ObjectiveForFlag shape: it delegates to the installed
+// resolver, or returns "" (any-objective) until one is set.
+func (l *LateObjectiveResolver) Resolve(flagKey string) string {
+	if p := l.fn.Load(); p != nil {
+		return (*p)(flagKey)
+	}
+	return ""
+}
+
+// storeRealGameFitness is the production RealGameFitness: it reads the most-recent
+// REAL-game fitness samples for the promoted flag's objective from the #965
+// FitnessStore — the SAME finalized-per-game real fitness the recent-real baseline
+// (#992) and the M7-7 Validator baseline read. It is the real-data source that turns
+// the watcher's injected reads into REAL ones; until real games populate the store it
+// returns 0 samples, so the watcher reports INSUFFICIENT and the apply stays
+// fail-closed-unverified (then re-watched) rather than falsely confirmed.
+type storeRealGameFitness struct {
+	store     *experiment.FitnessStore
+	objective ObjectiveForFlag
+}
+
+// NewStoreRealGameFitness builds the production RealGameFitness over the FitnessStore.
+// store MUST be non-nil (a nil store could never observe real games — the caller must
+// then wire no watcher so autonomous fails closed). objective may be nil → every read
+// matches any objective.
+func NewStoreRealGameFitness(store *experiment.FitnessStore, objective ObjectiveForFlag) *storeRealGameFitness {
+	return &storeRealGameFitness{store: store, objective: objective}
+}
+
+// Recent returns up to n most-recent REAL-game fitness scalars for flagKey's
+// objective, newest-first (the watcher only averages, so order is immaterial). A nil
+// store yields no samples (treated as INSUFFICIENT, never a false healthy verdict).
+func (s *storeRealGameFitness) Recent(_ context.Context, flagKey string, n int) ([]float64, error) {
+	if s.store == nil {
+		return nil, nil
+	}
+	objective := ""
+	if s.objective != nil {
+		objective = s.objective(flagKey)
+	}
+	samples := s.store.RecentReal(objective, n)
+	out := make([]float64, 0, len(samples))
+	for _, sample := range samples {
+		out = append(out, sample.Fitness)
+	}
+	return out, nil
+}
+
+// DefaultRewatchInterval / DefaultRewatchTimeout bound the background re-watch
+// (#1065 item 4): poll the watcher every interval until it renders a definitive
+// verdict (healthy/degraded/error) or the timeout elapses. Conservative defaults —
+// real games complete on the order of minutes, so a minute-scale poll over a
+// generous window catches a slowly-filling window without busy-spinning.
+const (
+	DefaultRewatchInterval = 1 * time.Minute
+	DefaultRewatchTimeout  = 60 * time.Minute
+)
+
+// pollingRewatcher is the production Rewatcher: on an insufficient-games apply it
+// spawns ONE background goroutine that re-observes the flag on an interval until the
+// watcher can judge it, then reverts on a confirmed degradation (or on a telemetry
+// error, fail-safe). It never blocks the promotion call. Bound to a root context so
+// agent shutdown cancels in-flight re-watches.
+type pollingRewatcher struct {
+	rootCtx  context.Context
+	interval time.Duration
+	timeout  time.Duration
+	now      func() time.Time
+	log      *slog.Logger
+}
+
+// NewPollingRewatcher builds the background re-watch scheduler. rootCtx binds every
+// spawned re-watch to the agent lifecycle (cancelled on shutdown). A non-positive
+// interval/timeout falls back to the defaults. log nil uses slog.Default().
+func NewPollingRewatcher(rootCtx context.Context, interval, timeout time.Duration, log *slog.Logger) *pollingRewatcher {
+	if rootCtx == nil {
+		rootCtx = context.Background()
+	}
+	if interval <= 0 {
+		interval = DefaultRewatchInterval
+	}
+	if timeout <= 0 {
+		timeout = DefaultRewatchTimeout
+	}
+	if log == nil {
+		log = slog.Default()
+	}
+	return &pollingRewatcher{rootCtx: rootCtx, interval: interval, timeout: timeout, now: time.Now, log: log}
+}
+
+// Schedule starts the background re-watch (non-blocking). It re-observes via the live
+// watcher on each tick:
+//   - VerdictDegraded or a telemetry error → revert (fail-safe) and stop.
+//   - VerdictHealthy → confirmed keep, stop.
+//   - VerdictInsufficient → keep polling until the timeout, then stop (apply stands;
+//     too few real games ever arrived to judge — never revert a change on no evidence).
+func (r *pollingRewatcher) Schedule(_ context.Context, flagKey string, baseline float64, watch Watcher, revert func(ctx context.Context)) {
+	obs, ok := watch.(Observer)
+	if !ok {
+		// A boolean-only watcher cannot report insufficiency, so it can never be the
+		// source of a re-watch; nothing to schedule.
+		return
+	}
+	go func() {
+		deadline := r.now().Add(r.timeout)
+		ticker := time.NewTicker(r.interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-r.rootCtx.Done():
+				r.log.Info("autonomous re-watch cancelled (shutdown)", "flag", flagKey)
+				return
+			case <-ticker.C:
+				verdict, err := obs.Observe(r.rootCtx, flagKey, baseline)
+				switch {
+				case err != nil:
+					r.log.Warn("autonomous re-watch: telemetry error, reverting fail-safe", "flag", flagKey, "error", err)
+					revert(r.rootCtx)
+					return
+				case verdict == VerdictDegraded:
+					r.log.Warn("autonomous re-watch: degradation confirmed, reverting", "flag", flagKey)
+					revert(r.rootCtx)
+					return
+				case verdict == VerdictHealthy:
+					r.log.Info("autonomous re-watch: fitness confirmed healthy, keeping apply", "flag", flagKey)
+					return
+				default: // VerdictInsufficient — keep waiting for more real games.
+					if r.now().After(deadline) {
+						r.log.Info("autonomous re-watch: timed out with insufficient real games; apply stands unverified", "flag", flagKey)
+						return
+					}
+				}
+			}
+		}
+	}()
+}
+
+// ensure the concrete types satisfy the seams at compile time.
+var (
+	_ RealGameFitness = (*storeRealGameFitness)(nil)
+	_ Rewatcher       = (*pollingRewatcher)(nil)
+)

--- a/services/agent/promote/live_test.go
+++ b/services/agent/promote/live_test.go
@@ -1,0 +1,236 @@
+package promote
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/joustmania/agent/experiment"
+)
+
+// live_test.go covers the LIVE-wired safety-net pieces (#1057/#1065): the
+// store-backed RealGameFitness source, the post-revert COOLDOWN that prevents
+// re-promotion thrash (item 3), the tri-state Observe + background RE-WATCH of an
+// insufficient-games apply (item 4).
+
+// --- RealGameFitness over the #965 FitnessStore (#1057 item 2) ---
+
+func TestStoreRealGameFitnessReadsRecentReal(t *testing.T) {
+	store := experiment.NewFitnessStore(0)
+	// Two real games for "endurance" and one shadow game (must be ignored).
+	store.Record(experiment.FitnessSample{GameID: "g1", Fitness: 0.7, Objective: "endurance", GameKind: experiment.GameKindReal})
+	store.Record(experiment.FitnessSample{GameID: "g2", Fitness: 0.6, Objective: "endurance", GameKind: experiment.GameKindReal})
+	store.Record(experiment.FitnessSample{GameID: "s1", Fitness: 0.1, Objective: "endurance", GameKind: "shadow"})
+
+	src := NewStoreRealGameFitness(store, func(string) string { return "endurance" })
+	got, err := src.Recent(context.Background(), "death_grace_period_ms", 5)
+	if err != nil {
+		t.Fatalf("Recent err = %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d real samples, want 2 (shadow excluded)", len(got))
+	}
+}
+
+func TestStoreRealGameFitnessNilStoreYieldsNoSamples(t *testing.T) {
+	src := NewStoreRealGameFitness(nil, nil)
+	got, err := src.Recent(context.Background(), "f", 5)
+	if err != nil || len(got) != 0 {
+		t.Fatalf("nil store: got (%v, %v), want (nil, no error)", got, err)
+	}
+}
+
+// --- tri-state Observe (#1065 item 4 foundation) ---
+
+func TestObserveTriState(t *testing.T) {
+	policy := WatchPolicy{MinGames: 3, DegradationMargin: 0.05, WindowGames: 5}
+	const baseline = 0.70
+	cases := []struct {
+		name    string
+		samples []float64
+		want    WatchVerdict
+	}{
+		{"insufficient", []float64{0.1, 0.1}, VerdictInsufficient},
+		{"healthy", []float64{0.70, 0.71, 0.69}, VerdictHealthy},
+		{"degraded", []float64{0.40, 0.42, 0.41}, VerdictDegraded},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := NewFitnessWatcher(fakeRealGameFitness{samples: tc.samples}, policy, discardLogger())
+			got, err := w.Observe(context.Background(), "f", baseline)
+			if err != nil {
+				t.Fatalf("Observe err = %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("Observe = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// --- post-revert COOLDOWN (#1065 item 3) ---
+
+// TestRevertCooldownSuppressesImmediateRepromotion: after a fail-safe revert (driven
+// by a telemetry error), an immediate autonomous re-promotion of the SAME flag is
+// suppressed (recorded no-op) while the cooldown holds — breaking the
+// err→revert→re-promote→err thrash loop.
+func TestRevertCooldownSuppressesImmediateRepromotion(t *testing.T) {
+	realDef := &recordingRealDefault{}
+	rev := &recordingReverter{}
+	// Watcher always errors → every apply fail-safe reverts.
+	erroring := fakeWatcher{err: errTelemetry}
+	p, _ := promoterWithRecorder(t, &recordingGitHub{}, &recordingGit{}, realDef, erroring, rev)
+
+	// Drive the clock manually so the test is deterministic.
+	now := time.Unix(1000, 0)
+	p.SetClock(func() time.Time { return now })
+	p.SetCooldown(5 * time.Minute)
+
+	cfg := Config{Mode: ModeAutonomous, Target: TargetLocal, Enabled: true}
+
+	// First promotion: applies, watch errors, reverts (sets cooldown at t=1000).
+	res1 := p.Promote(context.Background(), promoteProposal, promoteVerdict, cfg, testEvidence())
+	if res1.Outcome != OutcomeReverted {
+		t.Fatalf("first outcome = %q, want reverted", res1.Outcome)
+	}
+	if rev.calls != 1 {
+		t.Fatalf("revert calls = %d, want 1", rev.calls)
+	}
+
+	// Immediate re-promotion (still t=1000): suppressed by cooldown, no new apply.
+	res2 := p.Promote(context.Background(), promoteProposal, promoteVerdict, cfg, testEvidence())
+	if res2.Outcome != OutcomeDiscarded {
+		t.Fatalf("re-promotion outcome = %q, want discarded (cooldown)", res2.Outcome)
+	}
+	if len(realDef.calls) != 1 {
+		t.Errorf("SetRealDefault calls = %d, want 1 (re-apply suppressed by cooldown)", len(realDef.calls))
+	}
+
+	// After the cooldown elapses, a re-promotion is allowed again (applies + reverts).
+	now = now.Add(6 * time.Minute)
+	res3 := p.Promote(context.Background(), promoteProposal, promoteVerdict, cfg, testEvidence())
+	if res3.Outcome != OutcomeReverted {
+		t.Fatalf("post-cooldown outcome = %q, want reverted (allowed again)", res3.Outcome)
+	}
+	if len(realDef.calls) != 2 {
+		t.Errorf("SetRealDefault calls = %d, want 2 (re-apply after cooldown)", len(realDef.calls))
+	}
+}
+
+var errTelemetry = errTelemetryT("telemetry unreachable")
+
+type errTelemetryT string
+
+func (e errTelemetryT) Error() string { return string(e) }
+
+// --- RE-WATCH scheduling (#1065 item 4) ---
+
+// stepWatcher returns a sequence of verdicts across successive Observe calls — the
+// stand-in for a window that fills with more real games over time.
+type stepWatcher struct {
+	mu       sync.Mutex
+	verdicts []WatchVerdict
+	i        int
+}
+
+func (s *stepWatcher) Observe(context.Context, string, float64) (WatchVerdict, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	v := s.verdicts[len(s.verdicts)-1]
+	if s.i < len(s.verdicts) {
+		v = s.verdicts[s.i]
+		s.i++
+	}
+	return v, nil
+}
+
+// Degraded satisfies the Watcher interface (collapse to bool).
+func (s *stepWatcher) Degraded(ctx context.Context, f string, b float64) (bool, error) {
+	v, err := s.Observe(ctx, f, b)
+	return v == VerdictDegraded, err
+}
+
+// syncReverter is a thread-safe reverter for the background-re-watch tests (the
+// revert runs on the poller goroutine while the test goroutine reads calls).
+type syncReverter struct {
+	mu    sync.Mutex
+	calls int
+}
+
+func (r *syncReverter) RevertRealDefault(context.Context, string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls++
+	return nil
+}
+
+func (r *syncReverter) Calls() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.calls
+}
+
+// TestInsufficientGamesSchedulesRewatchThatReverts: an apply whose initial watch is
+// INSUFFICIENT schedules a re-watch; when the re-watch later confirms degradation it
+// reverts. The promotion call itself returns Applied (it never blocks on real games).
+func TestInsufficientGamesSchedulesRewatchThatReverts(t *testing.T) {
+	realDef := &recordingRealDefault{}
+	rev := &syncReverter{}
+	// Initial Observe: insufficient. Re-watch poll: insufficient again, then degraded.
+	watcher := &stepWatcher{verdicts: []WatchVerdict{VerdictInsufficient, VerdictInsufficient, VerdictDegraded}}
+	p, _ := promoterWithRecorder(t, &recordingGitHub{}, &recordingGit{}, realDef, watcher, rev)
+
+	rw := NewPollingRewatcher(context.Background(), time.Millisecond, time.Second, discardLogger())
+	p.SetRewatcher(rw)
+
+	res := p.Promote(context.Background(), promoteProposal, promoteVerdict,
+		Config{Mode: ModeAutonomous, Target: TargetLocal, Enabled: true}, testEvidence())
+
+	// The promotion applied (insufficient evidence does not revert synchronously).
+	if res.Outcome != OutcomeApplied {
+		t.Fatalf("outcome = %q, want applied (insufficient → apply stands, re-watch scheduled)", res.Outcome)
+	}
+
+	// The background re-watch eventually confirms degradation and reverts.
+	waitFor(t, time.Second, func() bool { return rev.Calls() >= 1 })
+	if rev.Calls() != 1 {
+		t.Errorf("re-watch revert calls = %d, want 1", rev.Calls())
+	}
+}
+
+// TestRewatchKeepsOnConfirmedHealthy: an insufficient apply whose re-watch later
+// confirms HEALTHY keeps the apply (no revert).
+func TestRewatchKeepsOnConfirmedHealthy(t *testing.T) {
+	realDef := &recordingRealDefault{}
+	rev := &syncReverter{}
+	watcher := &stepWatcher{verdicts: []WatchVerdict{VerdictInsufficient, VerdictHealthy}}
+	p, _ := promoterWithRecorder(t, &recordingGitHub{}, &recordingGit{}, realDef, watcher, rev)
+	rw := NewPollingRewatcher(context.Background(), time.Millisecond, time.Second, discardLogger())
+	p.SetRewatcher(rw)
+
+	res := p.Promote(context.Background(), promoteProposal, promoteVerdict,
+		Config{Mode: ModeAutonomous, Target: TargetLocal, Enabled: true}, testEvidence())
+	if res.Outcome != OutcomeApplied {
+		t.Fatalf("outcome = %q, want applied", res.Outcome)
+	}
+	// Give the re-watch a moment to observe HEALTHY and stop; it must NOT revert.
+	time.Sleep(50 * time.Millisecond)
+	if rev.Calls() != 0 {
+		t.Errorf("re-watch revert calls = %d, want 0 (confirmed healthy)", rev.Calls())
+	}
+}
+
+// waitFor polls cond until it is true or the deadline passes (a test helper for the
+// background re-watch, which acts on its own goroutine).
+func waitFor(t *testing.T, d time.Duration, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("condition not met within %s", d)
+}

--- a/services/agent/promote/promote.go
+++ b/services/agent/promote/promote.go
@@ -47,6 +47,8 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"sync"
+	"time"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -275,6 +277,68 @@ type Promoter struct {
 	repo     RepoRef             // owner/name/base used to build issue/PR/commit requests
 	tracer   trace.Tracer
 	log      *slog.Logger
+
+	// --- autonomous re-promotion COOLDOWN (#1065 item 3) ---
+	// A revert (especially the fail-safe revert on a telemetry error) must not be able
+	// to thrash: err→revert→re-promote→err→revert with no pause. After a revert the
+	// flag enters a cooldown; an autonomous re-promotion of the SAME flag inside the
+	// cooldown is refused (recorded no-op), so the loop cannot run hot. Defaults to
+	// DefaultRevertCooldown; SetCooldown overrides (env-driven from main.go).
+	cooldown   time.Duration
+	now        func() time.Time // injectable clock (tests); defaults to time.Now
+	mu         sync.Mutex       // guards lastRevert
+	lastRevert map[string]time.Time
+
+	// --- re-watch scheduling (#1065 item 4) ---
+	// When a watch sees INSUFFICIENT real games, the apply stands but is unverified. If
+	// a rewatcher is wired, the Promoter schedules a background re-watch that polls as
+	// more real games complete and reverts if a degradation is later CONFIRMED. nil →
+	// no re-watch (the apply stands unverified, exactly today's behavior). Wired in
+	// main.go alongside the live watcher.
+	rewatcher Rewatcher
+}
+
+// DefaultRevertCooldown is the default post-revert cooldown before the same flag may
+// be autonomously re-promoted (#1065 item 3). Conservative: long enough that a
+// telemetry-error revert loop cannot spin, short enough that a genuinely better arm
+// can be retried after the transient clears.
+const DefaultRevertCooldown = 10 * time.Minute
+
+// Rewatcher schedules a background re-watch of an autonomously-applied flag whose
+// initial watch had INSUFFICIENT real games to judge (#1065 item 4). The Promoter
+// hands it everything needed to re-observe and act: the flag, the pre-promotion
+// baseline, the live Watcher, and a revert closure that performs (and records) a
+// fail-safe revert. The implementation polls as more real games complete and invokes
+// revert on a CONFIRMED degradation. It runs in the background (a promotion call must
+// not block on real games), so a nil Rewatcher means "no re-watch" (apply stands).
+type Rewatcher interface {
+	// Schedule starts a background re-watch. It MUST NOT block the caller. watch is the
+	// live Watcher (reuse the same degradation policy); revert performs the gated
+	// fail-safe revert + journalling when a later cycle confirms degradation.
+	Schedule(ctx context.Context, flagKey string, baseline float64, watch Watcher, revert func(ctx context.Context))
+}
+
+// SetCooldown overrides the post-revert re-promotion cooldown (#1065 item 3). A
+// non-positive duration leaves the default in place. Called from main.go to make the
+// cooldown env-tunable without widening NewPromoter's heavily-used signature.
+func (pr *Promoter) SetCooldown(d time.Duration) {
+	if d > 0 {
+		pr.cooldown = d
+	}
+}
+
+// SetClock injects the time source the cooldown uses (tests drive a fake clock). A
+// nil clock is ignored. Production uses the default time.Now.
+func (pr *Promoter) SetClock(now func() time.Time) {
+	if now != nil {
+		pr.now = now
+	}
+}
+
+// SetRewatcher wires the background re-watch scheduler (#1065 item 4). nil leaves
+// re-watch disabled (an insufficient-games apply stands unverified, as today).
+func (pr *Promoter) SetRewatcher(r Rewatcher) {
+	pr.rewatcher = r
 }
 
 // RepoRef identifies the GitHub repo + default base branch a promotion targets.
@@ -307,14 +371,17 @@ func NewPromoter(github GitHubClient, git GitClient, realDef RealDefaultWriter, 
 		log = slog.Default()
 	}
 	return &Promoter{
-		github:   github,
-		git:      git,
-		realDef:  realDef,
-		watcher:  watcher,
-		reverter: reverter,
-		repo:     repo,
-		tracer:   tracer,
-		log:      log,
+		github:     github,
+		git:        git,
+		realDef:    realDef,
+		watcher:    watcher,
+		reverter:   reverter,
+		repo:       repo,
+		tracer:     tracer,
+		log:        log,
+		cooldown:   DefaultRevertCooldown,
+		now:        time.Now,
+		lastRevert: map[string]time.Time{},
 	}
 }
 

--- a/services/agent/promote/realdefault.go
+++ b/services/agent/promote/realdefault.go
@@ -34,10 +34,43 @@ import (
 // file in place. It mirrors the in-place write discipline of experiment.Writer
 // (O_NOFOLLOW, no temp+rename — EBUSY on the bind mount flagd watches) but writes
 // the REAL default, not a shadow rule.
+//
+// It also implements RealDefaultReverter: SetRealDefault SNAPSHOTS the pre-write
+// {defaultVariant name + its concrete value} at write time, and RevertRealDefault
+// RESTORES that exact prior state. Snapshotting the VALUE (not just the variant
+// name) is the safety-critical property (#1065): pointing defaultVariant back at a
+// remembered NAME is unsafe if an intervening promotion overwrote that variant's
+// value (e.g. a second autonomous write clobbers variants["promoted"]). Restoring
+// the captured value reconstructs exactly what real games resolved before the
+// promotion, regardless of what happened to the slot in between.
 type fileRealDefaultWriter struct {
 	path string
 	log  *slog.Logger
 	mu   sync.Mutex
+	// snapshots holds the pre-promotion state per flagKey, captured inside
+	// SetRealDefault before the mutation. RevertRealDefault restores from it. Keyed by
+	// flagKey so concurrent promotions of different flags each remember their own prior
+	// state. A re-promotion of the SAME flag is intentionally NOT re-snapshotted while a
+	// snapshot is already held (see SetRealDefault) so a revert always rolls back to the
+	// state BEFORE the agent first touched the flag, never to an intermediate
+	// agent-written value.
+	snapshots map[string]defaultSnapshot
+}
+
+// defaultSnapshot is the exact pre-promotion real-default state for one flag: the
+// defaultVariant NAME that was in effect and the concrete VALUE that name resolved
+// to. RevertRealDefault writes both back, so even if the named variant's value was
+// later overwritten the prior real resolution is reconstructed verbatim.
+type defaultSnapshot struct {
+	// hadDefault is false when the flag had NO defaultVariant before the promotion (a
+	// malformed/edge flag); revert then removes the agent-introduced default rather
+	// than inventing one.
+	hadDefault bool
+	// variant is the defaultVariant name in effect pre-promotion.
+	variant string
+	// value is the concrete JSON value that `variant` resolved to pre-promotion. Stored
+	// raw so it round-trips byte-for-byte. nil when the variant had no value entry.
+	value json.RawMessage
 }
 
 // NewRealDefaultWriterFromEnv returns the REAL-default writer IFF the autonomous
@@ -76,7 +109,7 @@ func NewRealDefaultWriterFromEnv(log *slog.Logger) (*fileRealDefaultWriter, erro
 	}
 	log.Warn("code_improvement AUTONOMOUS real-default writer ENABLED (#936): autonomous promotions WILL change the REAL defaultVariant for live players",
 		"path", path)
-	return &fileRealDefaultWriter{path: path, log: log}, nil
+	return &fileRealDefaultWriter{path: path, log: log, snapshots: map[string]defaultSnapshot{}}, nil
 }
 
 // SetRealDefault changes the REAL defaultVariant for flagKey to value: it ensures a
@@ -137,6 +170,32 @@ func (w *fileRealDefaultWriter) SetRealDefault(_ context.Context, flagKey string
 			}
 		}
 	}
+	// SNAPSHOT the pre-promotion state (#1065) BEFORE mutating, so RevertRealDefault
+	// can restore the EXACT prior {defaultVariant name + value}. We snapshot only the
+	// FIRST time we touch a flag (no snapshot held yet): a re-promotion of the same
+	// flag must still revert to the state before the agent EVER touched it, not to an
+	// intermediate agent-written value. The snapshot captures the VALUE, not just the
+	// name, so a later promotion overwriting the named slot cannot corrupt the revert.
+	if w.snapshots == nil {
+		w.snapshots = map[string]defaultSnapshot{}
+	}
+	if _, held := w.snapshots[flagKey]; !held {
+		snap := defaultSnapshot{}
+		if curDef, ok := flag["defaultVariant"]; ok {
+			var curName string
+			if json.Unmarshal(curDef, &curName) == nil {
+				snap.hadDefault = true
+				snap.variant = curName
+				if curRaw, present := variants[curName]; present {
+					// Copy the raw bytes so a later in-place mutation of `variants` cannot
+					// reach into the snapshot.
+					snap.value = append(json.RawMessage(nil), curRaw...)
+				}
+			}
+		}
+		w.snapshots[flagKey] = snap
+	}
+
 	// Point at an existing variant if one already equals value (keeps the file tidy),
 	// else add a reserved "promoted" variant. Either way defaultVariant moves.
 	variantName := "promoted"
@@ -163,6 +222,86 @@ func (w *fileRealDefaultWriter) SetRealDefault(_ context.Context, flagKey string
 	w.log.Warn("code_improvement.autonomous changing REAL defaultVariant (#936)",
 		"flag", flagKey, "variant", variantName)
 	return w.writeInPlace(append(out, '\n'))
+}
+
+// RevertRealDefault restores the EXACT pre-promotion real default for flagKey from
+// the snapshot SetRealDefault captured at write time (#1065). It rewrites both the
+// defaultVariant name AND the concrete value that name resolved to before the
+// promotion, so even if an intervening write overwrote the slot, real games resolve
+// the prior value verbatim after the revert. After a successful revert the snapshot
+// is dropped (a fresh promotion re-snapshots). It is the concrete RealDefaultReverter
+// the autonomous safety net rolls back through.
+func (w *fileRealDefaultWriter) RevertRealDefault(_ context.Context, flagKey string) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	snap, held := w.snapshots[flagKey]
+	if !held {
+		// Nothing to revert to: the agent never wrote this flag (or already reverted).
+		// Refuse rather than guess — a revert with no captured prior state could only
+		// fabricate one, which is exactly the unsafe behavior #1065 calls out.
+		return fmt.Errorf("revert real default %q: no pre-promotion snapshot captured", flagKey)
+	}
+
+	raw, err := os.ReadFile(w.path)
+	if err != nil {
+		return fmt.Errorf("read flag file %q: %w", w.path, err)
+	}
+	var doc struct {
+		Metadata json.RawMessage            `json:"metadata,omitempty"`
+		Flags    map[string]json.RawMessage `json:"flags"`
+	}
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		return fmt.Errorf("parse flag file: %w", err)
+	}
+	flagRaw, ok := doc.Flags[flagKey]
+	if !ok {
+		return fmt.Errorf("flag %q not present", flagKey)
+	}
+	var flag map[string]json.RawMessage
+	if err := json.Unmarshal(flagRaw, &flag); err != nil {
+		return fmt.Errorf("parse flag %q: %w", flagKey, err)
+	}
+
+	if !snap.hadDefault {
+		// The flag had no defaultVariant before the agent touched it; remove the one the
+		// promotion introduced rather than inventing a default.
+		delete(flag, "defaultVariant")
+	} else {
+		var variants map[string]json.RawMessage
+		if vr, ok := flag["variants"]; ok {
+			if err := json.Unmarshal(vr, &variants); err != nil {
+				return fmt.Errorf("parse variants of %q: %w", flagKey, err)
+			}
+		} else {
+			variants = map[string]json.RawMessage{}
+		}
+		// Restore the EXACT prior value into the prior variant name (it may have been
+		// overwritten by an intervening promotion), then point defaultVariant back at it.
+		if snap.value != nil {
+			variants[snap.variant] = append(json.RawMessage(nil), snap.value...)
+		}
+		vrOut, _ := json.Marshal(variants)
+		flag["variants"] = vrOut
+		dvOut, _ := json.Marshal(snap.variant)
+		flag["defaultVariant"] = dvOut
+	}
+
+	flagOut, _ := json.Marshal(flag)
+	doc.Flags[flagKey] = flagOut
+	out, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal flag file: %w", err)
+	}
+
+	w.log.Warn("code_improvement.autonomous REVERTING REAL defaultVariant to pre-promotion state (#1065)",
+		"flag", flagKey, "variant", snap.variant)
+	if err := w.writeInPlace(append(out, '\n')); err != nil {
+		return err
+	}
+	// Drop the snapshot so a subsequent promotion re-captures fresh prior state.
+	delete(w.snapshots, flagKey)
+	return nil
 }
 
 // writeInPlace overwrites the file at the same path WITHOUT temp+rename (EBUSY on

--- a/services/agent/promote/realdefault_test.go
+++ b/services/agent/promote/realdefault_test.go
@@ -128,3 +128,150 @@ func TestRealDefaultWriterRequiresAutonomousOptIn(t *testing.T) {
 		t.Errorf("writer built without AGENT_AUTONOMOUS_ENABLED: (%v, %v)", w, err)
 	}
 }
+
+// resolvedDefault reads back the value the flag's defaultVariant currently resolves
+// to (the value real games would see). "" means the flag has no defaultVariant.
+func resolvedDefault(t *testing.T, path, flagKey string) string {
+	t.Helper()
+	raw, _ := os.ReadFile(path)
+	var doc struct {
+		Flags map[string]struct {
+			Variants       map[string]json.RawMessage `json:"variants"`
+			DefaultVariant *string                    `json:"defaultVariant"`
+		} `json:"flags"`
+	}
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("re-parse: %v", err)
+	}
+	flag := doc.Flags[flagKey]
+	if flag.DefaultVariant == nil {
+		return ""
+	}
+	return string(flag.Variants[*flag.DefaultVariant])
+}
+
+func realDefaultWriterForTest(t *testing.T, path string) *fileRealDefaultWriter {
+	t.Helper()
+	t.Setenv("AGENT_CODE_IMPROVEMENT_ENABLED", "true")
+	t.Setenv("AGENT_AUTONOMOUS_ENABLED", "true")
+	t.Setenv("AGENT_REAL_DEFAULT_FLAG_PATH", path)
+	w, err := NewRealDefaultWriterFromEnv(discardLogger())
+	if err != nil || w == nil {
+		t.Fatalf("writer build: err=%v nil=%v", err, w == nil)
+	}
+	return w
+}
+
+// TestRevertRestoresExactPriorValue is the safety-critical property (#1065): a
+// revert restores the EXACT pre-promotion {defaultVariant name + value}, NOT merely a
+// remembered variant name. The flag starts at default=300; we promote to 500, then
+// revert, and the real default must resolve 300 again via the original "default"
+// variant.
+func TestRevertRestoresExactPriorValue(t *testing.T) {
+	dir := t.TempDir()
+	path := writeFlagFile(t, dir) // default=300, long=600, defaultVariant=default
+	w := realDefaultWriterForTest(t, path)
+	ctx := context.Background()
+
+	if got := resolvedDefault(t, path, "death_grace_period_ms"); got != "300" {
+		t.Fatalf("pre-promotion default = %s, want 300", got)
+	}
+	if err := w.SetRealDefault(ctx, "death_grace_period_ms", 500); err != nil {
+		t.Fatalf("SetRealDefault: %v", err)
+	}
+	if got := resolvedDefault(t, path, "death_grace_period_ms"); got != "500" {
+		t.Fatalf("post-promotion default = %s, want 500", got)
+	}
+	if err := w.RevertRealDefault(ctx, "death_grace_period_ms"); err != nil {
+		t.Fatalf("RevertRealDefault: %v", err)
+	}
+	if got := resolvedDefault(t, path, "death_grace_period_ms"); got != "300" {
+		t.Errorf("post-revert default = %s, want exact prior value 300", got)
+	}
+}
+
+// TestRevertRestoresValueDespiteInterveningSlotOverwrite proves WHY snapshotting the
+// VALUE (not just the name) is the safe design (#1065): an intervening write that
+// CLOBBERS the original default variant's value must not corrupt the revert. We
+// promote to 500 (snapshot captures {variant=default, value=300}), then an external
+// edit overwrites the "default" variant's value to a garbage 999 in the file, then we
+// revert. A name-only reverter would restore 999 (whatever the slot now holds); the
+// value-snapshotting reverter restores the EXACT prior 300.
+func TestRevertRestoresValueDespiteInterveningSlotOverwrite(t *testing.T) {
+	dir := t.TempDir()
+	path := writeFlagFile(t, dir)
+	w := realDefaultWriterForTest(t, path)
+	ctx := context.Background()
+
+	if err := w.SetRealDefault(ctx, "death_grace_period_ms", 500); err != nil {
+		t.Fatalf("SetRealDefault: %v", err)
+	}
+	// Simulate an intervening write clobbering the ORIGINAL default variant's value.
+	clobberVariantValue(t, path, "death_grace_period_ms", "default", 999)
+	if err := w.RevertRealDefault(ctx, "death_grace_period_ms"); err != nil {
+		t.Fatalf("RevertRealDefault: %v", err)
+	}
+	if got := resolvedDefault(t, path, "death_grace_period_ms"); got != "300" {
+		t.Errorf("post-revert default = %s, want exact snapshotted prior value 300 (NOT the clobbered 999)", got)
+	}
+}
+
+// clobberVariantValue rewrites one variant's value in the flag file in place,
+// simulating an external/second writer that overwrote the slot.
+func clobberVariantValue(t *testing.T, path, flagKey, variant string, value any) {
+	t.Helper()
+	raw, _ := os.ReadFile(path)
+	var doc map[string]any
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("clobber re-parse: %v", err)
+	}
+	flags := doc["flags"].(map[string]any)
+	flag := flags[flagKey].(map[string]any)
+	variants := flag["variants"].(map[string]any)
+	variants[variant] = value
+	out, _ := json.MarshalIndent(doc, "", "  ")
+	if err := os.WriteFile(path, out, 0o644); err != nil {
+		t.Fatalf("clobber write: %v", err)
+	}
+}
+
+// TestRevertToFirstSnapshotAcrossRepromotion: a second promotion of the SAME flag
+// must NOT re-snapshot — a revert always rolls back to the state BEFORE the agent
+// first touched the flag, never to an intermediate agent-written value (#1065).
+func TestRevertToFirstSnapshotAcrossRepromotion(t *testing.T) {
+	dir := t.TempDir()
+	path := writeFlagFile(t, dir) // default=300
+	w := realDefaultWriterForTest(t, path)
+	ctx := context.Background()
+
+	if err := w.SetRealDefault(ctx, "death_grace_period_ms", 500); err != nil {
+		t.Fatalf("first SetRealDefault: %v", err)
+	}
+	if err := w.SetRealDefault(ctx, "death_grace_period_ms", 600); err != nil {
+		t.Fatalf("second SetRealDefault: %v", err)
+	}
+	if err := w.RevertRealDefault(ctx, "death_grace_period_ms"); err != nil {
+		t.Fatalf("RevertRealDefault: %v", err)
+	}
+	if got := resolvedDefault(t, path, "death_grace_period_ms"); got != "300" {
+		t.Errorf("post-revert default = %s, want the original 300 (not the intermediate 500)", got)
+	}
+}
+
+// TestRevertWithoutSnapshotIsRefused: a revert with no captured prior state must be
+// refused rather than fabricating one (the unsafe behavior #1065 calls out).
+func TestRevertWithoutSnapshotIsRefused(t *testing.T) {
+	dir := t.TempDir()
+	path := writeFlagFile(t, dir)
+	w := realDefaultWriterForTest(t, path)
+	if err := w.RevertRealDefault(context.Background(), "death_grace_period_ms"); err == nil {
+		t.Fatal("RevertRealDefault with no snapshot should be refused, got nil error")
+	}
+}
+
+// TestWriterIsAlsoReverter: the concrete writer satisfies RealDefaultReverter so the
+// SAME instance backs both seams (it must, to share the at-write-time snapshot).
+func TestWriterIsAlsoReverter(t *testing.T) {
+	var _ RealDefaultReverter = (*fileRealDefaultWriter)(nil)
+	var _ RealDefaultWriter = (*fileRealDefaultWriter)(nil)
+}

--- a/services/agent/promote/watcher.go
+++ b/services/agent/promote/watcher.go
@@ -84,15 +84,11 @@ func (p WatchPolicy) normalize() WatchPolicy {
 		// "revert on any drop below baseline"; use the noise-absorbing default.
 		p.DegradationMargin = DefaultDegradationMargin
 	}
-	if p.WindowGames < p.MinGames {
-		p.WindowGames = p.MinGames
-	}
-	if p.WindowGames < DefaultWindowGames {
-		// Keep the window at least the default unless explicitly larger via MinGames.
-		if DefaultWindowGames >= p.MinGames {
-			p.WindowGames = DefaultWindowGames
-		}
-	}
+	// The window must be at least MinGames (it can never be narrower than the evidence
+	// floor) AND at least the default observation width (so an unset/small window still
+	// observes enough recent games). max of all three satisfies both invariants in one
+	// step.
+	p.WindowGames = maxInt(p.WindowGames, p.MinGames, DefaultWindowGames)
 	return p
 }
 
@@ -147,6 +143,56 @@ func DefaultWatchPolicy() WatchPolicy {
 	}
 }
 
+// WatchVerdict is the tri-state outcome of one observation window, distinguishing
+// the case the boolean Degraded conflates: a CONFIRMED healthy keep, a CONFIRMED
+// degradation (revert), and INSUFFICIENT evidence (too few real games to judge —
+// neither keep nor revert, re-watch as more games complete). Surfacing the
+// insufficient case is what lets the Promoter schedule a re-watch (#1065 item 4)
+// instead of silently keeping an unverified change.
+type WatchVerdict int
+
+const (
+	// VerdictInsufficient: fewer than MinGames real samples observed — cannot judge.
+	// The apply stands for now; a re-watch should run as more real games complete.
+	VerdictInsufficient WatchVerdict = iota
+	// VerdictHealthy: enough samples and fitness held within margin of baseline.
+	VerdictHealthy
+	// VerdictDegraded: enough samples and fitness fell past the degradation margin.
+	VerdictDegraded
+)
+
+// Observe is the tri-state form of Degraded: it returns VerdictInsufficient /
+// VerdictHealthy / VerdictDegraded plus any seam error (a read failure → caller
+// fails closed, same as Degraded). The Promoter uses it to tell "keep, verified"
+// apart from "keep, unverified — re-watch later". Degraded is kept as the Watcher
+// interface method (insufficient and healthy both map to false) for compatibility.
+func (w *fitnessWatcher) Observe(ctx context.Context, flagKey string, baseline float64) (WatchVerdict, error) {
+	samples, err := w.fitness.Recent(ctx, flagKey, w.policy.WindowGames)
+	if err != nil {
+		return VerdictInsufficient, fmt.Errorf("read recent real-game fitness for %q: %w", flagKey, err)
+	}
+	if len(samples) < w.policy.MinGames {
+		w.log.Info("autonomous watch: insufficient real games to judge degradation",
+			"flag", flagKey, "samples", len(samples), "min_games", w.policy.MinGames)
+		return VerdictInsufficient, nil
+	}
+	recent := mean(samples)
+	drop := baseline - recent
+	degraded := drop > w.policy.DegradationMargin
+	w.log.Info("autonomous watch: real-game fitness judged",
+		"flag", flagKey,
+		"baseline", baseline,
+		"recent_mean", recent,
+		"drop", drop,
+		"margin", w.policy.DegradationMargin,
+		"games", len(samples),
+		"degraded", degraded)
+	if degraded {
+		return VerdictDegraded, nil
+	}
+	return VerdictHealthy, nil
+}
+
 // Degraded reports whether real-game fitness degraded vs baseline after the
 // autonomous apply. The decision:
 //
@@ -160,33 +206,27 @@ func DefaultWatchPolicy() WatchPolicy {
 //  3. compute the recent mean and declare degradation when
 //     baseline - recentMean > DegradationMargin.
 func (w *fitnessWatcher) Degraded(ctx context.Context, flagKey string, baseline float64) (bool, error) {
-	samples, err := w.fitness.Recent(ctx, flagKey, w.policy.WindowGames)
+	// Delegate to the tri-state Observe and collapse it: only a CONFIRMED degradation
+	// reverts; INSUFFICIENT evidence and HEALTHY both keep the apply (false). A seam
+	// error surfaces so the Promoter's fail-safe revert fires (it treats err != nil as
+	// a revert).
+	verdict, err := w.Observe(ctx, flagKey, baseline)
 	if err != nil {
-		// Cannot read real-game fitness → cannot confirm healthy. Surface the error so
-		// the Promoter's fail-safe revert fires (it treats err != nil as a revert).
-		return false, fmt.Errorf("read recent real-game fitness for %q: %w", flagKey, err)
+		return false, err
 	}
-	if len(samples) < w.policy.MinGames {
-		// Not enough real games yet to judge. Do NOT revert (one/few games is not
-		// evidence of degradation), and do NOT error (the read succeeded). The apply
-		// stands; degradation can only be CONFIRMED with MinGames of evidence.
-		w.log.Info("autonomous watch: insufficient real games to judge degradation",
-			"flag", flagKey, "samples", len(samples), "min_games", w.policy.MinGames)
-		return false, nil
-	}
+	return verdict == VerdictDegraded, nil
+}
 
-	recent := mean(samples)
-	drop := baseline - recent
-	degraded := drop > w.policy.DegradationMargin
-	w.log.Info("autonomous watch: real-game fitness judged",
-		"flag", flagKey,
-		"baseline", baseline,
-		"recent_mean", recent,
-		"drop", drop,
-		"margin", w.policy.DegradationMargin,
-		"games", len(samples),
-		"degraded", degraded)
-	return degraded, nil
+// maxInt returns the largest of the given ints (used by normalize to clamp the
+// window up to both the MinGames floor and the default width in one step).
+func maxInt(xs ...int) int {
+	m := xs[0]
+	for _, x := range xs[1:] {
+		if x > m {
+			m = x
+		}
+	}
+	return m
 }
 
 // mean returns the arithmetic mean of a non-empty slice (callers guard len via


### PR DESCRIPTION
Live-wires the autonomous post-promotion watch + auto-revert seam so a verdict-driven flag promotion becomes a **closed loop**: apply → watch real OTel fitness → keep or auto-revert. Implements the concrete seams that `buildPromoter` previously wired nil. **Defaults are unchanged** (`agent.json` keeps `mode=issue`, `target=local`) — a fully-enabled agent still only opens an issue, and production stays fail-closed: if the watcher/fitness source can't be safely constructed, autonomous still refuses to apply (the #1016 contract).

## What changed

1. **Concrete `RealDefaultReverter`** — `fileRealDefaultWriter` now also implements `RealDefaultReverter`. `SetRealDefault` snapshots the pre-promotion `{defaultVariant name + concrete value}` **at write time**; `RevertRealDefault` restores that exact state. Snapshotting the **value** (not just the name) is the safety property: an intervening promotion that clobbers the named slot cannot corrupt the revert. A revert with no captured snapshot is **refused** rather than fabricating one.

2. **Concrete `RealGameFitness` + `NewFitnessWatcher` wiring** — `storeRealGameFitness` reads recent REAL-game fitness from the #965 `FitnessStore` (the same finalized-per-game real fitness the recent-real baseline uses). Wired in `buildPromoter` **only** when the autonomous env gate is satisfied AND a store exists; otherwise the Watcher stays nil → autonomous fails closed. Until real games populate the store, reads return 0 samples → INSUFFICIENT → apply stays unverified + re-watched, never a false healthy keep. The `FitnessStore` is hoisted to `main.go` so it backs both the experiment-loop validation seams and the Watcher.

3. **Error-path cooldown/backoff** — a post-revert cooldown parks the flag so `err→revert→re-promote→err→revert` cannot run hot. Env-tunable (`AGENT_AUTONOMOUS_REVERT_COOLDOWN_SECONDS`), injectable clock for tests.

4. **Re-watch scheduling** — tri-state `Observe` distinguishes INSUFFICIENT from HEALTHY; an insufficient-games apply schedules a background `pollingRewatcher` that re-observes as more real games complete and reverts on a later-confirmed degradation (never blocks the promotion call).

5. **Nits** — removed dead `actions.go:158 _ = degraded`; simplified the `normalize()` WindowGames clamp to a single `maxInt`.

## Safety
- Invariant gate (real-resolution-unchanged) untouched — the real-default writer's type-mismatch guard and the experiment Gate remain enforced.
- No change to `base.py` / game logic — agent-service Go only.
- Defaults verified unchanged; the live wiring is behind the existing `AGENT_CODE_IMPROVEMENT_ENABLED` + `AGENT_AUTONOMOUS_ENABLED` gate.

## Tests
- `restore exact prior value` proven 4 ways: exact-prior-value, **intervening-slot-overwrite** (a name-only reverter would restore the clobbered value; this one restores the snapshotted 300), re-promotion-keeps-first-snapshot, refuse-without-snapshot.
- Cooldown: suppresses immediate re-promotion, allows it after the window elapses (fake clock).
- Re-watch: insufficient→reverts-on-later-degradation, insufficient→keeps-on-later-healthy.
- Tri-state `Observe`, store fitness source (shadow games excluded).
- `gofmt -l`, `go vet ./...`, `go test ./... -race -count=1` all clean.

Part of #1057
Part of #1065

🤖 Generated with [Claude Code](https://claude.com/claude-code)