### PR TITLE
feat(agent): decision OTEL counters for fleet dashboard (#790)

### DIFF
--- a/services/agent/decision/decision.go
+++ b/services/agent/decision/decision.go
@@ -250,6 +250,18 @@ type Loop struct {
 	// wiring still works.
 	evaluations otelmetric.Int64Counter
 
+	// decisions counts EVERY decision the engine returns, applied or blocked
+	// (agent_decisions_total{action,blocked,block_reason}, #790), so the demo
+	// dashboard can split applied vs blocked by reason. Defaults to a no-op so a
+	// Loop built without metrics wiring still works.
+	decisions otelmetric.Int64Counter
+
+	// interventionsApplied counts decisions that pass every permission gate AND
+	// apply successfully through the action sink (agent_interventions_applied_total
+	// {action}, #790) — the numerator for the applied-rate panel. Defaults to a
+	// no-op so a Loop built without metrics wiring still works.
+	interventionsApplied otelmetric.Int64Counter
+
 	// asyncInferState is the per-Loop async-inference machinery (#917): the pile-up
 	// guard, the in-flight wait group, this loop's game id, the re-validation context
 	// provider, and the agent root context. Embedded so the async surface lives in one
@@ -309,15 +321,17 @@ func NewLoop(flagSource FlagSource, log *slog.Logger) *Loop {
 		flagSource = disabledFlags{}
 	}
 	return &Loop{
-		Flags:       flagSource,
-		Rules:       NoopRules{},
-		Actions:     NoopActions{},
-		Log:         log,
-		Tracer:      otel.Tracer(instrumentationName),
-		now:         time.Now,
-		throttle:    DefaultThrottleInterval,
-		llmGated:    defaultLLMGatedCounter(),
-		evaluations: defaultEvaluationsCounter(),
+		Flags:                flagSource,
+		Rules:                NoopRules{},
+		Actions:              NoopActions{},
+		Log:                  log,
+		Tracer:               otel.Tracer(instrumentationName),
+		now:                  time.Now,
+		throttle:             DefaultThrottleInterval,
+		llmGated:             defaultLLMGatedCounter(),
+		evaluations:          defaultEvaluationsCounter(),
+		decisions:            defaultDecisionsCounter(),
+		interventionsApplied: defaultInterventionsAppliedCounter(),
 		effectSampler: effectSampler{
 			effectDelta: defaultEffectDeltaHistogram(),
 		},
@@ -412,6 +426,43 @@ func (l *Loop) recordEvaluation(ctx context.Context, signal, outcome string) {
 	l.evaluations.Add(ctx, 1, otelmetric.WithAttributes(
 		attribute.String("signal", signal),
 		attribute.String("outcome", outcome),
+	))
+}
+
+// metricAction maps a Decision to the bounded action label for the #790 counters:
+// the intervention id, or "noop" when empty (a contract-following engine noop
+// yields an empty intervention). Keeping the empty case as the literal "noop"
+// matches the intervention vocabulary and keeps the label a small closed set.
+func metricAction(intervention string) string {
+	if intervention == "" {
+		return "noop"
+	}
+	return intervention
+}
+
+// recordDecision bumps agent_decisions_total for one decision the engine returned
+// (#790), applied OR blocked. block_reason is empty when applied and the specific
+// BlockReason ("not_allowed"/"battery_threshold"/"rate_limit") when blocked, so the
+// dashboard can split applied vs blocked by reason. Labels are bounded: action (the
+// intervention vocabulary), blocked (bool), block_reason (the closed BlockReason
+// set). The counter is never nil (NewLoop seeds a no-op), so this is safe from the
+// concurrent Export-handler goroutines that drive runDecision.
+func (l *Loop) recordDecision(ctx context.Context, action string, blocked bool, reason BlockReason) {
+	l.decisions.Add(ctx, 1, otelmetric.WithAttributes(
+		attribute.String("action", metricAction(action)),
+		attribute.Bool("blocked", blocked),
+		attribute.String("block_reason", string(reason)),
+	))
+}
+
+// recordInterventionApplied bumps agent_interventions_applied_total after a
+// decision passes every permission gate AND applies successfully through the action
+// sink (#790) — the numerator for the applied-rate panel. Label: action. The
+// counter is never nil (NewLoop seeds a no-op), so this is safe from the concurrent
+// Export-handler goroutines that drive runDecision.
+func (l *Loop) recordInterventionApplied(ctx context.Context, action string) {
+	l.interventionsApplied.Add(ctx, 1, otelmetric.WithAttributes(
+		attribute.String("action", metricAction(action)),
 	))
 }
 
@@ -884,6 +935,12 @@ func (l *Loop) runDecision(ctx context.Context, snapshot flags.Snapshot, c gamec
 	))
 	defer aSpan.End()
 
+	// Count EVERY decision the engine returned (#790), applied or blocked, before
+	// branching — block_reason is empty when applied, the BlockReason when blocked —
+	// so the demo dashboard can split applied vs blocked by reason. Emitted alongside
+	// the existing audit span/log, not in place of it.
+	l.recordDecision(ctx, d.Intervention, blocked, reason)
+
 	if blocked {
 		state.recordBlocked(d, reason, cost)
 		// Feed the BLOCKED outcome into this game's #916 rolling narrative timeline
@@ -937,7 +994,12 @@ func (l *Loop) runDecision(ctx context.Context, snapshot flags.Snapshot, c gamec
 		aSpan.SetStatus(codes.Error, err.Error())
 		l.Log.Error("agent.apply_failed",
 			"error", err, "intervention", d.Intervention)
+		return
 	}
+	// Apply succeeded: count the intervention as applied (#790) — the numerator for
+	// the dashboard's applied-rate panel. Only a clean Apply increments this; an
+	// apply error returns above so a failed dispatch is NOT counted as applied.
+	l.recordInterventionApplied(ctx, d.Intervention)
 }
 
 // emitDisabledSpan emits the kill-switch trace for a cycle where the existence

--- a/services/agent/decision/decision_metrics_test.go
+++ b/services/agent/decision/decision_metrics_test.go
@@ -1,0 +1,253 @@
+package decision
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+
+	"go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"github.com/joustmania/agent/flags"
+	"github.com/joustmania/agent/gamecontext"
+)
+
+// decisionMetricsLoop builds an enabled Loop wired with a recording tracer and BOTH
+// #790 counters (agent_decisions_total + agent_interventions_applied_total) reading
+// the same manual reader, so a single OnEvaluate can be asserted against both. The
+// caller supplies the flag snapshot so each test can exercise a specific permission
+// gate (allow-list / battery / rate limit) or the applied path.
+func decisionMetricsLoop(t *testing.T, snap flags.Snapshot) (*Loop, *fakeSink, *metric.ManualReader) {
+	t.Helper()
+	sr := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+
+	reader := metric.NewManualReader()
+	mp := metric.NewMeterProvider(metric.WithReader(reader))
+
+	fl := &settableFlags{snap: snap}
+	l := NewLoop(fl, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	l.Tracer = tp.Tracer("test")
+	l.decisions = newDecisionsCounter(mp)
+	l.interventionsApplied = newInterventionsAppliedCounter(mp)
+	sink := &fakeSink{}
+	l.Actions = sink
+	return l, sink, reader
+}
+
+// decisionsByLabels collects agent_decisions_total into an
+// "<action>/<blocked>/<block_reason>" -> count map.
+func decisionsByLabels(t *testing.T, reader *metric.ManualReader) map[string]int64 {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("collect metrics: %v", err)
+	}
+	out := map[string]int64{}
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != "agent_decisions_total" {
+				continue
+			}
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			if !ok {
+				t.Fatalf("expected Sum[int64], got %T", m.Data)
+			}
+			for _, dp := range sum.DataPoints {
+				action, _ := dp.Attributes.Value("action")
+				blocked, _ := dp.Attributes.Value("blocked")
+				reason, _ := dp.Attributes.Value("block_reason")
+				key := action.AsString() + "/" + blocked.Emit() + "/" + reason.AsString()
+				out[key] = dp.Value
+			}
+		}
+	}
+	return out
+}
+
+// appliedByAction collects agent_interventions_applied_total into an action -> count map.
+func appliedByAction(t *testing.T, reader *metric.ManualReader) map[string]int64 {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("collect metrics: %v", err)
+	}
+	out := map[string]int64{}
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != "agent_interventions_applied_total" {
+				continue
+			}
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			if !ok {
+				t.Fatalf("expected Sum[int64], got %T", m.Data)
+			}
+			for _, dp := range sum.DataPoints {
+				action, _ := dp.Attributes.Value("action")
+				out[action.AsString()] = dp.Value
+			}
+		}
+	}
+	return out
+}
+
+// permissiveSnap is an enabled, rules-mode snapshot that allows grant_shield with a
+// generous rate budget — the baseline for the applied path.
+func permissiveSnap() flags.Snapshot {
+	return flags.Snapshot{
+		Enabled:              true,
+		Mode:                 "rules",
+		InterventionsAllowed: []string{"grant_shield"},
+		Policy:               flags.Policy{MaxInterventionsPerMinute: 100},
+	}
+}
+
+// TestDecisionsCounter_Applied: a decision that passes every gate and applies
+// cleanly is counted once in agent_decisions_total with blocked=false / empty reason
+// AND once in agent_interventions_applied_total.
+func TestDecisionsCounter_Applied(t *testing.T) {
+	l, sink, reader := decisionMetricsLoop(t, permissiveSnap())
+	l.Rules = fakeRules{out: []Decision{{Intervention: "grant_shield", Reason: "x"}}}
+
+	l.OnEvaluate(context.Background(), gamecontext.GameContext{SessionID: "s"}, testTrigger())
+
+	if got := decisionsByLabels(t, reader)["grant_shield/false/"]; got != 1 {
+		t.Errorf("agent_decisions_total{grant_shield,false,} = %d, want 1 (all: %v)", got, decisionsByLabels(t, reader))
+	}
+	if got := appliedByAction(t, reader)["grant_shield"]; got != 1 {
+		t.Errorf("agent_interventions_applied_total{grant_shield} = %d, want 1", got)
+	}
+	if n := sink.calls.Load(); n != 1 {
+		t.Errorf("sink Apply calls = %d, want 1", n)
+	}
+}
+
+// TestDecisionsCounter_BlockReasons: each permission gate increments
+// agent_decisions_total with blocked=true and the correct block_reason, and NEVER
+// increments the applied counter (the decision was never dispatched).
+func TestDecisionsCounter_BlockReasons(t *testing.T) {
+	tests := []struct {
+		name   string
+		snap   flags.Snapshot
+		ctx    gamecontext.GameContext
+		dec    Decision
+		reason string
+	}{
+		{
+			name: "not_allowed",
+			// grant_shield NOT in the allow-list -> ReasonNotAllowed.
+			snap: flags.Snapshot{
+				Enabled:              true,
+				Mode:                 "rules",
+				InterventionsAllowed: []string{"noop"},
+				Policy:               flags.Policy{MaxInterventionsPerMinute: 100},
+			},
+			ctx:    gamecontext.GameContext{SessionID: "s"},
+			dec:    Decision{Intervention: "grant_shield", Reason: "x"},
+			reason: "not_allowed",
+		},
+		{
+			name: "battery_threshold",
+			// Player-targeted, allowed, but target battery below threshold.
+			snap: flags.Snapshot{
+				Enabled:              true,
+				Mode:                 "rules",
+				InterventionsAllowed: []string{"grant_shield"},
+				Policy:               flags.Policy{MaxInterventionsPerMinute: 100, BatteryThreshold: 50},
+			},
+			ctx: gamecontext.GameContext{
+				SessionID: "s",
+				Players: map[string]*gamecontext.PlayerSignals{
+					"MOCK0001": {BatteryPct: ptrF(10)},
+				},
+			},
+			dec:    Decision{Intervention: "grant_shield", TargetSerial: "MOCK0001", Reason: "x"},
+			reason: "battery_threshold",
+		},
+		{
+			name: "rate_limit",
+			// Allowed, no battery gate, but the per-minute budget is 0 -> exhausted.
+			snap: flags.Snapshot{
+				Enabled:              true,
+				Mode:                 "rules",
+				InterventionsAllowed: []string{"grant_shield"},
+				Policy:               flags.Policy{MaxInterventionsPerMinute: 0},
+			},
+			ctx:    gamecontext.GameContext{SessionID: "s"},
+			dec:    Decision{Intervention: "grant_shield", Reason: "x"},
+			reason: "rate_limit",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			l, sink, reader := decisionMetricsLoop(t, tc.snap)
+			l.Rules = fakeRules{out: []Decision{tc.dec}}
+
+			l.OnEvaluate(context.Background(), tc.ctx, testTrigger())
+
+			key := tc.dec.Intervention + "/true/" + tc.reason
+			counts := decisionsByLabels(t, reader)
+			if counts[key] != 1 {
+				t.Errorf("agent_decisions_total{%s} = %d, want 1 (all: %v)", key, counts[key], counts)
+			}
+			if applied := appliedByAction(t, reader); len(applied) != 0 {
+				t.Errorf("agent_interventions_applied_total non-empty on block: %v", applied)
+			}
+			if n := sink.calls.Load(); n != 0 {
+				t.Errorf("sink Apply calls = %d, want 0 (blocked decision is never applied)", n)
+			}
+		})
+	}
+}
+
+// TestDecisionsCounter_IdleCycleNoIncrement: a cycle where the engine returns no
+// decision (idle) touches neither #790 counter — they count per-decision, and there
+// was no decision.
+func TestDecisionsCounter_IdleCycleNoIncrement(t *testing.T) {
+	l, _, reader := decisionMetricsLoop(t, permissiveSnap())
+	l.Rules = fakeRules{out: nil}
+
+	l.OnEvaluate(context.Background(), gamecontext.GameContext{SessionID: "s"}, testTrigger())
+
+	if d := decisionsByLabels(t, reader); len(d) != 0 {
+		t.Errorf("agent_decisions_total non-empty on idle cycle: %v", d)
+	}
+	if a := appliedByAction(t, reader); len(a) != 0 {
+		t.Errorf("agent_interventions_applied_total non-empty on idle cycle: %v", a)
+	}
+}
+
+// TestDecisionsCounter_ApplyErrorNotApplied: a decision that passes every gate but
+// whose ActionSink.Apply returns an error IS counted in agent_decisions_total
+// (blocked=false — no gate refused it) but is NOT counted as applied (the dispatch
+// failed).
+func TestDecisionsCounter_ApplyErrorNotApplied(t *testing.T) {
+	l, sink, reader := decisionMetricsLoop(t, permissiveSnap())
+	sink.err = errors.New("boom")
+	l.Rules = fakeRules{out: []Decision{{Intervention: "grant_shield", Reason: "x"}}}
+
+	l.OnEvaluate(context.Background(), gamecontext.GameContext{SessionID: "s"}, testTrigger())
+
+	if got := decisionsByLabels(t, reader)["grant_shield/false/"]; got != 1 {
+		t.Errorf("agent_decisions_total{grant_shield,false,} = %d, want 1", got)
+	}
+	if a := appliedByAction(t, reader); len(a) != 0 {
+		t.Errorf("agent_interventions_applied_total non-empty after apply error: %v", a)
+	}
+}
+
+// TestMetricAction_EmptyIsNoop: an empty intervention id is labeled "noop" so the
+// action label stays a small closed set.
+func TestMetricAction_EmptyIsNoop(t *testing.T) {
+	if got := metricAction(""); got != "noop" {
+		t.Errorf("metricAction(\"\") = %q, want noop", got)
+	}
+	if got := metricAction("grant_shield"); got != "grant_shield" {
+		t.Errorf("metricAction(grant_shield) = %q, want grant_shield", got)
+	}
+}

