### PR TITLE
feat(agent): per-player movement time-series + proximity-to-death + game-speed context (#1082)

### DIFF
--- a/services/agent/gamecontext/extract_metrics.go
+++ b/services/agent/gamecontext/extract_metrics.go
@@ -22,6 +22,15 @@ const (
 	metricDeathsTotal    = "game_player_deaths_total"    // live
 	metricPeakAccel      = "game_player_peak_accel"      // live (game_id carrier)
 
+	// Game-speed / threshold reference frame (#1082). All three are SESSION-level
+	// gauges the coordinator already emits (no serial label): game_music_tempo is
+	// the applied game speed (1.0=slow..~1.3=fast); the effective thresholds are the
+	// tempo-interpolated death/warning thresholds in g-force, so proximity-to-death
+	// reads as "intensity vs threshold AT that tempo".
+	metricMusicTempo        = "game_music_tempo"                 // live (Phase 70)
+	metricEffectiveDeathThr = "game_effective_death_threshold"   // live (Phase 80)
+	metricEffectiveWarnThr  = "game_effective_warning_threshold" // live (Phase 80)
+
 	metricMovementVariance = "game_player_movement_variance" // live (coordinator emits at ~10Hz, #730/#1015)
 	metricBatteryPct       = "controller_battery_pct"        // proposed
 	metricSkillLevel       = "game_player_skill_level"       // live (coordinator emits at ~10Hz, #730/#1015)
@@ -276,6 +285,27 @@ func (s *Store) applyDataPoint(name string, dp pmetric.NumberDataPoint) bool {
 				s.SetGameMode(mv.AsString())
 				return true
 			}
+		}
+
+	// --- game-speed / threshold reference frame (#1082; session-level, no serial) ---
+	// These gauges carry no game_id label (like game_current_mode), so they are not
+	// routed through adoptGame; they record onto whatever partition the multiplexer
+	// selected. v==0 is the coordinator's "no game" sentinel for tempo/thresholds, so
+	// a zero reading is skipped rather than recorded as a real 0.0 speed/threshold.
+	case metricMusicTempo:
+		if v != 0 {
+			s.SetMusicTempo(v)
+			return true
+		}
+	case metricEffectiveDeathThr:
+		if v != 0 {
+			s.SetDeathThreshold(v)
+			return true
+		}
+	case metricEffectiveWarnThr:
+		if v != 0 {
+			s.SetWarningThreshold(v)
+			return true
 		}
 	}
 	return false

--- a/services/agent/gamecontext/extract_metrics_test.go
+++ b/services/agent/gamecontext/extract_metrics_test.go
@@ -380,3 +380,43 @@ func TestApplyMetrics_NoExperimentLabelsLeavesAttributionEmpty(t *testing.T) {
 		t.Fatalf("Arm = %q, want empty (real game has no arm)", snap.Arm)
 	}
 }
+
+// TestApplyMetrics_SpeedAndThreshold verifies the #1082 game-speed / threshold
+// reference-frame gauges (no serial label) are ingested into the session signals
+// and the speed track, and that the coordinator's v==0 "no game" sentinel is
+// skipped rather than recorded as a real 0.0.
+func TestApplyMetrics_SpeedAndThreshold(t *testing.T) {
+	s := newTestStore()
+
+	if !s.ApplyMetrics(metricsWith(metricMusicTempo, 1.3, nil)) {
+		t.Fatal("expected music tempo update")
+	}
+	if !s.ApplyMetrics(metricsWith(metricEffectiveDeathThr, 1.8, nil)) {
+		t.Fatal("expected death threshold update")
+	}
+	if !s.ApplyMetrics(metricsWith(metricEffectiveWarnThr, 1.2, nil)) {
+		t.Fatal("expected warning threshold update")
+	}
+	snap := s.Snapshot()
+	if snap.Session.MusicTempo == nil || *snap.Session.MusicTempo != 1.3 {
+		t.Errorf("music tempo = %v, want 1.3", snap.Session.MusicTempo)
+	}
+	if snap.Session.DeathThreshold == nil || *snap.Session.DeathThreshold != 1.8 {
+		t.Errorf("death threshold = %v, want 1.8", snap.Session.DeathThreshold)
+	}
+	if snap.Session.WarningThreshold == nil || *snap.Session.WarningThreshold != 1.2 {
+		t.Errorf("warning threshold = %v, want 1.2", snap.Session.WarningThreshold)
+	}
+	if len(snap.SpeedTrack) == 0 {
+		t.Error("speed track should carry the tempo/threshold samples")
+	}
+
+	// v==0 sentinel: a "no game" reading must NOT be recorded and must not be a hit.
+	s2 := newTestStore()
+	if s2.ApplyMetrics(metricsWith(metricMusicTempo, 0, nil)) {
+		t.Error("tempo v==0 (no game) should be skipped")
+	}
+	if s2.Snapshot().Session.MusicTempo != nil {
+		t.Error("tempo v==0 must not be recorded")
+	}
+}

