### PR TITLE
feat(agent): inject W3C traceparent on inference HTTP calls (#1096)

### DIFF
--- a/services/agent/inference/openai.go
+++ b/services/agent/inference/openai.go
@@ -35,6 +35,8 @@ import (
 	"time"
 
 	"github.com/joustmania/agent/llm"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
 )
 
 // DefaultBaseURL points at the HOST machine's Ollama OpenAI-compatible endpoint
@@ -207,6 +209,25 @@ func (b *OpenAIBackend) Infer(ctx context.Context, prompt llm.Prompt) (string, e
 	if b.apiKey != "" {
 		req.Header.Set("Authorization", "Bearer "+b.apiKey)
 	}
+
+	// W3C trace-context propagation (#1096, #1088 Phase 2 for the inference hop).
+	// Inject `traceparent` (the global propagator is otel.go's TraceContext) from the
+	// request's ctx, which carries the active inference span (sync llmDecide starts
+	// agent.llm.infer on this ctx before calling Infer). When the agent is routed
+	// through the litellm gateway (AGENT_INFERENCE_BASE_URL=.../litellm), the gateway
+	// reads this header and nests its provider-truth gen_ai span as a CHILD of the
+	// agent's span — one navigable trace (agent decision -> gateway call -> provider).
+	//
+	// OWNERSHIP SPLIT (#1096): the agent span keeps DECISION/INTENT attrs only
+	// (gen_ai.agent.name, gen_ai.operation.name, intended model, gen_ai.output.type);
+	// the GATEWAY owns PROVIDER TRUTH (actual model after fallback, token counts,
+	// latency, cost). We deliberately set NO provider-truth attrs here — we only LINK
+	// the traces so the gateway's span (which carries them) is reachable.
+	//
+	// DEFAULT-SAFE: Ollama-direct (the current setup) simply ignores an unknown
+	// `traceparent` header — no behavior change. If no span/propagator is active in
+	// ctx, Inject is a no-op (no header written). Never errors, never panics.
+	otel.GetTextMapPropagator().Inject(ctx, propagation.HeaderCarrier(req.Header))
 
 	resp, err := b.httpClient.Do(req)
 	if err != nil {

--- a/services/agent/inference/openai_test.go
+++ b/services/agent/inference/openai_test.go
@@ -12,6 +12,9 @@ import (
 	"time"
 
 	"github.com/joustmania/agent/llm"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 )
 
 // sampleCompletion is a realistic OpenAI-compatible /chat/completions response body.
@@ -228,4 +231,84 @@ func TestWithTimeout(t *testing.T) {
 			t.Errorf("timeout = %v, want default %v", b.httpClient.Timeout, DefaultTimeout)
 		}
 	})
+}
+
+// withTraceContextPropagator installs the W3C TraceContext propagator as the global
+// for the duration of a test, restoring the previous one afterward. This mirrors the
+// agent's real otel.go setup (a composite that includes propagation.TraceContext) so
+// the #1096 injection path under test behaves exactly as it does in production.
+func withTraceContextPropagator(t *testing.T) {
+	t.Helper()
+	prev := otel.GetTextMapPropagator()
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+	t.Cleanup(func() { otel.SetTextMapPropagator(prev) })
+}
+
+// TestInfer_InjectsTraceparentWithinActiveSpan is the #1096 core assertion: when Infer
+// is called with a ctx carrying an active (sampled) span — exactly what the sync
+// llmDecide path does after starting agent.llm.infer — the outbound request MUST carry
+// a W3C `traceparent` header whose trace-id matches the active span's trace-id. This is
+// what lets the litellm gateway nest its provider-truth gen_ai span under the agent's
+// span (one trace). Infer must still succeed normally.
+func TestInfer_InjectsTraceparentWithinActiveSpan(t *testing.T) {
+	withTraceContextPropagator(t)
+
+	var gotTraceparent string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotTraceparent = r.Header.Get("traceparent")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, sampleCompletion)
+	}))
+	defer srv.Close()
+
+	// A real SDK tracer provider with AlwaysSample so the started span is recording and
+	// sampled — only sampled spans produce a traceparent the downstream will honor.
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSampler(sdktrace.AlwaysSample()))
+	defer func() { _ = tp.Shutdown(context.Background()) }()
+	ctx, span := tp.Tracer("test").Start(context.Background(), "agent.llm.infer")
+	defer span.End()
+	wantTraceID := span.SpanContext().TraceID().String()
+
+	b := newMockBackend(srv, "", "phi4-mini")
+	if _, err := b.Infer(ctx, llm.Prompt{System: "s", User: "u"}); err != nil {
+		t.Fatalf("Infer error: %v", err)
+	}
+
+	if gotTraceparent == "" {
+		t.Fatal("no traceparent header sent despite active span; want one")
+	}
+	// W3C format: version-traceid-spanid-flags; assert the trace-id matches the active
+	// span so the gateway span will nest under THIS trace, not an orphan.
+	if !strings.Contains(gotTraceparent, wantTraceID) {
+		t.Errorf("traceparent %q does not carry active trace-id %q", gotTraceparent, wantTraceID)
+	}
+}
+
+// TestInfer_NoTraceparentWithoutActiveSpan asserts the default-safe path: with no active
+// span in ctx, Inject is a no-op (no traceparent header written) and Infer still works.
+// This covers the Ollama-direct current setup (it ignores the header anyway) and any
+// caller that runs outside a span — the injection must never break a plain call.
+func TestInfer_NoTraceparentWithoutActiveSpan(t *testing.T) {
+	withTraceContextPropagator(t)
+
+	var sawTraceparent bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, sawTraceparent = r.Header["Traceparent"]
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, sampleCompletion)
+	}))
+	defer srv.Close()
+
+	b := newMockBackend(srv, "", "phi4-mini")
+	// context.Background() carries no span -> propagator Inject writes nothing.
+	out, err := b.Infer(context.Background(), llm.Prompt{System: "s", User: "u"})
+	if err != nil {
+		t.Fatalf("Infer error with no active span: %v", err)
+	}
+	if out == "" {
+		t.Error("want content returned even with no active span")
+	}
+	if sawTraceparent {
+		t.Error("traceparent header sent without an active span; want none (no-op inject)")
+	}
 }


