### PR TITLE
feat(litellm): emit gen_ai spans to OTEL collector → Jaeger (#1087)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -818,6 +818,23 @@ services:
       # open on the internal docker network. When set, the agent must send it via
       # AGENT_INFERENCE_API_KEY.
       - LITELLM_MASTER_KEY=${LITELLM_MASTER_KEY:-}
+      # OpenTelemetry (#1087): the `otel` callback (config.yaml litellm_settings)
+      # emits one gen_ai span per LLM call to the shared collector -> Jaeger.
+      # LiteLLM's otel integration reads OTEL_EXPORTER + OTEL_ENDPOINT directly;
+      # the underlying OTEL SDK also honours OTEL_EXPORTER_OTLP_ENDPOINT, so set
+      # both to the collector. Service identity matches the stack convention
+      # (name=litellm, namespace=infrastructure). NB: LiteLLM builds its own
+      # Resource via OTELResourceDetector, which reads OTEL_SERVICE_NAME +
+      # OTEL_RESOURCE_ATTRIBUTES but NOT a standalone OTEL_SERVICE_NAMESPACE var —
+      # so service.namespace is carried in OTEL_RESOURCE_ATTRIBUTES here (the
+      # OTEL_SERVICE_NAMESPACE line is kept for convention/parity with the SDK
+      # services and harms nothing).
+      - OTEL_SERVICE_NAME=litellm
+      - OTEL_SERVICE_NAMESPACE=infrastructure
+      - OTEL_EXPORTER=otlp_grpc
+      - OTEL_ENDPOINT=http://otel-collector:4317
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
+      - OTEL_RESOURCE_ATTRIBUTES=service.namespace=infrastructure,host.name=${JOUSTMANIA_HOST:-joustmania}
     volumes:
       - ./services/litellm/config.yaml:/etc/litellm/config.yaml:ro
     # Reach the HOST machine's Ollama (same mechanism the agent uses, #1048).

--- a/services/litellm/config.yaml
+++ b/services/litellm/config.yaml
@@ -49,6 +49,12 @@ model_list:
       api_base: os.environ/OLLAMA_BASE_URL
 
 litellm_settings:
+  # OpenTelemetry (#1087): emit one span per LLM call (gen_ai semconv — model,
+  # token counts, latency, success/failure, fallback) to the shared collector.
+  # The "otel" callback covers both success and failure. Exporter target +
+  # service identity come from the OTEL_* env vars set on the gateway service in
+  # docker-compose.yml (OTEL_EXPORTER=otlp_grpc, OTEL_ENDPOINT=otel-collector:4317).
+  callbacks: ["otel"]
   # Fallback chains (#1046): a cloud outage degrades to LOCAL, never to nothing.
   # claude -> phi4-mini keeps inference answering on Anthropic failure/unset key.
   # The local routes have no cloud fallback (they ARE the terminal LLM tier);


### PR DESCRIPTION
Part of #1087

Hooks the LiteLLM gateway into the existing OpenTelemetry stack so LLM calls emit spans to the collector → Jaeger.

## Changes
- `services/litellm/config.yaml`: enable the `otel` logging callback (`callbacks: ["otel"]`) — covers success + failure.
- `docker-compose.yml` (gateway-profile `litellm` service): add the OTEL env LiteLLM's integration reads (`OTEL_EXPORTER=otlp_grpc`, `OTEL_ENDPOINT`/`OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317`) plus the stack's standard service identity (`OTEL_SERVICE_NAME=litellm`, namespace `infrastructure` carried via `OTEL_RESOURCE_ATTRIBUTES` + `host.name`).

## Notes
- The upstream `ghcr.io/berriai/litellm:v1.88.2` image already bundles `opentelemetry-api`/`-sdk` and the OTLP gRPC exporter, so **no extra image layer / Dockerfile is needed**.
- The collector traces pipeline has no service-name allowlist, so litellm traces route to Jaeger automatically — no collector change required.
- LiteLLM builds its own Resource via `OTELResourceDetector` (reads `OTEL_SERVICE_NAME` + `OTEL_RESOURCE_ATTRIBUTES`, NOT a standalone `OTEL_SERVICE_NAMESPACE` var) — hence `service.namespace` is carried in `OTEL_RESOURCE_ATTRIBUTES`.

## Live verification
Brought up the litellm container against the running stack and fired a `/v1/chat/completions`. A `litellm` service appeared in Jaeger; the request span carried `error.llm_provider=ollama_chat`, `error.code=500`, `http.response.status_code=500`, `otel.status_code=ERROR`, and process resource attrs `service.namespace=infrastructure`, `host.name=joustmania`. (This host's Ollama wasn't reachable on :11434, so it was a FAILURE-path span — which still proves the telemetry pipeline; token gen_ai attrs populate on a successful call.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)