--- a/services/agent/gamecontext/model.go
+++ b/services/agent/gamecontext/model.go
@@ -39,6 +39,15 @@ type PlayerSignals struct {
 	// Fallback source: controller_connected{serial} == 1.
 	Active *bool
 
+	// History is the bounded per-player movement TIME-SERIES (#1082): an oldest-
+	// first slice of bucketed (t, intensity[, variance]) samples, a SNAPSHOT copy
+	// of the Store's per-player ring (shares no backing array with the live ring,
+	// so it is safe to render after later Store mutations). nil until the first
+	// intensity sample for this player arrives. The llm prompt / retro and the
+	// game summary render it as a compact sparkline + a proximity-to-death track —
+	// never as raw floats — via RenderSparkline / ComputeProximity / ClassifyActivity.
+	History []MovementSample
+
 	// LastUpdate is the last time any signal for this player changed.
 	LastUpdate time.Time
 
@@ -73,6 +82,24 @@ type SessionSignals struct {
 	// Source: game_current_mode{mode} label (value != 0) (live), or span
 	// attribute game.mode.
 	GameMode *string
+
+	// MusicTempo is the current applied game speed / music tempo — the reference
+	// frame the per-player intensity tracks must be read against (#1082): the same
+	// intensity is near-death at slow tempo and barely trying at fast tempo.
+	// Source: game_music_tempo (live; 1.0=slow .. ~1.3=fast, 0=no game). nil until
+	// observed. The accelerate rules (R5/R6/R7) and adjust_music_tempo interventions
+	// ramp it over the game, so the Store also keeps a per-tick SpeedTrack.
+	MusicTempo *float64
+
+	// DeathThreshold / WarningThreshold are the current effective (tempo-
+	// interpolated) elimination / warning thresholds in g-force (#1082).
+	// Source: game_effective_death_threshold / game_effective_warning_threshold
+	// (live). These are SESSION-level (one effective value, after the slow<->fast
+	// LERP), not per-player — the per-sensitivity tables stay internal to the
+	// coordinator. Proximity-to-death is each player's MovementIntensity read
+	// against DeathThreshold. nil until observed.
+	DeathThreshold   *float64
+	WarningThreshold *float64
 
 	// LastUpdate is the last time any session signal changed.
 	LastUpdate time.Time
@@ -110,4 +137,13 @@ type GameContext struct {
 	// recorded yet. The llm package renders it into a compact timeline section in
 	// both the in-game prompt (#739) and the retro (#844) via RenderTimeline.
 	Timeline []TimelineEvent
+
+	// SpeedTrack is a bounded, oldest-first SNAPSHOT of the session game-speed /
+	// death-threshold track (#1082): per-tick (t, tempo, death_threshold) samples,
+	// the reference frame the per-player proximity-to-death is read against (the
+	// same intensity is near-death at slow tempo, barely-trying at fast tempo). It
+	// shares no backing array with the live ring (safe to render after later Store
+	// mutations). nil until the first tempo/threshold reading arrives. Rendered as a
+	// compact tempo sparkline (RenderSpeedTrack) alongside the per-player sparklines.
+	SpeedTrack []SpeedSample
 }

--- a/services/agent/gamecontext/playerhistory.go
+++ b/services/agent/gamecontext/playerhistory.go
@@ -1,0 +1,438 @@
+package gamecontext
+
+import (
+	"fmt"
+	"math"
+	"strings"
+	"time"
+)
+
+// playerhistory.go is the bounded per-player movement TIME-SERIES (#1082). The
+// #916 session timeline records only session-level aggregates (mean_intensity +
+// active_players) — a single number that averages every player into one band and
+// cannot answer the questions a tuning decision turns on: WHO was active vs idle,
+// WHEN, and WHO was close to death. This adds a per-`serial` movement series plus
+// a session-level game-speed / death-threshold track, mirroring the #916 ring-
+// buffer pattern but per player, so the prompt and the retro can render a compact
+// sparkline + a proximity-to-death track per player read against the tempo.
+//
+// Memory + token bound: each player keeps a FIXED-CAPACITY ring of bucketed
+// samples (playerHistoryCap), and recording is dedupe-bucketed to ~1Hz (a sample
+// is only appended once its bucket-second advances or the value changes
+// meaningfully), so the 60Hz/10Hz signal firehose can never churn the ring. The
+// rendered form is a single sparkline string per player — never an array of
+// floats — so it stays cheap in the prompt.
+//
+// Determinism contract (the golden tests depend on it): samples carry the
+// injected Store.now timestamp, the sparkline buckets render in time order with
+// fixed glyphs, and the proximity track is a pure function of the samples + the
+// observed threshold. The same sample stream always renders byte-identically.
+
+// playerHistoryCap is the FIXED ring-buffer capacity per player (#1082). 32
+// bucketed (~1Hz) samples comfortably cover the recent window the prompt cares
+// about (the sparkline is the most-recent ~30s of movement) while keeping the
+// per-player memory and the rendered sparkline width bounded to a constant.
+const playerHistoryCap = 32
+
+// movementBucket is the dedupe granularity for per-player samples: at most one
+// sample per bucket-second per player (the value at bucket roll-over). This is
+// the linchpin of the memory bound — the raw signal arrives at up to 60Hz, so
+// without bucketing the ring would churn in well under a second and bury the
+// trend. 1s matches the #916 narrative cadence and the proximity track's "@-Ns"
+// resolution.
+const movementBucket = time.Second
+
+// MovementSample is one bucketed per-player observation: the player's movement
+// intensity at an instant, with the variance when it was observed alongside.
+// Variance is a pointer so "intensity seen, variance not yet" stays distinct from
+// a genuine zero variance.
+type MovementSample struct {
+	At        time.Time
+	Intensity float64
+	Variance  *float64
+}
+
+// SpeedSample is one bucketed session-level observation of the game-speed /
+// death-threshold reference frame (#1082): the applied music tempo and the
+// effective (tempo-interpolated) death threshold at an instant. Both are pointers
+// so a track that only ever observed one of the two does not fabricate the other.
+type SpeedSample struct {
+	At             time.Time
+	Tempo          *float64
+	DeathThreshold *float64
+}
+
+// playerHistory is a fixed-capacity per-player ring of MovementSamples plus the
+// bucket-dedupe memory. Like the #916 timeline it is NOT independently locked:
+// every method runs while the owning Store holds s.mu, so it reuses that mutex.
+type playerHistory struct {
+	buf   []MovementSample // len == cap once warmed; pre-grown to playerHistoryCap
+	start int              // index of the OLDEST entry
+	size  int              // number of live entries (0..playerHistoryCap)
+
+	// lastBucket is the bucket-second of the last APPENDED sample, so a within-
+	// bucket update overwrites the tail rather than appending a new entry.
+	lastBucket time.Time
+}
+
+// record appends or coalesces a sample. Within the same bucket-second it
+// OVERWRITES the tail (keeping the latest value for that second); on a new bucket
+// it appends, evicting the oldest entry once at capacity. The bound is the cap.
+func (h *playerHistory) record(s MovementSample) {
+	if h.buf == nil {
+		h.buf = make([]MovementSample, playerHistoryCap)
+	}
+	bucket := s.At.Truncate(movementBucket)
+	if h.size > 0 && bucket.Equal(h.lastBucket) {
+		// Same second: replace the tail so the bucket holds its latest value.
+		tail := (h.start + h.size - 1) % playerHistoryCap
+		h.buf[tail] = s
+		return
+	}
+	h.lastBucket = bucket
+	end := (h.start + h.size) % playerHistoryCap
+	h.buf[end] = s
+	if h.size == playerHistoryCap {
+		h.start = (h.start + 1) % playerHistoryCap
+	} else {
+		h.size++
+	}
+}
+
+// samples returns the live entries oldest-first as a fresh slice, safe to hand
+// out in a snapshot (shares no backing array with the ring, so later records
+// never mutate a returned snapshot).
+func (h *playerHistory) samples() []MovementSample {
+	if h.size == 0 {
+		return nil
+	}
+	out := make([]MovementSample, h.size)
+	for i := 0; i < h.size; i++ {
+		out[i] = h.buf[(h.start+i)%playerHistoryCap]
+	}
+	return out
+}
+
+// speedTrackCap is the FIXED ring capacity of the session game-speed track
+// (#1082). 32 bucketed (~1Hz) samples cover the recent tempo ramp the prompt
+// renders while keeping the track memory- and token-bounded.
+const speedTrackCap = 32
+
+// speedTrack is the session-level fixed-capacity ring of SpeedSamples. Like the
+// player histories it reuses the owning Store's mutex (called only under s.mu).
+type speedTrack struct {
+	buf        []SpeedSample
+	start      int
+	size       int
+	lastBucket time.Time
+}
+
+// record appends or coalesces a session speed/threshold sample, bucketed to ~1Hz
+// exactly like the per-player ring. A within-bucket update overwrites the tail.
+func (t *speedTrack) record(s SpeedSample) {
+	if t.buf == nil {
+		t.buf = make([]SpeedSample, speedTrackCap)
+	}
+	bucket := s.At.Truncate(movementBucket)
+	if t.size > 0 && bucket.Equal(t.lastBucket) {
+		tail := (t.start + t.size - 1) % speedTrackCap
+		// Coalesce: keep whichever field this sample carries, preserving the other
+		// dimension already observed in this bucket (tempo and threshold arrive on
+		// separate metrics, so a bucket may be filled by two distinct samples).
+		prev := t.buf[tail]
+		if s.Tempo != nil {
+			prev.Tempo = s.Tempo
+		}
+		if s.DeathThreshold != nil {
+			prev.DeathThreshold = s.DeathThreshold
+		}
+		prev.At = s.At
+		t.buf[tail] = prev
+		return
+	}
+	t.lastBucket = bucket
+	end := (t.start + t.size) % speedTrackCap
+	t.buf[end] = s
+	if t.size == speedTrackCap {
+		t.start = (t.start + 1) % speedTrackCap
+	} else {
+		t.size++
+	}
+}
+
+// samples returns the live track entries oldest-first as a fresh slice (shares no
+// backing array with the ring).
+func (t *speedTrack) samples() []SpeedSample {
+	if t.size == 0 {
+		return nil
+	}
+	out := make([]SpeedSample, t.size)
+	for i := 0; i < t.size; i++ {
+		out[i] = t.buf[(t.start+i)%speedTrackCap]
+	}
+	return out
+}
+
+// reset clears the session speed track (new session / grace exit).
+func (t *speedTrack) reset() {
+	t.start = 0
+	t.size = 0
+	t.lastBucket = time.Time{}
+}
+
+// sparkGlyphs is the 8-level block ramp used by RenderSparkline, lowest-first.
+// A bucket with no movement (a true gap) renders as the separate idle glyph.
+var sparkGlyphs = []rune("▁▂▃▄▅▆▇█")
+
+// idleGlyph marks a bucket whose intensity is at/below the idle floor — a player
+// standing still — so a flat-low stretch reads as idleness, not just "lowest bar".
+const idleGlyph = '_'
+
+// idleFloor is the intensity at/below which a bucket is rendered as idle (`_`).
+// JoustMania accel magnitude sits near ~1.0g even when a controller is merely
+// held still (gravity), so a small absolute floor distinguishes "not moving"
+// from "moving a little". Tuned conservatively — only near-zero reads as idle.
+const idleFloor = 0.15
+
+// RenderSparkline renders a movement series as a compact Unicode block sparkline
+// scaled against scaleMax (the death threshold when known, so a full bar means
+// "at the elimination threshold"). When scaleMax is nil/non-positive the series
+// auto-scales to its own observed peak so the SHAPE still reads. Buckets at/below
+// the idle floor render as `_`. An empty series renders the empty string.
+//
+// It is exported so the llm and gamesummary packages render the identical glyphs
+// from the bounded slice carried on the GameContext snapshot.
+func RenderSparkline(samples []MovementSample, scaleMax *float64) string {
+	if len(samples) == 0 {
+		return ""
+	}
+	// Determine the scale: the threshold when positive, else the observed peak.
+	scale := 0.0
+	if scaleMax != nil && *scaleMax > 0 {
+		scale = *scaleMax
+	} else {
+		for _, s := range samples {
+			if s.Intensity > scale {
+				scale = s.Intensity
+			}
+		}
+	}
+	var b strings.Builder
+	for _, s := range samples {
+		b.WriteRune(glyphFor(s.Intensity, scale))
+	}
+	return b.String()
+}
+
+// glyphFor maps one intensity to its sparkline glyph against scale. At/below the
+// idle floor -> idle glyph; otherwise the value's position in [0,scale] selects a
+// block, clamped to the top block when it meets/exceeds the scale.
+func glyphFor(intensity, scale float64) rune {
+	if intensity <= idleFloor {
+		return idleGlyph
+	}
+	if scale <= 0 {
+		return sparkGlyphs[0]
+	}
+	frac := intensity / scale
+	if frac >= 1 {
+		return sparkGlyphs[len(sparkGlyphs)-1]
+	}
+	idx := int(frac * float64(len(sparkGlyphs)))
+	if idx >= len(sparkGlyphs) {
+		idx = len(sparkGlyphs) - 1
+	}
+	return sparkGlyphs[idx]
+}
+
+// Activity is the coarse per-window activity classification derived from a
+// player's recent movement series (#1082): the cheap "what was this player doing"
+// label that lets an elimination be read against its lead-up.
+type Activity string
+
+const (
+	// ActivityUnknown is the classification when there is no movement history to
+	// classify (an empty series).
+	ActivityUnknown Activity = "unknown"
+	// ActivityIdle means the recent window was mostly at/below the idle floor —
+	// the player was standing still.
+	ActivityIdle Activity = "idle"
+	// ActivityActive means steady, meaningful movement without wild swings.
+	ActivityActive Activity = "active"
+	// ActivityErratic means high swing between samples — bursty/jerky movement,
+	// the signature of a player flailing or thrashing.
+	ActivityErratic Activity = "erratic"
+)
+
+// erraticStdFrac is the swing-relative-to-mean ratio above which a window is
+// classified erratic: when the sample standard deviation exceeds this fraction of
+// the window mean, the movement is bursty rather than steady. 0.5 (swings of half
+// the mean) is a deliberately coarse, explainable cut.
+const erraticStdFrac = 0.5
+
+// ClassifyActivity classifies a movement window as idle / active / erratic, or
+// unknown when there is nothing to classify. It is a pure function of the samples
+// so the prompt and retro derive the same label deterministically. The window is
+// the most-recent activityWindow samples (the recent behavior is what matters for
+// a live decision; the full ring still feeds the sparkline).
+func ClassifyActivity(samples []MovementSample) Activity {
+	const activityWindow = 8
+	if len(samples) == 0 {
+		return ActivityUnknown
+	}
+	window := samples
+	if len(window) > activityWindow {
+		window = window[len(window)-activityWindow:]
+	}
+	var sum, sumSq float64
+	for _, s := range window {
+		sum += s.Intensity
+		sumSq += s.Intensity * s.Intensity
+	}
+	n := float64(len(window))
+	mean := sum / n
+	if mean <= idleFloor {
+		return ActivityIdle
+	}
+	variance := sumSq/n - mean*mean
+	if variance < 0 {
+		variance = 0 // floating-point guard
+	}
+	std := math.Sqrt(variance)
+	if std > erraticStdFrac*mean {
+		return ActivityErratic
+	}
+	return ActivityActive
+}
+
+// Proximity is the per-player proximity-to-death result (#1082): the closest the
+// player's movement came to the elimination threshold over the observed window,
+// expressed as a fraction of the threshold (1.0 == at the threshold), and WHEN
+// (relative to a reference time) that closest call happened. It reads the threshold
+// AT THE TIME of each sample when a per-sample threshold track is supplied, so a
+// "0.92×thr" call is interpreted against the tempo that was actually in force.
+type Proximity struct {
+	// Observed is false when proximity cannot be computed — no movement samples or
+	// no death-threshold observation. The renderers show "unknown" then.
+	Observed bool
+	// Ratio is the peak intensity/threshold over the window (the closest call).
+	Ratio float64
+	// At is the timestamp of the closest call (the sample that produced Ratio).
+	At time.Time
+	// Crossed is true when the player's intensity met or exceeded the threshold at
+	// some point (Ratio >= 1.0) — i.e. it entered death territory.
+	Crossed bool
+}
+
+// ComputeProximity finds a player's closest call to the death threshold over its
+// movement window. threshold is the session death-threshold track (SpeedSamples
+// carrying DeathThreshold); the nearest-in-time threshold sample at or before each
+// movement sample is used, so the ratio reflects the tempo in force then. When the
+// track is empty, fallbackThreshold (the last-known scalar threshold) is used for
+// every sample; when neither is available, Observed is false.
+func ComputeProximity(samples []MovementSample, track []SpeedSample, fallbackThreshold *float64) Proximity {
+	if len(samples) == 0 {
+		return Proximity{}
+	}
+	thrAt := thresholdLookup(track, fallbackThreshold)
+	var best Proximity
+	for _, s := range samples {
+		thr := thrAt(s.At)
+		if thr == nil || *thr <= 0 {
+			continue
+		}
+		ratio := s.Intensity / *thr
+		if !best.Observed || ratio > best.Ratio {
+			best = Proximity{Observed: true, Ratio: ratio, At: s.At, Crossed: ratio >= 1.0}
+		}
+	}
+	return best
+}
+
+// thresholdLookup returns a function mapping a sample time to the effective death
+// threshold then: the most-recent track sample at-or-before t that carries a
+// DeathThreshold, else the fallback scalar (the last observed threshold), else
+// nil. The track is assumed oldest-first.
+func thresholdLookup(track []SpeedSample, fallback *float64) func(time.Time) *float64 {
+	return func(t time.Time) *float64 {
+		var chosen *float64
+		for _, sp := range track {
+			if sp.DeathThreshold == nil {
+				continue
+			}
+			if sp.At.After(t) {
+				break
+			}
+			chosen = sp.DeathThreshold
+		}
+		if chosen != nil {
+			return chosen
+		}
+		return fallback
+	}
+}
+
+// RenderSpeedTrack renders the session game-speed series as a tempo sparkline,
+// scaled to the observed tempo span so the RAMP reads as a rising sparkline (the
+// accelerate rules / adjust_music_tempo step it over the game). An empty track
+// renders the empty string. The threshold dimension is folded into each player's
+// proximity readout, so the speed track itself shows only the tempo shape.
+func RenderSpeedTrack(track []SpeedSample) string {
+	tempos := make([]MovementSample, 0, len(track))
+	for _, sp := range track {
+		if sp.Tempo == nil {
+			continue
+		}
+		tempos = append(tempos, MovementSample{At: sp.At, Intensity: *sp.Tempo})
+	}
+	if len(tempos) == 0 {
+		return ""
+	}
+	// Auto-scale to the observed tempo span so a flat tempo reads flat and a ramp
+	// reads as a rising sparkline. Tempo never goes idle, so the idle glyph never
+	// applies here; pass a min-anchored copy by offsetting to the observed floor.
+	lo, hi := tempos[0].Intensity, tempos[0].Intensity
+	for _, t := range tempos {
+		if t.Intensity < lo {
+			lo = t.Intensity
+		}
+		if t.Intensity > hi {
+			hi = t.Intensity
+		}
+	}
+	span := hi - lo
+	var b strings.Builder
+	for _, t := range tempos {
+		if span <= 0 {
+			b.WriteRune(sparkGlyphs[len(sparkGlyphs)/2]) // flat tempo: a mid bar
+			continue
+		}
+		frac := (t.Intensity - lo) / span
+		idx := int(frac * float64(len(sparkGlyphs)-1))
+		if idx < 0 {
+			idx = 0
+		}
+		if idx >= len(sparkGlyphs) {
+			idx = len(sparkGlyphs) - 1
+		}
+		b.WriteRune(sparkGlyphs[idx])
+	}
+	return b.String()
+}
+
+// RenderProximity formats a Proximity as the compact "near-death@-Ns(R×thr)"
+// readout shown next to a player's sparkline, with "→elim" appended when the
+// player crossed the threshold. now is the reference for the relative age. An
+// unobserved proximity renders the "unknown" sentinel so the channel is never
+// silently dropped.
+func RenderProximity(p Proximity, now time.Time, crossedToElim bool) string {
+	if !p.Observed {
+		return "near-death=unknown"
+	}
+	age := int(p.At.Sub(now).Round(time.Second) / time.Second)
+	out := fmt.Sprintf("near-death@%+ds(%.2f×thr)", age, p.Ratio)
+	if crossedToElim {
+		out += "→elim"
+	}
+	return out
+}

--- a/services/agent/gamecontext/playerhistory_test.go
+++ b/services/agent/gamecontext/playerhistory_test.go
@@ -1,0 +1,262 @@
+package gamecontext
+
+import (
+	"testing"
+	"time"
+)
+
+func t0() time.Time { return time.Date(2026, time.June, 15, 12, 0, 0, 0, time.UTC) }
+
+func fp(v float64) *float64 { return &v }
+
+// TestPlayerHistoryBucketDedup: within one bucket-second the tail is overwritten
+// (latest value wins); a new second appends. This is the memory bound's linchpin.
+func TestPlayerHistoryBucketDedup(t *testing.T) {
+	var h playerHistory
+	base := t0()
+	// Three samples in the SAME second -> one entry holding the last value.
+	h.record(MovementSample{At: base.Add(10 * time.Millisecond), Intensity: 0.1})
+	h.record(MovementSample{At: base.Add(500 * time.Millisecond), Intensity: 0.2})
+	h.record(MovementSample{At: base.Add(900 * time.Millisecond), Intensity: 0.3})
+	if got := h.samples(); len(got) != 1 || got[0].Intensity != 0.3 {
+		t.Fatalf("same-bucket coalesce failed: %+v", got)
+	}
+	// A new second appends.
+	h.record(MovementSample{At: base.Add(1100 * time.Millisecond), Intensity: 0.9})
+	if got := h.samples(); len(got) != 2 || got[1].Intensity != 0.9 {
+		t.Fatalf("new-bucket append failed: %+v", got)
+	}
+}
+
+// TestPlayerHistoryRingBound: the ring never exceeds playerHistoryCap and keeps
+// the most-recent window (oldest entries evicted).
+func TestPlayerHistoryRingBound(t *testing.T) {
+	var h playerHistory
+	base := t0()
+	total := playerHistoryCap + 20
+	for i := 0; i < total; i++ {
+		h.record(MovementSample{At: base.Add(time.Duration(i) * time.Second), Intensity: float64(i)})
+	}
+	got := h.samples()
+	if len(got) != playerHistoryCap {
+		t.Fatalf("ring not bounded: len=%d want %d", len(got), playerHistoryCap)
+	}
+	// Oldest retained is total-cap; newest is total-1.
+	if got[0].Intensity != float64(total-playerHistoryCap) {
+		t.Errorf("oldest = %v, want %v", got[0].Intensity, float64(total-playerHistoryCap))
+	}
+	if got[len(got)-1].Intensity != float64(total-1) {
+		t.Errorf("newest = %v, want %v", got[len(got)-1].Intensity, float64(total-1))
+	}
+}
+
+// TestSparklineScaling: a value at the threshold renders the top block; idle
+// renders the idle glyph; an empty series renders "".
+func TestRenderSparkline(t *testing.T) {
+	base := t0()
+	samples := []MovementSample{
+		{At: base, Intensity: 0.0},                  // idle -> '_'
+		{At: base.Add(time.Second), Intensity: 0.9}, // mid
+		{At: base.Add(2 * time.Second), Intensity: 1.8},
+	}
+	thr := fp(1.8)
+	got := RenderSparkline(samples, thr)
+	r := []rune(got)
+	if len(r) != 3 {
+		t.Fatalf("sparkline len = %d, want 3 (%q)", len(r), got)
+	}
+	if r[0] != idleGlyph {
+		t.Errorf("idle bucket = %q, want %q", r[0], idleGlyph)
+	}
+	if r[2] != sparkGlyphs[len(sparkGlyphs)-1] {
+		t.Errorf("at-threshold bucket = %q, want top block", r[2])
+	}
+	if RenderSparkline(nil, thr) != "" {
+		t.Error("empty series must render empty string")
+	}
+	// nil threshold -> auto-scale to peak; the peak renders the top block.
+	auto := []rune(RenderSparkline(samples, nil))
+	if auto[2] != sparkGlyphs[len(sparkGlyphs)-1] {
+		t.Errorf("auto-scaled peak = %q, want top block", auto[2])
+	}
+}
+
+// TestClassifyActivity covers idle / active / erratic / unknown.
+func TestClassifyActivity(t *testing.T) {
+	base := t0()
+	mk := func(vals ...float64) []MovementSample {
+		out := make([]MovementSample, len(vals))
+		for i, v := range vals {
+			out[i] = MovementSample{At: base.Add(time.Duration(i) * time.Second), Intensity: v}
+		}
+		return out
+	}
+	if got := ClassifyActivity(nil); got != ActivityUnknown {
+		t.Errorf("empty = %q, want unknown", got)
+	}
+	if got := ClassifyActivity(mk(0.0, 0.05, 0.1, 0.02)); got != ActivityIdle {
+		t.Errorf("idle = %q, want idle", got)
+	}
+	if got := ClassifyActivity(mk(1.0, 1.05, 0.98, 1.02)); got != ActivityActive {
+		t.Errorf("steady = %q, want active", got)
+	}
+	if got := ClassifyActivity(mk(0.2, 1.8, 0.3, 1.7)); got != ActivityErratic {
+		t.Errorf("bursty = %q, want erratic", got)
+	}
+}
+
+// TestComputeProximity: the closest call uses the threshold IN FORCE at each
+// sample's time, marks Crossed when intensity meets the threshold, and reports
+// unobserved when there is no threshold to compare against.
+func TestComputeProximity(t *testing.T) {
+	base := t0()
+	samples := []MovementSample{
+		{At: base.Add(0 * time.Second), Intensity: 1.0},
+		{At: base.Add(10 * time.Second), Intensity: 1.9}, // crosses at the fast threshold
+		{At: base.Add(20 * time.Second), Intensity: 1.2},
+	}
+	track := []SpeedSample{
+		{At: base.Add(0 * time.Second), DeathThreshold: fp(2.0)},
+		{At: base.Add(10 * time.Second), DeathThreshold: fp(1.8)},
+	}
+	p := ComputeProximity(samples, track, nil)
+	if !p.Observed {
+		t.Fatal("expected observed proximity")
+	}
+	// At +10s: 1.9/1.8 = 1.056 -> crossed, the closest call.
+	if !p.Crossed {
+		t.Errorf("expected crossed; ratio=%.3f", p.Ratio)
+	}
+	if p.At != base.Add(10*time.Second) {
+		t.Errorf("closest-call time = %v, want +10s", p.At)
+	}
+	// No threshold anywhere -> unobserved.
+	if got := ComputeProximity(samples, nil, nil); got.Observed {
+		t.Error("no threshold must yield unobserved proximity")
+	}
+	// Fallback scalar threshold when track empty.
+	if got := ComputeProximity(samples, nil, fp(2.0)); !got.Observed {
+		t.Error("fallback threshold should yield observed proximity")
+	}
+}
+
+// TestRenderProximity formats the readout and the unobserved sentinel.
+func TestRenderProximity(t *testing.T) {
+	now := t0()
+	p := Proximity{Observed: true, Ratio: 0.92, At: now.Add(-3 * time.Second), Crossed: false}
+	if got := RenderProximity(p, now, false); got != "near-death@-3s(0.92×thr)" {
+		t.Errorf("proximity = %q", got)
+	}
+	crossed := Proximity{Observed: true, Ratio: 1.05, At: now.Add(-5 * time.Second), Crossed: true}
+	if got := RenderProximity(crossed, now, true); got != "near-death@-5s(1.05×thr)→elim" {
+		t.Errorf("crossed proximity = %q", got)
+	}
+	if got := RenderProximity(Proximity{}, now, false); got != "near-death=unknown" {
+		t.Errorf("unobserved = %q, want near-death=unknown", got)
+	}
+}
+
+// TestRenderSpeedTrack: a ramp renders rising; a flat tempo renders a mid bar;
+// empty renders "".
+func TestRenderSpeedTrack(t *testing.T) {
+	base := t0()
+	ramp := []SpeedSample{
+		{At: base, Tempo: fp(1.0)},
+		{At: base.Add(time.Second), Tempo: fp(1.15)},
+		{At: base.Add(2 * time.Second), Tempo: fp(1.3)},
+	}
+	got := []rune(RenderSpeedTrack(ramp))
+	if len(got) != 3 || got[0] != sparkGlyphs[0] || got[2] != sparkGlyphs[len(sparkGlyphs)-1] {
+		t.Errorf("ramp = %q, want rising lowest..highest", string(got))
+	}
+	if RenderSpeedTrack(nil) != "" {
+		t.Error("empty track must render empty string")
+	}
+	// Threshold-only samples (no tempo) render nothing.
+	if RenderSpeedTrack([]SpeedSample{{At: base, DeathThreshold: fp(1.5)}}) != "" {
+		t.Error("threshold-only track must render empty (no tempo dimension)")
+	}
+}
+
+// TestStoreRecordsPlayerSamples: SetPlayerIntensity feeds the per-player ring and
+// the snapshot carries it; SetMusicTempo/SetDeathThreshold feed the speed track.
+func TestStoreRecordsPlayerSamples(t *testing.T) {
+	clock := t0()
+	now := func() time.Time { return clock }
+	s := NewStore(time.Minute, time.Minute, now)
+
+	s.SetMusicTempo(1.0)
+	s.SetDeathThreshold(1.5)
+	clock = clock.Add(time.Second)
+	s.SetPlayerIntensity("AA:11", 0.5)
+	clock = clock.Add(time.Second)
+	s.SetMusicTempo(1.3)
+	s.SetPlayerIntensity("AA:11", 1.4)
+
+	snap := s.Snapshot()
+	if snap.Session.MusicTempo == nil || *snap.Session.MusicTempo != 1.3 {
+		t.Errorf("music tempo = %v, want 1.3", snap.Session.MusicTempo)
+	}
+	if snap.Session.DeathThreshold == nil || *snap.Session.DeathThreshold != 1.5 {
+		t.Errorf("death threshold = %v, want 1.5", snap.Session.DeathThreshold)
+	}
+	p := snap.Players["AA:11"]
+	if p == nil || len(p.History) != 2 {
+		t.Fatalf("player history = %+v, want 2 samples", p)
+	}
+	if p.History[0].Intensity != 0.5 || p.History[1].Intensity != 1.4 {
+		t.Errorf("history values = %+v", p.History)
+	}
+	if len(snap.SpeedTrack) < 1 {
+		t.Errorf("speed track empty: %+v", snap.SpeedTrack)
+	}
+}
+
+// TestStoreSnapshotHistoryIsolation: a snapshot's history shares no backing array
+// with the live ring — a later record never mutates a handed-out snapshot.
+func TestStoreSnapshotHistoryIsolation(t *testing.T) {
+	clock := t0()
+	now := func() time.Time { return clock }
+	s := NewStore(time.Minute, time.Minute, now)
+	s.SetPlayerIntensity("AA:11", 0.5)
+	snap := s.Snapshot()
+	clock = clock.Add(time.Second)
+	s.SetPlayerIntensity("AA:11", 9.9)
+	if got := len(snap.Players["AA:11"].History); got != 1 {
+		t.Errorf("snapshot history mutated after later record: len=%d, want 1", got)
+	}
+}
+
+// TestStoreResetClearsHistory: a new session (and grace exit) drops the per-player
+// history and the speed track so a back-to-back game starts clean.
+func TestStoreResetClearsHistory(t *testing.T) {
+	clock := t0()
+	now := func() time.Time { return clock }
+	s := NewStore(time.Minute, time.Minute, now)
+	s.SetGameActive(true)
+	s.SetPlayerIntensity("AA:11", 1.0)
+	s.SetMusicTempo(1.2)
+	// New session: reset.
+	s.SetGameActive(false)
+	s.SetGameActive(true)
+	snap := s.Snapshot()
+	if p := snap.Players["AA:11"]; p != nil && len(p.History) != 0 {
+		t.Errorf("history not reset on new session: %+v", p.History)
+	}
+	if len(snap.SpeedTrack) != 0 {
+		t.Errorf("speed track not reset on new session: %+v", snap.SpeedTrack)
+	}
+}
+
+// TestStoreEvictDropsHistory: TTL-evicting a player drops its movement ring.
+func TestStoreEvictDropsHistory(t *testing.T) {
+	clock := t0()
+	now := func() time.Time { return clock }
+	s := NewStore(time.Second, time.Minute, now)
+	s.SetPlayerIntensity("AA:11", 1.0)
+	clock = clock.Add(10 * time.Second) // past the 1s TTL
+	s.EvictStale()
+	if _, ok := s.playerHistory["AA:11"]; ok {
+		t.Error("evicted player's history ring not dropped")
+	}
+}

--- a/services/agent/gamecontext/store.go
+++ b/services/agent/gamecontext/store.go
@@ -29,6 +29,19 @@ type Store struct {
 	// the next session on the same partition.
 	history timeline
 
+	// playerHistory is the bounded per-player movement TIME-SERIES (#1082): one
+	// fixed-capacity ring per serial of bucketed (t, intensity[, variance]) samples,
+	// guarded by s.mu like the #916 narrative. It lives ON the Store so it is
+	// per-partition and is reset/evicted alongside the rest of the session-scoped
+	// state. A player's ring is dropped when that player is TTL-evicted.
+	playerHistory map[string]*playerHistory
+
+	// speedTrack is the bounded session game-speed / death-threshold track (#1082):
+	// per-tick (t, tempo, death_threshold) samples, the reference frame the per-
+	// player proximity-to-death reads against. Session-scoped like the narrative,
+	// reset on a new session and on grace exit.
+	speedTrack speedTrack
+
 	// deathCounts tracks the last game_player_deaths_total per serial, so the
 	// fallback elimination source can detect increases.
 	deathCounts map[string]float64
@@ -128,13 +141,14 @@ func NewStore(playerTTL, sessionGrace time.Duration, now func() time.Time) *Stor
 		ctx: GameContext{
 			Players: make(map[string]*PlayerSignals),
 		},
-		history:      newTimeline(),
-		deathCounts:  make(map[string]float64),
-		elimOrder:    make(map[string]int),
-		disconnected: make(map[string]bool),
-		playerTTL:    playerTTL,
-		sessionGrace: sessionGrace,
-		now:          now,
+		history:       newTimeline(),
+		playerHistory: make(map[string]*playerHistory),
+		deathCounts:   make(map[string]float64),
+		elimOrder:     make(map[string]int),
+		disconnected:  make(map[string]bool),
+		playerTTL:     playerTTL,
+		sessionGrace:  sessionGrace,
+		now:           now,
 	}
 }
 
@@ -233,9 +247,29 @@ func (s *Store) SetPlayerIntensity(serial string, v float64) {
 	p := s.player(serial)
 	p.MovementIntensity = ptr(v)
 	s.touch(p)
+	// Append to the per-player movement TIME-SERIES (#1082), bucket-deduped to ~1Hz
+	// so the 60Hz firehose never churns the ring. Carry the player's last-observed
+	// variance alongside so the sample is self-describing.
+	s.recordPlayerSample(serial, v, p.MovementVariance)
 	// A movement-intensity change can move the session mean — record a state delta
 	// (deduped) so the narrative captures the energy trend (#916).
 	s.recordStateDelta()
+}
+
+// recordPlayerSample appends a bucketed (t, intensity, variance) sample to the
+// player's movement ring (#1082), creating the ring on demand. Caller holds s.mu.
+func (s *Store) recordPlayerSample(serial string, intensity float64, variance *float64) {
+	h := s.playerHistory[serial]
+	if h == nil {
+		h = &playerHistory{}
+		s.playerHistory[serial] = h
+	}
+	var vcopy *float64
+	if variance != nil {
+		v := *variance
+		vcopy = &v
+	}
+	h.record(MovementSample{At: s.now(), Intensity: intensity, Variance: vcopy})
 }
 
 // SetPlayerVariance records movement variance, creating the player on demand.
@@ -353,6 +387,38 @@ func (s *Store) SetGameMode(mode string) {
 	s.touchSession()
 }
 
+// SetMusicTempo records the current applied game speed / music tempo (#1082) and
+// appends it to the session speed track (the reference frame proximity-to-death
+// reads against). Bucket-deduped to ~1Hz like the per-player samples.
+func (s *Store) SetMusicTempo(v float64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.ctx.Session.MusicTempo = ptr(v)
+	s.touchSession()
+	s.speedTrack.record(SpeedSample{At: s.now(), Tempo: ptr(v)})
+}
+
+// SetDeathThreshold records the current effective (tempo-interpolated) death
+// threshold (#1082) and appends it to the session speed track so proximity-to-
+// death can read the threshold IN FORCE at each movement sample's time.
+func (s *Store) SetDeathThreshold(v float64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.ctx.Session.DeathThreshold = ptr(v)
+	s.touchSession()
+	s.speedTrack.record(SpeedSample{At: s.now(), DeathThreshold: ptr(v)})
+}
+
+// SetWarningThreshold records the current effective warning threshold (#1082).
+// It is a session signal only (no track sample) — the proximity track keys off the
+// death threshold; the warning threshold is rendered as context in the header.
+func (s *Store) SetWarningThreshold(v float64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.ctx.Session.WarningThreshold = ptr(v)
+	s.touchSession()
+}
+
 // SetGameActive records game-active state and manages session lifecycle.
 // A false->true transition starts a new session (bumps the sequence, assigns a
 // synthetic SessionID, clears per-game state). A true->false transition opens
@@ -382,6 +448,11 @@ func (s *Store) SetGameActive(active bool) {
 		// "start" phase event (#916). Reset here (not only on grace exit) so a
 		// back-to-back restart cannot carry the previous game's trend.
 		s.history.reset()
+		// Drop the prior game's per-player movement series + speed track so a back-
+		// to-back restart cannot carry the previous game's trend (#1082), mirroring
+		// the #916 narrative reset.
+		s.playerHistory = make(map[string]*playerHistory)
+		s.speedTrack.reset()
 		s.history.append(TimelineEvent{At: s.now(), Kind: EventPhase, Detail: "start"})
 	case prev && !active:
 		s.endedAt = s.now()
@@ -593,6 +664,13 @@ func (s *Store) snapshotLocked() GameContext {
 	out.Players = make(map[string]*PlayerSignals, len(s.ctx.Players))
 	for serial, p := range s.ctx.Players {
 		cp := *p
+		// Attach a fresh, oldest-first copy of this player's movement series (#1082):
+		// samples() allocates a new slice sharing no backing array with the ring, so a
+		// later record never mutates a handed-out snapshot — the same shared-nothing
+		// guarantee Players / Timeline give.
+		if h := s.playerHistory[serial]; h != nil {
+			cp.History = h.samples()
+		}
 		out.Players[serial] = &cp
 	}
 	if s.ctx.Session.EliminationSequence != nil {
@@ -605,6 +683,9 @@ func (s *Store) snapshotLocked() GameContext {
 	// ring, so a later append never mutates a handed-out snapshot — the same
 	// shared-nothing guarantee the Players/EliminationSequence copies give.
 	out.Timeline = s.history.events()
+	// Carry a fresh, oldest-first copy of the session speed/threshold track (#1082),
+	// shared-nothing with the live ring like the timeline above.
+	out.SpeedTrack = s.speedTrack.samples()
 	return out
 }
 
@@ -649,6 +730,7 @@ func (s *Store) EvictStale() {
 			delete(s.ctx.Players, serial)
 			delete(s.disconnected, serial)
 			delete(s.deathCounts, serial)
+			delete(s.playerHistory, serial) // drop the evicted player's movement ring (#1082)
 		}
 	}
 
@@ -665,5 +747,9 @@ func (s *Store) EvictStale() {
 		// session-scoped state (#916): the ring buffer is evicted with the session
 		// so a new game on this partition starts with an empty timeline.
 		s.history.reset()
+		// Likewise drop the per-player movement series + the session speed track
+		// (#1082) so the next game on this partition starts with empty tracks.
+		s.playerHistory = make(map[string]*playerHistory)
+		s.speedTrack.reset()
 	}
 }

--- a/services/agent/gamesummary/summary.go
+++ b/services/agent/gamesummary/summary.go
@@ -83,6 +83,11 @@ type Summary struct {
 	// game moved through, oldest-first (#928 "engagement trend"). Derived entirely
 	// from the #916 timeline's state-delta entries.
 	EngagementTrend []EngagementPoint `json:"engagement_trend"`
+	// SpeedSparkline is the game-speed (music tempo) TIME-SERIES rendered as a
+	// sparkline (#1082): the reference frame the per-player proximity tracks are read
+	// against (the same intensity is near-death at slow tempo, barely-trying at
+	// fast). "" when no tempo was observed.
+	SpeedSparkline string `json:"speed_sparkline,omitempty"`
 	// Dominance is the dominant-player detection result (#928 "dominant player").
 	Dominance Dominance `json:"dominance"`
 	// Interventions is the list of agent interventions that fired and their outcome
@@ -119,6 +124,23 @@ type PlayerArc struct {
 	// known — the "how was this player doing" snapshot the arc closes on.
 	FinalSkill     *float64 `json:"final_skill,omitempty"`
 	FinalIntensity *float64 `json:"final_intensity,omitempty"`
+
+	// MovementSparkline is the compact movement TIME-SERIES for this player (#1082):
+	// the bucketed intensity series rendered as a Unicode block sparkline scaled
+	// against the session death threshold (a full bar == at the elimination
+	// threshold). "" when the player had no movement history. This is the per-player
+	// trajectory the issue calls for — the trend, not the single end snapshot.
+	MovementSparkline string `json:"movement_sparkline,omitempty"`
+	// Activity is the derived activity classification over the player's recent
+	// window: "idle" | "active" | "erratic" | "unknown" (#1082).
+	Activity string `json:"activity,omitempty"`
+	// NearDeathRatio is the player's CLOSEST call to the death threshold over the
+	// game, as a fraction of the threshold (1.0 == at the threshold). nil when no
+	// proximity could be computed (no movement samples or no threshold observed).
+	NearDeathRatio *float64 `json:"near_death_ratio,omitempty"`
+	// NearDeathOffsetSeconds is WHEN that closest call happened, relative to game
+	// start; nil when NearDeathRatio is nil.
+	NearDeathOffsetSeconds *float64 `json:"near_death_offset_seconds,omitempty"`
 }
 
 // EliminationEvent is one (offset, serial, order) point in the elimination
@@ -231,6 +253,7 @@ func BuildSummary(c gamecontext.GameContext, opts BuildOptions) Summary {
 		PlayerArcs:        arcs,
 		EliminationSpread: elims,
 		EngagementTrend:   trend,
+		SpeedSparkline:    gamecontext.RenderSpeedTrack(c.SpeedTrack),
 		Dominance:         dom,
 		Interventions:     interventions,
 	}
@@ -400,6 +423,20 @@ func buildPlayerArcs(c gamecontext.GameContext, elims []EliminationEvent, anchor
 		if p := c.Players[serial]; p != nil {
 			arc.FinalSkill = copyFloatPtr(p.SkillLevel)
 			arc.FinalIntensity = copyFloatPtr(p.MovementIntensity)
+			// Per-player movement TIME-SERIES (#1082): the sparkline (scaled against the
+			// session death threshold), the activity classification, and the closest call
+			// to the death threshold + when it happened (offset from game start). All
+			// derived from the bounded per-player history carried on the snapshot.
+			if len(p.History) > 0 {
+				arc.MovementSparkline = gamecontext.RenderSparkline(p.History, c.Session.DeathThreshold)
+				arc.Activity = string(gamecontext.ClassifyActivity(p.History))
+				if prox := gamecontext.ComputeProximity(p.History, c.SpeedTrack, c.Session.DeathThreshold); prox.Observed {
+					ratio := prox.Ratio
+					arc.NearDeathRatio = &ratio
+					off := offset(prox.At, anchor)
+					arc.NearDeathOffsetSeconds = &off
+				}
+			}
 		}
 		if elim, ok := elimBySerial[serial]; ok {
 			arc.Eliminated = true

--- a/services/agent/gamesummary/summary_test.go
+++ b/services/agent/gamesummary/summary_test.go
@@ -311,3 +311,64 @@ func TestBuildSummary_EmptyTimeline(t *testing.T) {
 }
 
 func bptr(b bool) *bool { return &b }
+
+// TestBuildSummary_MovementSeries verifies the #1082 per-player movement series +
+// game-speed track flow into the Summary: a player with movement history gets a
+// sparkline, an activity classification, and a proximity-to-death ratio/offset; the
+// summary carries the game-speed sparkline.
+func TestBuildSummary_MovementSeries(t *testing.T) {
+	clock := base
+	s := gamecontext.NewStore(time.Hour, time.Hour, func() time.Time { return clock })
+	var snap gamecontext.GameContext
+	s.OnGameEnd = func(c gamecontext.GameContext) { snap = c }
+
+	s.SetGameKind("real")
+	s.SetGameMode("ffa")
+	s.SetGameActive(true)
+	s.AdoptSessionID("game_move0001")
+	s.SetActivePlayerCount(2)
+
+	// Tempo + threshold ramp over the game (the reference frame).
+	s.SetMusicTempo(1.0)
+	s.SetDeathThreshold(1.5)
+	s.SetPlayerIntensity("AA:11", 0.5)
+	s.SetPlayerIntensity("BB:22", 1.0)
+
+	clock = at(20)
+	s.SetMusicTempo(1.2)
+	s.SetDeathThreshold(1.7)
+	s.SetPlayerIntensity("AA:11", 1.4)  // ramps toward threshold
+	s.SetPlayerIntensity("BB:22", 1.75) // crosses
+
+	clock = at(25)
+	s.SetEliminationOrder("BB:22", 1)
+	s.SetActivePlayerCount(1)
+
+	clock = at(40)
+	s.SetSessionDuration(40)
+	s.SetGameActive(false)
+
+	got := BuildSummary(snap, BuildOptions{Now: at(41)})
+
+	if got.SpeedSparkline == "" {
+		t.Error("expected non-empty SpeedSparkline")
+	}
+	byserial := map[string]PlayerArc{}
+	for _, a := range got.PlayerArcs {
+		byserial[a.Serial] = a
+	}
+	aa := byserial["AA:11"]
+	if aa.MovementSparkline == "" {
+		t.Error("AA:11 missing movement sparkline")
+	}
+	if aa.Activity == "" || aa.Activity == string(gamecontext.ActivityUnknown) {
+		t.Errorf("AA:11 activity = %q, want a real classification", aa.Activity)
+	}
+	if aa.NearDeathRatio == nil || aa.NearDeathOffsetSeconds == nil {
+		t.Errorf("AA:11 proximity not populated: ratio=%v off=%v", aa.NearDeathRatio, aa.NearDeathOffsetSeconds)
+	}
+	bb := byserial["BB:22"]
+	if bb.NearDeathRatio == nil || *bb.NearDeathRatio < 1.0 {
+		t.Errorf("BB:22 should have crossed the threshold; ratio=%v", bb.NearDeathRatio)
+	}
+}

--- a/services/agent/llm/prompt.go
+++ b/services/agent/llm/prompt.go
@@ -323,9 +323,15 @@ func buildUser(ctx gamecontext.GameContext, now time.Time) string {
 	fmt.Fprintf(&b, "  duration_seconds: %s\n", floatPtrOrUnknown(ctx.Session.DurationSeconds))
 	fmt.Fprintf(&b, "  active_players: %s\n", intPtrOrUnknown(ctx.Session.ActivePlayerCount))
 	fmt.Fprintf(&b, "  game_active: %s\n", boolPtrOrUnknown(ctx.Session.GameActive))
+	// Game-speed / threshold reference frame (#1082): the per-player intensity
+	// tracks below are read against these — the same intensity is near-death at
+	// slow tempo, barely-trying at fast tempo.
+	fmt.Fprintf(&b, "  music_tempo: %s\n", floatPtrOrUnknown(ctx.Session.MusicTempo))
+	fmt.Fprintf(&b, "  death_threshold: %s\n", floatPtrOrUnknown(ctx.Session.DeathThreshold))
 	fmt.Fprintf(&b, "  elimination_sequence: [%s]\n", strings.Join(ctx.Session.EliminationSequence, ", "))
 
 	writeTimeline(&b, ctx, now)
+	writeSpeedTrack(&b, ctx)
 
 	b.WriteString("\nPlayers (sorted by serial; \"unknown\" = signal never observed):\n")
 	if len(ctx.Players) == 0 {
@@ -351,9 +357,62 @@ func buildUser(ctx gamecontext.GameContext, now time.Time) string {
 			floatPtrOrUnknown(p.BatteryPct),
 			floatPtrOrUnknown(p.SkillLevel),
 		))
+		// #1082: a second, compact per-player line carrying the movement TIME-SERIES
+		// (sparkline), the derived activity classification, and the proximity-to-death
+		// readout — so the model can read an elimination against its lead-up, not just
+		// the terminal snapshot. Rendered only when the player has a movement series.
+		if track := renderPlayerTrack(p, ctx, now, eliminated(serial, ctx.Session.EliminationSequence)); track != "" {
+			lines = append(lines, track)
+		}
 	}
 	b.WriteString(strings.Join(lines, "\n"))
 	return b.String()
+}
+
+// renderPlayerTrack builds the compact per-player movement TIME-SERIES line
+// (#1082): "    <serial>: act<sparkline> <activity> <proximity>". The sparkline is
+// scaled against the session death threshold (a full bar == at the elimination
+// threshold); the proximity readout reads each sample's intensity against the
+// threshold IN FORCE then (via the session speed track). Returns "" when the
+// player has no movement history, so the second line is omitted entirely for a
+// player the agent never saw move.
+func renderPlayerTrack(p *gamecontext.PlayerSignals, ctx gamecontext.GameContext, now time.Time, isEliminated bool) string {
+	if p == nil || len(p.History) == 0 {
+		return ""
+	}
+	spark := gamecontext.RenderSparkline(p.History, ctx.Session.DeathThreshold)
+	activity := gamecontext.ClassifyActivity(p.History)
+	prox := gamecontext.ComputeProximity(p.History, ctx.SpeedTrack, ctx.Session.DeathThreshold)
+	return fmt.Sprintf("    %s: act%s %s %s",
+		p.Serial, spark, activity, gamecontext.RenderProximity(prox, now, isEliminated && prox.Crossed))
+}
+
+// eliminated reports whether a serial appears in the elimination sequence — used
+// to append the "→elim" marker to a player who crossed the death threshold AND
+// was eliminated (#1082).
+func eliminated(serial string, sequence []string) bool {
+	for _, s := range sequence {
+		if s == serial {
+			return true
+		}
+	}
+	return false
+}
+
+// writeSpeedTrack renders the session game-speed (tempo) sparkline (#1082): the
+// reference frame the per-player tracks are read against. The track ramps over the
+// game (accelerate rules / adjust_music_tempo step it), so it renders as a rising
+// sparkline. Omitted entirely when no tempo was ever observed (keeps the no-signal
+// prompt byte-identical to the pre-#1082 output for that section).
+func writeSpeedTrack(b *strings.Builder, ctx gamecontext.GameContext) {
+	spark := gamecontext.RenderSpeedTrack(ctx.SpeedTrack)
+	if spark == "" {
+		return
+	}
+	b.WriteString("\nGame speed (tempo over the game; oldest first):\n")
+	b.WriteString("  speed: ")
+	b.WriteString(spark)
+	b.WriteString("\n")
 }
 
 // writeTimeline renders the compact RECENT EVENTS section shared by the in-game

--- a/services/agent/llm/prompt_test.go
+++ b/services/agent/llm/prompt_test.go
@@ -105,6 +105,53 @@ func timelineContext() gamecontext.GameContext {
 	return ctx
 }
 
+// movementContext is the #1082 fixture: a populated per-player movement TIME-SERIES
+// plus a session game-speed/threshold track, exercising the sparkline + activity +
+// proximity-to-death rendering and the tempo ramp. It builds on timelineContext so
+// the new sections render alongside the #916 narrative.
+//
+// AA:11 is a steady-active player whose intensity ramps up and approaches the death
+// threshold (a near-death survivor). BB:22 is mostly idle (a fader). CC:33 (the
+// eliminated player) crosses the threshold right before its elimination. The speed
+// track ramps from slow (1.0) to fast (1.3), and the death threshold rises with it.
+func movementContext() gamecontext.GameContext {
+	ctx := timelineContext()
+	at := func(secsBefore int) time.Time {
+		return fixedNow.Add(time.Duration(-secsBefore) * time.Second)
+	}
+	// Session reference frame: current applied tempo + effective thresholds (#1082).
+	ctx.Session.MusicTempo = fptr(1.30)
+	ctx.Session.DeathThreshold = fptr(1.80)
+	ctx.Session.WarningThreshold = fptr(1.20)
+
+	// Session game-speed / death-threshold track, oldest-first, ramping over the game.
+	ms := func(secsBefore int, tempo, thr float64) gamecontext.SpeedSample {
+		return gamecontext.SpeedSample{At: at(secsBefore), Tempo: fptr(tempo), DeathThreshold: fptr(thr)}
+	}
+	ctx.SpeedTrack = []gamecontext.SpeedSample{
+		ms(60, 1.00, 1.50), ms(50, 1.05, 1.55), ms(40, 1.12, 1.62),
+		ms(30, 1.20, 1.70), ms(20, 1.25, 1.75), ms(10, 1.30, 1.80),
+	}
+
+	hist := func(samples ...gamecontext.MovementSample) []gamecontext.MovementSample { return samples }
+	smp := func(secsBefore int, intensity float64) gamecontext.MovementSample {
+		return gamecontext.MovementSample{At: at(secsBefore), Intensity: intensity}
+	}
+	// AA:11 (survivor): ramps from calm to near the threshold — steady & active.
+	ctx.Players["AA:11"].History = hist(
+		smp(60, 0.40), smp(50, 0.70), smp(40, 1.05), smp(30, 1.45), smp(20, 1.60), smp(10, 1.66),
+	)
+	// BB:22 (fader): a brief burst then idle — mostly standing still.
+	ctx.Players["BB:22"].History = hist(
+		smp(60, 0.90), smp(50, 0.50), smp(40, 0.10), smp(30, 0.05), smp(20, 0.02), smp(10, 0.00),
+	)
+	// CC:33 (eliminated #1): flailing hard, crosses the threshold right before elim.
+	ctx.Players["CC:33"].History = hist(
+		smp(60, 1.10), smp(55, 1.50), smp(50, 0.80), smp(48, 1.75),
+	)
+	return ctx
+}
+
 type goldenCase struct {
 	name     string
 	snapshot flags.Snapshot
@@ -151,6 +198,13 @@ func goldenCases() []goldenCase {
 			name:     "timeline_3players",
 			snapshot: baseSnapshot(balancedVariant),
 			context:  timelineContext(),
+		},
+		{
+			// #1082: per-player movement sparklines + activity + proximity-to-death,
+			// plus the session game-speed (tempo) track. Exercises every new section.
+			name:     "movement_3players",
+			snapshot: baseSnapshot(balancedVariant),
+			context:  movementContext(),
 		},
 		{
 			name: "all_unknown",
@@ -300,6 +354,8 @@ func TestNilSessionFields(t *testing.T) {
 		"duration_seconds: unknown",
 		"active_players: unknown",
 		"game_active: unknown",
+		"music_tempo: unknown",     // #1082
+		"death_threshold: unknown", // #1082
 		"kind=unknown",
 		"mode=unknown",
 		"elimination_sequence: []",

--- a/services/agent/llm/retro.go
+++ b/services/agent/llm/retro.go
@@ -133,6 +133,8 @@ func buildRetroUser(ctx gamecontext.GameContext, now time.Time) string {
 	// analyst sees the trend over the whole session (when players faded, when the
 	// game ended), not just the terminal snapshot.
 	writeTimeline(&b, ctx, now)
+	// #1082: the game-speed track the per-player proximity tracks are read against.
+	writeSpeedTrack(&b, ctx)
 
 	b.WriteString("\nPlayers (sorted by serial; \"unknown\" = signal never observed):\n")
 	if len(ctx.Players) == 0 {
@@ -152,6 +154,13 @@ func buildRetroUser(ctx gamecontext.GameContext, now time.Time) string {
 			floatPtrOrUnknown(p.MovementIntensity),
 			floatPtrOrUnknown(p.MovementVariance),
 		))
+		// #1082: the per-player movement TIME-SERIES line — sparkline + activity +
+		// proximity-to-death — so the analyst sees WHO was active/idle/erratic and WHO
+		// was close to death over the game, not just the end-state snapshot. The
+		// "→elim" marker fires for an eliminated player who crossed the threshold.
+		if track := renderPlayerTrack(p, ctx, now, eliminated(serial, ctx.Session.EliminationSequence)); track != "" {
+			lines = append(lines, track)
+		}
 	}
 	b.WriteString(strings.Join(lines, "\n"))
 	return b.String()

--- a/services/agent/llm/retro_test.go
+++ b/services/agent/llm/retro_test.go
@@ -79,6 +79,42 @@ func retroTimelineContext() gamecontext.GameContext {
 	return ctx
 }
 
+// retroMovementContext is retroTimelineContext plus per-player movement series and
+// a session game-speed/threshold track (#1082), so the retro golden exercises the
+// sparkline + activity + proximity-to-death + tempo rendering at game end. AA:11 is
+// the near-death survivor (winner); BB:22 faded to idle (eliminated #1); CC:33
+// crossed the threshold and was eliminated #2.
+func retroMovementContext() gamecontext.GameContext {
+	ctx := retroTimelineContext()
+	at := func(secsBefore int) time.Time {
+		return fixedNow.Add(time.Duration(-secsBefore) * time.Second)
+	}
+	ctx.Session.MusicTempo = fptr(1.25)
+	ctx.Session.DeathThreshold = fptr(1.75)
+	ctx.Session.WarningThreshold = fptr(1.15)
+
+	ms := func(secsBefore int, tempo, thr float64) gamecontext.SpeedSample {
+		return gamecontext.SpeedSample{At: at(secsBefore), Tempo: fptr(tempo), DeathThreshold: fptr(thr)}
+	}
+	ctx.SpeedTrack = []gamecontext.SpeedSample{
+		ms(140, 1.00, 1.50), ms(110, 1.08, 1.58), ms(80, 1.15, 1.65),
+		ms(50, 1.20, 1.70), ms(20, 1.25, 1.75),
+	}
+	smp := func(secsBefore int, intensity float64) gamecontext.MovementSample {
+		return gamecontext.MovementSample{At: at(secsBefore), Intensity: intensity}
+	}
+	ctx.Players["AA:11"].History = []gamecontext.MovementSample{
+		smp(140, 0.50), smp(110, 0.90), smp(80, 1.30), smp(50, 1.60), smp(20, 1.68),
+	}
+	ctx.Players["BB:22"].History = []gamecontext.MovementSample{
+		smp(140, 0.80), smp(110, 0.40), smp(80, 0.10), smp(50, 0.02),
+	}
+	ctx.Players["CC:33"].History = []gamecontext.MovementSample{
+		smp(140, 1.10), smp(100, 1.50), smp(92, 1.80),
+	}
+	return ctx
+}
+
 type retroCase struct {
 	name     string
 	snapshot flags.Snapshot
@@ -118,6 +154,13 @@ func retroCases() []retroCase {
 			name:     "retro_timeline",
 			snapshot: retroSnapshot(),
 			context:  retroTimelineContext(),
+		},
+		{
+			// #1082: per-player movement sparklines + activity + proximity-to-death +
+			// the session game-speed track, at game end.
+			name:     "retro_movement",
+			snapshot: retroSnapshot(),
+			context:  retroMovementContext(),
 		},
 		{
 			// No players, nil session signals: every field renders "unknown"/[].

--- a/services/agent/llm/testdata/aggressive_3players.golden
+++ b/services/agent/llm/testdata/aggressive_3players.golden
@@ -41,6 +41,8 @@ Session:
   duration_seconds: 95.50
   active_players: 2
   game_active: true
+  music_tempo: unknown
+  death_threshold: unknown
   elimination_sequence: [CC:33]
 
 Recent events (oldest first; age relative to captured_at):

--- a/services/agent/llm/testdata/all_unknown.golden
+++ b/services/agent/llm/testdata/all_unknown.golden
@@ -42,6 +42,8 @@ Session:
   duration_seconds: unknown
   active_players: unknown
   game_active: unknown
+  music_tempo: unknown
+  death_threshold: unknown
   elimination_sequence: []
 
 Recent events (oldest first; age relative to captured_at):

--- a/services/agent/llm/testdata/balanced_3players.golden
+++ b/services/agent/llm/testdata/balanced_3players.golden
@@ -40,6 +40,8 @@ Session:
   duration_seconds: 95.50
   active_players: 2
   game_active: true
+  music_tempo: unknown
+  death_threshold: unknown
   elimination_sequence: [CC:33]
 
 Recent events (oldest first; age relative to captured_at):

--- a/services/agent/llm/testdata/conservative_3players.golden
+++ b/services/agent/llm/testdata/conservative_3players.golden
@@ -42,6 +42,8 @@ Session:
   duration_seconds: 95.50
   active_players: 2
   game_active: true
+  music_tempo: unknown
+  death_threshold: unknown
   elimination_sequence: [CC:33]
 
 Recent events (oldest first; age relative to captured_at):

--- a/services/agent/llm/testdata/empty_players.golden
+++ b/services/agent/llm/testdata/empty_players.golden
@@ -42,6 +42,8 @@ Session:
   duration_seconds: 3.00
   active_players: 0
   game_active: false
+  music_tempo: unknown
+  death_threshold: unknown
   elimination_sequence: []
 
 Recent events (oldest first; age relative to captured_at):

--- a/services/agent/llm/testdata/movement_3players.golden
+++ b/services/agent/llm/testdata/movement_3players.golden
@@ -40,8 +40,8 @@ Session:
   duration_seconds: 95.50
   active_players: 2
   game_active: true
-  music_tempo: unknown
-  death_threshold: unknown
+  music_tempo: 1.30
+  death_threshold: 1.80
   elimination_sequence: [CC:33]
 
 Recent events (oldest first; age relative to captured_at):
@@ -53,7 +53,13 @@ Recent events (oldest first; age relative to captured_at):
   -20s intervention: set_music_tempo dispatched
   -5s intervention: grant_shield blocked -> BB:22
 
+Game speed (tempo over the game; oldest first):
+  speed: ▁▂▃▅▆█
+
 Players (sorted by serial; "unknown" = signal never observed):
   AA:11: active=true movement_intensity=1.25 movement_variance=0.40 battery_pct=85.00 skill=0.60
+    AA:11: act▂▄▅▇██ active near-death@-10s(0.92×thr)
   BB:22: active=true movement_intensity=0.00 movement_variance=0.05 battery_pct=15.00 skill=0.30
+    BB:22: act▅▃____ erratic near-death@-60s(0.60×thr)
   CC:33: active=unknown movement_intensity=unknown movement_variance=unknown battery_pct=unknown skill=unknown
+    CC:33: act▅▇▄█ active near-death@-48s(1.13×thr)→elim

--- a/services/agent/llm/testdata/retro_movement.golden
+++ b/services/agent/llm/testdata/retro_movement.golden
@@ -1,0 +1,63 @@
+=== MODEL ===
+phi4-mini
+=== SYSTEM ===
+You are the JoustMania post-game analyst. A physical movement party game has just
+ended. You receive a full session summary and must suggest CALIBRATION TWEAKS that
+would make the NEXT game more fun. You are NOT controlling a live game — you make
+at most a handful of recommendations, which a human reviews. Suggestions are
+RECORDED ONLY and never auto-applied.
+
+CALIBRATION SURFACE — you may ONLY suggest changes to these flags. Each is read at
+game INIT:
+
+  global_difficulty_factor   (float, ~0.5..1.5; 1.0 = current) — scales overall
+                             movement demand for the next game.
+  pacing_profile             (enum: "relaxed" | "standard" | "intense") — the
+                             music-schedule preset that shapes round tempo.
+  threshold_table            (named death/warning threshold table, e.g.
+                             "easy" | "standard" | "hard").
+  objective_variant          (enum: endurance | balanced | accelerate | chaos) —
+                             the session goal weighting for the next game.
+
+POLICY: suggest the SMALLEST change that addresses an observed problem. If the
+session looked healthy, return an empty suggestions list. Do not invent flags
+outside the calibration surface.
+
+RESPONSE CONTRACT — reply with EXACTLY ONE JSON object, no prose, matching:
+{
+  "session_assessment": "<one short sentence: how did this game go?>",
+  "suggestions": [
+    {
+      "flag": "<one of: global_difficulty_factor, pacing_profile, threshold_table, objective_variant>",
+      "value": "<the suggested value as a string>",
+      "reason": "<one short sentence tying the change to session evidence>"
+    }
+  ]
+}
+If no tweak is warranted, return "suggestions": [].
+=== USER ===
+SESSION RETROSPECTIVE (session=session-7, kind=real, mode=ffa, captured_at=2026-06-05T12:30:00Z)
+
+Outcome:
+  duration_seconds: 132.00
+  final_active_players: 1
+  elimination_order: [BB:22, CC:33]
+  winner: AA:11
+
+Recent events (oldest first; age relative to captured_at):
+  -150s phase: start
+  -140s state: active_players=3 mean_intensity=0.80
+  -90s elimination: CC:33 (#1)
+  -40s state: active_players=2 mean_intensity=0.45
+  +0s phase: end
+
+Game speed (tempo over the game; oldest first):
+  speed: ▁▃▅▆█
+
+Players (sorted by serial; "unknown" = signal never observed):
+  AA:11: outcome=survivor battery_pct=72.00 skill=0.80 movement_intensity=1.25 movement_variance=0.40
+    AA:11: act▃▅▆██ active near-death@-20s(0.96×thr)
+  BB:22: outcome=eliminated #1 battery_pct=40.00 skill=0.30 movement_intensity=0.10 movement_variance=0.05
+    BB:22: act▄▂__ erratic near-death@-140s(0.53×thr)
+  CC:33: outcome=eliminated #2 battery_pct=unknown skill=unknown movement_intensity=unknown movement_variance=unknown
+    CC:33: act▆▇█ active near-death@-92s(1.14×thr)→elim


### PR DESCRIPTION
Part of #1082

## What

The signal the agent hands the LLM (and the human-readable retro) was too information-poor to draw game conclusions from: the #916 timeline records only **session-level aggregates** (`mean_intensity` averaging all players into one 0.97–1.12 band, + `active_players`), and the per-player block is a single end-of-game snapshot with no trajectory. You couldn't answer the questions that drive a tuning decision: **who was active vs idle, when, and who was close to death — read against the current game speed.**

This adds a compact per-player movement **time-series** + **proximity-to-death** + **game-speed** to both the live prompt and the post-game retro.

## Phase A findings (signal availability — verified in game-coordinator)

All three reference-frame signals the issue + comment asked about are **already emitted** by game-coordinator as session-level OTel gauges — no cross-service work needed:

| signal | metric | notes |
|---|---|---|
| game speed / music tempo | `game_music_tempo` | `services/game_coordinator/games/base.py` (Phase 70); 1.0=slow..~1.3=fast, 0=no game |
| death threshold | `game_effective_death_threshold` | tempo-interpolated (LERP) effective threshold in g-force; **session-level, not per-player** (the per-sensitivity tables stay internal) |
| warning threshold | `game_effective_warning_threshold` | same |

So proximity-to-death **and** game-speed were both implemented **fully agent-side** (just ingestion). Because the death threshold is already tempo-interpolated, "intensity vs threshold" is naturally "intensity vs threshold **at that tempo**". The only deferred nuance: the threshold is one session-level value (all players share the sensitivity), so proximity is per-player intensity vs the one effective threshold rather than a distinct per-player threshold — that matches how the coordinator actually computes it.

## What's rendered

Live prompt (and retro) now carry a `speed:` tempo sparkline + a second per-player line:
```
Game speed (tempo over the game; oldest first):
  speed: ▁▂▃▅▆█
Players (...):
  AA:11: active=true movement_intensity=1.25 ...
    AA:11: act▂▄▅▇██ active near-death@-10s(0.92×thr)
  CC:33: ...
    CC:33: act▅▇▄█ active near-death@-48s(1.13×thr)→elim
```
Plus `music_tempo` / `death_threshold` header channels. The retro summary JSON gains `movement_sparkline` / `activity` / `near_death_ratio` / `near_death_offset_seconds` per arc and a `speed_sparkline`.

## Constraints honored
- **Token-compact**: sparklines + a single readout per player, never float arrays. Bucketed ~1Hz; fixed-capacity ring (memory-bounded). Existing no-signal goldens grew by only 2 header lines.
- **Default-safe / nil-safe**: missing signals render `unknown` and the per-player track line is omitted entirely; `v==0` "no game" sentinel skipped.
- Per-player rings reset on new session + grace exit, dropped on player TTL-eviction (mirrors #916).

## Tests
- New `playerhistory_test.go`: ring bound, bucket dedupe, sparkline scaling, activity classification, proximity (threshold-in-force + crossed + fallback), speed track, snapshot isolation, reset/eviction.
- Ingestion test for the three new gauges + sentinel.
- gamesummary movement-series test.
- Golden prompt/retro snapshots regenerated; new `movement_3players` / `retro_movement` goldens.
- `gofmt`/`go build`/`go vet`/`go test ./... -race` clean (experiment package is the known dynamic-declarer flake; passes in isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)