### PR TITLE
feat(agent): persist autonomous-promotion revert snapshot across restart (#1076)

### DIFF
--- a/services/agent/main.go
+++ b/services/agent/main.go
@@ -278,6 +278,12 @@ func buildPromoter(rootCtx context.Context, store *experiment.FitnessStore, objR
 
 	p := promote.NewPromoter(ghIface, gitIface, realDefIface, watcherIface, reverterIface, repo, nil, logger)
 	p.SetCooldown(revertCooldown())
+	// Seed the post-revert cooldown from the durable snapshot store (#1076 item 3) so
+	// thrash protection survives an agent restart. realDef carries the persisted revert
+	// timestamps; a nil writer (autonomous off) yields nothing to seed.
+	if realDef != nil {
+		p.SeedLastRevert(realDef.PersistedRevertTimes())
+	}
 	if rewatcher != nil {
 		p.SetRewatcher(rewatcher)
 	}

--- a/services/agent/promote/live_test.go
+++ b/services/agent/promote/live_test.go
@@ -118,6 +118,45 @@ func TestRevertCooldownSuppressesImmediateRepromotion(t *testing.T) {
 	}
 }
 
+// TestSeedLastRevertPreservesCooldownAcrossRestart: a post-revert cooldown stamp
+// recovered from the durable store (#1076 item 3) must suppress an immediate
+// re-promotion after a restart — modeling an agent that reverted, then restarted, then
+// is asked to re-promote the same flag inside the cooldown window.
+func TestSeedLastRevertPreservesCooldownAcrossRestart(t *testing.T) {
+	realDef := &recordingRealDefault{}
+	rev := &recordingReverter{}
+	healthy := fakeWatcher{degraded: false} // would normally apply + keep
+	p, _ := promoterWithRecorder(t, &recordingGitHub{}, &recordingGit{}, realDef, healthy, rev)
+
+	now := time.Unix(2000, 0)
+	p.SetClock(func() time.Time { return now })
+	p.SetCooldown(5 * time.Minute)
+
+	// Simulate a pre-restart revert at t=1900 recovered from the durable store.
+	p.SeedLastRevert(map[string]time.Time{promoteProposal.FlagKey: time.Unix(1900, 0)})
+
+	cfg := Config{Mode: ModeAutonomous, Target: TargetLocal, Enabled: true}
+
+	// Within the seeded cooldown (1900 + 5m > 2000): re-promotion is suppressed.
+	res := p.Promote(context.Background(), promoteProposal, promoteVerdict, cfg, testEvidence())
+	if res.Outcome != OutcomeDiscarded {
+		t.Fatalf("re-promotion outcome = %q, want discarded (seeded cooldown holds)", res.Outcome)
+	}
+	if len(realDef.calls) != 0 {
+		t.Errorf("SetRealDefault calls = %d, want 0 (apply suppressed by restored cooldown)", len(realDef.calls))
+	}
+
+	// Past the seeded cooldown: a re-promotion is allowed again.
+	now = time.Unix(1900, 0).Add(6 * time.Minute)
+	res2 := p.Promote(context.Background(), promoteProposal, promoteVerdict, cfg, testEvidence())
+	if res2.Outcome == OutcomeDiscarded {
+		t.Fatalf("post-cooldown outcome = %q, want NOT discarded (cooldown elapsed)", res2.Outcome)
+	}
+	if len(realDef.calls) != 1 {
+		t.Errorf("SetRealDefault calls = %d, want 1 (apply allowed after cooldown elapsed)", len(realDef.calls))
+	}
+}
+
 var errTelemetry = errTelemetryT("telemetry unreachable")
 
 type errTelemetryT string

--- a/services/agent/promote/promote.go
+++ b/services/agent/promote/promote.go
@@ -341,6 +341,28 @@ func (pr *Promoter) SetRewatcher(r Rewatcher) {
 	pr.rewatcher = r
 }
 
+// SeedLastRevert pre-populates the post-revert cooldown map from durably-persisted
+// revert timestamps (#1076 item 3), so post-revert thrash protection survives an
+// agent restart. Called once from main.go after construction with the reverter's
+// PersistedRevertTimes. A nil/empty map is a no-op. Existing in-memory entries are
+// only overwritten by a LATER persisted stamp (a fresh in-process revert always
+// wins), so seeding can never roll a cooldown backward.
+func (pr *Promoter) SeedLastRevert(times map[string]time.Time) {
+	if len(times) == 0 {
+		return
+	}
+	pr.mu.Lock()
+	defer pr.mu.Unlock()
+	if pr.lastRevert == nil {
+		pr.lastRevert = map[string]time.Time{}
+	}
+	for k, t := range times {
+		if existing, ok := pr.lastRevert[k]; !ok || t.After(existing) {
+			pr.lastRevert[k] = t
+		}
+	}
+}
+
 // RepoRef identifies the GitHub repo + default base branch a promotion targets.
 // Populated from env in main.go (GITHUB_REPOSITORY / GITHUB_BASE_BRANCH); the
 // fakes in tests use a fixed value.

--- a/services/agent/promote/realdefault.go
+++ b/services/agent/promote/realdefault.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync"
 	"syscall"
+	"time"
 )
 
 // realdefault.go is the autonomous mode's REAL defaultVariant mutation — the