--- a/services/agent/decision/metrics.go
+++ b/services/agent/decision/metrics.go
@@ -67,6 +67,61 @@ func defaultEvaluationsCounter() otelmetric.Int64Counter {
 	return newEvaluationsCounter(otel.GetMeterProvider())
 }
 
+// newDecisionsCounter builds the agent_decisions_total counter from the given
+// meter provider (#790). It is incremented once per decision the rules/llm engine
+// returns, INCLUDING the ones a permission gate blocks, so the demo dashboard's
+// applied-vs-blocked panel (#789/#1113) can break decisions down by outcome.
+// Labels: action=<intervention id or "noop">, blocked=<bool>, block_reason=<""
+// when applied; not_allowed|battery_threshold|rate_limit when blocked>. The
+// block_reason set is the closed set of decision.BlockReason values, so
+// cardinality stays bounded. An instrument-creation error yields a no-op counter
+// so the Loop always has a usable instrument and tests that never wire a real
+// meter provider still work — mirrors newLLMGatedCounter.
+func newDecisionsCounter(mp otelmetric.MeterProvider) otelmetric.Int64Counter {
+	c, err := mp.Meter(decisionMeterName).Int64Counter(
+		"agent_decisions_total",
+		otelmetric.WithDescription("Total decisions returned by the agent engine, labeled by action, blocked (bool), and block_reason (empty when applied; not_allowed|battery_threshold|rate_limit when blocked) (#790)"),
+	)
+	if err != nil {
+		c, _ = metricnoop.NewMeterProvider().Meter(decisionMeterName).Int64Counter("agent_decisions_total")
+	}
+	return c
+}
+
+// defaultDecisionsCounter is the no-op fallback counter a Loop uses until one is
+// injected (NewLoop wires the global meter provider; tests may leave it). It keeps
+// the per-decision increment path nil-safe without every test having to set a counter.
+func defaultDecisionsCounter() otelmetric.Int64Counter {
+	return newDecisionsCounter(otel.GetMeterProvider())
+}
+
+// newInterventionsAppliedCounter builds the agent_interventions_applied_total
+// counter from the given meter provider (#790). It is incremented once per
+// decision that passes EVERY permission gate AND is successfully applied through
+// the ActionSink — the numerator for the demo dashboard's "interventions applied"
+// rate panel (#789/#1113). Label: action=<intervention id or "noop">. An
+// instrument-creation error yields a no-op counter so the Loop always has a usable
+// instrument and tests that never wire a real meter provider still work — mirrors
+// newLLMGatedCounter.
+func newInterventionsAppliedCounter(mp otelmetric.MeterProvider) otelmetric.Int64Counter {
+	c, err := mp.Meter(decisionMeterName).Int64Counter(
+		"agent_interventions_applied_total",
+		otelmetric.WithDescription("Total interventions successfully applied through the action sink, labeled by action (#790)"),
+	)
+	if err != nil {
+		c, _ = metricnoop.NewMeterProvider().Meter(decisionMeterName).Int64Counter("agent_interventions_applied_total")
+	}
+	return c
+}
+
+// defaultInterventionsAppliedCounter is the no-op fallback counter a Loop uses
+// until one is injected (NewLoop wires the global meter provider; tests may leave
+// it). It keeps the post-Apply increment path nil-safe without every test having to
+// set a counter.
+func defaultInterventionsAppliedCounter() otelmetric.Int64Counter {
+	return newInterventionsAppliedCounter(otel.GetMeterProvider())
+}
+
 // newEffectDeltaHistogram builds the agent_intervention_effect_delta histogram from
 // the given meter provider (#918). It records the follow_up-baseline change in a
 // game's fitness/objective signal a follow-up window after an intervention was


