### PR TITLE
fix(agent): declare inference env knobs in compose + configurable timeout (#1078, #1079)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -707,6 +707,16 @@ services:
       - AGENT_INFERENCE_BASE_URL=${AGENT_INFERENCE_BASE_URL:-http://host.docker.internal:11434/v1}
       - AGENT_INFERENCE_MODEL=${AGENT_INFERENCE_MODEL:-phi4-mini}
       - AGENT_INFERENCE_API_KEY=${AGENT_INFERENCE_API_KEY:-}
+      # HTTP round-trip timeout for a single inference call, in seconds (#1079).
+      # Empty default = inference.DefaultTimeout (120s) — long enough for a local 8B
+      # cold-start, which was being cut off at the old hardcoded 60s. Bump higher
+      # (e.g. 180) for a heavier model / slower box.
+      - AGENT_INFERENCE_TIMEOUT_SECONDS=${AGENT_INFERENCE_TIMEOUT_SECONDS:-}
+      # LIVE per-minute LLM request budget override (#964/#1071). Read in main.go via
+      # SetLLMBudgetOverride; empty default = ignored (the flag-derived cap governs),
+      # matching the Go "non-positive = ignore" semantics. Declared here so a host
+      # `export` or `.env` value actually reaches the container (#1078).
+      - AGENT_LLM_MAX_REQUESTS_PER_MINUTE=${AGENT_LLM_MAX_REQUESTS_PER_MINUTE:-}
       # Experiment cohort loop (#982/#991). Opt-in master switch + the optional
       # env-seeded single experiment. Declared here (with default-off / empty
       # defaults) so a host `export` or `.env` value reaches the container — a

--- a/services/agent/inference/openai.go
+++ b/services/agent/inference/openai.go
@@ -49,13 +49,15 @@ const DefaultBaseURL = "http://host.docker.internal:11434/v1"
 // one-flag JSON replies the proposer/decision prompts ask for.
 const DefaultModel = "phi4-mini"
 
-// defaultTimeout bounds a single Infer round-trip when the caller's ctx carries no
-// deadline. A local model on a modest box can take a few seconds for a short
-// completion; 60s is generous enough not to truncate a legitimate slow reply while
-// still guaranteeing a hung endpoint cannot wedge the (already async, off-hot-path)
+// DefaultTimeout bounds a single Infer round-trip when the caller's ctx carries no
+// deadline. A local 8B model cold-loading on Ollama can take well over a minute for
+// a large-prompt completion (#1079: gemma4 cold-start was cut off at exactly 60s);
+// 120s is generous enough not to truncate a legitimate slow reply while still
+// guaranteeing a hung endpoint cannot wedge the (already async, off-hot-path)
 // inference goroutine forever. A caller-supplied ctx deadline still wins when it is
-// sooner — this only fills in a floor when none is set.
-const defaultTimeout = 60 * time.Second
+// sooner — this only fills in a floor when none is set. Override per-deployment via
+// AGENT_INFERENCE_TIMEOUT_SECONDS (#1079), plumbed through main.go + WithTimeout.
+const DefaultTimeout = 120 * time.Second
 
 // OpenAIBackend is the OpenAI-compatible inference backend. It POSTs a System+User
 // prompt to <BaseURL>/chat/completions and returns choices[0].message.content as
@@ -91,11 +93,24 @@ func WithHTTPClient(c *http.Client) Option {
 	}
 }
 
+// WithTimeout overrides the default http.Client timeout (#1079). A non-positive
+// duration is ignored so DefaultTimeout (or an injected WithHTTPClient) stands —
+// matching the "non-positive = ignore" env semantics used elsewhere. main.go feeds
+// AGENT_INFERENCE_TIMEOUT_SECONDS here so a local-8B-cold deployment can raise the
+// ceiling above the default without code changes.
+func WithTimeout(d time.Duration) Option {
+	return func(b *OpenAIBackend) {
+		if d > 0 {
+			b.httpClient.Timeout = d
+		}
+	}
+}
+
 // New builds an OpenAIBackend. An empty baseURL falls back to DefaultBaseURL and an
 // empty model to DefaultModel, so a partially-configured deployment still targets
 // the host Ollama rather than a broken empty URL. apiKey may be empty (the local,
-// no-key path). The default http.Client carries defaultTimeout as a backstop; a
-// per-call ctx deadline still applies on top of it.
+// no-key path). The default http.Client carries DefaultTimeout as a backstop (raise
+// it with WithTimeout); a per-call ctx deadline still applies on top of it.
 func New(baseURL, apiKey, model string, opts ...Option) *OpenAIBackend {
 	if strings.TrimSpace(baseURL) == "" {
 		baseURL = DefaultBaseURL
@@ -107,7 +122,7 @@ func New(baseURL, apiKey, model string, opts ...Option) *OpenAIBackend {
 		baseURL:    strings.TrimRight(baseURL, "/"),
 		apiKey:     apiKey,
 		model:      model,
-		httpClient: &http.Client{Timeout: defaultTimeout},
+		httpClient: &http.Client{Timeout: DefaultTimeout},
 	}
 	for _, opt := range opts {
 		opt(b)

--- a/services/agent/inference/openai_test.go
+++ b/services/agent/inference/openai_test.go
@@ -194,8 +194,8 @@ func TestNew_Defaults(t *testing.T) {
 	if b.model != DefaultModel {
 		t.Errorf("model = %q, want default %q", b.model, DefaultModel)
 	}
-	if b.httpClient == nil || b.httpClient.Timeout != defaultTimeout {
-		t.Errorf("httpClient timeout = %v, want %v", b.httpClient.Timeout, defaultTimeout)
+	if b.httpClient == nil || b.httpClient.Timeout != DefaultTimeout {
+		t.Errorf("httpClient timeout = %v, want %v", b.httpClient.Timeout, DefaultTimeout)
 	}
 }
 
@@ -204,4 +204,28 @@ func TestNew_TrimsTrailingSlash(t *testing.T) {
 	if b.baseURL != "http://x/v1" {
 		t.Errorf("baseURL = %q, want trailing slash trimmed", b.baseURL)
 	}
+}
+
+// TestWithTimeout covers the #1079 configurable HTTP timeout: a positive duration
+// overrides DefaultTimeout, while a non-positive (or zero) duration is ignored so
+// DefaultTimeout stands — mirroring the "non-positive = ignore" env semantics.
+func TestWithTimeout(t *testing.T) {
+	t.Run("positive overrides default", func(t *testing.T) {
+		b := New("", "", "", WithTimeout(180*time.Second))
+		if b.httpClient.Timeout != 180*time.Second {
+			t.Errorf("timeout = %v, want 180s", b.httpClient.Timeout)
+		}
+	})
+	t.Run("zero keeps default", func(t *testing.T) {
+		b := New("", "", "", WithTimeout(0))
+		if b.httpClient.Timeout != DefaultTimeout {
+			t.Errorf("timeout = %v, want default %v", b.httpClient.Timeout, DefaultTimeout)
+		}
+	})
+	t.Run("negative keeps default", func(t *testing.T) {
+		b := New("", "", "", WithTimeout(-5*time.Second))
+		if b.httpClient.Timeout != DefaultTimeout {
+			t.Errorf("timeout = %v, want default %v", b.httpClient.Timeout, DefaultTimeout)
+		}
+	})
 }

--- a/services/agent/main.go
+++ b/services/agent/main.go
@@ -363,8 +363,10 @@ type inferFunc = func(ctx context.Context, prompt llm.Prompt) (string, error)
 // behavior rather than to a broken backend. The base URL/model/key come from
 // AGENT_INFERENCE_BASE_URL (default the host Ollama), AGENT_INFERENCE_MODEL
 // (default phi4-mini), and AGENT_INFERENCE_API_KEY (optional — empty for the local
-// no-key path, set for a gateway/cloud target). Returns the chosen backend name for
-// the startup log too.
+// no-key path, set for a gateway/cloud target). The HTTP round-trip timeout comes
+// from AGENT_INFERENCE_TIMEOUT_SECONDS (#1079, default inference.DefaultTimeout) so a
+// local 8B cold-start can be given a longer ceiling than the 60s that was cutting it
+// off. Returns the chosen backend name for the startup log too.
 func selectInferenceBackend() (inferFunc, string) {
 	backend := strings.ToLower(strings.TrimSpace(getEnv("AGENT_INFERENCE_BACKEND", "stub")))
 	if backend != "openai" {
@@ -374,6 +376,7 @@ func selectInferenceBackend() (inferFunc, string) {
 		getEnv("AGENT_INFERENCE_BASE_URL", inference.DefaultBaseURL),
 		getEnv("AGENT_INFERENCE_API_KEY", ""),
 		getEnv("AGENT_INFERENCE_MODEL", inference.DefaultModel),
+		inference.WithTimeout(secondsEnv("AGENT_INFERENCE_TIMEOUT_SECONDS", inference.DefaultTimeout)),
 	)
 	return client.Infer, "openai"
 }


### PR DESCRIPTION
## Summary

Two related quick-win fixes that both edit the `agent` service `environment:` block in `docker-compose.yml` (done together to avoid a conflict).

### #1078 — `AGENT_LLM_MAX_REQUESTS_PER_MINUTE` unreachable in deployment
`main.go` reads this budget override (#1071 via `SetLLMBudgetOverride` / `llmBudgetOverride()`), but it was never declared in the compose env block, so Compose silently dropped a host `export`/`.env` value and the knob was unreachable. Declared with an empty default (`= ignored`, flag-derived cap governs — matches the Go "non-positive = ignore" semantics).

### #1079 — inference HTTP timeout hardcoded at 60s, too short for local 8B
`OpenAIBackend` (#1048) hardcoded a 60s HTTP client timeout. A local 8B model (gemma4 cold-load on Ollama) was cut off at exactly the ceiling (`code_improvement.propose_attempt` `dur_ms=60001`), silently degrading to rules/stub.

Fix:
- New `inference.WithTimeout(d)` option (non-positive = ignored, default stands).
- Raised `DefaultTimeout` 60s → **120s** (long enough for an 8B cold start; the old 60s was the exact failure boundary).
- Plumbed `AGENT_INFERENCE_TIMEOUT_SECONDS` through `main.go`'s `selectInferenceBackend` using the existing `secondsEnv()` helper, defaulting to `inference.DefaultTimeout`.
- Added `WithTimeout` unit tests (positive overrides; zero/negative keep default).

An unset env preserves current behavior except for the raised default.

## Verification
- `gofmt -l .`, `go build ./...`, `go vet ./...` clean.
- `go test ./... -race -count=1` passes (the `experiment` package flaked once on dynamic-declarer seed timing — passed on re-run; not a regression here).
- `docker-compose.yml` parses via `yaml.safe_load` (no duplicate keys).

Part of #1078
Part of #1079

🤖 Generated with [Claude Code](https://claude.com/claude-code)