### PR TITLE
fix(agent): route retro-capture inference through configured backend (#1080)

### DIFF
--- a/services/agent/decision/decision.go
+++ b/services/agent/decision/decision.go
@@ -461,6 +461,16 @@ func (l *Loop) OnEvaluate(ctx context.Context, c gamecontext.GameContext, trig E
 
 	snapshot := l.Flags.Evaluate(ctx)
 	state := newLayerState(snapshot)
+	// #1080 attribution: report inference.configured as the model of the configured
+	// inference backend (AGENT_INFERENCE_MODEL) when one is wired, not the stale
+	// agent.model flag. The resolver is the single source of truth (ConfiguredModel);
+	// empty (stub default, no real backend) leaves the flag-seeded value untouched, so
+	// the default path is byte-identical.
+	if l.resolver != nil {
+		if cfg := l.resolver.ConfiguredModel(); cfg != "" {
+			state.ConfiguredModel = cfg
+		}
+	}
 
 	// Existence layer: enabled=false short-circuits before any rules evaluation.
 	// This is the safe default when flagd is unreachable. The disabled state is
@@ -1152,7 +1162,7 @@ func layerStateAttributes(state *LayerState) []attribute.KeyValue {
 		attribute.String(AttrModel, state.Model),
 		attribute.String(AttrPromptVariant, state.PromptVariant),
 		// Inference attribution (path-agnostic).
-		attribute.String(AttrInferenceConfigured, state.Model),
+		attribute.String(AttrInferenceConfigured, state.ConfiguredModel),
 		attribute.String(AttrInferenceUsed, inferenceUsed),
 		attribute.String(AttrInferenceFallback, fallback),
 		// Permission layer.

--- a/services/agent/decision/inference_flow_test.go
+++ b/services/agent/decision/inference_flow_test.go
@@ -145,3 +145,48 @@ func TestInferenceFlow_UnreachableBackendStaysRules(t *testing.T) {
 		t.Errorf("action sink calls = %d, want 1 (rules decision dispatched)", sink.calls.Load())
 	}
 }
+
+// TestInferenceFlow_DecisionSpanConfiguredReflectsBackend is the #1080 attribution half:
+// the agent.decision span's inference.configured must report the CONFIGURED inference
+// model (AGENT_INFERENCE_MODEL = gemma4:latest), not the stale agent.model flag
+// (phi4-mini). It holds whether the backend is reachable (mode=llm) or unreachable
+// (degraded to rules) — the configured attribution is independent of reachability.
+// agent.model (AttrModel) still reports the raw flag, unchanged.
+func TestInferenceFlow_DecisionSpanConfiguredReflectsBackend(t *testing.T) {
+	cases := []struct {
+		name      string
+		reachable bool
+	}{
+		{"reachable", true},
+		{"unreachable", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			delegate := func(context.Context, llm.Prompt) (string, error) { return flowResponse, nil }
+			addr := "127.0.0.1:1" // unreachable by default
+			if tc.reachable {
+				var closeFn func()
+				addr, closeFn = listenLocal(t)
+				defer closeFn()
+			}
+			r := NewInferenceResolver(InferenceTier{Model: flowModel, Addr: addr, Infer: delegate}, Endpoints{}, 0)
+			r.Refresh(context.Background())
+
+			l, sr, _ := flowLoop(t, r)
+			l.OnEvaluate(context.Background(), gamecontext.GameContext{SessionID: "s1", GameKind: "real"}, testTrigger())
+
+			decs := spansByName(sr.Ended(), SpanDecision)
+			if len(decs) != 1 {
+				t.Fatalf("agent.decision spans = %d, want 1", len(decs))
+			}
+			if v, ok := attrValue(decs[0], AttrInferenceConfigured); !ok || v.AsString() != flowModel {
+				t.Errorf("inference.configured = %q, want %q (AGENT_INFERENCE_MODEL, not phi4-mini flag)", v.AsString(), flowModel)
+			}
+			// agent.model still reports the raw capability flag — only inference.configured
+			// reflects the configured backend.
+			if v, ok := attrValue(decs[0], AttrModel); !ok || v.AsString() != "phi4-mini" {
+				t.Errorf("agent.model = %q, want the raw flag %q", v.AsString(), "phi4-mini")
+			}
+		})
+	}
+}

--- a/services/agent/decision/layerstate.go
+++ b/services/agent/decision/layerstate.go
@@ -59,6 +59,15 @@ type LayerState struct {
 	Model         string
 	PromptVariant string
 
+	// ConfiguredModel is inference.configured on the decision span (#1080): the model
+	// of the configured inference backend (AGENT_INFERENCE_MODEL, e.g. gemma4:latest)
+	// when a real backend is wired, else the agent.model flag. newLayerState seeds it
+	// from the flag (Model); the loop overrides it with the resolver's configured
+	// model when AGENT_INFERENCE_BACKEND=openai, so the span reports the backend
+	// actually used instead of the stale phi4-mini flag. Distinct from Model, which
+	// stays the raw agent.model capability flag (agent.model attribute).
+	ConfiguredModel string
+
 	// LLMFallbackReason is the inference.fallback_reason this cycle's llm path
 	// resolved to (#847 + #741). It is the PER-CYCLE replacement for the static
 	// inferenceAttribution. On an llm cycle the loop sets it to, in order of
@@ -116,6 +125,11 @@ func newLayerState(s flags.Snapshot) LayerState {
 		Mode:       s.Mode,
 		Objectives: s.Objectives,
 		Model:      s.Capability.Model,
+		// inference.configured defaults to the agent.model flag; the loop overrides it
+		// with the configured inference model (AGENT_INFERENCE_MODEL) when a real
+		// backend is wired (#1080), so a default phi4-mini flag no longer mislabels a
+		// gemma4-configured span.
+		ConfiguredModel: s.Capability.Model,
 		// Record the EFFECTIVE prompt variant (#740), not the raw flag value: the
 		// llm path resolves an unknown/garbage prompt_variant to "conservative"
 		// before building the prompt, so the decision span's agent.prompt_variant

--- a/services/agent/decision/resolver.go
+++ b/services/agent/decision/resolver.go
@@ -285,6 +285,31 @@ func InferenceProbeAddr(baseURL string) string {
 	return net.JoinHostPort(host, port)
 }
 
+// ConfiguredModel returns the name of the configured real-inference tier (#964) —
+// AGENT_INFERENCE_MODEL — when one was wired via NewInferenceResolver, else "".
+// It is the single source of truth for "what model is the configured inference
+// backend" so the decision-span and retro-capture attribution (#1080) can report
+// the model actually configured (e.g. gemma4:latest) instead of the stale
+// agent.model flag (phi4-mini). Empty means no real backend is configured (the
+// stub default), and callers fall back to the flag — byte-identical to before.
+func (r *Resolver) ConfiguredModel() string { return r.inferenceTier }
+
+// ResolveConfigured resolves WHICH tier would serve right now, starting from the
+// configured-inference tier when one is wired, else from the given fallback model
+// flag (#1080). It is the public entry the retro-capture seam uses: it reuses the
+// SAME resolve()/availability cache the decision loop uses, so retro inference
+// targets the configured backend (gemma4) and only degrades when that is genuinely
+// unreachable — instead of always hitting the unreachable phi4-mini legacy tier.
+// When no real backend is configured (inferenceTier == "") it resolves against the
+// fallbackModel flag exactly as the decision loop does, preserving prior behavior.
+func (r *Resolver) ResolveConfigured(fallbackModel string) Resolution {
+	model := r.inferenceTier
+	if model == "" {
+		model = fallbackModel
+	}
+	return r.resolve(model)
+}
+
 // resolveTierFromModel maps the configured agent.model flag to the index of the
 // chain tier it selects as the TOP of the walk. claude/copilot -> the cloud tier
 // (index 0); gemma3:4b -> the Jetson tier; phi4-mini -> the localhost tier; any

--- a/services/agent/decision/retro_capture.go
+++ b/services/agent/decision/retro_capture.go
@@ -94,6 +94,16 @@ type RetroCoordinator struct {
 	// ungated by the global cap (used by tests / single-purpose wiring that does not
 	// share a budget — capture proceeds as before #847). Injected via SetLLMBudget.
 	budget *llmBudget
+	// resolver is the SHARED inference fallback-chain resolver (#741/#964), injected
+	// via SetResolver — the SAME instance every per-game Loop holds (#1080). When a
+	// real inference backend is configured (AGENT_INFERENCE_BACKEND=openai), the retro
+	// resolves against it (gemma4 @ AGENT_INFERENCE_BASE_URL) so retro attribution
+	// targets the configured model/tier and only degrades when it is genuinely
+	// unreachable — instead of always hitting the unreachable phi4-mini legacy tier.
+	// A nil resolver (tests / stub-default wiring without one) preserves the pre-#1080
+	// behavior: model = the agent.model flag, used = "none", fallback =
+	// no_backend_available, exactly as before.
+	resolver *Resolver
 	// llmGated counts gated retro captures (agent_llm_gated_total{reason=...}),
 	// sharing the in-game counter name. Defaults to a no-op so tests need not wire it.
 	llmGated otelmetric.Int64Counter
@@ -133,6 +143,15 @@ func NewRetroCoordinator(flagSource FlagSource, log *slog.Logger) *RetroCoordina
 // uses. main.go passes the one instance every per-game Loop also holds. Not safe
 // to call concurrently with OnGameEnd — set it during construction.
 func (rc *RetroCoordinator) SetLLMBudget(b *llmBudget) { rc.budget = b }
+
+// SetResolver injects the SHARED inference fallback-chain resolver (#1080), the same
+// instance every per-game Loop holds (SetResolver on the Loop). The retro then routes
+// its inference attribution through the SAME configured backend the decision loop and
+// proposer use: when AGENT_INFERENCE_BACKEND=openai the resolver's configured tier
+// (AGENT_INFERENCE_MODEL @ AGENT_INFERENCE_BASE_URL) is the canonical path, so retro
+// no longer reports the unreachable phi4-mini legacy tier. Not safe to call
+// concurrently with OnGameEnd — set it during construction.
+func (rc *RetroCoordinator) SetResolver(r *Resolver) { rc.resolver = r }
 
 // OnGameEnd is the gamecontext.Store.OnGameEnd callback. It captures the
 // retrospective prompt for a finished session exactly once. It is defensive:
@@ -183,6 +202,17 @@ func (rc *RetroCoordinator) OnGameEnd(c gamecontext.GameContext) {
 		Now:      now(),
 	})
 
+	// #1080: resolve the inference attribution through the SAME shared resolver the
+	// decision loop and proposer use, so a configured backend (gemma4) is reported as
+	// the model/tier — not the agent.model flag's unreachable phi4-mini legacy tier.
+	// retroInference falls back to the flag-only "none"/no_backend_available attribution
+	// when no resolver is wired (the pre-#1080 default), keeping that path identical.
+	attr := rc.retroInference(snapshot.Capability.Model)
+	// Attribute the prompt to the model that WOULD serve (the configured backend when
+	// one is wired), overriding the flag-derived BuildRetro model so the span's
+	// gen_ai.request.model and the log line both name the configured model.
+	prompt.Model = attr.configured
+
 	_, span := rc.Tracer.Start(context.Background(), SpanLLMRetro,
 		trace.WithAttributes(retroPromptAttributes(retroPromptAttrs{
 			prompt:     prompt,
@@ -190,15 +220,74 @@ func (rc *RetroCoordinator) OnGameEnd(c gamecontext.GameContext) {
 			gameKind:   c.GameKind,
 			objectives: snapshot.Objectives,
 			allowed:    snapshot.InterventionsAllowed,
+			configured: attr.configured,
+			used:       attr.used,
+			fallback:   attr.fallback,
 		})...))
 	span.End()
 
 	rc.Log.Info("agent.llm.retro_captured",
 		"session_id", c.SessionID,
-		"model", prompt.Model,
+		"model", attr.configured,
 		"bytes", len(prompt.System)+len(prompt.User),
-		"fallback_reason", FallbackNoBackend,
+		"fallback_reason", attr.fallback,
 	)
+}
+
+// retroAttribution is the inference attribution for one retro capture: the
+// configured model (gen_ai.request.model / inference.configured), the tier that
+// WOULD serve (inference.used), and any degradation reason (#1080).
+type retroAttribution struct {
+	configured string
+	used       string
+	fallback   string
+}
+
+// retroInference computes the retro span/log inference attribution (#1080), routing
+// through the SHARED resolver so it matches the decision loop's configured backend.
+//
+//   - No resolver wired (tests / stub-default without one): preserve the pre-#1080
+//     attribution exactly — configured = the agent.model flag, used = "none"
+//     (DefaultInference: a retro has no rules fallback, see the DIVERGENCE note on
+//     retroPromptAttributes), fallback = no_backend_available.
+//   - Resolver wired: configured = the configured inference model when one is set
+//     (AGENT_INFERENCE_MODEL), else the flag. used/fallback come from resolving the
+//     SAME availability cache the decision loop reads:
+//   - configured tier reachable -> used = the tier, fallback = "" (a real backend
+//     WOULD serve the retro — no degradation);
+//   - a lower legacy tier serves -> used = that tier, fallback = endpoint_unreachable;
+//   - whole chain unreachable    -> used = "none" (DefaultInference, NOT "rules":
+//     the retro DIVERGENCE — no rules fallback at game end), fallback =
+//     no_backend_available — byte-identical to the legacy stub path.
+func (rc *RetroCoordinator) retroInference(flagModel string) retroAttribution {
+	if rc.resolver == nil {
+		return retroAttribution{
+			configured: flagModel,
+			used:       DefaultInference,
+			fallback:   FallbackNoBackend,
+		}
+	}
+	configured := rc.resolver.ConfiguredModel()
+	if configured == "" {
+		configured = flagModel
+	}
+	res := rc.resolver.ResolveConfigured(flagModel)
+	// A nil Backend means the whole chain was unreachable and the decision loop would
+	// fall back to rules; the retro has no rules fallback, so it reports used="none"
+	// (the DIVERGENCE) with the chain's no_backend_available reason — identical to the
+	// pre-#1080 stub attribution.
+	if res.Backend == nil {
+		return retroAttribution{
+			configured: configured,
+			used:       DefaultInference,
+			fallback:   res.FallbackReason,
+		}
+	}
+	return retroAttribution{
+		configured: configured,
+		used:       res.Used,
+		fallback:   res.FallbackReason,
+	}
 }
 
 // claimSession records sessionID as captured and reports whether THIS call won
@@ -230,6 +319,13 @@ type retroPromptAttrs struct {
 	gameKind   string
 	objectives map[string]float64
 	allowed    []string
+	// configured/used/fallback are the #1080 inference attribution resolved through
+	// the shared resolver: the configured backend model, the tier that WOULD serve,
+	// and any degradation reason. They replace the formerly hard-coded
+	// model-flag/"none"/no_backend_available trio.
+	configured string
+	used       string
+	fallback   string
 }
 
 // retroPromptAttributes is the SOLE builder of the agent.llm.retro span attribute
@@ -245,16 +341,23 @@ type retroPromptAttrs struct {
 //   - session.id / game.id  = the finished session's id (= the real game_id, #1088)
 //   - llm.retro.system / llm.retro.user = the FULL prompt text (uncapped)
 //   - llm.retro.bytes       = len(system)+len(user)
-//   - inference.configured  = <model flag>
-//   - inference.used        = "none"   (see DIVERGENCE below)
-//   - inference.fallback_reason = "no_backend_available"
+//   - inference.configured  = the configured backend model (#1080), or the model flag
+//   - inference.used        = the tier that WOULD serve, or "none" (see DIVERGENCE)
+//   - inference.fallback_reason = "" when the configured backend is reachable, else
+//     endpoint_unreachable / no_backend_available
 //
-// DIVERGENCE from the in-game capture: inference.used is "none", NOT "rules".
-// The in-game path falls back to the rules engine, so "rules" is the honest
-// answer for "what decided this cycle". A retrospective has NO rules fallback —
-// nothing runs in place of the offline analyst at game end, so claiming "rules"
-// would be a lie. "none" (DefaultInference) is the honest value: no inference of
-// any kind ran. #741's backend will supply used="llm" once it answers.
+// #1080: configured/used/fallback are resolved through the SHARED resolver (the same
+// one the decision loop uses), so when AGENT_INFERENCE_BACKEND=openai the retro names
+// the configured model (gemma4) instead of the agent.model flag's unreachable
+// phi4-mini legacy tier. With no resolver wired the legacy flag-only attribution is
+// preserved exactly (see retroInference).
+//
+// DIVERGENCE from the in-game capture: when nothing is reachable, inference.used is
+// "none", NOT "rules". The in-game path falls back to the rules engine, so "rules" is
+// the honest answer for "what decided this cycle". A retrospective has NO rules
+// fallback — nothing runs in place of the offline analyst at game end, so claiming
+// "rules" would be a lie. "none" (DefaultInference) is the honest value: no inference
+// of any kind ran. A reachable configured backend (#1080) reports used=<that tier>.
 func retroPromptAttributes(in retroPromptAttrs) []attribute.KeyValue {
 	system := in.prompt.System
 	user := in.prompt.User
@@ -278,11 +381,13 @@ func retroPromptAttributes(in retroPromptAttrs) []attribute.KeyValue {
 		attribute.String(AttrLLMRetroSystem, system),
 		attribute.String(AttrLLMRetroUser, user),
 		attribute.Int(AttrLLMRetroBytes, len(system)+len(user)),
-		// Inference attribution: the prompt was captured, but no backend ran and
-		// there is no rules fallback for a retrospective, so used="none".
-		attribute.String(AttrInferenceConfigured, in.prompt.Model),
-		attribute.String(AttrInferenceUsed, DefaultInference),
-		attribute.String(AttrInferenceFallback, FallbackNoBackend),
+		// Inference attribution (#1080): resolved through the shared resolver so the
+		// configured backend (gemma4) is named when one is wired; used is the tier that
+		// WOULD serve (or "none" when nothing is reachable — the retro DIVERGENCE), and
+		// fallback is empty when the configured backend is reachable.
+		attribute.String(AttrInferenceConfigured, in.configured),
+		attribute.String(AttrInferenceUsed, in.used),
+		attribute.String(AttrInferenceFallback, in.fallback),
 	}
 }
 

--- a/services/agent/decision/retro_capture_test.go
+++ b/services/agent/decision/retro_capture_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/joustmania/agent/flags"
 	"github.com/joustmania/agent/gamecontext"
+	"github.com/joustmania/agent/llm"
 )
 
 // retroSnapshot is a representative llm-mode snapshot for the retro capture tests.
@@ -255,5 +256,94 @@ func TestRetroCapture_SkipsEmptySession(t *testing.T) {
 	rc.OnGameEnd(c)
 	if n := len(spansByName(sr.Ended(), SpanLLMRetro)); n != 0 {
 		t.Errorf("agent.llm.retro spans = %d, want 0 for an empty session id", n)
+	}
+}
+
+// TestRetroCapture_ConfiguredBackendReachable is the #1080 fix: with a real inference
+// backend wired via the SHARED resolver (AGENT_INFERENCE_BACKEND=openai → gemma4) and
+// reachable, the retro span and log report the CONFIGURED model (gemma4:latest), use
+// it as the resolved tier, and carry NO fallback reason — NOT the agent.model flag's
+// (phi4-mini) unreachable legacy tier with no_backend_available.
+func TestRetroCapture_ConfiguredBackendReachable(t *testing.T) {
+	addr, closeFn := listenLocal(t)
+	defer closeFn()
+
+	const configured = "gemma4:latest"
+	delegate := func(context.Context, llm.Prompt) (string, error) { return `{"intervention":"noop"}`, nil }
+	// The flag snapshot still says phi4-mini (the ci default) — the configured backend
+	// must win regardless, exactly like the decision loop.
+	rc, sr := recordingRetro(t, retroFlagSnapshot())
+	r := NewInferenceResolver(InferenceTier{Model: configured, Addr: addr, Infer: delegate}, Endpoints{}, 0)
+	r.Refresh(context.Background())
+	rc.SetResolver(r)
+
+	rc.OnGameEnd(endedSession())
+
+	span := spansByName(sr.Ended(), SpanLLMRetro)[0]
+	want := map[string]string{
+		"gen_ai.request.model":  configured,
+		AttrInferenceConfigured: configured,
+		AttrInferenceUsed:       configured,
+		AttrInferenceFallback:   "", // configured backend reachable: no degradation
+	}
+	for key, expected := range want {
+		if v, ok := attrValue(span, key); !ok || v.AsString() != expected {
+			t.Errorf("attr %s = %q (present=%v), want %q", key, v.AsString(), ok, expected)
+		}
+	}
+}
+
+// TestRetroCapture_ConfiguredBackendUnreachable: with a configured backend wired but
+// unreachable (and the legacy chain down), the retro still ATTRIBUTES the configured
+// model (gemma4), but honestly reports used="none" (the retro DIVERGENCE — no rules
+// fallback at game end) with no_backend_available. This is the genuine-unreachable
+// degradation, distinct from the #1080 bug where it always hit phi4-mini.
+func TestRetroCapture_ConfiguredBackendUnreachable(t *testing.T) {
+	const configured = "gemma4:latest"
+	delegate := func(context.Context, llm.Prompt) (string, error) { return "", nil }
+	rc, sr := recordingRetro(t, retroFlagSnapshot())
+	// Addr nothing listens on → probe fails; legacy endpoints empty → all unreachable.
+	r := NewInferenceResolver(InferenceTier{Model: configured, Addr: "127.0.0.1:1", Infer: delegate}, Endpoints{}, 0)
+	r.Refresh(context.Background())
+	rc.SetResolver(r)
+
+	rc.OnGameEnd(endedSession())
+
+	span := spansByName(sr.Ended(), SpanLLMRetro)[0]
+	want := map[string]string{
+		"gen_ai.request.model":  configured, // still attribute the configured model
+		AttrInferenceConfigured: configured,
+		AttrInferenceUsed:       DefaultInference, // "none" — retro has no rules fallback
+		AttrInferenceFallback:   FallbackNoBackend,
+	}
+	for key, expected := range want {
+		if v, ok := attrValue(span, key); !ok || v.AsString() != expected {
+			t.Errorf("attr %s = %q (present=%v), want %q", key, v.AsString(), ok, expected)
+		}
+	}
+	if v, _ := attrValue(span, AttrInferenceUsed); v.AsString() == InferenceRules {
+		t.Errorf("inference.used = %q, must NOT be %q for a retrospective", v.AsString(), InferenceRules)
+	}
+}
+
+// TestRetroCapture_StubDefaultUnchanged: with NO resolver wired (the stub default),
+// the retro attribution is byte-identical to pre-#1080 — model = the agent.model flag
+// (phi4-mini), used = "none", fallback = no_backend_available. This is the
+// default-safety guarantee: the stub path does not change.
+func TestRetroCapture_StubDefaultUnchanged(t *testing.T) {
+	rc, sr := recordingRetro(t, retroFlagSnapshot()) // no SetResolver
+	rc.OnGameEnd(endedSession())
+
+	span := spansByName(sr.Ended(), SpanLLMRetro)[0]
+	want := map[string]string{
+		"gen_ai.request.model":  "phi4-mini",
+		AttrInferenceConfigured: "phi4-mini",
+		AttrInferenceUsed:       DefaultInference,
+		AttrInferenceFallback:   FallbackNoBackend,
+	}
+	for key, expected := range want {
+		if v, ok := attrValue(span, key); !ok || v.AsString() != expected {
+			t.Errorf("attr %s = %q (present=%v), want %q", key, v.AsString(), ok, expected)
+		}
 	}
 }

--- a/services/agent/main.go
+++ b/services/agent/main.go
@@ -759,6 +759,13 @@ func main() {
 	// budget the in-game gate uses (#847 acceptance #7): inject the one instance the
 	// per-game loops also hold, so a retro at game end cannot blow the per-minute cap.
 	retro.SetLLMBudget(sharedLLMBudget)
+	// #1080: route the retro inference attribution through the SAME shared resolver the
+	// per-game loops use (SetResolver above), so when AGENT_INFERENCE_BACKEND=openai the
+	// retro reports the configured backend (gemma4 @ AGENT_INFERENCE_BASE_URL) instead of
+	// resolving the agent.model flag's unreachable phi4-mini legacy tier. With the stub
+	// default the resolver has no configured tier and the chain is unreachable, so the
+	// retro degrades to used="none"/no_backend_available exactly as before.
+	retro.SetResolver(sharedResolver)
 
 	// Game narrative builder (#928, M7-1): on the SAME GameActive true->false
 	// transition, aggregate the partition's pre-reset snapshot (live signals + the


### PR DESCRIPTION
Part of #1080

## Root cause
The retro-capture seam (#844, `decision/retro_capture.go`) never consulted the shared inference resolver the decision loop uses (#1071/#964). It:
- set `prompt.Model = Snapshot.Capability.Model` — the `agent.model` flag, default `phi4-mini` (the legacy unreachable localhost tier);
- hard-coded `inference.used="none"` and `inference.fallback_reason="no_backend_available"` on the `agent.llm.retro` span and log.

So even when `AGENT_INFERENCE_BACKEND=openai` pointed at gemma4 @ `AGENT_INFERENCE_BASE_URL`, the retro logged `model=phi4-mini ... fallback_reason=no_backend_available`.

Separately, the decision span tagged `inference.configured = state.Model` (the same `phi4-mini` flag), so `agent.decision` traces looked like phi4-mini even though the resolver used gemma4.

## Retro routing fix
- `RetroCoordinator` gains a shared `*Resolver` via `SetResolver`, wired in `main.go` to the SAME `sharedResolver` every per-game `Loop` holds.
- New `Resolver.ConfiguredModel()` (returns `inferenceTier`, the configured `AGENT_INFERENCE_MODEL`) and `Resolver.ResolveConfigured(fallbackModel)` (resolves from the configured tier when set, else the flag) are the single source of truth, reusing the existing availability cache.
- `OnGameEnd` now resolves attribution through the resolver: configured backend reachable → `inference.configured`/`gen_ai.request.model`/`inference.used` = the configured model (gemma4), `fallback=""`. The prompt's `Model` is overridden to the configured model.

## Attribution fix
- `LayerState.ConfiguredModel` added (defaults to the `agent.model` flag); `OnEvaluate` overrides it with `resolver.ConfiguredModel()` when a real backend is wired. The decision span's `inference.configured` now reads this. `agent.model` still reports the raw flag.

## Retro DIVERGENCE preserved
A retrospective has no rules fallback, so when the whole chain is genuinely unreachable the retro reports `inference.used="none"` (not `"rules"`) with `no_backend_available` — the documented #844 divergence, unchanged.

## Stub-default safety
With `AGENT_INFERENCE_BACKEND=stub` (default) `main.go` builds a resolver with no configured tier and an unreachable chain, so retro attribution is byte-identical: `model=phi4-mini`, `used="none"`, `fallback=no_backend_available`. A nil resolver (tests) also preserves this. Confirmed by the unchanged `TestRetroCapture_SchemaComplete` and a new `TestRetroCapture_StubDefaultUnchanged`.

## Scope
Backend/model SELECTION + attribution only. No change to decision/gate logic or the retro PROMPT content (#844/#1082).

## Tests
- `TestRetroCapture_ConfiguredBackendReachable` / `_ConfiguredBackendUnreachable` / `_StubDefaultUnchanged`
- `TestInferenceFlow_DecisionSpanConfiguredReflectsBackend` (reachable + unreachable subtests)
- `gofmt -l .` clean, `go build ./...`, `go vet ./...`, `go test ./... -race -count=1` all green (experiment pkg incl. #1097 flake passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)