### PR DESCRIPTION
Part of #790, #789

## What

Adds two decision-activity OTEL counters to the agent's decision loop so the #791 fleet dashboard's stat/rate panels have real metrics. Emitted alongside the existing audit spans in `services/agent/decision/decision.go`, registered via the agent's decision meter in `services/agent/decision/metrics.go` (mirroring `agent_llm_gated_total` / `agent_evaluations_total`).

| Counter | Labels | Emit point |
|---|---|---|
| `agent_decisions_total` | `action` (intervention id, or `noop` when empty), `blocked` (bool), `block_reason` (`""` applied; `not_allowed` / `battery_threshold` / `rate_limit` blocked) | `runDecision`, before the block/dispatch branch — counts EVERY decision the engine returns, including blocked ones |
| `agent_interventions_applied_total` | `action` | after a successful `ActionSink.Apply()` (an apply error returns first, so a failed dispatch is NOT counted as applied) |
| `agent_evaluations_total` | (unchanged, #1053) | already the every-cycle denominator — reused, not duplicated |

The `block_reason` values are the existing `decision.BlockReason` constants (`layerstate.go`): `not_allowed`, `battery_threshold`, `rate_limit` — not invented.

## Constraints

Counters only — no behavior change to decisions or gating. Both new counters are seeded as no-ops in `NewLoop` (nil-safe for un-wired loops), reading the global meter provider exactly like the existing counters. Label cardinality is bounded (`action` vocabulary, `blocked` bool, `block_reason` closed set).

## Tests

New `decision_metrics_test.go` (manual-reader pattern, mirrors `signal_telemetry_test.go`): applied path (decision + applied both +1), each block reason (+1 decision blocked, 0 applied, 0 Apply calls), idle cycle (neither counter touched), and the apply-error path (counted as a decision, NOT as applied).

`gofmt -l .` clean; `go build`, `go vet`, `go test ./... -race -count=1` all green.

## Follow-up

Once merged, the #1113 dashboard's applied-vs-blocked panel can be upgraded to `agent_decisions_total{blocked, block_reason}` (a dashboard-only change, not this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)