### PR DESCRIPTION
## What

Injects the W3C `traceparent` header on the agent's outbound `/v1/chat/completions` request in `services/agent/inference/openai.go`, using the global OTel `TextMapPropagator` (the `TraceContext` composite set up in `otel.go`), seeded from the request `ctx`.

```go
otel.GetTextMapPropagator().Inject(ctx, propagation.HeaderCarrier(req.Header))
```

The sync `llmDecide` path starts the `agent.llm.infer` span on this `ctx` *before* calling `Infer` (`decision/llm_decide.go:124-142`), so the active span context rides along on the request. When the agent is routed through the litellm gateway (`AGENT_INFERENCE_BASE_URL=http://litellm:4000/v1`), the gateway reads the header and nests its provider-truth gen_ai span as a **child of `agent.llm.infer`** -- one navigable trace (agent decision -> gateway call -> provider). This is **#1088 Phase 2 for the inference hop** (real outbound HTTP call carries the header, no exemplar link needed).

## Ownership split (gen_ai telemetry, per #1096)

- **Agent keeps** DECISION/INTENT attrs only: `gen_ai.agent.name`, `gen_ai.operation.name`, intended model, `gen_ai.output.type` (already on its spans).
- **Gateway owns** PROVIDER TRUTH: actual model after fallback, token counts, latency, cost.

This PR adds **no** provider-truth attrs to agent spans -- it only **LINKS** the traces via `traceparent` so the gateway span (which carries them) is navigable under the agent trace. Documented in a code comment on the injection site.

## Default-safe

- **Ollama-direct (current setup)** simply ignores an unknown `traceparent` header -- no behavior change.
- With **no active span/propagator** in `ctx`, `Inject` is a no-op (no header written). Never errors, never panics -- preserves the "every failure degrades cleanly" contract.

## Scope notes

- Does **not** change routing (agent still talks to whatever `AGENT_INFERENCE_BASE_URL` says -- that's an ops/config decision).
- Does **not** touch game-coordinator or the decision-loop control flow.

## Tests

Added to `inference/openai_test.go`:
- `TestInfer_InjectsTraceparentWithinActiveSpan` -- with a real sampled SDK span on `ctx`, the outbound request carries a `traceparent` whose trace-id matches the active span; Infer still succeeds.
- `TestInfer_NoTraceparentWithoutActiveSpan` -- with `context.Background()` (no span), no `traceparent` is written and Infer still works.

`gofmt -l . && go build ./... && go vet ./... && go test ./... -race -count=1` all green.

Part of #1096, #1088

🤖 Generated with [Claude Code](https://claude.com/claude-code)