### PR TITLE
feat(agent): stamp queryable game.id on all per-game agent spans (#1088)

### DIFF
--- a/services/agent/decision/async_apply.go
+++ b/services/agent/decision/async_apply.go
@@ -133,6 +133,12 @@ func (l *Loop) emitAsyncInferSpan(ctx context.Context, out asyncOutcome) ([]Deci
 		trace.WithTimestamp(out.start),
 		trace.WithAttributes(semconvGenAIChat(out.backend.Name())...),
 	)
+	// session.id + game.id (#1088): the async inference span is attributable to its
+	// game like its agent.llm.apply parent and the synchronous infer span.
+	span.SetAttributes(
+		attribute.String(AttrSessionID, l.gameID),
+		attribute.String(AttrGameID, l.gameID),
+	)
 	span.SetAttributes(attribute.Int64(AttrLLMLatencyMs, out.latencyMs()))
 	// M7-2 (#929): record the cross-game context-window count actually injected into
 	// the prompt on the REAL inference span, mirroring the synchronous llmDecide path

--- a/services/agent/decision/async_infer_test.go
+++ b/services/agent/decision/async_infer_test.go
@@ -237,6 +237,19 @@ func TestAsync_FreshResultApplied(t *testing.T) {
 	if v, ok := attrValue(apply[0], "inference.applied"); !ok || !v.AsBool() {
 		t.Error("apply span inference.applied must be true for a fresh applied result")
 	}
+	// #1088: both the apply root and the async inference span carry game.id (= the
+	// loop's game id) so the whole async fire->infer->apply trace is queryable by
+	// game.id, alongside the synchronous per-game spans.
+	if v, ok := attrValue(apply[0], AttrGameID); !ok || v.AsString() != "g1" {
+		t.Errorf("apply span %s = %q (present=%v), want g1", AttrGameID, v.AsString(), ok)
+	}
+	inf := spansByName(sr.Ended(), SpanLLMInfer)
+	if len(inf) != 1 {
+		t.Fatalf("agent.llm.infer spans = %d, want 1", len(inf))
+	}
+	if v, ok := attrValue(inf[0], AttrGameID); !ok || v.AsString() != "g1" {
+		t.Errorf("async infer span %s = %q (present=%v), want g1", AttrGameID, v.AsString(), ok)
+	}
 }
 
 // ---- Acceptance: stale result discarded — game ended during inference ----

--- a/services/agent/decision/attribution_test.go
+++ b/services/agent/decision/attribution_test.go
@@ -122,6 +122,41 @@ func TestDecisionSpan_BlockedAttribution(t *testing.T) {
 	}
 }
 
