### PR TITLE
feat(game): flag-gated tempo schedule SOURCE with live config listener (#1109)

### DIFF
--- a/lib/feature_flags.py
+++ b/lib/feature_flags.py
@@ -365,7 +365,7 @@ def read_float_flag(domain: str, flag_key: str, default: float, game_id: str | N
         return default
 
 
-def read_string_flag(domain: str, flag_key: str, default: str) -> str:
+def read_string_flag(domain: str, flag_key: str, default: str, game_id: str | None = None) -> str:
     """
     Read a string-typed flag live, with a hardcoded fallback.
 
@@ -380,6 +380,9 @@ def read_string_flag(domain: str, flag_key: str, default: str) -> str:
         domain: OpenFeature domain / flagSetId (e.g. "game")
         flag_key: String flag key (e.g. "shadow_policy")
         default: Fallback value returned on any error or missing flag
+        game_id: Optional owning game id (#838/#1109); added as the ``gameId``
+            context so flagd targeting can scope the value per game. ``None``/empty
+            resolves identically to today (pure context addition).
 
     Returns:
         The flag's string value, or ``default`` on failure.
@@ -387,7 +390,7 @@ def read_string_flag(domain: str, flag_key: str, default: str) -> str:
     try:
         init_flag_domain(domain)
         client = get_flag_client(domain)
-        details = client.get_string_details(flag_key, default, EvaluationContext())
+        details = client.get_string_details(flag_key, default, _calibration_context(game_id))
         if _report_details_error(flag_key, details):
             return default
         value = details.value

--- a/services/flagd/ci/game.json
+++ b/services/flagd/ci/game.json
@@ -11,6 +11,14 @@
       },
       "defaultVariant": "allow"
     },
+    "tempo_schedule_mode": {
+      "state": "ENABLED",
+      "variants": {
+        "rule": "rule",
+        "agent": "agent"
+      },
+      "defaultVariant": "rule"
+    },
     "sensitivity": {
       "state": "ENABLED",
       "variants": {

--- a/services/flagd/game.json
+++ b/services/flagd/game.json
@@ -11,6 +11,14 @@
       },
       "defaultVariant": "block"
     },
+    "tempo_schedule_mode": {
+      "state": "ENABLED",
+      "variants": {
+        "rule": "rule",
+        "agent": "agent"
+      },
+      "defaultVariant": "rule"
+    },
     "sensitivity": {
       "state": "ENABLED",
       "variants": {

--- a/services/game_coordinator/games/base.py
+++ b/services/game_coordinator/games/base.py
@@ -34,6 +34,7 @@ from lib.feature_flags import (
     GAME_KIND_SHADOW,
     read_float_flag,
     read_object_flag,
+    read_string_flag,
     set_game_transaction_context,
 )
 from lib.telemetry import inject_trace_context
@@ -56,6 +57,40 @@ COUNTDOWN_BEEP_COUNT = 3  # Number of beeps (Red/Yellow/Green)
 SLOW_MUSIC_SPEED = 1.0  # Normal playback
 FAST_MUSIC_SPEED = 1.3  # 30% faster
 MUSIC_TRANSITION_DURATION = 1.5  # Seconds to smoothly transition
+
+# #1109: tempo-schedule SOURCE selector (``game.tempo_schedule_mode`` flag).
+# The tempo-change decision ALWAYS flows through the single pacing-policy seam
+# (``_decide_next_change_delay``); this flag selects which policy that seam runs:
+#   * "rule"  — the rule engine owns the decision. The DEFAULT rule reproduces
+#     the historical random-window timing (``_rng.uniform`` within the lerped
+#     ``music_windows``) byte-for-byte, so the unset/default behavior is
+#     unchanged WITHOUT a second legacy code path. A deterministic non-random
+#     rule is a follow-up policy (#1108) — the default rule simply keeps the RNG.
+#   * "agent" — the seam yields the next-change decision to agent tempo
+#     directives (#1103 ramp_tempo, a follow-up). Until that primitive lands the
+#     mode is a clean STUB: with no directive present it falls back to the
+#     default rule, so selecting "agent" early is safe (never freezes pacing).
+# There is intentionally NO "random" mode: randomness survives as the default
+# RULE, not as a separate mode (maintainer re-scope, #1109).
+TEMPO_MODE_RULE = "rule"
+TEMPO_MODE_AGENT = "agent"
+# Unset / unknown values resolve to the rule engine's default rule => back-compat.
+TEMPO_SCHEDULE_MODE_DEFAULT = TEMPO_MODE_RULE
+_VALID_TEMPO_SCHEDULE_MODES = (TEMPO_MODE_RULE, TEMPO_MODE_AGENT)
+
+
+def resolve_tempo_schedule_mode(value: object) -> str:
+    """Validate the ``game.tempo_schedule_mode`` flag value.
+
+    Any value other than the known modes (``rule``/``agent``) — including a
+    missing flag, a non-string, or a stale ``random`` left over from an older
+    config — resolves to :data:`TEMPO_SCHEDULE_MODE_DEFAULT` (``rule``), whose
+    default policy reproduces today's behavior. This keeps the seam default-safe.
+    """
+    if isinstance(value, str) and value in _VALID_TEMPO_SCHEDULE_MODES:
+        return value
+    return TEMPO_SCHEDULE_MODE_DEFAULT
+
 
 # Span attribute keys (S1192 - avoid duplicate string literals)
 GAME_MODE_ATTR = "game.mode"
@@ -590,6 +625,25 @@ class BaseGameMode(ABC):
         # neutral profile. Never reassigned after init (the live handler swaps
         # ``self.music_windows`` only).
         self.init_music_windows = self.music_windows
+
+        # #1109: tempo-schedule SOURCE mode (``game.tempo_schedule_mode``). Read
+        # ONCE here for the initial value, then kept LIVE by the
+        # PROVIDER_CONFIGURATION_CHANGED listener (TempoScheduleManager), which
+        # atomically swaps ``self.tempo_schedule_mode`` mid-game exactly like the
+        # F6 ``music_windows`` seam. The single pacing pathway
+        # (``_decide_next_change_delay``) reads this attribute fresh on every
+        # tempo-change decision, so flipping the flag switches the source LIVE
+        # without a restart. Default/unknown => "rule" (default rule reproduces
+        # today's random-window timing => behavior unchanged).
+        self.tempo_schedule_mode = resolve_tempo_schedule_mode(
+            read_string_flag("game", "tempo_schedule_mode", TEMPO_SCHEDULE_MODE_DEFAULT, game_id=self.game_id)
+        )
+        # #1109 agent-mode seam (#1103 follow-up): the next-change delay an agent
+        # tempo directive (ramp_tempo) wants the schedule to honor. ``None`` =>
+        # no directive present => "agent" mode falls back to the default rule.
+        # Set by the agent primitive in a follow-up PR; never set in this PR.
+        self.agent_tempo_next_delay: float | None = None
+
         # #766 F6: live global difficulty factor (analogue of per-player
         # ``sensitivity_factor``). Combined with the per-player factor in
         # ``_compute_effective_thresholds``; 1.0 is neutral (baseline behavior).
@@ -2493,6 +2547,53 @@ class BaseGameMode(ABC):
 
         As more players die, tempo changes become more frequent.
         Returns absolute time (time.time() + delay).
+
+        #1109: this is the SINGLE pacing pathway. The delay is produced by the
+        pacing-policy seam (:meth:`_decide_next_change_delay`), which dispatches
+        on the live ``self.tempo_schedule_mode``. There is no separate legacy RNG
+        branch beside the seam — the historical random-window timing is folded in
+        as the rule engine's default rule (:meth:`_default_rule_delay`).
+        """
+        return time.time() + self._decide_next_change_delay()
+
+    def _decide_next_change_delay(self) -> float:
+        """Pacing-policy seam: produce the delay (seconds) until the next change.
+
+        Dispatches on ``self.tempo_schedule_mode`` (read fresh every call, so the
+        PROVIDER_CONFIGURATION_CHANGED listener's live swap takes effect on the
+        next tempo decision):
+
+        * ``rule`` (default / back-compat) — run the rule engine. The default
+          rule is :meth:`_default_rule_delay`, the windowed RNG that reproduces
+          today's timing exactly.
+        * ``agent`` — yield to an agent tempo directive
+          (``self.agent_tempo_next_delay``, set by the #1103 follow-up). STUB for
+          Phase 1: with no directive present, fall back to the default rule so
+          pacing never freezes when ``agent`` is selected before the primitive
+          ships.
+
+        Any unexpected mode falls through to the default rule (fail-safe).
+        """
+        mode = self.tempo_schedule_mode
+        if mode == TEMPO_MODE_AGENT:
+            directive = self.agent_tempo_next_delay
+            if directive is not None and directive >= 0:
+                return float(directive)
+            # No directive yet (#1103 not shipped) -> hold the established pacing
+            # by falling back to the default rule. (A future variant could hold
+            # the current tempo instead; falling back keeps pacing alive today.)
+            return self._default_rule_delay()
+        # mode == "rule" (and any unknown value): the rule engine's default rule.
+        return self._default_rule_delay()
+
+    def _default_rule_delay(self) -> float:
+        """Default pacing rule: the historical random-window schedule.
+
+        Folds the former ``_get_music_change_time`` body in verbatim so the
+        ``rule`` mode's default policy is byte-for-byte the pre-#1109 timing:
+        a ``_rng.uniform`` draw within the (game-progression-lerped, F6-swappable)
+        ``self.music_windows``. Randomness survives here as a RULE, not a mode.
+        Returns a relative delay in seconds.
         """
         # Calculate game progression (0.0 = start, 1.0 = near end)
         min_moves = len(self.players) - 2
@@ -2513,8 +2614,22 @@ class BaseGameMode(ABC):
             min_t = self._lerp(windows.fast_min, windows.end_fast_min, game_percent)
             max_t = self._lerp(windows.fast_max, windows.end_fast_max, game_percent)
 
-        delay = self._rng.uniform(min_t, max_t)
-        return time.time() + delay
+        return self._rng.uniform(min_t, max_t)
+
+    def apply_tempo_schedule_mode(self, value: object) -> None:
+        """Atomically swap the live tempo-schedule SOURCE mode (#1109).
+
+        Called by the PROVIDER_CONFIGURATION_CHANGED listener
+        (TempoScheduleManager) with the freshly-resolved ``game.tempo_schedule_mode``
+        flag value for THIS game's ``gameId``. The value is validated and stored
+        in a single attribute store (like the F6 ``music_windows`` swap), so the
+        100ms music loop / ``_decide_next_change_delay`` picks up the new source
+        on its next decision without tearing — live mid-game mode switching.
+        """
+        new_mode = resolve_tempo_schedule_mode(value)
+        if new_mode != self.tempo_schedule_mode:
+            logger.info(f"tempo_schedule_mode: {self.tempo_schedule_mode} -> {new_mode}")
+        self.tempo_schedule_mode = new_mode  # atomic single-store swap
 
     async def _apply_tempo_change(self, target_tempo: float) -> None:
         """

--- a/services/game_coordinator/servicer.py
+++ b/services/game_coordinator/servicer.py
@@ -56,6 +56,7 @@ from services.game_coordinator.event_bus import EventBus
 from services.game_coordinator.game_session import GAME_KIND_PRIMARY, GAME_KIND_SHADOW, GameSession
 from services.game_coordinator.interventions import InterventionManager, SessionView
 from services.game_coordinator.lifecycle_handlers import register_lifecycle_handlers
+from services.game_coordinator.tempo_schedule import TempoScheduleManager
 
 logger = logging.getLogger(__name__)
 
@@ -180,6 +181,14 @@ class GameCoordinatorServicer(game_coordinator_pb2_grpc.GameCoordinatorServiceSe
         # shield_seconds (per-player grace shield), eliminate_player, revive_player.
         register_lifecycle_handlers(self.intervention_manager)
         self.intervention_manager.start()
+
+        # Tempo-schedule SOURCE listener (#1109): subscribes to flagd's
+        # PROVIDER_CONFIGURATION_CHANGED event and re-reads `game.tempo_schedule_mode`
+        # for every live session's gameId, atomically swapping each game's
+        # `tempo_schedule_mode` so the pacing SOURCE (rule | agent) switches LIVE
+        # mid-game. Reuses the same per-session seam as the InterventionManager.
+        self.tempo_schedule_manager = TempoScheduleManager(get_sessions=self.get_intervention_sessions)
+        self.tempo_schedule_manager.start()
 
         logger.info("GameCoordinator initialized")
 
@@ -898,6 +907,12 @@ class GameCoordinatorServicer(game_coordinator_pb2_grpc.GameCoordinatorServiceSe
             self.intervention_manager.stop()
         except Exception as e:
             logger.debug(f"InterventionManager stop failed: {e}")
+
+        # Stop tempo-schedule SOURCE subscription (#1109)
+        try:
+            self.tempo_schedule_manager.stop()
+        except Exception as e:
+            logger.debug(f"TempoScheduleManager stop failed: {e}")
 
         with self._sessions_lock:
             sessions = list(self.sessions.values())

--- a/services/game_coordinator/tempo_schedule.py
+++ b/services/game_coordinator/tempo_schedule.py
@@ -1,0 +1,135 @@
+"""
+Tempo-schedule SOURCE listener (#1109).
+
+Keeps each live game's tempo-schedule SOURCE mode (``game.tempo_schedule_mode``)
+fresh by subscribing to flagd's ``PROVIDER_CONFIGURATION_CHANGED`` event — the
+same live-reload mechanism :class:`RuntimeConfigManager` and
+:class:`InterventionManager` already use. Flipping the flag mid-game switches the
+pacing SOURCE LIVE (no restart): on the next change event this manager re-reads
+``tempo_schedule_mode`` for every live session's ``gameId`` and atomically swaps
+the game's ``self.tempo_schedule_mode`` (the same single-store swap pattern as the
+F6 ``music_windows`` seam). The 100ms music loop / ``_decide_next_change_delay``
+then reads the new mode on its next tempo decision.
+
+This is the SOURCE selector only — the rule engine (default rule = today's
+random-window timing) and the agent-directive seam both live on the game in
+``games/base.py``. This manager does not change the threshold math (#1107) or
+interventions; it is game-coordinator-only and reads a human/ops-set flag (the
+agent never persists it).
+"""
+
+import logging
+import threading
+
+from openfeature.provider import ProviderEvent
+
+from lib.feature_flags import read_string_flag
+from services.game_coordinator.games.base import TEMPO_SCHEDULE_MODE_DEFAULT
+
+logger = logging.getLogger(__name__)
+
+
+class TempoScheduleManager:
+    """Owns the ``game.tempo_schedule_mode`` flag client + live-reload handler.
+
+    Lifecycle mirrors :class:`InterventionManager`: ``start()`` initializes the
+    ``game`` flag domain, registers the change handler, and does an initial
+    evaluation; ``stop()`` removes the handler. ``get_sessions`` is the per-game
+    seam (one :class:`SessionView` per live game) so each game's mode is resolved
+    against its own ``gameId`` context — a shadow game can run a different source
+    than the primary, live.
+    """
+
+    def __init__(self, get_sessions):
+        # get_sessions() -> list[SessionView]; same callable the servicer feeds
+        # the InterventionManager. Each view carries game_id (-> gameId context)
+        # and the live game instance.
+        self._get_sessions = get_sessions
+        self._game_client = None
+        self._started = False
+        self._lock = threading.RLock()
+
+    def start(self) -> None:
+        """Initialize the game flag client, register the handler, prime modes."""
+        if self._started:
+            return
+        try:
+            from openfeature import api
+
+            from lib.feature_flags import get_flag_client, init_flag_domain
+
+            init_flag_domain("game")
+            self._game_client = get_flag_client("game")
+
+            api.add_handler(ProviderEvent.PROVIDER_CONFIGURATION_CHANGED, self._on_flags_changed)
+            logger.info("TempoScheduleManager: registered PROVIDER_CONFIGURATION_CHANGED handler")
+            self._started = True
+        except ImportError:
+            logger.warning("TempoScheduleManager: OpenFeature unavailable, tempo mode stays init-frozen")
+            return
+        except Exception as e:
+            logger.error(f"TempoScheduleManager: failed to initialize: {e}")
+            return
+
+        # Initial evaluation applies any already-set mode to live games (none at
+        # startup) and is harmless / idempotent.
+        self.evaluate_all()
+
+    def stop(self) -> None:
+        """Remove the change handler."""
+        if not self._started:
+            return
+        try:
+            from openfeature import api
+
+            api.remove_handler(ProviderEvent.PROVIDER_CONFIGURATION_CHANGED, self._on_flags_changed)
+        except Exception as e:
+            logger.debug(f"TempoScheduleManager: handler removal failed: {e}")
+        self._started = False
+
+    def _on_flags_changed(self, _event_details) -> None:
+        """Event handler: re-read tempo_schedule_mode for every live game.
+
+        Synchronous (OpenFeature handler), fired on a background thread. The swap
+        it performs is a plain attribute store on each game (no awaitable, no
+        loop-bound gRPC client), so unlike :class:`InterventionManager` it can run
+        the evaluation inline on the handler thread — the music loop reads the new
+        value on its next tick.
+        """
+        self.evaluate_all()
+
+    def evaluate_all(self) -> None:
+        """Re-read ``tempo_schedule_mode`` for each live session and swap it in.
+
+        Each session's value is resolved with that session's ``gameId`` context
+        so flagd targeting can scope the source per game. ``resolve_tempo_schedule_mode``
+        (applied in ``apply_tempo_schedule_mode``) keeps the swap default-safe: any
+        missing/unknown value resolves to ``rule`` => today's behavior.
+        """
+        if self._get_sessions is None:
+            return
+        try:
+            sessions = list(self._get_sessions() or [])
+        except Exception as e:
+            logger.error(f"TempoScheduleManager: get_sessions failed: {e}")
+            return
+
+        for session in sessions:
+            game = getattr(session, "game", None)
+            if game is None:
+                continue
+            value = self._read_mode(getattr(session, "game_id", "") or None)
+            try:
+                game.apply_tempo_schedule_mode(value)
+            except Exception as e:  # one bad session must not stop the rest
+                logger.warning(f"TempoScheduleManager: failed to apply mode for {session.game_id}: {e}")
+
+    def _read_mode(self, game_id):
+        """Read the live ``game.tempo_schedule_mode`` value for a ``gameId``.
+
+        Returns the raw flag string (validation happens in
+        ``apply_tempo_schedule_mode``). On any failure returns the default so the
+        swap stays behavior-neutral.
+        """
+        with self._lock:
+            return read_string_flag("game", "tempo_schedule_mode", TEMPO_SCHEDULE_MODE_DEFAULT, game_id=game_id)

--- a/services/game_coordinator/tests/test_tempo_schedule_mode.py
+++ b/services/game_coordinator/tests/test_tempo_schedule_mode.py
@@ -1,0 +1,315 @@
+"""
+Tests for #1109: feature-flag-gated tempo-schedule SOURCE + live config listener.
+
+Covers the re-scoped design (maintainer refinements on #1109):
+- ONE pacing pathway: ``_get_music_change_time`` -> ``_decide_next_change_delay``.
+  The historical random-window timing is the rule engine's DEFAULT RULE
+  (``_default_rule_delay``), NOT a separate legacy branch. There is no ``random``
+  mode; the flag selects ``rule`` | ``agent`` only.
+- Default-safe / byte-identical: with the default mode, the delay drawn for a
+  fixed RNG seed + state is identical to calling the default rule directly (proof
+  that ``rule``'s default policy reproduces pre-#1109 timing exactly).
+- ``agent`` mode is a clean STUB: no directive => fall back to the default rule
+  (pacing never freezes); a directive => honored.
+- The PROVIDER_CONFIGURATION_CHANGED listener (TempoScheduleManager) swaps the
+  mode LIVE mid-game, game_id-scoped, without a restart.
+- ``game.tempo_schedule_mode`` flag JSON is well-formed (rule/agent, default rule).
+"""
+
+import json
+import random
+import sys
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+# Setup paths for imports
+test_dir = Path(__file__).parent
+service_dir = test_dir.parent
+project_root = service_dir.parent.parent
+sys.path.insert(0, str(project_root))
+sys.path.insert(0, str(test_dir))
+
+from conftest import EventCollector
+
+from services.game_coordinator.games.base import (
+    TEMPO_MODE_AGENT,
+    TEMPO_MODE_RULE,
+    TEMPO_SCHEDULE_MODE_DEFAULT,
+    resolve_tempo_schedule_mode,
+)
+from services.game_coordinator.games.ffa import FFAGame
+from services.game_coordinator.interventions import SessionView
+from services.game_coordinator.tempo_schedule import TempoScheduleManager
+
+GAME_JSON = project_root / "services" / "flagd" / "game.json"
+
+
+def _make_ffa(game_id: str = ""):
+    return FFAGame(
+        controller_manager_client=None,
+        event_publisher=EventCollector().publish,
+        sensitivity=2,
+        game_id=game_id,
+    )
+
+
+def _arm_game(game, *, players=2, dead=0, speed_up=True):
+    game.players = {chr(ord("a") + i): object() for i in range(players)}
+    game.dead_count = dead
+    game.speed_up = speed_up
+
+
+# ========================================================================
+# resolve_tempo_schedule_mode
+# ========================================================================
+
+
+def test_resolve_known_modes():
+    assert resolve_tempo_schedule_mode("rule") == TEMPO_MODE_RULE
+    assert resolve_tempo_schedule_mode("agent") == TEMPO_MODE_AGENT
+
+
+def test_resolve_unknown_falls_back_to_rule():
+    # missing / non-string / a stale "random" all resolve to the default rule.
+    for bad in (None, "", "random", "RULE", 5, [], True, "agentx"):
+        assert resolve_tempo_schedule_mode(bad) == TEMPO_SCHEDULE_MODE_DEFAULT == TEMPO_MODE_RULE
+
+
+# ========================================================================
+# Default mode = rule, init-resolved (flagd unavailable in unit tests => "rule")
+# ========================================================================
+
+
+def test_default_mode_is_rule():
+    game = _make_ffa()
+    assert game.tempo_schedule_mode == TEMPO_MODE_RULE
+    assert game.agent_tempo_next_delay is None
+
+
+# ========================================================================
+# Single pathway + byte-identical default-rule proof
+# ========================================================================
+
+
+def test_default_mode_byte_identical_to_default_rule():
+    """In ``rule`` mode the seam returns EXACTLY the default rule's draw.
+
+    Seed the per-game RNG identically before each call: the value the single
+    pathway produces must equal a direct ``_default_rule_delay()`` draw — proof
+    the windowed-RNG timing is folded into the default rule with no behavior
+    change (no separate legacy branch alters the result).
+    """
+    game = _make_ffa()
+    _arm_game(game, players=4, dead=1, speed_up=True)
+    assert game.tempo_schedule_mode == TEMPO_MODE_RULE
+
+    for seed in range(50):
+        game._rng = random.Random(seed)
+        via_seam = game._decide_next_change_delay()
+        game._rng = random.Random(seed)
+        via_rule = game._default_rule_delay()
+        assert via_seam == via_rule
+
+
+def test_get_music_change_time_uses_seam():
+    """``_get_music_change_time`` == now + seam delay (single pathway)."""
+    game = _make_ffa()
+    _arm_game(game)
+    with patch.object(game, "_decide_next_change_delay", return_value=7.5):
+        before = time.time()
+        result = game._get_music_change_time()
+    assert abs(result - (before + 7.5)) < 0.05
+
+
+def test_default_rule_stays_within_windows():
+    """Default rule keeps drawing within the same constant ranges as pre-#1109."""
+    from services.game_coordinator.games.base import (
+        MAX_MUSIC_FAST_TIME,
+        MAX_MUSIC_SLOW_TIME,
+        MIN_MUSIC_FAST_TIME,
+        MIN_MUSIC_SLOW_TIME,
+    )
+
+    game = _make_ffa()
+    _arm_game(game, players=2, dead=0)
+    for speed_up, lo, hi in (
+        (True, MIN_MUSIC_SLOW_TIME, MAX_MUSIC_SLOW_TIME),
+        (False, MIN_MUSIC_FAST_TIME, MAX_MUSIC_FAST_TIME),
+    ):
+        game.speed_up = speed_up
+        for _ in range(200):
+            delay = game._decide_next_change_delay()
+            assert lo - 0.001 <= delay <= hi + 0.001
+
+
+# ========================================================================
+# agent mode STUB: no directive => fall back to default rule; directive => honor
+# ========================================================================
+
+
+def test_agent_mode_no_directive_falls_back_to_default_rule():
+    """``agent`` with no directive draws the same delay as the default rule."""
+    game = _make_ffa()
+    _arm_game(game, players=4, dead=1, speed_up=False)
+    game.tempo_schedule_mode = TEMPO_MODE_AGENT
+    game.agent_tempo_next_delay = None  # no #1103 directive yet
+
+    for seed in range(50):
+        game._rng = random.Random(seed)
+        agent_delay = game._decide_next_change_delay()
+        game._rng = random.Random(seed)
+        rule_delay = game._default_rule_delay()
+        assert agent_delay == rule_delay
+
+
+def test_agent_mode_honors_directive():
+    """A present, non-negative directive is used verbatim (no RNG draw)."""
+    game = _make_ffa()
+    _arm_game(game)
+    game.tempo_schedule_mode = TEMPO_MODE_AGENT
+    game.agent_tempo_next_delay = 3.25
+    for _ in range(20):
+        assert game._decide_next_change_delay() == 3.25
+
+
+def test_agent_mode_negative_directive_falls_back():
+    """A malformed (negative) directive is ignored => default rule."""
+    game = _make_ffa()
+    _arm_game(game)
+    game.tempo_schedule_mode = TEMPO_MODE_AGENT
+    game.agent_tempo_next_delay = -1.0
+    game._rng = random.Random(123)
+    via_seam = game._decide_next_change_delay()
+    game._rng = random.Random(123)
+    assert via_seam == game._default_rule_delay()
+
+
+# ========================================================================
+# apply_tempo_schedule_mode: atomic swap, default-safe
+# ========================================================================
+
+
+def test_apply_mode_swaps_atomically():
+    game = _make_ffa()
+    assert game.tempo_schedule_mode == TEMPO_MODE_RULE
+    game.apply_tempo_schedule_mode("agent")
+    assert game.tempo_schedule_mode == TEMPO_MODE_AGENT
+    game.apply_tempo_schedule_mode("rule")
+    assert game.tempo_schedule_mode == TEMPO_MODE_RULE
+
+
+def test_apply_unknown_mode_resolves_to_rule():
+    game = _make_ffa()
+    game.apply_tempo_schedule_mode("agent")
+    game.apply_tempo_schedule_mode("garbage")  # unknown => default rule
+    assert game.tempo_schedule_mode == TEMPO_MODE_RULE
+
+
+# ========================================================================
+# Live listener: TempoScheduleManager swaps the mode mid-game, game_id-scoped
+# ========================================================================
+
+
+def test_listener_switches_mode_live_midgame():
+    """Flipping the flag via the PROVIDER_CONFIGURATION_CHANGED handler switches
+    a RUNNING game's source mode without a restart.
+
+    Drive the manager directly through its handler (``_on_flags_changed``) the way
+    flagd's change event would, with the flag read mocked to flip from rule->agent
+    ->rule. After each change-event the live game's ``tempo_schedule_mode`` reflects
+    the new value — the music loop's next ``_decide_next_change_delay`` honors it.
+    """
+    game = _make_ffa(game_id="game_abc123")
+    _arm_game(game)
+    assert game.tempo_schedule_mode == TEMPO_MODE_RULE
+
+    sessions = [SessionView(game_id="game_abc123", game=game, publish=EventCollector().publish)]
+
+    flag_value = {"v": TEMPO_MODE_RULE}
+
+    def fake_read(domain, key, default, game_id=None):  # noqa: ARG001
+        # Only this game's id is queried (game_id-scoped read).
+        assert game_id == "game_abc123"
+        return flag_value["v"]
+
+    manager = TempoScheduleManager(get_sessions=lambda: sessions)
+
+    with patch("services.game_coordinator.tempo_schedule.read_string_flag", side_effect=fake_read):
+        # Operator flips the flag to agent -> change event fires.
+        flag_value["v"] = TEMPO_MODE_AGENT
+        manager._on_flags_changed(None)
+        assert game.tempo_schedule_mode == TEMPO_MODE_AGENT  # live, no restart
+
+        # Flip back to rule -> next change event reverts it.
+        flag_value["v"] = TEMPO_MODE_RULE
+        manager._on_flags_changed(None)
+        assert game.tempo_schedule_mode == TEMPO_MODE_RULE
+
+
+def test_listener_scopes_per_game():
+    """Two live games get their own gameId-scoped mode (shadow != primary)."""
+    primary = _make_ffa(game_id="game_primary00")
+    shadow = _make_ffa(game_id="game_shadow000")
+    _arm_game(primary)
+    _arm_game(shadow)
+
+    sessions = [
+        SessionView(game_id="game_primary00", game=primary, publish=EventCollector().publish),
+        SessionView(game_id="game_shadow000", game=shadow, publish=EventCollector().publish),
+    ]
+
+    # Primary stays rule; shadow flips to agent (targeting by gameId).
+    per_game = {"game_primary00": TEMPO_MODE_RULE, "game_shadow000": TEMPO_MODE_AGENT}
+
+    def fake_read(domain, key, default, game_id=None):  # noqa: ARG001
+        return per_game.get(game_id, default)
+
+    manager = TempoScheduleManager(get_sessions=lambda: sessions)
+    with patch("services.game_coordinator.tempo_schedule.read_string_flag", side_effect=fake_read):
+        manager._on_flags_changed(None)
+
+    assert primary.tempo_schedule_mode == TEMPO_MODE_RULE
+    assert shadow.tempo_schedule_mode == TEMPO_MODE_AGENT
+
+
+def test_listener_skips_sessions_without_game():
+    """A session with no constructed game yet is skipped (no crash)."""
+    sessions = [SessionView(game_id="game_x", game=None, publish=EventCollector().publish)]
+    manager = TempoScheduleManager(get_sessions=lambda: sessions)
+    with patch("services.game_coordinator.tempo_schedule.read_string_flag", return_value="agent"):
+        manager._on_flags_changed(None)  # must not raise
+
+
+def test_listener_one_bad_session_does_not_stop_others():
+    good = _make_ffa(game_id="game_good")
+
+    class Boom:
+        def apply_tempo_schedule_mode(self, value):
+            raise RuntimeError("boom")
+
+    sessions = [
+        SessionView(game_id="game_bad", game=Boom(), publish=EventCollector().publish),
+        SessionView(game_id="game_good", game=good, publish=EventCollector().publish),
+    ]
+    manager = TempoScheduleManager(get_sessions=lambda: sessions)
+    with patch("services.game_coordinator.tempo_schedule.read_string_flag", return_value="agent"):
+        manager._on_flags_changed(None)  # bad session logged, good still applied
+    assert good.tempo_schedule_mode == TEMPO_MODE_AGENT
+
+
+# ========================================================================
+# game.json flag is well-formed
+# ========================================================================
+
+
+def test_game_json_tempo_schedule_mode_well_formed():
+    data = json.loads(GAME_JSON.read_text())
+    flag = data["flags"]["tempo_schedule_mode"]
+    assert flag["state"] == "ENABLED"
+    assert set(flag["variants"]) == {"rule", "agent"}
+    # No "random" variant (maintainer re-scope).
+    assert "random" not in flag["variants"]
+    # Default variant is the rule engine => back-compat.
+    assert flag["defaultVariant"] == "rule"
+    assert resolve_tempo_schedule_mode(flag["variants"][flag["defaultVariant"]]) == TEMPO_MODE_RULE


### PR DESCRIPTION
## Summary

Feature-flag-gated game-speed/tempo **SOURCE** with a single deterministic pacing pathway that works with **no agent**, driven by the live config-change listener. Implements the maintainer re-scope of #1109: **no separate `random` mode** — the rule engine is the one pacing mechanism, and random survives only as the *default rule*.

### The flag + single-pathway refactor
- New flag **`game.tempo_schedule_mode`** (`services/flagd/game.json` + `ci/`), variants **`rule` (default)** and **`agent`**. No `random` variant.
- The tempo-change decision now ALWAYS flows through ONE seam: `_get_music_change_time` → `_decide_next_change_delay()`. The former windowed-RNG body (`_rng.uniform` within the lerped, F6-swappable `music_windows`) is folded in verbatim as `_default_rule_delay()` — the rule engine's **default rule**. There is no separate legacy `random` branch beside the seam.

### How the listener makes it live
- `TempoScheduleManager` (`services/game_coordinator/tempo_schedule.py`) subscribes to flagd's **`PROVIDER_CONFIGURATION_CHANGED`** event — the same live-reload precedent as `RuntimeConfigManager`/`InterventionManager`. On every change it re-reads `tempo_schedule_mode` for each live session's `gameId` and atomically swaps `game.tempo_schedule_mode` (single-store, same pattern as the F6 `music_windows` seam). The 100ms music loop reads the new mode on its next decision → **live mid-game switching, no restart**, game_id-scoped (a shadow game's source can differ from the primary).
- Wired into the servicer alongside the InterventionManager (start/stop).
- Test proving the mid-game switch: `test_listener_switches_mode_live_midgame` (flips rule→agent→rule on a running game via the handler) and `test_listener_scopes_per_game`.

### The agent-seam stub
- `agent` mode yields to `self.agent_tempo_next_delay` (set by the #1103 `ramp_tempo` follow-up — **not** in this PR). For Phase 1 it is a clean stub: no directive (or a negative one) → fall back to the default rule, so selecting `agent` early never freezes pacing. (`services/agent` untouched.)

### Default-byte-identical proof
- `test_default_mode_byte_identical_to_default_rule`: for 50 seeds, the value the seam produces in `rule` mode equals a direct `_default_rule_delay()` draw — i.e. the default policy reproduces pre-#1109 timing exactly. `resolve_tempo_schedule_mode` resolves any missing/unknown/stale-`random` value to `rule`, so unset behavior is unchanged.

## Verification
- `cd services/game_coordinator && uv run --extra test pytest` → **1042 passed** (16 new in `test_tempo_schedule_mode.py`; existing `test_music_window_flags`/`test_f6_intervention_levers` unchanged).
- `lib/tests/test_feature_flags.py` → 43 passed (`read_string_flag` gained an optional `game_id` param, context-only addition).
- Flag JSON validated; `make lint` clean.
- No threshold-math (#1107) or interventions changes; game-coordinator-only.

Part of #1108, #1109

🤖 Generated with [Claude Code](https://claude.com/claude-code)