### PR TITLE
fix(agent): classify monotonic fade as idle, not erratic

### DIFF
--- a/services/agent/gamecontext/playerhistory.go
+++ b/services/agent/gamecontext/playerhistory.go
@@ -270,6 +270,15 @@ const (
 // the mean) is a deliberately coarse, explainable cut.
 const erraticStdFrac = 0.5
 
+// idleTailLen is how many of the most-recent window samples define the player's
+// CURRENT state for the idle short-circuit (#1085). A player who has faded out and
+// is now standing still should read as idle even if earlier samples were high; the
+// std-vs-mean erratic test would otherwise fire on the smooth decline (the early
+// high samples both keep the mean above idleFloor and inflate the std), labelling a
+// faded-out player a thrasher — the opposite engagement signal. Kept short so it
+// reflects where the player *settled*, not the tail of the decline.
+const idleTailLen = 2
+
 // ClassifyActivity classifies a movement window as idle / active / erratic, or
 // unknown when there is nothing to classify. It is a pure function of the samples
 // so the prompt and retro derive the same label deterministically. The window is
@@ -292,6 +301,22 @@ func ClassifyActivity(samples []MovementSample) Activity {
 	n := float64(len(window))
 	mean := sum / n
 	if mean <= idleFloor {
+		return ActivityIdle
+	}
+	// Recency short-circuit (#1085): the player's CURRENT state is what matters for
+	// a live decision. If the most-recent samples are at/below the idle floor, the
+	// player has settled into stillness — classify idle before the erratic test,
+	// which would otherwise mislabel a smooth fade-out (0.90→…→0.00) as thrashing.
+	// A genuinely bursty player keeps a high tail, so this leaves erratic intact.
+	tail := window
+	if len(tail) > idleTailLen {
+		tail = tail[len(tail)-idleTailLen:]
+	}
+	var tailSum float64
+	for _, s := range tail {
+		tailSum += s.Intensity
+	}
+	if tailSum/float64(len(tail)) <= idleFloor {
 		return ActivityIdle
 	}
 	variance := sumSq/n - mean*mean

--- a/services/agent/gamecontext/playerhistory_test.go
+++ b/services/agent/gamecontext/playerhistory_test.go
@@ -103,6 +103,24 @@ func TestClassifyActivity(t *testing.T) {
 	if got := ClassifyActivity(mk(0.2, 1.8, 0.3, 1.7)); got != ActivityErratic {
 		t.Errorf("bursty = %q, want erratic", got)
 	}
+	// #1085: a smooth monotonic fade-out (high → settled-to-still) must read idle —
+	// the player's CURRENT state — not erratic. The std-vs-mean test alone fires on
+	// the decline because the early high samples inflate both mean and std.
+	if got := ClassifyActivity(mk(0.90, 0.50, 0.10, 0.05, 0.02, 0.00)); got != ActivityIdle {
+		t.Errorf("monotonic fade = %q, want idle", got)
+	}
+	// Guard the other direction: a genuinely bursty tail must stay erratic even
+	// though its window mean is comparable to the fade above.
+	if got := ClassifyActivity(mk(0.1, 0.9, 0.1, 0.8, 0.1, 0.9)); got != ActivityErratic {
+		t.Errorf("sustained bursty = %q, want erratic", got)
+	}
+	// Steady high keeps reading active; steady low keeps reading idle.
+	if got := ClassifyActivity(mk(0.9, 0.95, 0.92, 0.9, 0.93, 0.91)); got != ActivityActive {
+		t.Errorf("steady high = %q, want active", got)
+	}
+	if got := ClassifyActivity(mk(0.05, 0.1, 0.08, 0.02, 0.0, 0.03)); got != ActivityIdle {
+		t.Errorf("steady low = %q, want idle", got)
+	}
 }
 
 // TestComputeProximity: the closest call uses the threshold IN FORCE at each

--- a/services/agent/llm/retro_test.go
+++ b/services/agent/llm/retro_test.go
@@ -72,7 +72,7 @@ func retroTimelineContext() gamecontext.GameContext {
 	ctx.Timeline = []gamecontext.TimelineEvent{
 		{At: at(150), Kind: gamecontext.EventPhase, Detail: "start"},
 		{At: at(140), Kind: gamecontext.EventStateDelta, ActivePlayers: iptr(3), MeanIntensity: fptr(0.80)},
-		{At: at(90), Kind: gamecontext.EventElimination, Serial: "CC:33", Order: 1},
+		{At: at(90), Kind: gamecontext.EventElimination, Serial: "BB:22", Order: 1},
 		{At: at(40), Kind: gamecontext.EventStateDelta, ActivePlayers: iptr(2), MeanIntensity: fptr(0.45)},
 		{At: at(0), Kind: gamecontext.EventPhase, Detail: "end"},
 	}

--- a/services/agent/llm/testdata/movement_3players.golden
+++ b/services/agent/llm/testdata/movement_3players.golden
@@ -88,6 +88,6 @@ Players (sorted by serial; "unknown" = signal never observed):
   AA:11: active=true movement_intensity=1.25 movement_variance=0.40 battery_pct=85.00 skill=0.60
     AA:11: act▂▄▅▇██ active near-death@-10s(0.92×thr)
   BB:22: active=true movement_intensity=0.00 movement_variance=0.05 battery_pct=15.00 skill=0.30
-    BB:22: act▅▃____ erratic near-death@-60s(0.60×thr)
+    BB:22: act▅▃____ idle near-death@-60s(0.60×thr)
   CC:33: active=unknown movement_intensity=unknown movement_variance=unknown battery_pct=unknown skill=unknown
     CC:33: act▅▇▄█ active near-death@-48s(1.13×thr)→elim

--- a/services/agent/llm/testdata/retro_movement.golden
+++ b/services/agent/llm/testdata/retro_movement.golden
@@ -47,7 +47,7 @@ Outcome:
 Recent events (oldest first; age relative to captured_at):
   -150s phase: start
   -140s state: active_players=3 mean_intensity=0.80
-  -90s elimination: CC:33 (#1)
+  -90s elimination: BB:22 (#1)
   -40s state: active_players=2 mean_intensity=0.45
   +0s phase: end
 
@@ -58,6 +58,6 @@ Players (sorted by serial; "unknown" = signal never observed):
   AA:11: outcome=survivor battery_pct=72.00 skill=0.80 movement_intensity=1.25 movement_variance=0.40
     AA:11: act▃▅▆██ active near-death@-20s(0.96×thr)
   BB:22: outcome=eliminated #1 battery_pct=40.00 skill=0.30 movement_intensity=0.10 movement_variance=0.05
-    BB:22: act▄▂__ erratic near-death@-140s(0.53×thr)
+    BB:22: act▄▂__ idle near-death@-140s(0.53×thr)
   CC:33: outcome=eliminated #2 battery_pct=unknown skill=unknown movement_intensity=unknown movement_variance=unknown
     CC:33: act▆▇█ active near-death@-92s(1.14×thr)→elim

--- a/services/agent/llm/testdata/retro_timeline.golden
+++ b/services/agent/llm/testdata/retro_timeline.golden
@@ -47,7 +47,7 @@ Outcome:
 Recent events (oldest first; age relative to captured_at):
   -150s phase: start
   -140s state: active_players=3 mean_intensity=0.80
-  -90s elimination: CC:33 (#1)
+  -90s elimination: BB:22 (#1)
   -40s state: active_players=2 mean_intensity=0.45
   +0s phase: end
 


### PR DESCRIPTION
Part of #1085

A smooth monotonic fade-out (`0.90→0.50→0.10→0.05→0.02→0.00`) was classified `erratic` by `ClassifyActivity`: the std-vs-mean test fires on the decline because the early high samples both keep the window mean above `idleFloor` and inflate the std. A faded-out (now-idle) player therefore read as a thrasher — the opposite engagement signal for the LLM.

## Fix
Recency short-circuit: if the most-recent samples (`idleTailLen=2`, the player's CURRENT settled state) are at/below `idleFloor`, classify `idle` before applying the erratic test. A genuinely bursty player keeps a high tail, so `active` and `erratic` are unchanged.

## Classification matrix (unit test)
| pattern | result |
|---|---|
| monotonic fade `0.90…0.00` | idle |
| sustained bursty `0.1,0.9,0.1,0.8,0.1,0.9` | erratic |
| steady high `0.9…0.91` | active |
| steady low `0.05…0.03` | idle |

## Goldens
`movement_3players` and `retro_movement` now read the fader (BB:22) as `idle`. Also reconciled the retro fixture timeline elimination event (BB:22 is #1 per `elimination_order`, was inconsistently CC:33) — fixture-only readability fix flagged in the issue.

## Verify
`gofmt -l`, `go build`, `go vet` clean; `go test ./... -race -count=1` all green (no #1097 flake hit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)