+// TestPerGameSpans_CarryGameID is the #1088 correlation assertion: every agent
+// span that operates on a specific game carries the SAME game.id (and its
+// session.id alias) as its agent.signal_received root, so a Jaeger query by
+// game.id matches the whole per-game trace — not just the root — and correlates
+// the agent's orphan trace with the coordinator's per-game trace. game.id IS the
+// SessionID (= the real game_id since #845 PR A).
+func TestPerGameSpans_CarryGameID(t *testing.T) {
+	const gameID = "game_abc123def456"
+	snap := flags.Snapshot{
+		Enabled:              true,
+		Mode:                 "rules",
+		InterventionsAllowed: []string{"grant_shield"},
+		Policy:               flags.Policy{MaxInterventionsPerMinute: 10},
+	}
+	l, sr := recordingLoop(t, snap, []Decision{{Intervention: "grant_shield", Reason: "x"}})
+
+	l.OnEvaluate(context.Background(), gamecontext.GameContext{SessionID: gameID, GameKind: "shadow"}, testTrigger())
+
+	ended := sr.Ended()
+	// Every per-game span family in this cycle must carry game.id == the session id.
+	for _, name := range []string{SignalReceived, SpanDecision, SpanAction} {
+		spans := spansByName(ended, name)
+		if len(spans) != 1 {
+			t.Fatalf("%s spans = %d, want 1", name, len(spans))
+		}
+		s := spans[0]
+		if v, ok := attrValue(s, AttrGameID); !ok || v.AsString() != gameID {
+			t.Errorf("%s: %s = %q (present=%v), want %q", name, AttrGameID, v.AsString(), ok, gameID)
+		}
+		if v, ok := attrValue(s, AttrSessionID); !ok || v.AsString() != gameID {
+			t.Errorf("%s: %s = %q (present=%v), want %q", name, AttrSessionID, v.AsString(), ok, gameID)
+		}
+	}
+}
+
 // TestDisabledSpan_EmittedWithFlagAttribution: the kill switch (enabled=false)
 // still emits a trace showing "agent off" with the flags in effect (#729 §4).
 func TestDisabledSpan_EmittedWithFlagAttribution(t *testing.T) {

--- a/services/agent/decision/decision.go
+++ b/services/agent/decision/decision.go
@@ -848,7 +848,7 @@ func (l *Loop) runDecision(ctx context.Context, snapshot flags.Snapshot, c gamec
 	reason, blocked := l.evaluatePermission(snapshot, c, d, now, cost)
 
 	dCtx, dSpan := l.Tracer.Start(ctx, SpanDecision,
-		trace.WithAttributes(decisionAttributes(state, d, blocked, reason, c.GameKind)...))
+		trace.WithAttributes(decisionAttributes(state, d, blocked, reason, c.GameKind, c.SessionID)...))
 	defer dSpan.End()
 
 	// The interventions.allowed evaluation as a feature_flag.* span event
@@ -867,6 +867,10 @@ func (l *Loop) runDecision(ctx context.Context, snapshot flags.Snapshot, c gamec
 	_, aSpan := l.Tracer.Start(dCtx, SpanAction, trace.WithAttributes(
 		attribute.String(AttrDecisionAction, d.Intervention),
 		attribute.Bool(AttrDecisionBlocked, blocked),
+		// session.id + game.id (#1088): the action span acts on a specific game, so
+		// it carries the same game.id as its parent decision span for correlation.
+		attribute.String(AttrSessionID, c.SessionID),
+		attribute.String(AttrGameID, c.SessionID),
 	))
 	defer aSpan.End()
 
@@ -961,7 +965,7 @@ func (l *Loop) emitDisabledSpan(ctx context.Context, snapshot flags.Snapshot, c 
 	// nothing. AttrDecisionAction is empty (no action) and AttrDecisionBlocked is
 	// false (no decision was blocked by a permission gate — the loop never ran).
 	_, dSpan := l.Tracer.Start(rootCtx, SpanDisabled,
-		trace.WithAttributes(decisionAttributes(&state, Decision{}, false, "", c.GameKind)...))
+		trace.WithAttributes(decisionAttributes(&state, Decision{}, false, "", c.GameKind, c.SessionID)...))
 	dSpan.End()
 }
 
@@ -1054,7 +1058,7 @@ func (l *Loop) shouldLog() bool {
 // attribute; subsystems that do not exist yet contribute explicit placeholder
 // values (see telemetry.go). The block reason (#728) is carried only when a
 // decision is blocked.
-func decisionAttributes(state *LayerState, d Decision, blocked bool, reason BlockReason, gameKind string) []attribute.KeyValue {
+func decisionAttributes(state *LayerState, d Decision, blocked bool, reason BlockReason, gameKind, gameID string) []attribute.KeyValue {
 	objective := d.ObjectiveServed
 	if objective == "" {
 		objective = DefaultObjectives
@@ -1063,6 +1067,14 @@ func decisionAttributes(state *LayerState, d Decision, blocked bool, reason Bloc
 		semconv.GenAIAgentName(AgentName),
 		// game.kind (#845): schema-complete — empty string when unknown.
 		attribute.String(AttrGameKind, gameKind),
+		// session.id + game.id alias (#1088): the child agent.decision / agent.disabled
+		// spans carry the SAME game.id as their agent.signal_received root, so a Jaeger
+		// query by game.id matches every per-game span — not just the root — and
+		// correlates the agent's orphan trace with the coordinator's per-game trace.
+		// game.id IS the SessionID (= the real game_id since #845 PR A); empty when
+		// unknown (schema-complete).
+		attribute.String(AttrSessionID, gameID),
+		attribute.String(AttrGameID, gameID),
 	}
 	// Cycle-level flag attribution: lift the whole LayerState onto the span so a
 	// single trace answers "which flags were in effect" (#729). agent.objectives

--- a/services/agent/decision/llm_decide.go
+++ b/services/agent/decision/llm_decide.go
@@ -123,6 +123,10 @@ func (l *Loop) llmDecide(ctx context.Context, backend Backend, snapshot flags.Sn
 	// the COUNT actually injected — what the model truly saw, not the raw flag.
 	infCtx, span := l.Tracer.Start(ctx, SpanLLMInfer, trace.WithAttributes(
 		append(semconvGenAIChat(backend.Name()),
+			// session.id + game.id (#1088): the real inference span is attributable to
+			// its game like the sibling decision / agent.llm.prompt spans.
+			attribute.String(AttrSessionID, c.SessionID),
+			attribute.String(AttrGameID, c.SessionID),
 			attribute.Int(AttrLLMContextGames, contextCount),
 			// M7-3 (#930): the operator-note view on the REAL inference span — present +
 			// rune length, the bounded low-cardinality record of what the model saw.

--- a/services/agent/decision/llm_decide_test.go
+++ b/services/agent/decision/llm_decide_test.go
@@ -148,6 +148,11 @@ func TestLLMDecide_ValidResponseTakesLLMPath(t *testing.T) {
 	if v, ok := attrValue(inf[0], "gen_ai.request.model"); !ok || v.AsString() != "phi4-mini" {
 		t.Errorf("infer span gen_ai.request.model = %q, want phi4-mini", v.AsString())
 	}
+	// #1088: the real inference span carries game.id (= the session id) for
+	// per-game correlation, like the sibling decision / agent.llm.prompt spans.
+	if v, ok := attrValue(inf[0], AttrGameID); !ok || v.AsString() != "s1" {
+		t.Errorf("infer span %s = %q (present=%v), want s1", AttrGameID, v.AsString(), ok)
+	}
 }
 
 // unavailableBackend is a chain tier whose probe never reports reachable, used to

--- a/services/agent/decision/retro_capture.go
+++ b/services/agent/decision/retro_capture.go
@@ -242,7 +242,7 @@ type retroPromptAttrs struct {
 //   - agent.mode            = "retro"
 //   - agent.objectives      = sorted "k=v" weights (summarizeObjectives)
 //   - interventions.allowed = the allow-list summary (allowedSummary)
-//   - session.id            = the finished session's id
+//   - session.id / game.id  = the finished session's id (= the real game_id, #1088)
 //   - llm.retro.system / llm.retro.user = the FULL prompt text (uncapped)
 //   - llm.retro.bytes       = len(system)+len(user)
 //   - inference.configured  = <model flag>
@@ -268,7 +268,12 @@ func retroPromptAttributes(in retroPromptAttrs) []attribute.KeyValue {
 		attribute.String(AttrGameKind, in.gameKind),
 		attribute.String(AttrObjectives, summarizeObjectives(in.objectives)),
 		attribute.String(AttrInterventionsAllowed, allowedSummary(in.allowed)),
-		attribute.String("session.id", in.sessionID),
+		// session.id + game.id (#1088): the post-game retro span is attributable to the
+		// finished game like the in-game agent.llm.prompt span, so a Jaeger query by
+		// game.id surfaces the retrospective alongside the game's in-play decisions.
+		// game.id IS the SessionID (= the real game_id since #845 PR A).
+		attribute.String(AttrSessionID, in.sessionID),
+		attribute.String(AttrGameID, in.sessionID),
 		// The captured prompt: full text (uncapped) plus its size.
 		attribute.String(AttrLLMRetroSystem, system),
 		attribute.String(AttrLLMRetroUser, user),

--- a/services/agent/decision/retro_capture_test.go
+++ b/services/agent/decision/retro_capture_test.go
@@ -141,9 +141,12 @@ func TestRetroCapture_SchemaComplete(t *testing.T) {
 		AttrObjectives:           "chaos=0.3,endurance=0.7",
 		AttrInterventionsAllowed: "noop,grant_shield",
 		"session.id":             "session-7",
-		AttrInferenceConfigured:  "phi4-mini",
-		AttrInferenceUsed:        DefaultInference, // "none", NOT "rules"
-		AttrInferenceFallback:    FallbackNoBackend,
+		// #1088: the retro span carries game.id (= the session id) so a Jaeger query
+		// by game.id surfaces the post-game retrospective alongside the in-game spans.
+		AttrGameID:              "session-7",
+		AttrInferenceConfigured: "phi4-mini",
+		AttrInferenceUsed:       DefaultInference, // "none", NOT "rules"
+		AttrInferenceFallback:   FallbackNoBackend,
 	}
 	for key, expected := range wantStr {
 		if v, ok := attrValue(span, key); !ok || v.AsString() != expected {

--- a/services/agent/gamerunner/runner.go
+++ b/services/agent/gamerunner/runner.go
@@ -342,7 +342,14 @@ func (r *Runner) RunShadowGame(ctx context.Context, spec Spec) (Result, error) {
 	res.GameName = spec.GameName
 	res.Duration = time.Since(start)
 	if res.GameID != "" {
-		span.SetAttributes(attribute.String("shadow_game.game_id", res.GameID))
+		// shadow_game.game_id is the run-domain key; game.id (#1088) is the SAME
+		// game_<uuid> under the canonical, cross-family key so a Jaeger query by
+		// game.id correlates this run span with the agent's decision/llm spans and
+		// the coordinator's per-game trace.
+		span.SetAttributes(
+			attribute.String("shadow_game.game_id", res.GameID),
+			attribute.String("game.id", res.GameID),
+		)
 	}
 	span.SetAttributes(
 		attribute.String("shadow_game.outcome", string(res.Outcome)),


### PR DESCRIPTION
Part of #1088

## Problem
The agent ingests game state as OTel **metrics** (no trace context), so its spans start fresh root traces, disconnected from the game-coordinator's per-game trace. The `agent.signal_received` root already carried `game.id` (the `game_<uuid>` session id), but its child/sibling per-game spans did **not** — so a Jaeger query by `game.id` matched only the root, and `agent.llm.retro` was stamped `session.id` only (the maintainer's "what about llm.retro spans?" comment).

## Phase 1 — the shippable correlation layer
One consistent attribute key, `game.id` (set to the `game_<uuid>` session id the span's context already has, alongside the existing `session.id` alias), stamped on **every** agent span that operates on a specific game:

| Span | Before | After |
|------|--------|-------|
| `agent.decision` | game.kind only | + game.id / session.id |
| `agent.disabled` | game.kind only | + game.id / session.id |
| `agent.action` | — | + game.id / session.id |
| `agent.llm.infer` (sync) | — | + game.id / session.id |
| `agent.llm.infer` (async #917) | — | + game.id / session.id |
| **`agent.llm.retro`** | session.id only | + **game.id** |
| `agent.shadow_game.run` | shadow_game.game_id | + canonical game.id |

Already carried `game.id` (unchanged): `agent.signal_received`, `agent.llm.prompt`, `agent.llm.apply`, `agent.game.summary`.

Deliberately **left off** (requirement #2 — no game in scope, no fabricated id): `agent.infrastructure.decision` (acts on a service/rollout target) and the `code_improvement.*` family (`propose_attempt` / `proposed` / `synthetic_validation` / `apply` / `discard` / `promote` — these act on a flag proposal across N games, not one game).

`game.kind` is kept; `game.id` is purely additive. **No decision/gate/experiment logic changed** — span-attribute enrichment only.

## Phase 2 (NOT in this PR — documented only)
Phase 2 = OTel span **Links** from `agent.decision` to the game trace via the game `trace_id` propagated through metric **exemplars**. That is out of scope here; the shared `game.id` attribute (Phase 1) is the correlation layer that ships and is what most Jaeger queries need.

## Tests
- New `TestPerGameSpans_CarryGameID` asserting `game.id` + `session.id` on `agent.signal_received` / `agent.decision` / `agent.action`.
- Extended `TestRetroCapture_SchemaComplete` (game.id on `agent.llm.retro`), the sync `agent.llm.infer` attribution test, and `TestAsync_FreshResultApplied` (game.id on the async infer + apply spans).
- `gofmt -l .` clean, `go build ./...`, `go vet ./...`, `go test ./... -race -count=1` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)