### PR TITLE
feat(agent): set_player_handicap shadow-only intervention (#1107)

### DIFF
--- a/services/agent/actions/testdata/interventions.json
+++ b/services/agent/actions/testdata/interventions.json
@@ -35,6 +35,17 @@
       "defaultVariant": "default",
       "targeting": {}
     },
+    "player_handicap_factor": {
+      "state": "ENABLED",
+      "variants": {
+        "default": 1.0,
+        "rein_in": 0.75,
+        "help": 1.25,
+        "big_help": 1.75
+      },
+      "defaultVariant": "default",
+      "targeting": {}
+    },
     "shield_seconds": {
       "state": "ENABLED",
       "variants": {

--- a/services/agent/actions/writer.go
+++ b/services/agent/actions/writer.go
@@ -45,6 +45,7 @@ const (
 	flagMusicTempoOverride        = "music_tempo_override"
 	flagGlobalSensitivityOverride = "global_sensitivity_override"
 	flagPlayerSensitivityFactor   = "player_sensitivity_factor"
+	flagPlayerHandicapFactor      = "player_handicap_factor" // #1107 (#1103 MVP action 1)
 	flagShieldSeconds             = "shield_seconds"
 	flagVolumeOverride            = "volume_override"
 	flagGlobalDifficultyFactor    = "global_difficulty_factor" // #766 F6
@@ -100,6 +101,7 @@ const (
 	defaultVolume            = 0.7  // matches "normal"
 	defaultGlobalSensitivity = 2    // matches "medium"
 	defaultPlayerSensitivity = 1.5  // matches "handicap"
+	defaultPlayerHandicap    = 1.25 // #1107: mild "help" (>1 harder to die), within [0.5,2.0]
 	defaultShieldSeconds     = 5    // matches "default"
 	defaultGlobalDifficulty  = 1.5  // matches interventions.json "hard" (#766 F6)
 	defaultPacingProfile     = "frantic"
@@ -382,6 +384,8 @@ func (w *Writer) mutate(doc *orderedDoc, d decision.Decision) error {
 	// Per-player state-shaped overrides (flagd targeting if-ladder).
 	case decision.InterventionAdjustPlayerSensitivity:
 		return w.setTargeted(doc, flagPlayerSensitivityFactor, neutralDefault, d.TargetSerial, w.numOr(d.Value, defaultPlayerSensitivity))
+	case decision.InterventionSetPlayerHandicap: // #1107 (#1103 MVP action 1), shadow-only
+		return w.setTargeted(doc, flagPlayerHandicapFactor, neutralDefault, d.TargetSerial, w.numOr(d.Value, defaultPlayerHandicap))
 	case decision.InterventionGrantShield:
 		return w.setTargeted(doc, flagShieldSeconds, neutralNone, d.TargetSerial, w.numOr(d.Value, defaultShieldSeconds))
 

--- a/services/agent/actions/writer_test.go
+++ b/services/agent/actions/writer_test.go
@@ -295,6 +295,46 @@ func TestGrantShieldTargeted(t *testing.T) {
 	}
 }
 
+// TestSetPlayerHandicapTargeted verifies the #1107 set_player_handicap writer
+// case emits the player_handicap_factor flag as a per-serial targeted state flag
+// (mirrors adjust_player_sensitivity), with the neutral "default" fall-through.
+func TestSetPlayerHandicapTargeted(t *testing.T) {
+	w, path := newTestWriter(t)
+	// >1 = "help" (harder to die); <1 = "rein in" (easier).
+	if err := w.Apply(context.Background(), decision.Decision{Intervention: decision.InterventionSetPlayerHandicap, TargetSerial: "AA", Value: "1.75"}); err != nil {
+		t.Fatalf("apply AA: %v", err)
+	}
+	if err := w.Apply(context.Background(), decision.Decision{Intervention: decision.InterventionSetPlayerHandicap, TargetSerial: "BB", Value: "0.6"}); err != nil {
+		t.Fatalf("apply BB: %v", err)
+	}
+
+	assertTargetingResolves(t, path, flagPlayerHandicapFactor, "AA", "agent_AA")
+	assertTargetingResolves(t, path, flagPlayerHandicapFactor, "BB", "agent_BB")
+	assertTargetingResolves(t, path, flagPlayerHandicapFactor, "ZZ", neutralDefault)
+
+	variants := readFlag(t, path, flagPlayerHandicapFactor)["variants"].(map[string]any)
+	if variants["agent_AA"].(float64) != 1.75 || variants["agent_BB"].(float64) != 0.6 {
+		t.Fatalf("variant values wrong: %v", variants)
+	}
+	assertStructurallyValid(t, path)
+}
+
+// TestSetPlayerHandicapDefaultValue verifies an empty Value falls back to the
+// writer's neutral-leaning default (within the [0.5,2.0] clamp band).
+func TestSetPlayerHandicapDefaultValue(t *testing.T) {
+	w, path := newTestWriter(t)
+	if err := w.Apply(context.Background(), decision.Decision{Intervention: decision.InterventionSetPlayerHandicap, TargetSerial: "AA"}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	v := readFlag(t, path, flagPlayerHandicapFactor)["variants"].(map[string]any)["agent_AA"].(float64)
+	if v != defaultPlayerHandicap {
+		t.Fatalf("default handicap value = %v, want %v", v, defaultPlayerHandicap)
+	}
+	if v < 0.5 || v > 2.0 {
+		t.Fatalf("default handicap %v outside clamp band [0.5,2.0]", v)
+	}
+}
+
 func TestTargetedRequiresSerial(t *testing.T) {
 	w, _ := newTestWriter(t)
 	err := w.Apply(context.Background(), decision.Decision{Intervention: decision.InterventionAdjustPlayerSensitivity})

--- a/services/agent/decision/ratelimit.go
+++ b/services/agent/decision/ratelimit.go
@@ -46,6 +46,13 @@ const (
 	InterventionAdjustVolume            = "adjust_volume"
 	InterventionAdjustMusicTempo        = "adjust_music_tempo"
 	InterventionAdjustPlayerSensitivity = "adjust_player_sensitivity"
+	// InterventionSetPlayerHandicap (#1107, #1103 MVP action 1) is a per-player
+	// MULTIPLICATIVE handicap on the death threshold that composes with — does not
+	// replace — adjust_player_sensitivity (>1 harder to die / "help", <1 easier /
+	// "rein in"). SHADOW-game-only initially: allow-listed only via the
+	// `shadow_experimental` interventions_allowed variant (services/flagd/agent.json),
+	// never the real-facing ambient/standard/full variants.
+	InterventionSetPlayerHandicap       = "set_player_handicap"
 	InterventionGrantShield             = "grant_shield"
 	InterventionAdjustGlobalSensitivity = "adjust_global_sensitivity"
 	InterventionAdjustGlobalDifficulty  = "adjust_global_difficulty"
@@ -80,6 +87,7 @@ var interventionWeights = map[string]float64{
 	// Medium (1)
 	InterventionAdjustMusicTempo:        1,
 	InterventionAdjustPlayerSensitivity: 1,
+	InterventionSetPlayerHandicap:       1, // #1107 (#1103 MVP action 1)
 	InterventionGrantShield:             1,
 	InterventionAdjustGlobalDifficulty:  1, // #766 F6
 	InterventionSetPacingProfile:        1, // #766 F6

--- a/services/agent/decision/shadow_gate_test.go
+++ b/services/agent/decision/shadow_gate_test.go
@@ -1,0 +1,74 @@
+package decision
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// agentFlagDoc is the minimal shape needed to read interventions_allowed variants
+// from a flagd agent flag file.
+type agentFlagDoc struct {
+	Flags struct {
+		InterventionsAllowed struct {
+			Variants map[string][]string `json:"variants"`
+		} `json:"interventions_allowed"`
+	} `json:"flags"`
+}
+
+func readInterventionsAllowed(t *testing.T, path string) map[string][]string {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var doc agentFlagDoc
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("unmarshal %s: %v", path, err)
+	}
+	v := doc.Flags.InterventionsAllowed.Variants
+	if len(v) == 0 {
+		t.Fatalf("%s: interventions_allowed has no variants", path)
+	}
+	return v
+}
+
+// TestSetPlayerHandicapIsShadowOnly is the load-bearing gating proof for #1107
+// (#1103 MVP action 1): set_player_handicap MUST appear ONLY in the
+// shadow_experimental variant of interventions_allowed and MUST be absent from
+// every real-facing variant (ambient/standard/full). The allow-list is the
+// enforcement gate (decode.go validates the LLM's chosen intervention against the
+// live snapshot, and the rules engine reads the same flag), so absence from the
+// real variants means set_player_handicap is rejected for real games by
+// construction. Asserted on BOTH the production and CI flagd agent configs.
+func TestSetPlayerHandicapIsShadowOnly(t *testing.T) {
+	paths := []string{
+		filepath.Join("..", "..", "flagd", "agent.json"),
+		filepath.Join("..", "..", "flagd", "ci", "agent.json"),
+	}
+	for _, path := range paths {
+		t.Run(path, func(t *testing.T) {
+			variants := readInterventionsAllowed(t, path)
+
+			shadow, ok := variants["shadow_experimental"]
+			if !ok {
+				t.Fatalf("%s: missing shadow_experimental variant", path)
+			}
+			if !contains(shadow, InterventionSetPlayerHandicap) {
+				t.Fatalf("%s: shadow_experimental must include %q", path, InterventionSetPlayerHandicap)
+			}
+
+			// Real-facing variants must NOT carry the shadow-only intervention.
+			for _, realVariant := range []string{"ambient", "standard", "full"} {
+				list, ok := variants[realVariant]
+				if !ok {
+					t.Fatalf("%s: missing expected real variant %q", path, realVariant)
+				}
+				if contains(list, InterventionSetPlayerHandicap) {
+					t.Fatalf("%s: real variant %q must NOT include %q (shadow-only)", path, realVariant, InterventionSetPlayerHandicap)
+				}
+			}
+		})
+	}
+}

--- a/services/agent/llm/prompt.go
+++ b/services/agent/llm/prompt.go
@@ -242,7 +242,11 @@ var modeFragments = map[string]string{
     sensitivity, grant a short per-player movement-grace shield to a player about
     to be unfairly eliminated, and play audio cues / controller effects to steer
     the room. note: death_grace_period_seconds governs post-death respawn grace
-    and has NO effect in FFA (no respawns) — it is not a lever here.`,
+    and has NO effect in FFA (no respawns) — it is not a lever here.
+  - set_player_handicap: per-player multiplier on that player's death threshold
+    (>1 = higher threshold = harder to eliminate / "help"; <1 = lower = easier /
+    "rein in"), clamped 0.5-2.0; COMPOSES WITH (does not replace) per-player
+    sensitivity, so use it for continuous rubber-banding toward fairness.`,
 	"zombie":     `GAME MODE — Zombie (role-based, respawn): humans vs zombies; a tagged human becomes a zombie and respawn/role-change exists, so eliminated players CAN re-enter as the other role. (Detailed levers not yet specified — reason conservatively within the physics above.)`,
 	"swapper":    `GAME MODE — Swapper (role/team-swap, respawn): players swap roles/teams during play and respawn exists, so an eliminated player is not necessarily permanently out. (Detailed levers not yet specified — reason conservatively within the physics above.)`,
 	"tournament": `GAME MODE — Tournament (bracket): players advance through a bracket of matches rather than one free-for-all; elimination is per-match. (Detailed levers not yet specified — reason conservatively within the physics above.)`,

--- a/services/agent/llm/testdata/aggressive_3players.golden
+++ b/services/agent/llm/testdata/aggressive_3players.golden
@@ -34,6 +34,10 @@ GAME MODE — FFA (Free-For-All), last player standing:
     to be unfairly eliminated, and play audio cues / controller effects to steer
     the room. note: death_grace_period_seconds governs post-death respawn grace
     and has NO effect in FFA (no respawns) — it is not a lever here.
+  - set_player_handicap: per-player multiplier on that player's death threshold
+    (>1 = higher threshold = harder to eliminate / "help"; <1 = lower = easier /
+    "rein in"), clamped 0.5-2.0; COMPOSES WITH (does not replace) per-player
+    sensitivity, so use it for continuous rubber-banding toward fairness.
 
 OBJECTIVES (weights; higher = more important this session):
   balanced=0.7, chaos=0.1, endurance=0.1

--- a/services/agent/llm/testdata/balanced_3players.golden
+++ b/services/agent/llm/testdata/balanced_3players.golden
@@ -34,6 +34,10 @@ GAME MODE — FFA (Free-For-All), last player standing:
     to be unfairly eliminated, and play audio cues / controller effects to steer
     the room. note: death_grace_period_seconds governs post-death respawn grace
     and has NO effect in FFA (no respawns) — it is not a lever here.
+  - set_player_handicap: per-player multiplier on that player's death threshold
+    (>1 = higher threshold = harder to eliminate / "help"; <1 = lower = easier /
+    "rein in"), clamped 0.5-2.0; COMPOSES WITH (does not replace) per-player
+    sensitivity, so use it for continuous rubber-banding toward fairness.
 
 OBJECTIVES (weights; higher = more important this session):
   balanced=0.7, chaos=0.1, endurance=0.1

--- a/services/agent/llm/testdata/conservative_3players.golden
+++ b/services/agent/llm/testdata/conservative_3players.golden
@@ -34,6 +34,10 @@ GAME MODE — FFA (Free-For-All), last player standing:
     to be unfairly eliminated, and play audio cues / controller effects to steer
     the room. note: death_grace_period_seconds governs post-death respawn grace
     and has NO effect in FFA (no respawns) — it is not a lever here.
+  - set_player_handicap: per-player multiplier on that player's death threshold
+    (>1 = higher threshold = harder to eliminate / "help"; <1 = lower = easier /
+    "rein in"), clamped 0.5-2.0; COMPOSES WITH (does not replace) per-player
+    sensitivity, so use it for continuous rubber-banding toward fairness.
 
 OBJECTIVES (weights; higher = more important this session):
   balanced=0.7, chaos=0.1, endurance=0.1

--- a/services/agent/llm/testdata/empty_players.golden
+++ b/services/agent/llm/testdata/empty_players.golden
@@ -34,6 +34,10 @@ GAME MODE — FFA (Free-For-All), last player standing:
     to be unfairly eliminated, and play audio cues / controller effects to steer
     the room. note: death_grace_period_seconds governs post-death respawn grace
     and has NO effect in FFA (no respawns) — it is not a lever here.
+  - set_player_handicap: per-player multiplier on that player's death threshold
+    (>1 = higher threshold = harder to eliminate / "help"; <1 = lower = easier /
+    "rein in"), clamped 0.5-2.0; COMPOSES WITH (does not replace) per-player
+    sensitivity, so use it for continuous rubber-banding toward fairness.
 
 OBJECTIVES (weights; higher = more important this session):
   balanced=0.7, chaos=0.1, endurance=0.1

--- a/services/agent/llm/testdata/movement_3players.golden
+++ b/services/agent/llm/testdata/movement_3players.golden
@@ -34,6 +34,10 @@ GAME MODE — FFA (Free-For-All), last player standing:
     to be unfairly eliminated, and play audio cues / controller effects to steer
     the room. note: death_grace_period_seconds governs post-death respawn grace
     and has NO effect in FFA (no respawns) — it is not a lever here.
+  - set_player_handicap: per-player multiplier on that player's death threshold
+    (>1 = higher threshold = harder to eliminate / "help"; <1 = lower = easier /
+    "rein in"), clamped 0.5-2.0; COMPOSES WITH (does not replace) per-player
+    sensitivity, so use it for continuous rubber-banding toward fairness.
 
 OBJECTIVES (weights; higher = more important this session):
   balanced=0.7, chaos=0.1, endurance=0.1

--- a/services/agent/llm/testdata/timeline_3players.golden
+++ b/services/agent/llm/testdata/timeline_3players.golden
@@ -34,6 +34,10 @@ GAME MODE — FFA (Free-For-All), last player standing:
     to be unfairly eliminated, and play audio cues / controller effects to steer
     the room. note: death_grace_period_seconds governs post-death respawn grace
     and has NO effect in FFA (no respawns) — it is not a lever here.
+  - set_player_handicap: per-player multiplier on that player's death threshold
+    (>1 = higher threshold = harder to eliminate / "help"; <1 = lower = easier /
+    "rein in"), clamped 0.5-2.0; COMPOSES WITH (does not replace) per-player
+    sensitivity, so use it for continuous rubber-banding toward fairness.
 
 OBJECTIVES (weights; higher = more important this session):
   balanced=0.7, chaos=0.1, endurance=0.1

--- a/services/flagd/agent.json
+++ b/services/flagd/agent.json
@@ -108,6 +108,21 @@
           "eliminate_player",
           "revive_player",
           "end_game"
+        ],
+        "shadow_experimental": [
+          "play_audio_cue",
+          "send_controller_effect",
+          "adjust_volume",
+          "adjust_music_tempo",
+          "set_pacing_profile",
+          "adjust_player_sensitivity",
+          "grant_shield",
+          "adjust_global_sensitivity",
+          "adjust_global_difficulty",
+          "eliminate_player",
+          "revive_player",
+          "end_game",
+          "set_player_handicap"
         ]
       },
       "defaultVariant": "ambient"

--- a/services/flagd/ci/agent.json
+++ b/services/flagd/ci/agent.json
@@ -108,6 +108,21 @@
           "eliminate_player",
           "revive_player",
           "end_game"
+        ],
+        "shadow_experimental": [
+          "play_audio_cue",
+          "send_controller_effect",
+          "adjust_volume",
+          "adjust_music_tempo",
+          "set_pacing_profile",
+          "adjust_player_sensitivity",
+          "grant_shield",
+          "adjust_global_sensitivity",
+          "adjust_global_difficulty",
+          "eliminate_player",
+          "revive_player",
+          "end_game",
+          "set_player_handicap"
         ]
       },
       "defaultVariant": "ambient"

--- a/services/flagd/ci/interventions.json
+++ b/services/flagd/ci/interventions.json
@@ -35,6 +35,17 @@
       "defaultVariant": "default",
       "targeting": {}
     },
+    "player_handicap_factor": {
+      "state": "ENABLED",
+      "variants": {
+        "default": 1.0,
+        "rein_in": 0.75,
+        "help": 1.25,
+        "big_help": 1.75
+      },
+      "defaultVariant": "default",
+      "targeting": {}
+    },
     "shield_seconds": {
       "state": "ENABLED",
       "variants": {

--- a/services/flagd/interventions.json
+++ b/services/flagd/interventions.json
@@ -35,6 +35,17 @@
       "defaultVariant": "default",
       "targeting": {}
     },
+    "player_handicap_factor": {
+      "state": "ENABLED",
+      "variants": {
+        "default": 1.0,
+        "rein_in": 0.75,
+        "help": 1.25,
+        "big_help": 1.75
+      },
+      "defaultVariant": "default",
+      "targeting": {}
+    },
     "shield_seconds": {
       "state": "ENABLED",
       "variants": {

--- a/services/game_coordinator/difficulty_handlers.py
+++ b/services/game_coordinator/difficulty_handlers.py
@@ -19,6 +19,12 @@ intervention flags against the InterventionManager registry built in PR A:
 - ``player_sensitivity_factor``   — N1: per-serial ``targeting_key`` evaluation
   sets each active player's ``sensitivity_factor`` (clamped 0.5-2.0); serials
   with no targeting match get the neutral default (1.0).
+- ``player_handicap_factor``      — #1107 (#1103 MVP action 1): per-serial
+  ``targeting_key`` evaluation sets each active player's ``handicap_factor``
+  (clamped 0.5-2.0), a SEPARATE multiplicative knob that COMPOSES with
+  ``sensitivity_factor`` (>1 harder to die / "help", <1 easier / "rein in").
+  SHADOW-game-only initially via the ``shadow_experimental`` interventions_allowed
+  variant; serials with no targeting match get the neutral default (1.0).
 
 Handler contract (PR A): handlers are ``async def handler(ctx) -> None``, called
 only after the enforcement chain passes (they do NOT re-check policy), and the
@@ -52,6 +58,13 @@ SENSITIVITY_FACTOR_DEFAULT = 1.0
 GLOBAL_DIFFICULTY_FACTOR_MIN = 0.5
 GLOBAL_DIFFICULTY_FACTOR_MAX = 2.0
 GLOBAL_DIFFICULTY_FACTOR_DEFAULT = 1.0
+
+# Per-player handicap factor clamp + neutral (#1107). Mirrors the independent
+# handicap clamp in base.py _compute_effective_thresholds. A SEPARATE knob that
+# composes multiplicatively with sensitivity_factor (>1 harder to die, <1 easier).
+HANDICAP_FACTOR_MIN = 0.5
+HANDICAP_FACTOR_MAX = 2.0
+HANDICAP_FACTOR_DEFAULT = 1.0
 
 # Profile names that mean "neutral / restore the game's init-resolved windows".
 _NEUTRAL_PACING_PROFILES = frozenset({"none", "default", ""})
@@ -161,6 +174,48 @@ async def handle_player_sensitivity_factor(ctx: InterventionContext, manager: In
         clamped = max(SENSITIVITY_FACTOR_MIN, min(SENSITIVITY_FACTOR_MAX, factor))
         player.sensitivity_factor = clamped
         logger.info(f"player_sensitivity_factor: {serial} -> {clamped:.2f}")
+
+
+async def handle_player_handicap_factor(ctx: InterventionContext, manager: InterventionManager) -> None:
+    """Apply per-player MULTIPLICATIVE handicap factors (#1107, #1103 MVP action 1).
+
+    Mirrors :func:`handle_player_sensitivity_factor`: resolves the flag once per
+    active serial via the manager's reusable ``resolve_player_targets`` helper
+    (per-serial ``targeting_key`` + per-game ``gameId`` composition), clamps each
+    resolved value to [0.5, 2.0], and writes it to the player's ``handicap_factor``
+    (consumed next frame by ``_compute_effective_thresholds`` where it MULTIPLIES
+    the threshold, composing with — not replacing — ``sensitivity_factor``).
+
+    Intent-framed and OPPOSITE in direction to sensitivity: >1.0 raises the
+    threshold (harder to die / "help"); <1.0 lowers it (easier / "rein in").
+    Serials with no targeting match resolve to the neutral default (1.0), so a
+    partial revert restores the reverted players to neutral on the next change.
+    Battery-gated serials are skipped by the helper. SHADOW-game-only initially:
+    rejected for real games by the interventions_allowed allow-list (the
+    load-bearing chain gate), so this handler only ever runs in shadow games.
+    """
+    game = ctx.game
+    if game is None:
+        logger.debug("player_handicap_factor: no live game, ignoring")
+        return
+
+    factors = manager.resolve_player_targets(
+        flag_key=ctx.spec.flag_key,
+        default=HANDICAP_FACTOR_DEFAULT,
+        game=game,
+        value_kind="float",
+        battery_gate=True,
+        game_id=ctx.game_id,
+    )
+
+    players = getattr(game, "players", {})
+    for serial, factor in factors.items():
+        player = players.get(serial)
+        if player is None:
+            continue
+        clamped = max(HANDICAP_FACTOR_MIN, min(HANDICAP_FACTOR_MAX, factor))
+        player.handicap_factor = clamped
+        logger.info(f"player_handicap_factor: {serial} -> {clamped:.2f}")
 
 
 async def handle_global_difficulty_factor(ctx: InterventionContext) -> None:
@@ -273,6 +328,16 @@ def register_difficulty_handlers(manager: InterventionManager) -> None:
     manager.register_handler(
         "player_sensitivity_factor",
         lambda ctx: handle_player_sensitivity_factor(ctx, manager),
+    )
+    # player_handicap_factor (#1107) mirrors player_sensitivity_factor exactly:
+    # it is a player-targeted state flag, so reverts are handled inside the apply
+    # handler (unmatched serials resolve to the neutral 1.0 default), NOT via
+    # _revert_handlers — the targeted-state evaluation path never consults that
+    # map (see InterventionManager._evaluate_targeted_state). Same closure-binds-
+    # the-manager shape as sensitivity above.
+    manager.register_handler(
+        "player_handicap_factor",
+        lambda ctx: handle_player_handicap_factor(ctx, manager),
     )
     # #766 F6: two new state-shaped levers. Both restore their baseline on revert.
     manager.register_handler("global_difficulty_factor", handle_global_difficulty_factor)

--- a/services/game_coordinator/games/base.py
+++ b/services/game_coordinator/games/base.py
@@ -384,6 +384,14 @@ class Player:
     # 1.0 = default, >1.0 = more sensitive (easier to die), <1.0 = less sensitive (harder to die)
     # Thresholds are divided by this factor: higher factor = lower threshold = easier to trigger
     sensitivity_factor: float = 1.0
+    # Per-player MULTIPLICATIVE handicap on the death/warning threshold (#1107,
+    # #1103 MVP action 1). A SEPARATE agent-only knob that COMPOSES with (does not
+    # replace) sensitivity_factor. Intent-framed and OPPOSITE in direction to
+    # sensitivity_factor: >1.0 raises the effective threshold (harder to die ->
+    # "help"); <1.0 lowers it (easier to die -> "rein in"). Clamped [0.5, 2.0] in
+    # _compute_effective_thresholds. 1.0 = neutral (no effect). Shadow-game-only
+    # initially via the interventions_allowed allow-list gate.
+    handicap_factor: float = 1.0
     # Per-player countdown span (created before countdown, ended after)
     _countdown_span: trace.Span | None = None
     # Health tracking (#571: controller health on player_lifecycle spans)
@@ -1342,7 +1350,18 @@ class BaseGameMode(ABC):
         # neutral 1.0/1.0 this preserves the prior behavior exactly.
         combined_factor = player.sensitivity_factor * self.global_difficulty_factor
         clamped_factor = max(0.5, min(2.0, combined_factor))
-        return base_warn / clamped_factor, base_death / clamped_factor
+        warn = base_warn / clamped_factor
+        death = base_death / clamped_factor
+
+        # Apply the per-player agent handicap (#1107) as a SEPARATE multiplicative
+        # knob that composes with — does not replace — the sensitivity/difficulty
+        # factor above. It is clamped independently to [0.5, 2.0] and MULTIPLIES
+        # the threshold (intent-framed, opposite direction to sensitivity_factor):
+        # >1.0 raises the threshold (harder to die / "help"); <1.0 lowers it
+        # (easier / "rein in"). At the neutral 1.0 this is a no-op, preserving the
+        # prior behavior exactly.
+        handicap = max(0.5, min(2.0, player.handicap_factor))
+        return warn * handicap, death * handicap
 
     def _record_player_analytics(
         self,

--- a/services/game_coordinator/interventions.py
+++ b/services/game_coordinator/interventions.py
@@ -150,7 +150,7 @@ class InterventionSpec:
     payload_required: bool = True
 
 
-# Registry of all 10 intervention flags (§8). Ordered to keep diffs stable.
+# Registry of all intervention flags (§8). Ordered to keep diffs stable.
 # PRs C/D/E attach real handlers via register_handler(); they do NOT edit this
 # table. Adding a brand-new intervention appends one row here.
 INTERVENTION_SPECS: tuple[InterventionSpec, ...] = (
@@ -181,6 +181,21 @@ INTERVENTION_SPECS: tuple[InterventionSpec, ...] = (
         player_targeted=True,
         value_kind="float",
         # 1.0 is the neutral default; a value != 1.0 is an intervention.
+        none_value=1.0,
+    ),
+    InterventionSpec(
+        flag_key="player_handicap_factor",
+        type_id="set_player_handicap",
+        weight=WEIGHT_MEDIUM,
+        edge_triggered=False,
+        player_targeted=True,
+        value_kind="float",
+        # 1.0 is the neutral default; a value != 1.0 is an intervention (#1107,
+        # #1103 MVP action 1). MULTIPLICATIVE per-player handicap that COMPOSES
+        # with player_sensitivity_factor (>1 harder to die / "help", <1 easier /
+        # "rein in"), clamped [0.5, 2.0] in base.py. SHADOW-game-only initially:
+        # the agent's interventions_allowed allow-list (the load-bearing gate)
+        # only includes this type in the new `shadow_experimental` variant.
         none_value=1.0,
     ),
     InterventionSpec(

--- a/services/game_coordinator/tests/test_base_helpers.py
+++ b/services/game_coordinator/tests/test_base_helpers.py
@@ -274,6 +274,73 @@ class TestComputeEffectiveThresholds:
         assert warn_above == pytest.approx(warn_at_max, abs=1e-9)
         assert death_above == pytest.approx(death_at_max, abs=1e-9)
 
+    # --- #1107: per-player MULTIPLICATIVE handicap_factor ---------------- #
+
+    def test_handicap_neutral_is_noop(self, game):
+        """handicap_factor=1.0 (the default) leaves thresholds unchanged."""
+        from lib.types import Sensitivity
+
+        game.sensitivity = Sensitivity.MEDIUM
+        game.music_speed = SLOW_MUSIC_SPEED
+        base = Player(serial="test", sensitivity_factor=1.0, handicap_factor=1.0)
+        warn_b, death_b = game._compute_effective_thresholds(base)
+        # Default constructed player has handicap_factor 1.0 too.
+        plain = Player(serial="test", sensitivity_factor=1.0)
+        warn_p, death_p = game._compute_effective_thresholds(plain)
+        assert warn_b == pytest.approx(warn_p) and death_b == pytest.approx(death_p)
+
+    def test_handicap_above_one_raises_threshold(self, game):
+        """handicap_factor > 1 MULTIPLIES the threshold up (harder to die / help)."""
+        from lib.types import Sensitivity
+
+        game.sensitivity = Sensitivity.MEDIUM
+        game.music_speed = SLOW_MUSIC_SPEED
+        neutral = Player(serial="t", sensitivity_factor=1.0, handicap_factor=1.0)
+        helped = Player(serial="t", sensitivity_factor=1.0, handicap_factor=1.5)
+        warn_n, death_n = game._compute_effective_thresholds(neutral)
+        warn_h, death_h = game._compute_effective_thresholds(helped)
+        assert warn_h == pytest.approx(warn_n * 1.5)
+        assert death_h == pytest.approx(death_n * 1.5)
+
+    def test_handicap_below_one_lowers_threshold(self, game):
+        """handicap_factor < 1 lowers the threshold (easier to die / rein in)."""
+        from lib.types import Sensitivity
+
+        game.sensitivity = Sensitivity.MEDIUM
+        game.music_speed = SLOW_MUSIC_SPEED
+        neutral = Player(serial="t", sensitivity_factor=1.0, handicap_factor=1.0)
+        reined = Player(serial="t", sensitivity_factor=1.0, handicap_factor=0.5)
+        _, death_n = game._compute_effective_thresholds(neutral)
+        _, death_r = game._compute_effective_thresholds(reined)
+        assert death_r == pytest.approx(death_n * 0.5)
+
+    def test_handicap_clamped_to_band(self, game):
+        """handicap_factor is independently clamped to [0.5, 2.0]."""
+        from lib.types import Sensitivity
+
+        game.sensitivity = Sensitivity.MEDIUM
+        game.music_speed = SLOW_MUSIC_SPEED
+        above = Player(serial="t", sensitivity_factor=1.0, handicap_factor=5.0)
+        at_max = Player(serial="t", sensitivity_factor=1.0, handicap_factor=2.0)
+        below = Player(serial="t", sensitivity_factor=1.0, handicap_factor=0.1)
+        at_min = Player(serial="t", sensitivity_factor=1.0, handicap_factor=0.5)
+        assert game._compute_effective_thresholds(above) == pytest.approx(game._compute_effective_thresholds(at_max))
+        assert game._compute_effective_thresholds(below) == pytest.approx(game._compute_effective_thresholds(at_min))
+
+    def test_handicap_composes_multiplicatively_with_sensitivity(self, game):
+        """handicap and sensitivity are SEPARATE knobs that compose: a 2.0
+        sensitivity (halves) and a 2.0 handicap (doubles) net to neutral."""
+        from lib.types import Sensitivity
+
+        game.sensitivity = Sensitivity.MEDIUM
+        game.music_speed = SLOW_MUSIC_SPEED
+        neutral = Player(serial="t", sensitivity_factor=1.0, handicap_factor=1.0)
+        composed = Player(serial="t", sensitivity_factor=2.0, handicap_factor=2.0)
+        warn_n, death_n = game._compute_effective_thresholds(neutral)
+        warn_c, death_c = game._compute_effective_thresholds(composed)
+        assert warn_c == pytest.approx(warn_n)
+        assert death_c == pytest.approx(death_n)
+
 
 # ========================================================================
 # _process_controller_state (player name capture)

--- a/services/game_coordinator/tests/test_difficulty_interventions.py
+++ b/services/game_coordinator/tests/test_difficulty_interventions.py
@@ -38,6 +38,7 @@ from services.game_coordinator.difficulty_handlers import (
     handle_global_sensitivity_override,
     handle_music_tempo_override,
     handle_music_tempo_override_revert,
+    handle_player_handicap_factor,
     handle_player_sensitivity_factor,
     register_difficulty_handlers,
 )
@@ -320,6 +321,81 @@ class TestPlayerSensitivityFactor:
         await handle_player_sensitivity_factor(make_ctx("player_sensitivity_factor", 1.5, None), mgr)
 
 
+class TestPlayerHandicapFactor:
+    """#1107 (#1103 MVP action 1): per-player MULTIPLICATIVE handicap that
+    COMPOSES with sensitivity_factor (>1 harder to die, <1 easier), clamped
+    [0.5, 2.0]."""
+
+    @pytest.mark.asyncio
+    async def test_targeted_player_changed_others_default(self):
+        game = make_game(num_players=3)
+        mgr, _ = make_manager(game=game)
+        mgr._interventions_client = TargetingFlagClient(default=1.0, per_serial={"p2": 1.5})
+
+        await handle_player_handicap_factor(make_ctx("player_handicap_factor", 1.5, game), mgr)
+
+        assert game.players["p1"].handicap_factor == pytest.approx(1.0)
+        assert game.players["p2"].handicap_factor == pytest.approx(1.5)
+        assert game.players["p3"].handicap_factor == pytest.approx(1.0)
+
+    @pytest.mark.asyncio
+    async def test_factor_is_clamped(self):
+        game = make_game(num_players=2)
+        mgr, _ = make_manager(game=game)
+        mgr._interventions_client = TargetingFlagClient(default=1.0, per_serial={"p1": 5.0, "p2": 0.1})
+
+        await handle_player_handicap_factor(make_ctx("player_handicap_factor", 0, game), mgr)
+
+        assert game.players["p1"].handicap_factor == pytest.approx(2.0)
+        assert game.players["p2"].handicap_factor == pytest.approx(0.5)
+
+    @pytest.mark.asyncio
+    async def test_help_raises_threshold_rein_in_lowers(self):
+        """>1 handicap = higher (harder) threshold; <1 = lower (easier)."""
+        game = make_game(num_players=2)
+        p1 = game.players["p1"]
+        _, death_neutral = game._compute_effective_thresholds(p1)
+
+        mgr, _ = make_manager(game=game)
+        mgr._interventions_client = TargetingFlagClient(default=1.0, per_serial={"p1": 1.5})
+        await handle_player_handicap_factor(make_ctx("player_handicap_factor", 1.5, game), mgr)
+        _, death_help = game._compute_effective_thresholds(p1)
+        assert death_help > death_neutral  # harder to die
+
+        mgr._interventions_client = TargetingFlagClient(default=1.0, per_serial={"p1": 0.5})
+        await handle_player_handicap_factor(make_ctx("player_handicap_factor", 0.5, game), mgr)
+        _, death_rein = game._compute_effective_thresholds(p1)
+        assert death_rein < death_neutral  # easier to die
+
+    @pytest.mark.asyncio
+    async def test_composes_with_sensitivity_not_replaces(self):
+        """Handicap and sensitivity are SEPARATE knobs that both apply."""
+        game = make_game(num_players=1)
+        p1 = game.players["p1"]
+        _, death_neutral = game._compute_effective_thresholds(p1)
+
+        # sensitivity_factor 2.0 alone halves the threshold (easier).
+        p1.sensitivity_factor = 2.0
+        _, death_sens_only = game._compute_effective_thresholds(p1)
+        assert death_sens_only == pytest.approx(death_neutral / 2.0)
+
+        # Add a 2.0 handicap (harder): it MULTIPLIES the already-divided threshold,
+        # composing back to the neutral threshold (0.5 * 2.0 == 1.0 net).
+        mgr, _ = make_manager(game=game)
+        mgr._interventions_client = TargetingFlagClient(default=1.0, per_serial={"p1": 2.0})
+        await handle_player_handicap_factor(make_ctx("player_handicap_factor", 2.0, game), mgr)
+        _, death_both = game._compute_effective_thresholds(p1)
+        assert p1.sensitivity_factor == pytest.approx(2.0)  # sensitivity untouched
+        assert p1.handicap_factor == pytest.approx(2.0)
+        assert death_both == pytest.approx(death_neutral)
+
+    @pytest.mark.asyncio
+    async def test_no_live_game_is_noop(self):
+        mgr, _ = make_manager(game=None)
+        mgr._interventions_client = TargetingFlagClient(default=1.0)
+        await handle_player_handicap_factor(make_ctx("player_handicap_factor", 1.5, None), mgr)
+
+
 # --------------------------------------------------------------------------- #
 # resolve_player_targets (reusable helper) — PR D consumes this
 # --------------------------------------------------------------------------- #
@@ -384,6 +460,8 @@ class TestRegistration:
         assert mgr._handlers["global_sensitivity_override"] is handle_global_sensitivity_override
         # player_sensitivity_factor is bound via closure (not identity-equal).
         assert callable(mgr._handlers["player_sensitivity_factor"])
+        # #1107: player_handicap_factor is also closure-bound (mirrors sensitivity).
+        assert callable(mgr._handlers["player_handicap_factor"])
         # #922: music_tempo_override needs an explicit revert handler (the manager
         # routes reverts to _revert_handlers, not back to the apply-handler).
         assert mgr._revert_handlers["music_tempo_override"] is handle_music_tempo_override_revert


### PR DESCRIPTION
Part of #1103, #1107.

MVP action 1 from the #1103 design. Adds a `set_player_handicap` agent intervention: a per-player **MULTIPLICATIVE** handicap on the FFA death threshold, a **separate** knob that **composes with** (does not replace) `adjust_player_sensitivity`. Maintainer-chosen semantics: multiplicative (reuse the existing [0.5, 2.0] clamp), **shadow-game-only** initially.

## Behavior
Intent-framed: `>1` = higher threshold = harder to eliminate ("help"); `<1` = easier ("rein in"). Clamped independently to `[0.5, 2.0]`. Default-safe: neutral `1.0` = no effect, absent = no effect. No `game.json` persistence (interventions.json only, per the ownership model). Continuous rubber-banding — the replacement for the binary shield.

### Threshold math (`base.py:_compute_effective_thresholds`)
The existing sensitivity/global-difficulty combined factor still divides the lerped threshold (clamped `[0.5, 2.0]`), unchanged. The new `handicap_factor` is then applied as a **separate** independently-clamped multiplier **after** that division:

```
warn  = lerp(...) / clamp(sensitivity_factor * global_difficulty_factor)
death = ...
return warn * clamp(handicap_factor), death * clamp(handicap_factor)
```

So a `2.0` sensitivity (halves) and a `2.0` handicap (doubles) net back to the neutral threshold — they compose, neither replaces the other.

## Integration points
- **base.py** — new `Player.handicap_factor` (default 1.0); `_compute_effective_thresholds` multiplicative compose + independent clamp.
- **interventions.py** — `InterventionSpec(set_player_handicap, flag=player_handicap_factor, float, player_targeted, none_value=1.0, WEIGHT_MEDIUM)`. FFA allows it via the existing capability matrix (FFA only denies `revive_player`).
- **difficulty_handlers.py** — `handle_player_handicap_factor` (mirrors `handle_player_sensitivity_factor`: per-serial targeting, clamp, neutral-default revert via the apply path) + registration.
- **agent/actions/writer.go** — `set_player_handicap` case (`setTargeted` + `numOr`).
- **agent/decision/ratelimit.go** — `InterventionSetPlayerHandicap` constant + MEDIUM (1.0) weight.
- **agent/llm/prompt.go** — one-line FFA impact-model fragment; golden snapshots regenerated (FFA-mode goldens only).
- **flagd** — `shadow_experimental` variant in `agent.json` (+ ci copy); `player_handicap_factor` flag in `interventions.json` (+ ci + writer test fixture).

## Shadow-only gating (load-bearing)
A new `shadow_experimental` `interventions_allowed` variant carries `set_player_handicap`; `ambient`/`standard`/`full` do **not**. The allow-list is the enforcement gate (`decode.go` validates the LLM's choice against the live snapshot; the rules engine reads the same flag), so the type is **rejected for real games by construction**. Proven by `TestSetPlayerHandicapIsShadowOnly` (asserts presence in `shadow_experimental`, absence from the three real variants, on both production and CI agent.json).

## Tests
- Threshold math: neutral no-op, `>1` raises / `<1` lowers, independent clamp, multiplicative compose with sensitivity (`test_base_helpers.py`).
- Handler: apply per-serial, clamp, help/rein-in direction, compose-not-replace, no-live-game no-op (`test_difficulty_interventions.py`).
- Writer emits the targeted flag + default value within clamp band (`writer_test.go`).
- Shadow-only gating proof (`shadow_gate_test.go`).

All green: `game_coordinator` 1026 passed; `agent` `go test ./... -race` all packages ok (incl. the #1097 flake package); `make lint` clean; all touched JSON validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)