### PR TITLE
feat(agent): enrich agent.llm.retro span with game outcome + experiment correlation (#1100)

### DIFF
--- a/services/agent/decision/retro_capture.go
+++ b/services/agent/decision/retro_capture.go
@@ -58,6 +58,41 @@ const (
 	AttrLLMRetroBytes = "llm.retro.bytes"
 )
 
+// Structured game-outcome and experiment-correlation attribute keys (#1100). They
+// surface the game outcome (winner / final active players / elimination count /
+// duration) and the shadow-experiment attribution (id / arm / recorded fitness)
+// as DISCRETE, queryable span attributes — the outcome was previously buried only
+// in the llm.retro.user prompt TEXT, and the experiment correlation was absent
+// entirely, so a retro could not be joined to the experiment/arm that spawned it
+// or pivoted on its outcome. The outcome keys reuse the established game.* /
+// experiment.* vocabulary (game.id/game.kind on this span, experiment.id/
+// experiment.arm on the gamecontext span attrs, gamesummary's duration_seconds).
+// Every key is ADDITIVE and OMITTED when its signal is absent (a non-experiment
+// game carries no experiment.* attrs; an unobserved outcome field is dropped), so
+// the schema never emits empty or garbage tags.
+const (
+	// AttrGameWinner is the sole survivor's serial. Omitted when there is no single
+	// unambiguous winner (zero or multiple survivors).
+	AttrGameWinner = "game.winner"
+	// AttrGameFinalActivePlayers is the session's final active-player count. Omitted
+	// when never observed.
+	AttrGameFinalActivePlayers = "game.final_active_players"
+	// AttrGameEliminationCount is the number of eliminations recorded for the game.
+	AttrGameEliminationCount = "game.elimination_count"
+	// AttrGameDurationSeconds is the final observed game duration. Omitted when unknown.
+	AttrGameDurationSeconds = "game.duration_seconds"
+	// AttrExperimentID / AttrExperimentArm are the shadow-experiment attribution this
+	// game belonged to. They mirror the gamecontext span attribute keys (extract_spans.go)
+	// so a Jaeger query joins the retro to the experiment that spawned it. Omitted for a
+	// real / standalone game (no experiment id).
+	AttrExperimentID  = "experiment.id"
+	AttrExperimentArm = "experiment.arm"
+	// AttrExperimentFitness is the game's recorded objective fitness (the #965 finalized
+	// per-game sample) when it is available at retro time. Omitted when no fitness lookup
+	// is wired or the store has no settled sample for this game yet.
+	AttrExperimentFitness = "experiment.fitness"
+)
+
 // retroModeValue is the agent.mode value recorded on the retro-capture span. The
 // span only ever exists at game end on the offline-analyst path, so it is
 // constant — distinct from the in-game llmModeValue.
@@ -108,6 +143,15 @@ type RetroCoordinator struct {
 	// sharing the in-game counter name. Defaults to a no-op so tests need not wire it.
 	llmGated otelmetric.Int64Counter
 
+	// fitnessLookup resolves a finished game's recorded objective fitness by game_id
+	// (#1100), reading the #965 finalized-per-game FitnessStore. When wired and a
+	// settled sample exists, the retro stamps experiment.fitness on the span so a
+	// retro is joinable to the fitness its arm scored. nil (the default / tests /
+	// pre-#1100 wiring) means no fitness attribute is ever emitted — the span is
+	// byte-identical to before except for the always-additive outcome attrs. Injected
+	// via SetFitnessLookup; not safe to call concurrently with OnGameEnd.
+	fitnessLookup func(gameID string) (float64, bool)
+
 	// mu guards the captured-session dedupe state.
 	mu sync.Mutex
 	// captured is the set of recently captured SessionIDs (membership = already
@@ -152,6 +196,18 @@ func (rc *RetroCoordinator) SetLLMBudget(b *llmBudget) { rc.budget = b }
 // no longer reports the unreachable phi4-mini legacy tier. Not safe to call
 // concurrently with OnGameEnd — set it during construction.
 func (rc *RetroCoordinator) SetResolver(r *Resolver) { rc.resolver = r }
+
+// SetFitnessLookup injects the recorded-fitness lookup seam (#1100): a func that
+// returns a finished game's settled objective fitness by game_id (reading the #965
+// FitnessStore) and whether one is available. When wired and a sample exists at
+// retro time, the retro stamps experiment.fitness on the span so a retro joins to
+// the fitness its arm scored. A nil lookup (the default) means experiment.fitness
+// is never emitted — default-safe, the span is unchanged but for the additive
+// outcome attrs. Not safe to call concurrently with OnGameEnd — set it during
+// construction.
+func (rc *RetroCoordinator) SetFitnessLookup(f func(gameID string) (float64, bool)) {
+	rc.fitnessLookup = f
+}
 
 // OnGameEnd is the gamecontext.Store.OnGameEnd callback. It captures the
 // retrospective prompt for a finished session exactly once. It is defensive:
@@ -213,17 +269,26 @@ func (rc *RetroCoordinator) OnGameEnd(c gamecontext.GameContext) {
 	// gen_ai.request.model and the log line both name the configured model.
 	prompt.Model = attr.configured
 
+	attrs := retroPromptAttributes(retroPromptAttrs{
+		prompt:     prompt,
+		sessionID:  c.SessionID,
+		gameKind:   c.GameKind,
+		objectives: snapshot.Objectives,
+		allowed:    snapshot.InterventionsAllowed,
+		configured: attr.configured,
+		used:       attr.used,
+		fallback:   attr.fallback,
+	})
+	// #1100: structured game-outcome attributes (queryable, not buried in the prompt
+	// text) and shadow-experiment correlation (id / arm / recorded fitness). All are
+	// additive and cleanly OMITTED when their signal is absent (a non-experiment game,
+	// an unobserved outcome field, no fitness lookup wired), so the schema never emits
+	// empty/garbage tags and the default path is unchanged.
+	attrs = append(attrs, rc.outcomeAttributes(c)...)
+	attrs = append(attrs, rc.experimentAttributes(c)...)
+
 	_, span := rc.Tracer.Start(context.Background(), SpanLLMRetro,
-		trace.WithAttributes(retroPromptAttributes(retroPromptAttrs{
-			prompt:     prompt,
-			sessionID:  c.SessionID,
-			gameKind:   c.GameKind,
-			objectives: snapshot.Objectives,
-			allowed:    snapshot.InterventionsAllowed,
-			configured: attr.configured,
-			used:       attr.used,
-			fallback:   attr.fallback,
-		})...))
+		trace.WithAttributes(attrs...))
 	span.End()
 
 	rc.Log.Info("agent.llm.retro_captured",
@@ -389,6 +454,59 @@ func retroPromptAttributes(in retroPromptAttrs) []attribute.KeyValue {
 		attribute.String(AttrInferenceUsed, in.used),
 		attribute.String(AttrInferenceFallback, in.fallback),
 	}
+}
+
+// outcomeAttributes builds the STRUCTURED game-outcome span attributes (#1100):
+// winner / final-active-players / elimination-count / duration as DISCRETE,
+// queryable tags. They are derived from the same already-structured GameContext
+// fields the retro prompt renders its Outcome block from (llm.DeriveRetroOutcome —
+// the SINGLE source of truth shared with the prompt), so the span and the prompt
+// text can never disagree, and NOTHING is re-parsed out of the prompt. Each
+// optional field is omitted when its signal was never observed (winner ambiguous,
+// active-count/duration nil) so the span carries no misleading zeros. The
+// elimination count is always present (a finished game has a definite, possibly
+// empty, elimination sequence).
+func (rc *RetroCoordinator) outcomeAttributes(c gamecontext.GameContext) []attribute.KeyValue {
+	o := llm.DeriveRetroOutcome(c)
+	out := make([]attribute.KeyValue, 0, 4)
+	if o.Winner != "" {
+		out = append(out, attribute.String(AttrGameWinner, o.Winner))
+	}
+	if o.FinalActivePlayers != nil {
+		out = append(out, attribute.Int(AttrGameFinalActivePlayers, *o.FinalActivePlayers))
+	}
+	out = append(out, attribute.Int(AttrGameEliminationCount, o.EliminationCount))
+	if o.DurationSeconds != nil {
+		out = append(out, attribute.Float64(AttrGameDurationSeconds, *o.DurationSeconds))
+	}
+	return out
+}
+
+// experimentAttributes builds the shadow-EXPERIMENT correlation span attributes
+// (#1100): experiment.id + experiment.arm when the finished game was an experiment
+// arm, plus experiment.fitness when a recorded fitness sample is available at retro
+// time via the injected lookup seam. The id / arm come straight off the GameContext
+// (the cohort enrichment carried on every lifecycle signal — extract_spans.go), so
+// no registry seam is needed and the lookup never races the registry's conclude-time
+// binding deletion. For a REAL / standalone game (ExperimentID == "") this returns
+// NOTHING — the correlation attrs are absent entirely, never emitted empty. Fitness
+// is stamped only when a lookup is wired AND a settled sample exists; otherwise it
+// is simply omitted (default-safe).
+func (rc *RetroCoordinator) experimentAttributes(c gamecontext.GameContext) []attribute.KeyValue {
+	if c.ExperimentID == "" {
+		return nil // not part of an experiment: emit no experiment.* attrs.
+	}
+	out := make([]attribute.KeyValue, 0, 3)
+	out = append(out, attribute.String(AttrExperimentID, c.ExperimentID))
+	if c.Arm != "" {
+		out = append(out, attribute.String(AttrExperimentArm, c.Arm))
+	}
+	if rc.fitnessLookup != nil {
+		if fitness, ok := rc.fitnessLookup(c.SessionID); ok {
+			out = append(out, attribute.Float64(AttrExperimentFitness, fitness))
+		}
+	}
+	return out
 }
 
 // compile-time guard: RetroCoordinator.OnGameEnd matches the store hook signature.

--- a/services/agent/decision/retro_capture_test.go
+++ b/services/agent/decision/retro_capture_test.go
@@ -326,6 +326,113 @@ func TestRetroCapture_ConfiguredBackendUnreachable(t *testing.T) {
 	}
 }
 
+// attrAbsent fails if the named attribute is present on the span — used to assert
+// the #1100 experiment.* correlation attrs are cleanly OMITTED for a non-experiment
+// game (no empty/garbage tags).
+func attrAbsent(t *testing.T, span sdktrace.ReadOnlySpan, key string) {
+	t.Helper()
+	if _, ok := attrValue(span, key); ok {
+		t.Errorf("attr %s must be ABSENT, but it is present", key)
+	}
+}
+
+// TestRetroCapture_OutcomeAttributes: every retro span carries the STRUCTURED
+// game-outcome attributes (#1100) derived from the GameContext (not the prompt
+// text). endedSession() has survivor AA:11, one elimination (BB:22), duration 90,
+// and no observed active-player count.
+func TestRetroCapture_OutcomeAttributes(t *testing.T) {
+	rc, sr := recordingRetro(t, retroFlagSnapshot())
+	rc.OnGameEnd(endedSession())
+
+	span := spansByName(sr.Ended(), SpanLLMRetro)[0]
+	if v, ok := attrValue(span, AttrGameWinner); !ok || v.AsString() != "AA:11" {
+		t.Errorf("game.winner = %q (present=%v), want %q", v.AsString(), ok, "AA:11")
+	}
+	if v, ok := attrValue(span, AttrGameEliminationCount); !ok || v.AsInt64() != 1 {
+		t.Errorf("game.elimination_count = %d (present=%v), want 1", v.AsInt64(), ok)
+	}
+	if v, ok := attrValue(span, AttrGameDurationSeconds); !ok || v.AsFloat64() != 90.0 {
+		t.Errorf("game.duration_seconds = %v (present=%v), want 90", v.AsFloat64(), ok)
+	}
+	// No active-player count was observed, so the attribute is cleanly omitted (not 0).
+	attrAbsent(t, span, AttrGameFinalActivePlayers)
+}
+
+// TestRetroCapture_ExperimentAttributesPresent: when the finished game was a
+// shadow-experiment arm (ExperimentID/Arm on the GameContext) AND a recorded
+// fitness sample is available via the lookup seam, the retro span stamps
+// experiment.id / experiment.arm / experiment.fitness (#1100).
+func TestRetroCapture_ExperimentAttributesPresent(t *testing.T) {
+	rc, sr := recordingRetro(t, retroFlagSnapshot())
+	rc.SetFitnessLookup(func(gameID string) (float64, bool) {
+		if gameID == "session-7" {
+			return 0.42, true
+		}
+		return 0, false
+	})
+
+	c := endedSession()
+	c.GameKind = "shadow"
+	c.ExperimentID = "exp_abc123def456"
+	c.Arm = "experimental"
+	rc.OnGameEnd(c)
+
+	span := spansByName(sr.Ended(), SpanLLMRetro)[0]
+	if v, ok := attrValue(span, AttrExperimentID); !ok || v.AsString() != "exp_abc123def456" {
+		t.Errorf("experiment.id = %q (present=%v), want %q", v.AsString(), ok, "exp_abc123def456")
+	}
+	if v, ok := attrValue(span, AttrExperimentArm); !ok || v.AsString() != "experimental" {
+		t.Errorf("experiment.arm = %q (present=%v), want %q", v.AsString(), ok, "experimental")
+	}
+	if v, ok := attrValue(span, AttrExperimentFitness); !ok || v.AsFloat64() != 0.42 {
+		t.Errorf("experiment.fitness = %v (present=%v), want 0.42", v.AsFloat64(), ok)
+	}
+}
+
+// TestRetroCapture_ExperimentAttributesAbsentForRealGame: a non-experiment (real /
+// standalone) game carries NO experiment.* correlation attrs — they are cleanly
+// omitted, never emitted empty/garbage (#1100). The structured outcome attrs are
+// still present (they apply to every game).
+func TestRetroCapture_ExperimentAttributesAbsentForRealGame(t *testing.T) {
+	rc, sr := recordingRetro(t, retroFlagSnapshot())
+	// A fitness lookup IS wired, but the game is not an experiment, so it must never
+	// be consulted and experiment.fitness must be absent.
+	rc.SetFitnessLookup(func(string) (float64, bool) { return 0.99, true })
+
+	rc.OnGameEnd(endedSession()) // ExperimentID == "" (a real game)
+
+	span := spansByName(sr.Ended(), SpanLLMRetro)[0]
+	attrAbsent(t, span, AttrExperimentID)
+	attrAbsent(t, span, AttrExperimentArm)
+	attrAbsent(t, span, AttrExperimentFitness)
+	// Outcome attrs are game-agnostic, so they are still present.
+	if _, ok := attrValue(span, AttrGameEliminationCount); !ok {
+		t.Error("game.elimination_count must be present for a real game too")
+	}
+}
+
+// TestRetroCapture_ExperimentFitnessOmittedWhenUnavailable: an experiment game with
+// id/arm but NO recorded fitness yet (lookup reports not-found, or no lookup wired)
+// stamps experiment.id / experiment.arm but OMITS experiment.fitness — default-safe
+// (#1100).
+func TestRetroCapture_ExperimentFitnessOmittedWhenUnavailable(t *testing.T) {
+	rc, sr := recordingRetro(t, retroFlagSnapshot())
+	// No fitness lookup wired at all (the pre-#1100 / nil-seam default).
+	c := endedSession()
+	c.ExperimentID = "exp_no_fitness"
+	c.Arm = "control"
+	rc.OnGameEnd(c)
+
+	span := spansByName(sr.Ended(), SpanLLMRetro)[0]
+	if v, ok := attrValue(span, AttrExperimentID); !ok || v.AsString() != "exp_no_fitness" {
+		t.Errorf("experiment.id = %q (present=%v), want %q", v.AsString(), ok, "exp_no_fitness")
+	}
+	if v, ok := attrValue(span, AttrExperimentArm); !ok || v.AsString() != "control" {
+		t.Errorf("experiment.arm = %q (present=%v), want %q", v.AsString(), ok, "control")
+	}
+	attrAbsent(t, span, AttrExperimentFitness)
+}
+
 // TestRetroCapture_StubDefaultUnchanged: with NO resolver wired (the stub default),
 // the retro attribution is byte-identical to pre-#1080 — model = the agent.model flag
 // (phi4-mini), used = "none", fallback = no_backend_available. This is the

--- a/services/agent/llm/retro.go
+++ b/services/agent/llm/retro.go
@@ -190,6 +190,46 @@ func playerOutcome(serial string, eliminationSequence []string) string {
 	return "survivor"
 }
 
+// RetroOutcome is the STRUCTURED game outcome the retro is built from (#1100):
+// the same winner / final-active-players / elimination-count / duration the
+// retrospective prompt renders into its "Outcome" block, but exposed as discrete
+// values so retro_capture.go can stamp them as queryable span ATTRIBUTES instead
+// of leaving them buried in the prompt text. Pointers distinguish "the signal was
+// never observed" (nil) from a real zero, so the span omits an unobserved attr
+// rather than emitting a misleading 0.
+type RetroOutcome struct {
+	// Winner is the sole survivor's serial, or "" when there is no single,
+	// unambiguous winner (zero or multiple survivors) — see winnerSerial.
+	Winner string
+	// FinalActivePlayers is the session's final active-player count, or nil when
+	// never observed.
+	FinalActivePlayers *int
+	// EliminationCount is the number of players in the elimination sequence.
+	EliminationCount int
+	// DurationSeconds is the final observed game duration, or nil when unknown.
+	DurationSeconds *float64
+}
+
+// DeriveRetroOutcome extracts the structured game outcome from a finished-game
+// GameContext (#1100). It is the SINGLE source of truth shared with the prompt:
+// it derives the winner from the SAME (roster, elimination sequence) pair that
+// buildRetroUser renders, so the span attributes and the prompt text can never
+// disagree. It reads only already-structured GameContext fields — it NEVER parses
+// the rendered prompt text. The winner is "" (not the prompt's "unknown" literal)
+// when ambiguous, so the caller can cleanly omit the attribute.
+func DeriveRetroOutcome(ctx gamecontext.GameContext) RetroOutcome {
+	winner := winnerSerial(sortedSerials(ctx.Players), ctx.Session.EliminationSequence)
+	if winner == unknown {
+		winner = ""
+	}
+	return RetroOutcome{
+		Winner:             winner,
+		FinalActivePlayers: ctx.Session.ActivePlayerCount,
+		EliminationCount:   len(ctx.Session.EliminationSequence),
+		DurationSeconds:    ctx.Session.DurationSeconds,
+	}
+}
+
 // winnerSerial returns the sole survivor's serial — a player present in the
 // roster but absent from the elimination sequence — when EXACTLY one player
 // survived. Zero survivors (everyone eliminated) or more than one survivor both

--- a/services/agent/main.go
+++ b/services/agent/main.go
@@ -850,6 +850,20 @@ func main() {
 	// (#1057). The experiment loop's onGameEnd Records into it; the Watcher reads
 	// recent REAL samples out of it.
 	fitnessStore := experiment.NewFitnessStore(fitnessStoreCapacity())
+	// #1100: give the retro span access to a finished experiment game's RECORDED
+	// fitness, keyed by game_id, so an agent.llm.retro span carries experiment.fitness
+	// alongside experiment.id / experiment.arm — making a retro joinable to the fitness
+	// its arm scored. The experiment loop's onGameEnd (chained BEFORE retro.OnGameEnd
+	// below) Records the settled sample into THIS store first, so the lookup sees it at
+	// retro time. A non-experiment game has no sample (and carries no ExperimentID), so
+	// the lookup is never even consulted for it — default-safe.
+	retro.SetFitnessLookup(func(gameID string) (float64, bool) {
+		s, ok := fitnessStore.Get(gameID)
+		if !ok {
+			return 0, false
+		}
+		return s.Fitness, true
+	})
 	// objResolver maps a promoted flag → its experiment's objective for the Watcher's
 	// store reads. It is late-bound: the registry that knows the mapping is built inside
 	// buildExperimentLoop (below), so the resolver is SET there once the registry exists.
@@ -908,22 +922,27 @@ func main() {
 		s := gamecontext.NewStore(lifecycle.PlayerTTL, lifecycle.SessionGrace, nil)
 		s.SetTTLSources(lifecycleHolder.PlayerTTL, lifecycleHolder.SessionGrace)
 		s.SetOwnService(ownService)
-		// Chain BOTH game-end consumers onto the single store hook (#928): the #844
-		// retrospective AND the M7-1 summary builder both fire on game end with the
-		// pre-reset snapshot. Each has its OWN once-per-game dedupe, so chaining cannot
-		// make either double-fire. Order is retro-then-summary, but they are independent
-		// (neither reads the other's state).
-		// Chain the #991 experiment conclusion hook too (nil when the loop is
-		// disabled, so chainGameEnd skips it — zero overhead in the default path). For
-		// an experiment-bound shadow game it folds the game's fitness into the cohort
-		// journal via Registry.ConcludeGame; for every NON-experiment game it is a
-		// no-op (ConcludeGame ignores an unknown game_id), so the existing retro/
-		// summary behavior is untouched.
+		// Chain the game-end consumers onto the single store hook (#928): the #991
+		// experiment conclusion hook, the #844 retrospective, the M7-1 summary builder,
+		// and the M7-4 proposer all fire on game end with the pre-reset snapshot. Each
+		// has its OWN once-per-game dedupe, so chaining cannot make any double-fire, and
+		// they are otherwise independent (no consumer reads another's in-memory state).
+		//
+		// ORDER (#1100): the experiment conclusion hook runs FIRST so it records the
+		// game's finalized fitness into the #965 FitnessStore BEFORE the retro reads it
+		// back by game_id (SetFitnessLookup) — making experiment.fitness available on the
+		// agent.llm.retro span at retro time for an experiment arm. The chain is one
+		// synchronous call on this goroutine, so "record-then-read" is guaranteed. The
+		// experiment hook is nil when the loop is disabled (chainGameEnd skips it — zero
+		// overhead in the default path); for an experiment-bound shadow game it folds the
+		// fitness into the cohort journal via Registry.ConcludeGame, and for every
+		// NON-experiment game it is a no-op (ConcludeGame ignores an unknown game_id), so
+		// the existing retro/summary behavior is untouched.
 		var experimentOnGameEnd func(gamecontext.GameContext)
 		if expLoop != nil {
 			experimentOnGameEnd = expLoop.onGameEnd
 		}
-		s.OnGameEnd = chainGameEnd(retro.OnGameEnd, summaries.OnGameEnd, proposeOnGameEnd, experimentOnGameEnd)
+		s.OnGameEnd = chainGameEnd(experimentOnGameEnd, retro.OnGameEnd, summaries.OnGameEnd, proposeOnGameEnd)
 		return s
 	})
 	mux.SetOwnService(ownService)


### PR DESCRIPTION
Part of #1100

The `agent.llm.retro` span was an orphan single-span trace carrying the game outcome only inside the `llm.retro.user` prompt TEXT, with no experiment correlation. You could not pivot a retro on its outcome or join it to the experiment/arm that spawned it. This adds discrete, queryable span ATTRIBUTES (additive only — prompt text and #1099 inference attribution unchanged).

## Structured game-outcome attributes
Derived from the same already-structured `GameContext` fields the prompt renders its Outcome block from (new `llm.DeriveRetroOutcome`, the single source of truth shared with the prompt — no prompt-text re-parsing):
- `game.winner` — omitted when no single unambiguous winner
- `game.final_active_players` — omitted when never observed
- `game.elimination_count`
- `game.duration_seconds` — omitted when unknown

## Experiment correlation
Sourced straight off the `GameContext` cohort enrichment (`experiment.id` / `experiment.arm`, the same keys `extract_spans.go` reads), so **no registry seam is needed** and the read never races the registry's conclude-time binding deletion:
- `experiment.id` / `experiment.arm` — present only for a shadow-experiment arm
- `experiment.fitness` — the recorded #965 finalized-per-game fitness, via an injected lookup seam (`SetFitnessLookup`) over the `FitnessStore`, keyed by game_id

The experiment conclusion hook is chained BEFORE `retro.OnGameEnd` so the finalized fitness is recorded into the store before the retro reads it back (one synchronous call — record-then-read guaranteed).

## Default-safety
A real / standalone game (`ExperimentID == ""`) emits NO `experiment.*` attrs. A nil fitness lookup or no settled sample omits `experiment.fitness`. Unobserved outcome fields are omitted (no misleading zeros). The stub/no-resolver path is unchanged.

## Tests
New tests in `decision/retro_capture_test.go`: outcome attrs present and correct; experiment attrs (id/arm/fitness) present for an experiment arm; experiment attrs absent for a real game; fitness omitted when unavailable. `gofmt`/`go build`/`go vet` clean; `go test ./... -race` green except the known #1097 flake (`TestConcurrentAllocateAndConcludeNoLeak`), which passes on re-run (no experiment-package code touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)