### PR TITLE
fix(agent): dry-run enable script flips flagd experiment gates (#1077)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,12 +87,17 @@ up-mock:
 # mismatch fix lives in docker-compose.dry-run.yml).
 #
 # Gating chain (all must be satisfied for the loop to ACT):
-#   1. AGENT_EXPERIMENTS_ENABLED=true  -> set by docker-compose.dry-run.yml
-#   2. agent.json `enabled` = on       -> MANUAL opt-in, see step below (the
-#      master kill-switch stays fail-closed `off` by default; we do NOT mutate
-#      the committed flag here). Without it the loop self-aborts:
+#   1. flagd `experiments_enabled` flag = on  -> the LIVE gate post-#1044. It
+#      OVERRIDES the AGENT_EXPERIMENTS_ENABLED env, which is now dead config for
+#      this purpose. Fail-closed `off` by default; MANUAL opt-in via the enable
+#      step below.
+#   2. agent.json `enabled` = on       -> master kill-switch, fail-closed `off`
+#      by default. Without it the loop self-aborts:
 #      `experiment.torn_down ... reason="kill-switch: agent disabled"`.
+#      (The enable step below flips BOTH 1 and 2 in one command.)
 #   3. code_improvement.* promotion gates -> remain default (promotion stays off)
+# We do NOT mutate the committed flag files here; the operator runs the enable
+# step, which flips the ci/ flag dir at runtime only.
 .PHONY: dry-run
 dry-run:
 	IMAGE_TAG=$(or $(IMAGE_TAG),latest) docker compose \
@@ -110,12 +115,14 @@ dry-run:
 	@echo "  Flag dir:      services/flagd/ci  (shared rw by agent + flagd -> writes are effective)"
 	@echo ""
 	@echo "  Experiment loop gating:"
-	@echo "    [x] AGENT_EXPERIMENTS_ENABLED=true   (set by docker-compose.dry-run.yml)"
+	@echo "    [!] flagd experiments_enabled flag is the LIVE gate (post-#1044) and"
+	@echo "        OVERRIDES AGENT_EXPERIMENTS_ENABLED env. Fail-closed off by default."
 	@echo "    [x] seeded experiment: death_grace_period_seconds = 0.75 (objective=balanced, N=8/arm)"
-	@echo "    [ ] agent kill-switch  -> ENABLE IT (fail-closed off by default):"
-	@echo "        ./scripts/agent-killswitch.sh on   # flips services/flagd/ci/agent.json enabled -> on"
+	@echo "    [ ] ENABLE experiments  -> ONE step (flips enabled + experiments_enabled on):"
+	@echo "        ./scripts/agent-dryrun-enable.sh on   # ci/agent.json: enabled + experiments_enabled -> on"
+	@echo "        # add AGENT_INFERENCE_BACKEND=openai to also flip mode -> llm"
 	@echo "        docker compose -f docker-compose.yml -f docker-compose.ci.yml --profile agent restart agent"
-	@echo "        (or edit services/flagd/ci/agent.json: flags.enabled.defaultVariant = \"on\")"
+	@echo "        # restore defaults afterwards: ./scripts/agent-dryrun-enable.sh off"
 	@echo "    [ ] code_improvement.* promotion gates stay OFF (no real-default promotion)"
 	@echo ""
 	@echo "  Observability:"

--- a/docs/agent-dry-run-runbook.md
+++ b/docs/agent-dry-run-runbook.md
@@ -11,23 +11,45 @@ The fastest path is:
 
 ```bash
 make dry-run
-./scripts/agent-killswitch.sh on    # the loop is inert until you do this
+./scripts/agent-dryrun-enable.sh on   # the loop is inert until you do this
 docker compose -f docker-compose.yml -f docker-compose.ci.yml --profile agent restart agent
 ```
 
+`./scripts/agent-dryrun-enable.sh on` flips **both** live gates in the ci/ flag
+dir in one step — the master `enabled` kill-switch **and** the
+`experiments_enabled` flag (the LIVE experiment gate post-#1044). With an
+inference backend configured, also exercise `mode=llm`:
+
+```bash
+AGENT_INFERENCE_BACKEND=openai ./scripts/agent-dryrun-enable.sh on   # also flips mode -> llm
+```
+
+Restore the fail-closed defaults afterwards with
+`./scripts/agent-dryrun-enable.sh off`.
+
 `make dry-run` prints the same steps and the observability URLs on completion.
+
+> **Why a manual step at all?** After #1044 the experiment config moved from env
+> vars to flagd flags. The `experiments_enabled` flag is now the LIVE gate and it
+> **overrides** the `AGENT_EXPERIMENTS_ENABLED=true` env that
+> `docker-compose.dry-run.yml` sets — so the env alone produces **zero**
+> experiment activity (#1077). The enable script is the single opt-in that turns
+> the loop on without changing any production fail-closed default.
 
 ---
 
 ## Why a plain `docker compose up` produces a DEAD run
 
-Three defaults silently combine into a loop that never runs (the #999 findings):
+Several defaults silently combine into a loop that never runs (the #999 + #1077
+findings):
 
 | # | Default | Symptom | Fix in the dry-run path |
 |---|---------|---------|-------------------------|
-| 1 | `.env` pins `IMAGE_TAG=0.7.0` (release-please) | A plain `up` runs the last RELEASE images — they predate the experiment framework, so `AGENT_EXPERIMENTS_ENABLED=true` is silently ignored (no `Experiment cohort loop ENABLED` log) | `make dry-run` pins `IMAGE_TAG=latest` (override with `IMAGE_TAG=... make dry-run`, or add `BUILD=1` to build locally) |
-| 2 | Agent master kill-switch `agent.json` `enabled` = `off` (fail-closed) | Loop declares + writes targeting then self-aborts: `experiment.torn_down ... reason="kill-switch: agent disabled"` | **Manual opt-in** — `./scripts/agent-killswitch.sh on` (flips the **ci** flag dir only; production default stays `off`) |
+| 1 | `.env` pins `IMAGE_TAG=0.7.0` (release-please) | A plain `up` runs the last RELEASE images — they predate the experiment framework, so the loop never constructs (no `Experiment cohort loop` log) | `make dry-run` pins `IMAGE_TAG=latest` (override with `IMAGE_TAG=... make dry-run`, or add `BUILD=1` to build locally) |
+| 2 | Agent master kill-switch `agent.json` `enabled` = `off` (fail-closed) | Loop declares + writes targeting then self-aborts: `experiment.torn_down ... reason="kill-switch: agent disabled"` | **Manual opt-in** — `./scripts/agent-dryrun-enable.sh on` (flips the **ci** flag dir only; production default stays `off`) |
 | 3 | The agent compose env did not declare `AGENT_EXPERIMENTS_ENABLED` / `AGENT_EXPERIMENT_SEED_*` | A host `export` never reached the container (needed a custom override) | These vars are now declared (default-off) on the `agent` service in `docker-compose.yml`; the dry-run override turns them on |
+| 5 | **(#1044/#1077)** flagd `experiments_enabled` flag = `off` (fail-closed) **overrides** the `AGENT_EXPERIMENTS_ENABLED=true` env | The loop is constructed but `gated LIVE by agent.json experiments_enabled` — `env_enabled_default=true` is dead config; **zero** `experiment.*` activity | **Manual opt-in** — `./scripts/agent-dryrun-enable.sh on` flips `experiments_enabled` (and `enabled`, row 2) in the **ci** flag dir only; production default stays `off` |
+| 6 | **(#1044/#1077)** flagd `mode` flag = `rules` (fail-closed) | Even with experiments on, the inference backend is never exercised (stays on the rules engine) | `AGENT_INFERENCE_BACKEND=openai ./scripts/agent-dryrun-enable.sh on` flips `mode -> llm` in the ci flag dir; without a backend `rules` is correct (stub) |
 
 And one **silent-ineffective** trap:
 
@@ -44,18 +66,26 @@ value to the real default, three independent gates must be satisfied. They are
 intentionally separate so a dry run can spawn shadows without ever risking a
 real-default change.
 
-1. **Experiments opt-in** — `AGENT_EXPERIMENTS_ENABLED=true`.
-   Constructs the `experiment.Registry` and runs the
-   declare → spawn → conclude → verdict → (gated) promote loop. Default `false`
-   ⇒ no Registry, no shadow spawns, no targeting writes, no promotions.
-   *Set by `docker-compose.dry-run.yml`.*
+1. **Experiments opt-in** — flagd `experiments_enabled` flag = `on`.
+   Post-#1044 this **flagd flag is the LIVE gate** and **overrides** the
+   `AGENT_EXPERIMENTS_ENABLED=true` env (which `docker-compose.dry-run.yml` still
+   sets, but is now dead config for this purpose — the loop logs
+   `gated LIVE by agent.json experiments_enabled`). When `off` (the fail-closed
+   default) there are no shadow spawns, no targeting writes, no promotions.
+   *Manual opt-in via `./scripts/agent-dryrun-enable.sh on` — never default-on.*
 
 2. **Agent master kill-switch** — `agent.json` `enabled` flag = `on`.
    Read live from flagd each cycle. When `off` (the fail-closed default) the
    loop short-circuits before any work and emits a throttled
    `kill-switch: agent disabled` span. Hot-reloaded — no restart needed for the
    flag flip itself, but the agent re-reads it each cycle.
-   *Manual opt-in via `./scripts/agent-killswitch.sh on` — never default-on.*
+   *Flipped together with gate 1 by `./scripts/agent-dryrun-enable.sh on` —
+   never default-on.*
+
+   *(Optional) inference backend* — flagd `mode` flag = `llm`. Default `rules`
+   (the stub backend, correct without a backend). When an inference backend is
+   configured, `AGENT_INFERENCE_BACKEND=openai ./scripts/agent-dryrun-enable.sh on`
+   also flips `mode -> llm` so the dry run exercises the LLM decision path.
 
 3. **`code_improvement.*` promotion gates** — separate flags in the agent
    domain (`code_improvement.mode`, `.target`, `.validation_games`,
@@ -108,8 +138,13 @@ seed at the targeting write).
 
 ## Verifying it is alive
 
-- **Logs**: `docker compose ... logs -f agent` shows `Experiment cohort loop ENABLED`
-  and per-tick `AllocateAndSpawn` activity (not `kill-switch: agent disabled`).
+- **Logs**: `docker compose ... logs -f agent`. At startup the loop is always
+  *constructed* (`Experiment cohort loop constructed … gated LIVE by agent.json
+  experiments_enabled`, `env_enabled_default=true`) — that line alone does NOT
+  mean it is running. Once `experiments_enabled` is flipped `on`, you see
+  per-tick `experiment.declared` / `experiment.started` / `experiment.game_assigned`
+  activity (not `kill-switch: agent disabled` and not the
+  `experiments_enabled flag off` abort).
 - **Jaeger** (`http://localhost/jaeger/`, service `agent`): experiment
   declare/spawn/conclude/verdict spans.
 - **flagd**: `services/flagd/ci/game.json` gains a reserved experiment variant +
@@ -123,5 +158,5 @@ docker compose \
   -f docker-compose.yml -f docker-compose.override.yml \
   -f docker-compose.ci.yml -f docker-compose.dry-run.yml \
   --profile agent --profile dashboard down
-./scripts/agent-killswitch.sh off    # restore the fail-closed default
+./scripts/agent-dryrun-enable.sh off    # restore the fail-closed defaults (enabled/experiments_enabled/mode)
 ```

--- a/scripts/agent-dryrun-enable.sh
+++ b/scripts/agent-dryrun-enable.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Enable the experiment cohort loop for a `make dry-run` (#1077).
+#
+# After #1044 migrated the experiment config from env vars to flagd flags, the
+# LIVE gate for the cohort loop is the `experiments_enabled` flag in the agent
+# flagd domain — and it OVERRIDES the `AGENT_EXPERIMENTS_ENABLED=true` env the
+# dry-run override sets. Both that flag and the master `enabled` kill-switch are
+# fail-closed `off` by DEFAULT in BOTH the production flag dir
+# (services/flagd/agent.json) and the ci/dry-run dir (services/flagd/ci/agent.json).
+# So a plain `make dry-run` produces ZERO experiment activity until they are
+# flipped on.
+#
+# This helper flips, in the CI/DRY-RUN flag dir ONLY (the dir `make dry-run`
+# serves — same file ./scripts/agent-killswitch.sh mutates):
+#   - `enabled`             -> on   (master kill-switch; mirrors agent-killswitch.sh)
+#   - `experiments_enabled` -> on   (the LIVE experiment-loop gate, post-#1044)
+#   - `mode`                -> llm  (ONLY when AGENT_INFERENCE_BACKEND=openai is
+#                                    set; otherwise `mode` is left untouched so
+#                                    the stub backend stays on `rules`)
+#
+# It NEVER touches the production services/flagd/agent.json defaults — those stay
+# fail-closed by design.
+#
+# Usage:
+#   ./scripts/agent-dryrun-enable.sh on     # enable experiments (dry-run)
+#   ./scripts/agent-dryrun-enable.sh off    # restore fail-closed defaults
+#   ./scripts/agent-dryrun-enable.sh status
+#
+# `mode=llm` is applied on `on` only when an inference backend is configured:
+#   AGENT_INFERENCE_BACKEND=openai ./scripts/agent-dryrun-enable.sh on
+#
+# After flipping, flagd hot-reloads the file; restart the agent so the loop
+# re-reads the existence layer:
+#   docker compose -f docker-compose.yml -f docker-compose.ci.yml --profile agent restart agent
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+FLAG_FILE="${AGENT_FLAG_FILE:-${REPO_ROOT}/services/flagd/ci/agent.json}"
+INFERENCE_BACKEND="${AGENT_INFERENCE_BACKEND:-}"
+
+action="${1:-status}"
+
+case "${action}" in
+  on|off)
+    python3 - "${FLAG_FILE}" "${action}" "${INFERENCE_BACKEND}" <<'PY'
+import json
+import sys
+
+path, action, backend = sys.argv[1], sys.argv[2], sys.argv[3]
+with open(path) as fh:
+    data = json.load(fh)
+
+flags = data["flags"]
+
+
+def set_variant(name, variant):
+    flag = flags[name]
+    if variant not in flag["variants"]:
+        sys.exit(f"variant {variant!r} not defined for flag {name!r} in {path}")
+    flag["defaultVariant"] = variant
+    print(f"  {name} -> {variant}")
+
+
+if action == "on":
+    set_variant("enabled", "on")
+    set_variant("experiments_enabled", "on")
+    if backend == "openai":
+        # Exercise the inference backend only when one is configured.
+        set_variant("mode", "llm")
+    else:
+        print("  mode -> (unchanged; set AGENT_INFERENCE_BACKEND=openai for llm)")
+else:  # off -> restore the fail-closed defaults
+    set_variant("enabled", "off")
+    set_variant("experiments_enabled", "off")
+    set_variant("mode", "rules")
+
+with open(path, "w") as fh:
+    json.dump(data, fh, indent=2)
+    fh.write("\n")
+print(f"dry-run experiment gate -> {action}  ({path})")
+PY
+    ;;
+  status)
+    python3 - "${FLAG_FILE}" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+with open(path) as fh:
+    data = json.load(fh)
+flags = data["flags"]
+for name in ("enabled", "experiments_enabled", "mode"):
+    print(f"{name} = {flags[name]['defaultVariant']}")
+print(f"({path})")
+PY
+    ;;
+  *)
+    echo "usage: $0 {on|off|status}" >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
## Problem

After #1044 migrated experiment config from env vars to flagd flags, the documented `make dry-run` flow no longer started experiments. The flagd `experiments_enabled` flag (default `off`) is the LIVE gate and **overrides** the `AGENT_EXPERIMENTS_ENABLED=true` env that `docker-compose.dry-run.yml` sets. The loop was only ever *constructed* (`gated LIVE by agent.json experiments_enabled`, `env_enabled_default=true`), never run — zero `experiment.*` activity (confirmed live 2026-06-15).

## Fix

New `scripts/agent-dryrun-enable.sh`, mirroring the existing `scripts/agent-killswitch.sh` pattern (which already mutates the same tracked `services/flagd/ci/agent.json` for local runs). In one step it flips, in the **ci/ flag dir only**:
- `enabled` -> `on` (master kill-switch)
- `experiments_enabled` -> `on` (the LIVE experiment gate, post-#1044)
- `mode` -> `llm` **only** when `AGENT_INFERENCE_BACKEND=openai` is set (else `mode` is left as-is / `rules` for the stub backend)

Idempotent, with an `off` counterpart that restores the fail-closed defaults (`off`/`off`/`rules`) and a `status` subcommand.

Also:
- Fixed the misleading `make dry-run` echo (`[x] AGENT_EXPERIMENTS_ENABLED=true`) to state the flagd flag is the live gate and point at the one-command enable step.
- Updated `docs/agent-dry-run-runbook.md`: fastest path, the #999 findings table (added rows 5/6 for the flagd-flag-overrides-env reality), the gating chain, and the verify/teardown steps.

## Approach choice

Chose a helper script over a compose flag overlay because (a) it matches the established `agent-killswitch.sh` pattern operators already know, (b) it keeps a single clear enable/off step, and (c) flag flips hot-reload in flagd — a compose-baked override would require a different ci flag dir and complicate the existing shared-dir story. Production defaults are never touched.

## Operator step (new)

```bash
make dry-run
./scripts/agent-dryrun-enable.sh on    # flips enabled + experiments_enabled on
docker compose -f docker-compose.yml -f docker-compose.ci.yml --profile agent restart agent
# add AGENT_INFERENCE_BACKEND=openai before the enable to also flip mode -> llm
# restore: ./scripts/agent-dryrun-enable.sh off
```

## Safety

- Production `services/flagd/agent.json` defaults unchanged (`off`/`off`/`rules`).
- Committed `services/flagd/ci/agent.json` defaults unchanged (`off`/`off`/`rules`) — the script flips them at runtime only.

Part of #1077

🤖 Generated with [Claude Code](https://claude.com/claude-code)