@@ -55,6 +56,27 @@ type fileRealDefaultWriter struct {
 	// state BEFORE the agent first touched the flag, never to an intermediate
 	// agent-written value.
 	snapshots map[string]defaultSnapshot
+	// snaps is the DURABLE backing for snapshots + the post-revert cooldown stamps
+	// (#1076). Without it, a restart between an autonomous apply and a later revert
+	// strands the regression (RevertRealDefault finds no snapshot in memory). It is
+	// loaded on construction and written through on first-touch snapshot + on
+	// successful revert. nil only when the persistence dir was unreadable at
+	// construction (logged); the in-memory map then still works for the live process.
+	snaps *snapStore
+	// clock is an injectable time source for the persisted post-revert cooldown stamp
+	// (#1076). nil → time.Now (production). Tests set it to drive the stamp.
+	clock func() time.Time
+}
+
+// PersistedRevertTimes exposes the durable post-revert cooldown stamps so the
+// Promoter can seed its in-memory lastRevert map after a restart (#1076 item 3),
+// preserving post-revert thrash protection across the restart boundary. Empty when
+// no flag has been reverted or the store is unavailable.
+func (w *fileRealDefaultWriter) PersistedRevertTimes() map[string]time.Time {
+	if w.snaps == nil {
+		return nil
+	}
+	return w.snaps.loadLastRevert()
 }
 
 // defaultSnapshot is the exact pre-promotion real-default state for one flag: the
@@ -107,9 +129,25 @@ func NewRealDefaultWriterFromEnv(log *slog.Logger) (*fileRealDefaultWriter, erro
 	if _, err := os.Stat(path); err != nil {
 		return nil, fmt.Errorf("AGENT_REAL_DEFAULT_FLAG_PATH=%q not readable: %w", path, err)
 	}
+	// Load the DURABLE snapshot store (#1076) from the persisted volume so a revert
+	// after an agent restart still finds the pre-promotion snapshot. A missing file
+	// is a clean first run; a corrupt/unreadable file is logged and the agent starts
+	// with an empty in-memory map rather than refusing to boot — the durable copy is
+	// a safety net, not a hard prerequisite for the (default-off) autonomous path.
+	dir := snapStoreDir()
+	snaps, err := newSnapStore(dir)
+	if err != nil {
+		log.Warn("code_improvement real-default snapshot store could not be loaded; starting with empty in-memory snapshots (a revert of a PRE-restart promotion may be unavailable until re-snapshotted)",
+			"dir", dir, "error", err)
+	}
+	loaded := snaps.loadSnapshots()
+	if len(loaded) > 0 {
+		log.Warn("code_improvement real-default reverter restored pre-promotion snapshots from durable store (#1076): a post-restart revert can roll these back",
+			"flags", len(loaded))
+	}
 	log.Warn("code_improvement AUTONOMOUS real-default writer ENABLED (#936): autonomous promotions WILL change the REAL defaultVariant for live players",
 		"path", path)
-	return &fileRealDefaultWriter{path: path, log: log, snapshots: map[string]defaultSnapshot{}}, nil
+	return &fileRealDefaultWriter{path: path, log: log, snapshots: loaded, snaps: snaps}, nil
 }
 
 // SetRealDefault changes the REAL defaultVariant for flagKey to value: it ensures a
@@ -194,6 +232,19 @@ func (w *fileRealDefaultWriter) SetRealDefault(_ context.Context, flagKey string
 			}
 		}
 		w.snapshots[flagKey] = snap
+		// Persist the snapshot DURABLY before the mutating write (#1076), so a revert
+		// after an agent restart can still roll back. Surface a persistence failure as
+		// an error and ABORT the promotion: applying a real-default change whose revert
+		// snapshot did not reach disk would reintroduce the exact strand-on-restart bug
+		// this issue closes (the flag file would hold the promoted value with no durable
+		// way to undo it after a restart). Drop the in-memory snapshot too so state stays
+		// consistent with the un-mutated file.
+		if w.snaps != nil {
+			if err := w.snaps.putSnapshot(flagKey, snap); err != nil {
+				delete(w.snapshots, flagKey)
+				return fmt.Errorf("persist pre-promotion snapshot for %q (refusing to promote without a durable revert path): %w", flagKey, err)
+			}
+		}
 	}
 
 	// Point at an existing variant if one already equals value (keeps the file tidy),
@@ -301,7 +352,30 @@ func (w *fileRealDefaultWriter) RevertRealDefault(_ context.Context, flagKey str
 	}
 	// Drop the snapshot so a subsequent promotion re-captures fresh prior state.
 	delete(w.snapshots, flagKey)
+	// Durably drop the snapshot AND stamp the revert time (#1076), so (a) a restart
+	// does not resurrect a stale snapshot for an already-reverted flag, and (b) the
+	// post-revert cooldown (#1065 item 3) survives a restart — the Promoter seeds
+	// lastRevert from this stamp on boot. Persistence failure here is logged, NOT
+	// returned: the revert itself ALREADY succeeded (the file holds the prior value),
+	// so failing the call would wrongly imply the rollback did not happen. The only
+	// cost of a lost stamp is a missed cooldown across a restart that coincides with a
+	// store-write failure — strictly less dangerous than a stranded regression.
+	if w.snaps != nil {
+		if err := w.snaps.markReverted(flagKey, w.now()); err != nil {
+			w.log.Warn("code_improvement real-default revert succeeded but durable snapshot/cooldown update failed; cooldown may not survive a restart (#1076)",
+				"flag", flagKey, "error", err)
+		}
+	}
 	return nil
+}
+
+// now returns the writer's time source. Production uses time.Now; tests can swap it
+// to drive the persisted cooldown stamp deterministically.
+func (w *fileRealDefaultWriter) now() time.Time {
+	if w.clock != nil {
+		return w.clock()
+	}
+	return time.Now()
 }
 
 // writeInPlace overwrites the file at the same path WITHOUT temp+rename (EBUSY on

--- a/services/agent/promote/realdefault_test.go
+++ b/services/agent/promote/realdefault_test.go
@@ -43,6 +43,7 @@ func TestRealDefaultWriterChangesDefaultVariant(t *testing.T) {
 	t.Setenv("AGENT_CODE_IMPROVEMENT_ENABLED", "true")
 	t.Setenv("AGENT_AUTONOMOUS_ENABLED", "true")
 	t.Setenv("AGENT_REAL_DEFAULT_FLAG_PATH", path)
+	t.Setenv("AGENT_EXPERIMENT_DIR", t.TempDir()) // durable snapshot store (#1076) → temp
 
 	w, err := NewRealDefaultWriterFromEnv(discardLogger())
 	if err != nil {
@@ -94,6 +95,7 @@ func TestRealDefaultWriterRejectsTypeMismatch(t *testing.T) {
 	t.Setenv("AGENT_CODE_IMPROVEMENT_ENABLED", "true")
 	t.Setenv("AGENT_AUTONOMOUS_ENABLED", "true")
 	t.Setenv("AGENT_REAL_DEFAULT_FLAG_PATH", path)
+	t.Setenv("AGENT_EXPERIMENT_DIR", t.TempDir()) // durable snapshot store (#1076) → temp
 	w, err := NewRealDefaultWriterFromEnv(discardLogger())
 	if err != nil || w == nil {
 		t.Fatalf("writer build: err=%v nil=%v", err, w == nil)
@@ -152,14 +154,9 @@ func resolvedDefault(t *testing.T, path, flagKey string) string {
 
 func realDefaultWriterForTest(t *testing.T, path string) *fileRealDefaultWriter {
 	t.Helper()
-	t.Setenv("AGENT_CODE_IMPROVEMENT_ENABLED", "true")
-	t.Setenv("AGENT_AUTONOMOUS_ENABLED", "true")
-	t.Setenv("AGENT_REAL_DEFAULT_FLAG_PATH", path)
-	w, err := NewRealDefaultWriterFromEnv(discardLogger())
-	if err != nil || w == nil {
-		t.Fatalf("writer build: err=%v nil=%v", err, w == nil)
-	}
-	return w
+	// Point the durable snapshot store (#1076) at a temp dir so tests never touch the
+	// real /var/lib persistence path.
+	return realDefaultWriterForTestWithStore(t, path, t.TempDir())
 }
 
 // TestRevertRestoresExactPriorValue is the safety-critical property (#1065): a
@@ -266,6 +263,151 @@ func TestRevertWithoutSnapshotIsRefused(t *testing.T) {
 	w := realDefaultWriterForTest(t, path)
 	if err := w.RevertRealDefault(context.Background(), "death_grace_period_ms"); err == nil {
 		t.Fatal("RevertRealDefault with no snapshot should be refused, got nil error")
+	}
+}
+
+// realDefaultWriterForTestWithStore builds a writer like realDefaultWriterForTest but
+// also points the durable snapshot store (#1076) at storeDir, so the test can build a
+// SECOND writer over the same dir to simulate an agent restart. Returns the writer.
+func realDefaultWriterForTestWithStore(t *testing.T, path, storeDir string) *fileRealDefaultWriter {
+	t.Helper()
+	t.Setenv("AGENT_CODE_IMPROVEMENT_ENABLED", "true")
+	t.Setenv("AGENT_AUTONOMOUS_ENABLED", "true")
+	t.Setenv("AGENT_REAL_DEFAULT_FLAG_PATH", path)
+	t.Setenv("AGENT_EXPERIMENT_DIR", storeDir)
+	w, err := NewRealDefaultWriterFromEnv(discardLogger())
+	if err != nil || w == nil {
+		t.Fatalf("writer build: err=%v nil=%v", err, w == nil)
+	}
+	return w
+}
+
+// TestSnapshotSurvivesRestartAndReverts is the #1076 key test: a snapshot persisted by
+// one writer must let a SUBSEQUENT writer (a new instance over the SAME durable store,
+// modeling an agent restart between apply and revert) revert to the EXACT pre-promotion
+// value. Without persistence the second writer would find no snapshot and refuse the
+// revert, stranding the regression on live players.
+func TestSnapshotSurvivesRestartAndReverts(t *testing.T) {
+	dir := t.TempDir()
+	path := writeFlagFile(t, dir) // default=300, defaultVariant=default
+	storeDir := t.TempDir()
+	ctx := context.Background()
+
+	// --- "before restart" writer: apply the promotion (captures + persists snapshot).
+	w1 := realDefaultWriterForTestWithStore(t, path, storeDir)
+	if err := w1.SetRealDefault(ctx, "death_grace_period_ms", 500); err != nil {
+		t.Fatalf("SetRealDefault: %v", err)
+	}
+	if got := resolvedDefault(t, path, "death_grace_period_ms"); got != "500" {
+		t.Fatalf("post-promotion default = %s, want 500", got)
+	}
+
+	// --- simulate restart: a brand-new writer over the SAME durable store dir. It must
+	// rehydrate the snapshot from disk (w1's in-memory map is gone).
+	w2 := realDefaultWriterForTestWithStore(t, path, storeDir)
+	if _, held := w2.snapshots["death_grace_period_ms"]; !held {
+		t.Fatal("restart writer did not rehydrate the persisted snapshot (#1076 strand-on-restart bug)")
+	}
+	if err := w2.RevertRealDefault(ctx, "death_grace_period_ms"); err != nil {
+		t.Fatalf("post-restart RevertRealDefault: %v", err)
+	}
+	if got := resolvedDefault(t, path, "death_grace_period_ms"); got != "300" {
+		t.Errorf("post-restart revert default = %s, want exact pre-promotion 300", got)
+	}
+}
+
+// TestSnapshotSurvivesRestartDespiteInterveningClobber mirrors the #1065
+// intervening-slot-overwrite test but across a RESTART boundary: the persisted
+// snapshot must carry the VALUE (not just the variant name), so a post-restart revert
+// restores the exact prior value even if the original variant's slot was clobbered.
+func TestSnapshotSurvivesRestartDespiteInterveningClobber(t *testing.T) {
+	dir := t.TempDir()
+	path := writeFlagFile(t, dir)
+	storeDir := t.TempDir()
+	ctx := context.Background()
+
+	w1 := realDefaultWriterForTestWithStore(t, path, storeDir)
+	if err := w1.SetRealDefault(ctx, "death_grace_period_ms", 500); err != nil {
+		t.Fatalf("SetRealDefault: %v", err)
+	}
+	// An intervening write clobbers the ORIGINAL "default" variant's value to garbage.
+	clobberVariantValue(t, path, "death_grace_period_ms", "default", 999)
+
+	// Restart: new writer, must restore the SNAPSHOTTED 300, not the clobbered 999.
+	w2 := realDefaultWriterForTestWithStore(t, path, storeDir)
+	if err := w2.RevertRealDefault(ctx, "death_grace_period_ms"); err != nil {
+		t.Fatalf("post-restart RevertRealDefault: %v", err)
+	}
+	if got := resolvedDefault(t, path, "death_grace_period_ms"); got != "300" {
+		t.Errorf("post-restart revert default = %s, want exact snapshotted 300 (NOT clobbered 999)", got)
+	}
+}
+
+// TestRevertDropsPersistedSnapshotButKeepsCooldown: after a successful revert the
+// durable snapshot is dropped (a fresh promotion re-snapshots), but the post-revert
+// cooldown stamp is PERSISTED so thrash protection survives a restart. A restart after
+// the revert must therefore NOT resurrect a stale snapshot, yet must expose the revert
+// timestamp.
+func TestRevertDropsPersistedSnapshotButKeepsCooldown(t *testing.T) {
+	dir := t.TempDir()
+	path := writeFlagFile(t, dir)
+	storeDir := t.TempDir()
+	ctx := context.Background()
+
+	w1 := realDefaultWriterForTestWithStore(t, path, storeDir)
+	if err := w1.SetRealDefault(ctx, "death_grace_period_ms", 500); err != nil {
+		t.Fatalf("SetRealDefault: %v", err)
+	}
+	if err := w1.RevertRealDefault(ctx, "death_grace_period_ms"); err != nil {
+		t.Fatalf("RevertRealDefault: %v", err)
+	}
+
+	// Restart: the stale snapshot must NOT come back, but the cooldown stamp must.
+	w2 := realDefaultWriterForTestWithStore(t, path, storeDir)
+	if _, held := w2.snapshots["death_grace_period_ms"]; held {
+		t.Error("restart resurrected a snapshot for an already-reverted flag (would mis-revert a future un-snapshotted state)")
+	}
+	times := w2.PersistedRevertTimes()
+	if _, ok := times["death_grace_period_ms"]; !ok {
+		t.Error("post-revert cooldown stamp did not survive restart (#1076 item 3)")
+	}
+	// A revert with no snapshot is correctly refused after restart.
+	if err := w2.RevertRealDefault(ctx, "death_grace_period_ms"); err == nil {
+		t.Error("revert of an already-reverted flag after restart should be refused")
+	}
+}
+
+// TestPromoteFailsClosedWhenSnapshotCannotPersist: if the durable snapshot write
+// fails, SetRealDefault must REFUSE the promotion rather than mutate the flag file
+// without a durable revert path (which would reintroduce the strand-on-restart bug).
+func TestPromoteFailsClosedWhenSnapshotCannotPersist(t *testing.T) {
+	dir := t.TempDir()
+	path := writeFlagFile(t, dir)
+	before, _ := os.ReadFile(path)
+	storeDir := t.TempDir()
+	ctx := context.Background()
+
+	w := realDefaultWriterForTestWithStore(t, path, storeDir)
+	// Make the store path unwritable: replace the store DIR with a regular file so the
+	// MkdirAll/CreateTemp inside flush fails.
+	if err := os.RemoveAll(storeDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(storeDir, []byte("not a dir"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.SetRealDefault(ctx, "death_grace_period_ms", 500); err == nil {
+		t.Fatal("SetRealDefault must fail closed when the snapshot cannot be persisted")
+	}
+	// The flag file must be UNCHANGED — no real-default mutation without a durable revert.
+	after, _ := os.ReadFile(path)
+	if string(before) != string(after) {
+		t.Error("flag file was mutated despite the snapshot-persist failure (strand-on-restart risk)")
+	}
+	// The in-memory snapshot must not linger (it would imply a revert is possible when
+	// the file was never mutated).
+	if _, held := w.snapshots["death_grace_period_ms"]; held {
+		t.Error("in-memory snapshot lingered after a failed persist")
 	}
 }
 

--- a/services/agent/promote/snapstore.go
+++ b/services/agent/promote/snapstore.go
@@ -1,0 +1,236 @@
+package promote
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+// snapstore.go is the DURABLE backing for the autonomous real-default reverter
+// (#1076). The pre-promotion snapshot the reverter rolls back through, and the
+// post-revert cooldown timestamps, were previously in-memory ONLY: if the agent
+// restarted between an autonomous apply and a later revert, RevertRealDefault
+// found no snapshot and could not roll the regression back — the bad real default
+// rode on live players indefinitely. The flag FILE still held the promoted value
+// after restart, so a persisted snapshot is the only missing ingredient.
+//
+// This is a MINIMAL durable store, NOT a journal reuse: the #983 journal is
+// modeled per-experiment ({intent, append-only events, rolling summary} keyed by
+// experiment_id) and is the wrong shape for a flat {flagKey -> snapshot} map. It
+// DOES live in the SAME persisted location as the journal (AGENT_EXPERIMENT_DIR /
+// the #1025 named volume), reusing the journal's proven atomic-write discipline
+// (temp + fsync + rename) so the file survives both a process restart and a
+// container recreation.
+//
+// DEFAULT-SAFE: this store adds DURABILITY to the EXISTING reverter only. It is
+// constructed solely inside NewRealDefaultWriterFromEnv, behind the same two env
+// gates; it enables/weakens NO gate. A persistence error never aborts the apply
+// or the revert — the in-memory map remains authoritative for the live process,
+// and the durable copy is best-effort-plus-logged. The one safety-critical write
+// (snapshot at apply time) IS surfaced as an error from SetRealDefault so a
+// strand-on-restart cannot be introduced silently.
+
+// realDefaultSnapshotFile is the fixed file name under the persistence root that
+// holds the durable snapshot + cooldown state. It is a SINGLE JSON document (not
+// a per-flag dir) because the map is tiny — one entry per agent-touched flag.
+const realDefaultSnapshotFile = "real_default_snapshots.json"
+
+// snapStoreDirEnv overrides where the durable snapshot file lives. It mirrors the
+// journal's AGENT_EXPERIMENT_DIR so, by default (env unset), the snapshot file
+// lands in the SAME persisted volume as the journal. A test points it at a
+// t.TempDir() to exercise the restart boundary without touching real state.
+const snapStoreDirEnv = "AGENT_EXPERIMENT_DIR"
+
+// defaultSnapStoreDir mirrors journal.DefaultDir. Duplicated as a string rather
+// than imported so the promote package keeps no dependency on the journal package
+// (which would couple two otherwise-independent durability mechanisms).
+const defaultSnapStoreDir = "/var/lib/joustmania/agent/experiments"
+
+// persistedRecord is the on-disk shape for one flag's durable revert state. It
+// carries BOTH the pre-promotion snapshot (so a post-restart revert restores the
+// exact prior value, #1065) AND the last-revert timestamp (so post-revert thrash
+// protection, #1065 item 3, survives restart). A record may hold only the
+// cooldown stamp (snapshot already reverted) — Snapshot is then nil.
+type persistedRecord struct {
+	// Snapshot is the pre-promotion {hadDefault, variant, value} captured at
+	// first-touch. nil once the flag has been reverted (the snapshot is dropped so
+	// a fresh promotion re-snapshots) — but the record may persist for its
+	// LastRevert stamp.
+	Snapshot *persistedSnapshot `json:"snapshot,omitempty"`
+	// LastRevert is the time of the most recent successful revert of this flag, used
+	// to seed the Promoter's post-revert cooldown after a restart. Zero when never
+	// reverted.
+	LastRevert time.Time `json:"lastRevert,omitempty"`
+}
+
+// persistedSnapshot mirrors defaultSnapshot for on-disk storage. defaultSnapshot's
+// fields are unexported (so they cannot be JSON-marshaled directly); this exported
+// twin is the serialization boundary.
+type persistedSnapshot struct {
+	HadDefault bool            `json:"hadDefault"`
+	Variant    string          `json:"variant"`
+	Value      json.RawMessage `json:"value,omitempty"`
+}
+
+// snapStore is the durable {flagKey -> persistedRecord} store. It owns the on-disk
+// file and an in-memory copy guarded by its own mutex (the fileRealDefaultWriter's
+// mutex already serializes SetRealDefault/RevertRealDefault, but the store guards
+// itself too so seedLastRevert can be read concurrently from the Promoter on boot).
+type snapStore struct {
+	path string
+
+	mu      sync.Mutex
+	records map[string]persistedRecord
+}
+
+// snapStoreDir resolves the persistence directory from snapStoreDirEnv, falling
+// back to defaultSnapStoreDir — the single env-override seam, mirroring
+// journal.DirFromEnv.
+func snapStoreDir() string {
+	if d := strings.TrimSpace(os.Getenv(snapStoreDirEnv)); d != "" {
+		return d
+	}
+	return defaultSnapStoreDir
+}
+
+// newSnapStore builds a store over the snapshot file under dir and LOADS any
+// existing records from disk (the restart-survival path). A missing file is not an
+// error — a first-run agent starts with an empty store. A corrupt/unreadable file
+// is logged-and-ignored by the caller (the store returns the error so the caller
+// decides); the in-memory map then starts empty rather than aborting agent start.
+func newSnapStore(dir string) (*snapStore, error) {
+	s := &snapStore{
+		path:    filepath.Join(dir, realDefaultSnapshotFile),
+		records: map[string]persistedRecord{},
+	}
+	raw, err := os.ReadFile(s.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return s, nil
+		}
+		return s, fmt.Errorf("read real-default snapshot store %q: %w", s.path, err)
+	}
+	if len(raw) == 0 {
+		return s, nil
+	}
+	var recs map[string]persistedRecord
+	if err := json.Unmarshal(raw, &recs); err != nil {
+		return s, fmt.Errorf("parse real-default snapshot store %q: %w", s.path, err)
+	}
+	if recs != nil {
+		s.records = recs
+	}
+	return s, nil
+}
+
+// loadSnapshots returns the persisted snapshots as the in-memory defaultSnapshot
+// map the writer uses. Only records that still HOLD a snapshot are returned (a
+// reverted flag's record carries only a cooldown stamp). Copies the raw value
+// bytes so a later in-place mutation cannot reach into the loaded map.
+func (s *snapStore) loadSnapshots() map[string]defaultSnapshot {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make(map[string]defaultSnapshot, len(s.records))
+	for k, r := range s.records {
+		if r.Snapshot == nil {
+			continue
+		}
+		snap := defaultSnapshot{
+			hadDefault: r.Snapshot.HadDefault,
+			variant:    r.Snapshot.Variant,
+		}
+		if r.Snapshot.Value != nil {
+			snap.value = append(json.RawMessage(nil), r.Snapshot.Value...)
+		}
+		out[k] = snap
+	}
+	return out
+}
+
+// loadLastRevert returns the persisted last-revert timestamps so the Promoter can
+// seed its post-revert cooldown after a restart. Records with a zero stamp are
+// omitted.
+func (s *snapStore) loadLastRevert() map[string]time.Time {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make(map[string]time.Time, len(s.records))
+	for k, r := range s.records {
+		if !r.LastRevert.IsZero() {
+			out[k] = r.LastRevert
+		}
+	}
+	return out
+}
+
+// putSnapshot durably records the pre-promotion snapshot for flagKey, preserving
+// any existing LastRevert stamp. Called at first-touch in SetRealDefault. Returns
+// any persistence error so the caller can surface it (a snapshot that fails to
+// persist is the strand-on-restart bug this issue closes).
+func (s *snapStore) putSnapshot(flagKey string, snap defaultSnapshot) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	rec := s.records[flagKey]
+	ps := &persistedSnapshot{HadDefault: snap.hadDefault, Variant: snap.variant}
+	if snap.value != nil {
+		ps.Value = append(json.RawMessage(nil), snap.value...)
+	}
+	rec.Snapshot = ps
+	s.records[flagKey] = rec
+	return s.flushLocked()
+}
+
+// markReverted drops flagKey's snapshot (so a fresh promotion re-snapshots) but
+// records the revert time so the cooldown survives a restart. Called after a
+// successful revert. The record is KEPT (not deleted) precisely so LastRevert
+// persists; a future putSnapshot overwrites Snapshot in place.
+func (s *snapStore) markReverted(flagKey string, at time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	rec := s.records[flagKey]
+	rec.Snapshot = nil
+	rec.LastRevert = at
+	s.records[flagKey] = rec
+	return s.flushLocked()
+}
+
+// flushLocked atomically rewrites the snapshot file (temp + fsync + rename in the
+// same directory), so a concurrent reader / a crash never observes a half-written
+// store. Mirrors journal's writeJSONAtomic. Caller holds s.mu.
+func (s *snapStore) flushLocked() error {
+	dir := filepath.Dir(s.path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("create snapshot store dir %q: %w", dir, err)
+	}
+	data, err := json.MarshalIndent(s.records, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal snapshot store: %w", err)
+	}
+	data = append(data, '\n')
+
+	tmp, err := os.CreateTemp(dir, "."+realDefaultSnapshotFile+"-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temp snapshot file: %w", err)
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }()
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write temp snapshot file: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("sync temp snapshot file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp snapshot file: %w", err)
+	}
+	if err := os.Rename(tmpName, s.path); err != nil {
+		return fmt.Errorf("rename temp snapshot file to %q: %w", s.path, err)
+	}
+	return nil
+}


### PR DESCRIPTION
Part of #1076

## Problem
`fileRealDefaultWriter.snapshots` (the pre-promotion `{variant, value}` map backing `RealDefaultReverter`) and the post-revert cooldown were **in-memory only**. An agent restart between an autonomous apply and a later revert left `RevertRealDefault` with no snapshot, so a bad real default could not be rolled back — the regression rode on live players. The flag file still held the promoted value after restart, so a persisted snapshot was the only missing ingredient.

## Fix
New minimal durable store `services/agent/promote/snapstore.go` — a single atomic JSON file (`real_default_snapshots.json`) under the **same persisted volume as the #983 journal** (`AGENT_EXPERIMENT_DIR` / the #1025 named volume), reusing the journal's temp+fsync+rename write discipline.

- **Persist at apply (first-touch):** `SetRealDefault` writes the `{hadDefault, variant, value}` snapshot durably **before** the mutating write and **fails closed** — refuses the promotion and leaves the flag file untouched — if the snapshot cannot reach disk (so it can never reintroduce the strand-on-restart bug).
- **Load on boot:** `NewRealDefaultWriterFromEnv` rehydrates persisted snapshots into the in-memory map, so a post-restart `RevertRealDefault` restores the **exact** pre-promotion value (#1065 value-not-just-name).
- **Cooldown survives restart:** a successful revert drops the durable snapshot but persists the revert timestamp; `Promoter.SeedLastRevert` (wired in `main.go`) seeds `lastRevert` from it so post-revert thrash protection holds across a restart.

### Why not reuse the journal package directly
The #983 journal is modeled per-experiment (`{intent, append-only events, rolling summary}` keyed by `experiment_id`) — the wrong shape for a flat `{flagKey -> snapshot}` map. This store reuses the journal's **persistence location + atomic-write pattern** without coupling the two mechanisms.

## Default-safety
The store is constructed only inside the existing two env gates (`AGENT_CODE_IMPROVEMENT_ENABLED` + `AGENT_AUTONOMOUS_ENABLED`); no gate is enabled or weakened, a nil writer/reverter still refuses (#1016). `agent.json` defaults unchanged. The #1065 invariant (exact-prior-VALUE restore) holds across the restart boundary.

## Tests
- `TestSnapshotSurvivesRestartAndReverts` — apply with one writer, build a **new writer over the same store dir** (restart), revert restores the original value.
- `TestSnapshotSurvivesRestartDespiteInterveningClobber` — #1065 intervening-clobber test across a restart boundary (value, not just name).
- `TestRevertDropsPersistedSnapshotButKeepsCooldown` — restart does not resurrect a stale snapshot, but the cooldown stamp survives.
- `TestPromoteFailsClosedWhenSnapshotCannotPersist` — unwritable store → promotion refused, flag file untouched.
- `TestSeedLastRevertPreservesCooldownAcrossRestart` — seeded cooldown suppresses re-promotion, allowed again after it elapses.

`gofmt`/`go vet`/`go build` clean; `go test ./... -race -count=1` green (known flake #1097 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)