### PR TITLE
feat(agent): ramp_tempo scheduled tempo-curve intervention (#1117)

### DIFF
--- a/services/agent/actions/writer.go
+++ b/services/agent/actions/writer.go
@@ -29,6 +29,7 @@ import (
 	"os"
 	"sort"
 	"strconv"
+	"strings"
 	"sync"
 
 	"go.opentelemetry.io/otel"
@@ -50,6 +51,7 @@ const (
 	flagVolumeOverride            = "volume_override"
 	flagGlobalDifficultyFactor    = "global_difficulty_factor" // #766 F6
 	flagPacingProfile             = "pacing_profile"           // #766 F6
+	flagTempoRamp                 = "tempo_ramp"               // #1117 (#1103 MVP action 2)
 	flagEliminatePlayer           = "eliminate_player"
 	flagRevivePlayer              = "revive_player"
 	flagAudioCue                  = "audio_cue"
@@ -105,7 +107,19 @@ const (
 	defaultShieldSeconds     = 5    // matches "default"
 	defaultGlobalDifficulty  = 1.5  // matches interventions.json "hard" (#766 F6)
 	defaultPacingProfile     = "frantic"
+	// defaultTempoRamp is the safe fallback ramp_tempo curve (#1117): ramp to the
+	// fast tempo over 8s, linear — used when a Decision carries no Value or a
+	// malformed one. Matches interventions.json "ramp_up".
+	defaultTempoRamp = "1.3:8:linear"
 )
+
+// tempoRampMaxSeconds bounds a single ramp's duration (mirrors base.py
+// RAMP_TEMPO_MAX_SECONDS) so the writer never emits a curve that could suspend
+// the natural schedule for a whole game.
+const tempoRampMaxSeconds = 60.0
+
+// validTempoRampCurves is the closed curve vocabulary (mirrors base.py).
+var validTempoRampCurves = map[string]bool{"linear": true, "ease": true}
 
 // Writer is the production ActionSink. It is safe for concurrent use; the agent
 // is the only writer of the interventions file.
@@ -346,6 +360,7 @@ var stateNeutral = map[string]string{
 	flagVolumeOverride:            neutralNone,
 	flagGlobalDifficultyFactor:    neutralDefault, // #766 F6 (neutral = 1.0 "default")
 	flagPacingProfile:             neutralNone,    // #766 F6 (neutral = "none")
+	flagTempoRamp:                 neutralNone,    // #1117 (neutral = "none")
 }
 
 var targetedNeutral = map[string]string{
@@ -380,6 +395,8 @@ func (w *Writer) mutate(doc *orderedDoc, d decision.Decision) error {
 		return w.setState(doc, flagGlobalDifficultyFactor, w.numOr(d.Value, defaultGlobalDifficulty))
 	case decision.InterventionSetPacingProfile: // #766 F6 (string state-shaped)
 		return w.setStateString(doc, flagPacingProfile, w.payloadOr(d.Value, defaultPacingProfile))
+	case decision.InterventionRampTempo: // #1117 (#1103 MVP action 2), shadow-only
+		return w.setStateString(doc, flagTempoRamp, w.tempoRampOr(d.Value, defaultTempoRamp))
 
 	// Per-player state-shaped overrides (flagd targeting if-ladder).
 	case decision.InterventionAdjustPlayerSensitivity:
@@ -498,6 +515,32 @@ func (w *Writer) setTargeted(doc *orderedDoc, flagKey, neutral, serial string, v
 // payloadOr returns v, or the default when v is empty.
 func (w *Writer) payloadOr(v, def string) string {
 	if v == "" {
+		return def
+	}
+	return v
+}
+
+// tempoRampOr validates a ramp_tempo directive "<target>:<seconds>:<curve>" and
+// returns it, or def when v is empty/malformed/out-of-bounds (#1117). It is a
+// defensive sibling of numOr: the game-side parser (base.py parse_ramp_tempo_value)
+// independently validates again and no-ops on garbage, but validating here keeps a
+// malformed LLM value from ever being written to the flag file. Bounds mirror
+// base.py: target in [1.0, 1.3], seconds > 0 (capped), curve in {linear, ease}.
+func (w *Writer) tempoRampOr(v, def string) string {
+	if v == "" {
+		return def
+	}
+	parts := strings.Split(strings.TrimSpace(v), ":")
+	if len(parts) != 3 {
+		w.log.Warn("agent.action_bad_value", "value", v, "fallback", def)
+		return def
+	}
+	target, terr := strconv.ParseFloat(strings.TrimSpace(parts[0]), 64)
+	seconds, serr := strconv.ParseFloat(strings.TrimSpace(parts[1]), 64)
+	curve := strings.ToLower(strings.TrimSpace(parts[2]))
+	if terr != nil || serr != nil || !validTempoRampCurves[curve] ||
+		seconds <= 0 || target < 1.0 || target > 1.3 || seconds > tempoRampMaxSeconds {
+		w.log.Warn("agent.action_bad_value", "value", v, "fallback", def)
 		return def
 	}
 	return v

--- a/services/agent/decision/ratelimit.go
+++ b/services/agent/decision/ratelimit.go
@@ -57,9 +57,16 @@ const (
 	InterventionAdjustGlobalSensitivity = "adjust_global_sensitivity"
 	InterventionAdjustGlobalDifficulty  = "adjust_global_difficulty"
 	InterventionSetPacingProfile        = "set_pacing_profile"
-	InterventionEliminatePlayer         = "eliminate_player"
-	InterventionRevivePlayer            = "revive_player"
-	InterventionEndGame                 = "end_game"
+	// InterventionRampTempo (#1117, #1103 MVP action 2) is a session-scoped
+	// scheduled tempo CURVE ("<target>:<seconds>:<curve>") that fills the #1114
+	// agent-mode tempo seam — one budget charge buys a ramp instead of re-emitting
+	// discrete adjust_music_tempo steps. SHADOW-game-only initially: allow-listed
+	// only via the `shadow_experimental` interventions_allowed variant
+	// (services/flagd/agent.json), never the real-facing ambient/standard/full.
+	InterventionRampTempo       = "ramp_tempo"
+	InterventionEliminatePlayer = "eliminate_player"
+	InterventionRevivePlayer    = "revive_player"
+	InterventionEndGame         = "end_game"
 
 	// InterventionNoop is the probe-mode synthetic intervention (ProbeRules). It
 	// carries no game effect: when dispatched through the action sink it is a
@@ -91,6 +98,7 @@ var interventionWeights = map[string]float64{
 	InterventionGrantShield:             1,
 	InterventionAdjustGlobalDifficulty:  1, // #766 F6
 	InterventionSetPacingProfile:        1, // #766 F6
+	InterventionRampTempo:               1, // #1117 (#1103 MVP action 2)
 	// Hard (2)
 	InterventionAdjustGlobalSensitivity: 2,
 	InterventionEliminatePlayer:         2,

--- a/services/agent/decision/shadow_gate_test.go
+++ b/services/agent/decision/shadow_gate_test.go
@@ -72,3 +72,39 @@ func TestSetPlayerHandicapIsShadowOnly(t *testing.T) {
 		})
 	}
 }
+
+// TestRampTempoIsShadowOnly is the load-bearing gating proof for #1117 (#1103 MVP
+// action 2): ramp_tempo MUST appear ONLY in the shadow_experimental variant of
+// interventions_allowed and MUST be absent from every real-facing variant
+// (ambient/standard/full). The allow-list is the enforcement gate, so absence from
+// the real variants means ramp_tempo is rejected for real games by construction.
+// Asserted on BOTH the production and CI flagd agent configs.
+func TestRampTempoIsShadowOnly(t *testing.T) {
+	paths := []string{
+		filepath.Join("..", "..", "flagd", "agent.json"),
+		filepath.Join("..", "..", "flagd", "ci", "agent.json"),
+	}
+	for _, path := range paths {
+		t.Run(path, func(t *testing.T) {
+			variants := readInterventionsAllowed(t, path)
+
+			shadow, ok := variants["shadow_experimental"]
+			if !ok {
+				t.Fatalf("%s: missing shadow_experimental variant", path)
+			}
+			if !contains(shadow, InterventionRampTempo) {
+				t.Fatalf("%s: shadow_experimental must include %q", path, InterventionRampTempo)
+			}
+
+			for _, realVariant := range []string{"ambient", "standard", "full"} {
+				list, ok := variants[realVariant]
+				if !ok {
+					t.Fatalf("%s: missing expected real variant %q", path, realVariant)
+				}
+				if contains(list, InterventionRampTempo) {
+					t.Fatalf("%s: real variant %q must NOT include %q (shadow-only)", path, realVariant, InterventionRampTempo)
+				}
+			}
+		})
+	}
+}

--- a/services/agent/llm/prompt.go
+++ b/services/agent/llm/prompt.go
@@ -288,6 +288,10 @@ Higher sensitivity level = higher bar = HARDER to die; slower tempo = lower bar
   - adjust_music_tempo / set_pacing_profile: shifts EVERYONE's bar along the
     LERP. e.g. at sens 2, tempo 1.0->1.3 raises the death bar 1.8->2.8 (much
     more movement tolerated); dropping tempo lowers it (eliminations come faster).
+  - ramp_tempo ("<target>:<seconds>:<curve>", curve linear|ease): the same
+    tempo lever as a SCHEDULED CURVE — ramps everyone's bar to the target tempo
+    smoothly over N seconds instead of one step. One action buys a whole pacing
+    arc (e.g. "1.3:8:linear" eases the room toward "more movement tolerated").
   - adjust_global_sensitivity / adjust_player_sensitivity: steps the level for
     all / one player. e.g. at slow tempo, level 2->3 moves that bar 1.8->2.5
     (harder to die); 2->1 moves it 1.8->1.5 (easier). One step is a sizable jump.

--- a/services/agent/llm/testdata/aggressive_3players.golden
+++ b/services/agent/llm/testdata/aggressive_3players.golden
@@ -55,6 +55,10 @@ Higher sensitivity level = higher bar = HARDER to die; slower tempo = lower bar
   - adjust_music_tempo / set_pacing_profile: shifts EVERYONE's bar along the
     LERP. e.g. at sens 2, tempo 1.0->1.3 raises the death bar 1.8->2.8 (much
     more movement tolerated); dropping tempo lowers it (eliminations come faster).
+  - ramp_tempo ("<target>:<seconds>:<curve>", curve linear|ease): the same
+    tempo lever as a SCHEDULED CURVE — ramps everyone's bar to the target tempo
+    smoothly over N seconds instead of one step. One action buys a whole pacing
+    arc (e.g. "1.3:8:linear" eases the room toward "more movement tolerated").
   - adjust_global_sensitivity / adjust_player_sensitivity: steps the level for
     all / one player. e.g. at slow tempo, level 2->3 moves that bar 1.8->2.5
     (harder to die); 2->1 moves it 1.8->1.5 (easier). One step is a sizable jump.

--- a/services/agent/llm/testdata/balanced_3players.golden
+++ b/services/agent/llm/testdata/balanced_3players.golden
@@ -55,6 +55,10 @@ Higher sensitivity level = higher bar = HARDER to die; slower tempo = lower bar
   - adjust_music_tempo / set_pacing_profile: shifts EVERYONE's bar along the
     LERP. e.g. at sens 2, tempo 1.0->1.3 raises the death bar 1.8->2.8 (much
     more movement tolerated); dropping tempo lowers it (eliminations come faster).
+  - ramp_tempo ("<target>:<seconds>:<curve>", curve linear|ease): the same
+    tempo lever as a SCHEDULED CURVE — ramps everyone's bar to the target tempo
+    smoothly over N seconds instead of one step. One action buys a whole pacing
+    arc (e.g. "1.3:8:linear" eases the room toward "more movement tolerated").
   - adjust_global_sensitivity / adjust_player_sensitivity: steps the level for
     all / one player. e.g. at slow tempo, level 2->3 moves that bar 1.8->2.5
     (harder to die); 2->1 moves it 1.8->1.5 (easier). One step is a sizable jump.

--- a/services/agent/llm/testdata/conservative_3players.golden
+++ b/services/agent/llm/testdata/conservative_3players.golden
@@ -55,6 +55,10 @@ Higher sensitivity level = higher bar = HARDER to die; slower tempo = lower bar
   - adjust_music_tempo / set_pacing_profile: shifts EVERYONE's bar along the
     LERP. e.g. at sens 2, tempo 1.0->1.3 raises the death bar 1.8->2.8 (much
     more movement tolerated); dropping tempo lowers it (eliminations come faster).
+  - ramp_tempo ("<target>:<seconds>:<curve>", curve linear|ease): the same
+    tempo lever as a SCHEDULED CURVE — ramps everyone's bar to the target tempo
+    smoothly over N seconds instead of one step. One action buys a whole pacing
+    arc (e.g. "1.3:8:linear" eases the room toward "more movement tolerated").
   - adjust_global_sensitivity / adjust_player_sensitivity: steps the level for
     all / one player. e.g. at slow tempo, level 2->3 moves that bar 1.8->2.5
     (harder to die); 2->1 moves it 1.8->1.5 (easier). One step is a sizable jump.

--- a/services/agent/llm/testdata/empty_players.golden
+++ b/services/agent/llm/testdata/empty_players.golden
@@ -55,6 +55,10 @@ Higher sensitivity level = higher bar = HARDER to die; slower tempo = lower bar
   - adjust_music_tempo / set_pacing_profile: shifts EVERYONE's bar along the
     LERP. e.g. at sens 2, tempo 1.0->1.3 raises the death bar 1.8->2.8 (much
     more movement tolerated); dropping tempo lowers it (eliminations come faster).
+  - ramp_tempo ("<target>:<seconds>:<curve>", curve linear|ease): the same
+    tempo lever as a SCHEDULED CURVE — ramps everyone's bar to the target tempo
+    smoothly over N seconds instead of one step. One action buys a whole pacing
+    arc (e.g. "1.3:8:linear" eases the room toward "more movement tolerated").
   - adjust_global_sensitivity / adjust_player_sensitivity: steps the level for
     all / one player. e.g. at slow tempo, level 2->3 moves that bar 1.8->2.5
     (harder to die); 2->1 moves it 1.8->1.5 (easier). One step is a sizable jump.

--- a/services/agent/llm/testdata/movement_3players.golden
+++ b/services/agent/llm/testdata/movement_3players.golden
@@ -55,6 +55,10 @@ Higher sensitivity level = higher bar = HARDER to die; slower tempo = lower bar
   - adjust_music_tempo / set_pacing_profile: shifts EVERYONE's bar along the
     LERP. e.g. at sens 2, tempo 1.0->1.3 raises the death bar 1.8->2.8 (much
     more movement tolerated); dropping tempo lowers it (eliminations come faster).
+  - ramp_tempo ("<target>:<seconds>:<curve>", curve linear|ease): the same
+    tempo lever as a SCHEDULED CURVE — ramps everyone's bar to the target tempo
+    smoothly over N seconds instead of one step. One action buys a whole pacing
+    arc (e.g. "1.3:8:linear" eases the room toward "more movement tolerated").
   - adjust_global_sensitivity / adjust_player_sensitivity: steps the level for
     all / one player. e.g. at slow tempo, level 2->3 moves that bar 1.8->2.5
     (harder to die); 2->1 moves it 1.8->1.5 (easier). One step is a sizable jump.

--- a/services/agent/llm/testdata/timeline_3players.golden
+++ b/services/agent/llm/testdata/timeline_3players.golden
@@ -55,6 +55,10 @@ Higher sensitivity level = higher bar = HARDER to die; slower tempo = lower bar
   - adjust_music_tempo / set_pacing_profile: shifts EVERYONE's bar along the
     LERP. e.g. at sens 2, tempo 1.0->1.3 raises the death bar 1.8->2.8 (much
     more movement tolerated); dropping tempo lowers it (eliminations come faster).
+  - ramp_tempo ("<target>:<seconds>:<curve>", curve linear|ease): the same
+    tempo lever as a SCHEDULED CURVE — ramps everyone's bar to the target tempo
+    smoothly over N seconds instead of one step. One action buys a whole pacing
+    arc (e.g. "1.3:8:linear" eases the room toward "more movement tolerated").
   - adjust_global_sensitivity / adjust_player_sensitivity: steps the level for
     all / one player. e.g. at slow tempo, level 2->3 moves that bar 1.8->2.5
     (harder to die); 2->1 moves it 1.8->1.5 (easier). One step is a sizable jump.

--- a/services/flagd/agent.json
+++ b/services/flagd/agent.json
@@ -122,7 +122,8 @@
           "eliminate_player",
           "revive_player",
           "end_game",
-          "set_player_handicap"
+          "set_player_handicap",
+          "ramp_tempo"
         ]
       },
       "defaultVariant": "ambient"

--- a/services/flagd/ci/agent.json
+++ b/services/flagd/ci/agent.json
@@ -122,7 +122,8 @@
           "eliminate_player",
           "revive_player",
           "end_game",
-          "set_player_handicap"
+          "set_player_handicap",
+          "ramp_tempo"
         ]
       },
       "defaultVariant": "ambient"

--- a/services/flagd/ci/interventions.json
+++ b/services/flagd/ci/interventions.json
@@ -88,6 +88,16 @@
       },
       "defaultVariant": "none"
     },
+    "tempo_ramp": {
+      "state": "ENABLED",
+      "variants": {
+        "none": "none",
+        "ramp_up": "1.3:8:linear",
+        "ramp_down": "1.0:8:linear",
+        "ease_up": "1.3:8:ease"
+      },
+      "defaultVariant": "none"
+    },
     "eliminate_player": {
       "state": "ENABLED",
       "variants": {

--- a/services/flagd/interventions.json
+++ b/services/flagd/interventions.json
@@ -88,6 +88,16 @@
       },
       "defaultVariant": "none"
     },
+    "tempo_ramp": {
+      "state": "ENABLED",
+      "variants": {
+        "none": "none",
+        "ramp_up": "1.3:8:linear",
+        "ramp_down": "1.0:8:linear",
+        "ease_up": "1.3:8:ease"
+      },
+      "defaultVariant": "none"
+    },
     "eliminate_player": {
       "state": "ENABLED",
       "variants": {

--- a/services/game_coordinator/difficulty_handlers.py
+++ b/services/game_coordinator/difficulty_handlers.py
@@ -39,11 +39,13 @@ not conflict structurally.
 """
 
 import logging
+import time
+from dataclasses import replace
 
 from lib.feature_flags import read_object_flag_variant
 from lib.types import Sensitivity
 
-from .games.base import resolve_music_windows
+from .games.base import parse_ramp_tempo_value, resolve_music_windows
 from .interventions import InterventionContext, InterventionManager
 
 logger = logging.getLogger(__name__)
@@ -308,6 +310,58 @@ def _restore_init_windows(game: object) -> None:
     logger.info("pacing_profile: restored init-resolved music windows")
 
 
+async def handle_ramp_tempo(ctx: InterventionContext) -> None:
+    """Arm a scheduled tempo CURVE on the live game (#1117, #1103 MVP action 2).
+
+    State-shaped STRING: ``ctx.value`` is ``"<target>:<seconds>:<curve>"`` (e.g.
+    ``"1.3:8:linear"``). The value is parsed + bounds-validated by
+    :func:`parse_ramp_tempo_value` (target clamped to the valid tempo range,
+    seconds > 0 and capped, curve in {linear, ease}); a MALFORMED value yields
+    ``None`` and is a safe no-op (the descriptor is NOT changed, so no garbage is
+    dispatched). On a valid value the descriptor's interpolation origin is anchored
+    to the live music_speed + now and stored on ``game.tempo_ramp``; the game's
+    100ms ``_check_music_speed`` loop then interpolates toward the target via the
+    SINGLE tempo-owner seam (no second writer). When ``tempo_schedule_mode==agent``
+    this curve drives the schedule. The neutral value ("none") never reaches here;
+    reverting drops the descriptor via :func:`handle_ramp_tempo_revert`.
+    """
+    game = ctx.game
+    if game is None:
+        logger.debug("ramp_tempo: no live game, ignoring")
+        return
+
+    descriptor = parse_ramp_tempo_value(ctx.value)
+    if descriptor is None:
+        logger.warning(f"ramp_tempo: malformed value {ctx.value!r}, ignoring (no-op)")
+        return
+
+    # Anchor the curve's origin to the live tempo + clock so it ramps from where
+    # the music actually is right now.
+    armed = replace(descriptor, start_tempo=game.music_speed, start_time=time.time())
+    game.tempo_ramp = armed
+    logger.info(
+        f"ramp_tempo: armed {armed.start_tempo:.2f}x -> {armed.target_tempo:.2f}x "
+        f"over {armed.duration:.1f}s ({armed.curve})"
+    )
+
+
+async def handle_ramp_tempo_revert(ctx: InterventionContext) -> None:
+    """Drop the ramp descriptor on revert so the default rule resumes (#1117).
+
+    The manager routes a state flag's revert-to-neutral ("none") to
+    ``_revert_handlers`` rather than re-invoking the apply handler, so without this
+    entry ``game.tempo_ramp`` would stay pinned at the last curve and the music
+    loop would hold at its target forever. Clearing it lets ``_check_music_speed``
+    resume the natural slow/fast schedule from the held tempo on its next tick.
+    """
+    game = ctx.game
+    if game is None:
+        logger.debug("ramp_tempo: no live game on revert, ignoring")
+        return
+    game.tempo_ramp = None
+    logger.info("ramp_tempo: reverted, natural schedule resumes from held tempo")
+
+
 def register_difficulty_handlers(manager: InterventionManager) -> None:
     """Wire the difficulty handlers onto the manager (one line per flag).
 
@@ -344,3 +398,9 @@ def register_difficulty_handlers(manager: InterventionManager) -> None:
     manager._revert_handlers["global_difficulty_factor"] = handle_global_difficulty_factor_revert
     manager.register_handler("pacing_profile", handle_pacing_profile)
     manager._revert_handlers["pacing_profile"] = handle_pacing_profile_revert
+    # #1117 ramp_tempo: session-scoped string state flag (scheduled tempo curve).
+    # Like music_tempo_override it needs an explicit revert handler (#922): the
+    # manager routes the revert-to-neutral ("none") to _revert_handlers, NOT the
+    # apply handler, so the descriptor must be dropped there or it stays pinned.
+    manager.register_handler("tempo_ramp", handle_ramp_tempo)
+    manager._revert_handlers["tempo_ramp"] = handle_ramp_tempo_revert

--- a/services/game_coordinator/games/base.py
+++ b/services/game_coordinator/games/base.py
@@ -112,6 +112,13 @@ _VALID_RAMP_CURVES = (RAMP_CURVE_LINEAR, RAMP_CURVE_EASE)
 # schedule for an entire game.
 RAMP_TEMPO_MAX_SECONDS = 60.0
 
+# Per-step audio transition for a ramp (#1122 review): the ramp applies a small
+# tempo step every ~100ms loop tick, so each step's ChangeTempo must glide over
+# roughly one tick rather than MUSIC_TRANSITION_DURATION (1.5s) — otherwise every
+# tick stacks an overlapping 1.5s transition chasing a stale target. The loop's
+# interpolation owns the overall smoothness; the audio just tracks each step.
+RAMP_TEMPO_STEP_TRANSITION = 0.12
+
 
 @dataclass(frozen=True)
 class RampDescriptor:
@@ -2819,7 +2826,13 @@ class BaseGameMode(ABC):
                 audio_pb2.ChangeTempoRequest(
                     track_id=self.music_track_id,
                     new_tempo=target_tempo,
-                    transition_duration=MUSIC_TRANSITION_DURATION,
+                    # Short per-step transition (#1122 review): the ramp applies
+                    # a small step every ~100ms tick, so each step must glide over
+                    # roughly one tick — NOT the 1.5s MUSIC_TRANSITION_DURATION,
+                    # which would stack ~N overlapping 1.5s transitions all chasing
+                    # a stale target. The loop's own interpolation provides the
+                    # overall smoothness; the audio just needs to track each step.
+                    transition_duration=RAMP_TEMPO_STEP_TRANSITION,
                 )
             )
 

--- a/services/game_coordinator/games/base.py
+++ b/services/game_coordinator/games/base.py
@@ -92,6 +92,111 @@ def resolve_tempo_schedule_mode(value: object) -> str:
     return TEMPO_SCHEDULE_MODE_DEFAULT
 
 
+# #1117 (#1103 MVP action 2): ``ramp_tempo`` — a scheduled tempo CURVE that fills
+# the #1114 ``agent``-mode seam. The agent emits a single string directive
+# ``"<target>:<seconds>:<curve>"`` (e.g. ``"1.3:8:linear"``); the game-side records
+# a RampDescriptor and ``_check_music_speed`` interpolates the live tempo toward
+# the target over the duration (the SAME single tempo-owner seam the override /
+# ``agent`` mode uses — no competing tempo writer), holding at target when done.
+#
+# Bounds (validated at parse time so a malformed value degrades to a safe no-op,
+# never dispatches garbage): target is clamped to the valid music-speed range
+# [SLOW_MUSIC_SPEED, FAST_MUSIC_SPEED]; seconds must be > 0 and is capped at
+# RAMP_TEMPO_MAX_SECONDS so a stray huge value can't freeze pacing for the whole
+# round; curve is one of the closed vocabulary {linear, ease}.
+RAMP_CURVE_LINEAR = "linear"
+RAMP_CURVE_EASE = "ease"
+_VALID_RAMP_CURVES = (RAMP_CURVE_LINEAR, RAMP_CURVE_EASE)
+# Upper bound on a single ramp's duration (seconds). Generous enough for a slow
+# pacing curve, small enough that a malformed huge value can't suspend the natural
+# schedule for an entire game.
+RAMP_TEMPO_MAX_SECONDS = 60.0
+
+
+@dataclass(frozen=True)
+class RampDescriptor:
+    """A scheduled tempo curve (#1117). Immutable; replaced wholesale on a new ramp.
+
+    Attributes:
+        start_tempo: Music speed when the ramp began (the interpolation origin).
+        target_tempo: Clamped destination tempo, held once reached.
+        start_time: ``time.time()`` when the ramp began.
+        duration: Ramp length in seconds (> 0, capped at RAMP_TEMPO_MAX_SECONDS).
+        curve: Interpolation shape — ``linear`` or ``ease`` (smoothstep).
+    """
+
+    start_tempo: float
+    target_tempo: float
+    start_time: float
+    duration: float
+    curve: str
+
+    def tempo_at(self, now: float) -> float:
+        """Interpolated tempo at ``now``; clamped to the target once complete."""
+        if self.duration <= 0:
+            return self.target_tempo
+        progress = (now - self.start_time) / self.duration
+        if progress <= 0.0:
+            return self.start_tempo
+        if progress >= 1.0:
+            return self.target_tempo
+        if self.curve == RAMP_CURVE_EASE:
+            # Smoothstep: ease in and out, monotone, hits 0/1 at the endpoints.
+            progress = progress * progress * (3.0 - 2.0 * progress)
+        return self.start_tempo + (self.target_tempo - self.start_tempo) * progress
+
+    def is_complete(self, now: float) -> bool:
+        """True once the ramp has reached (and should hold at) its target."""
+        return self.duration <= 0 or (now - self.start_time) >= self.duration
+
+
+def parse_ramp_tempo_value(value: object) -> RampDescriptor | None:
+    """Parse a ``ramp_tempo`` directive ``"<target>:<seconds>:<curve>"`` (#1117).
+
+    Returns a partially-filled :class:`RampDescriptor` (``start_tempo`` /
+    ``start_time`` are 0.0 placeholders — the handler fills them from the live
+    game) on a VALID directive, or ``None`` for any malformed / neutral input so
+    the caller degrades to a safe no-op (never dispatches garbage). Validation:
+
+    * exactly three ``:``-delimited fields;
+    * target is a finite number, clamped to ``[SLOW_MUSIC_SPEED, FAST_MUSIC_SPEED]``;
+    * seconds is a finite number ``> 0``, capped at :data:`RAMP_TEMPO_MAX_SECONDS`;
+    * curve is one of :data:`_VALID_RAMP_CURVES`.
+
+    ``"none"`` / ``""`` (the neutral value) and any parse failure return ``None``.
+    """
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    if text == "" or text.lower() == "none":
+        return None
+    parts = text.split(":")
+    if len(parts) != 3:
+        return None
+    target_raw, seconds_raw, curve_raw = (p.strip() for p in parts)
+    curve = curve_raw.lower()
+    if curve not in _VALID_RAMP_CURVES:
+        return None
+    try:
+        target = float(target_raw)
+        seconds = float(seconds_raw)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(target) or not math.isfinite(seconds):
+        return None
+    if seconds <= 0.0:
+        return None
+    seconds = min(seconds, RAMP_TEMPO_MAX_SECONDS)
+    target = max(SLOW_MUSIC_SPEED, min(FAST_MUSIC_SPEED, target))
+    return RampDescriptor(
+        start_tempo=0.0,  # filled by the handler from the live music_speed
+        target_tempo=target,
+        start_time=0.0,  # filled by the handler from time.time()
+        duration=seconds,
+        curve=curve,
+    )
+
+
 # Span attribute keys (S1192 - avoid duplicate string literals)
 GAME_MODE_ATTR = "game.mode"
 
@@ -643,6 +748,13 @@ class BaseGameMode(ABC):
         # no directive present => "agent" mode falls back to the default rule.
         # Set by the agent primitive in a follow-up PR; never set in this PR.
         self.agent_tempo_next_delay: float | None = None
+        # #1117 (#1103 MVP action 2): active ramp_tempo CURVE descriptor, or None
+        # for no ramp (the default-safe state — behavior unchanged). When set, the
+        # single tempo owner (``_check_music_speed``) interpolates the live tempo
+        # toward the descriptor's target over its duration and holds there. Set by
+        # the ramp_tempo handler; cleared by its revert handler. Lives ONLY on the
+        # game object (bounded delta — never persisted to game.json, ownership §1).
+        self.tempo_ramp: RampDescriptor | None = None
 
         # #766 F6: live global difficulty factor (analogue of per-player
         # ``sensitivity_factor``). Combined with the per-player factor in
@@ -2685,6 +2797,36 @@ class BaseGameMode(ABC):
 
         logger.debug(f"Next tempo change at +{self.change_time - time.time():.1f}s")
 
+    async def _apply_ramp_tempo(self, target_tempo: float) -> None:
+        """Apply one interpolated step of a ramp_tempo curve (#1117).
+
+        Like :meth:`_apply_tempo_change` this sends the audio ``ChangeTempo`` RPC
+        and updates ``music_speed`` + metrics, so the ramp goes through the SAME
+        single tempo owner (no second writer / no race). It deliberately does NOT
+        flip ``speed_up`` or reset ``change_time``: a ramp applies many small steps
+        toward a target, and leaving the schedule bookkeeping untouched lets the
+        natural slow/fast schedule resume from the held tempo once the ramp is
+        reverted — exactly like the override path.
+        """
+        from proto import audio_pb2
+
+        old_tempo = self.music_speed
+        with tracer.start_as_current_span("music_tempo_ramp") as span:
+            span.set_attribute("old_tempo", old_tempo)
+            span.set_attribute("new_tempo", target_tempo)
+            span.set_attribute("dead_count", self.dead_count)
+            await self.audio_client.ChangeTempo(
+                audio_pb2.ChangeTempoRequest(
+                    track_id=self.music_track_id,
+                    new_tempo=target_tempo,
+                    transition_duration=MUSIC_TRANSITION_DURATION,
+                )
+            )
+
+        self.music_speed = target_tempo
+        metrics.music_tempo.set(self.music_speed)
+        self._emit_threshold_metrics()
+
     async def _check_music_speed(self):
         """
         Check and update music tempo (Phase 70).
@@ -2706,6 +2848,23 @@ class BaseGameMode(ABC):
                     await self._apply_tempo_change(self.tempo_override)
                 except Exception as e:
                     logger.warning(f"Failed to apply tempo override: {e}")
+            return
+
+        # #1117 ramp_tempo CURVE (#1103 MVP action 2): while a ramp descriptor is
+        # active the music loop interpolates the live tempo toward the target each
+        # 100ms tick and holds at target when complete — the SAME single tempo
+        # owner the override uses, so there is no second tempo writer / no race.
+        # This drives the schedule when ``tempo_schedule_mode == agent``: the agent
+        # primitive replaces the schedule's discrete slow/fast hops with this
+        # curve. ``change_time`` is left untouched so the natural slow/fast schedule
+        # resumes from the held tempo once the ramp is reverted (mirrors override).
+        if self.tempo_ramp is not None:
+            desired = self.tempo_ramp.tempo_at(time.time())
+            if abs(self.music_speed - desired) > 1e-3:
+                try:
+                    await self._apply_ramp_tempo(desired)
+                except Exception as e:
+                    logger.warning(f"Failed to apply ramp tempo: {e}")
             return
 
         if time.time() >= self.change_time:

--- a/services/game_coordinator/interventions.py
+++ b/services/game_coordinator/interventions.py
@@ -237,6 +237,24 @@ INTERVENTION_SPECS: tuple[InterventionSpec, ...] = (
         # "none" (and "default") mean the neutral init-resolved windows.
         none_value="none",
     ),
+    # #1117 (#1103 MVP action 2) — ramp_tempo: a scheduled tempo CURVE that fills
+    # the #1114 ``agent``-mode tempo seam. Session-scoped STRING state flag whose
+    # value is "<target>:<seconds>:<curve>" (e.g. "1.3:8:linear"); the handler
+    # records a RampDescriptor and the game's 100ms _check_music_speed loop
+    # interpolates toward target via the single tempo-owner seam (no second
+    # writer). SHADOW-game-only initially: allow-listed ONLY via the
+    # `shadow_experimental` interventions_allowed variant (the load-bearing gate),
+    # never the real-facing ambient/standard/full variants.
+    InterventionSpec(
+        flag_key="tempo_ramp",
+        type_id="ramp_tempo",
+        weight=WEIGHT_MEDIUM,
+        edge_triggered=False,
+        player_targeted=False,
+        value_kind="string",
+        # "none" means no ramp (the default-safe neutral value).
+        none_value="none",
+    ),
     # --- Edge-triggered (one-shot) flags ---
     InterventionSpec(
         flag_key="eliminate_player",

--- a/services/game_coordinator/tests/test_ramp_tempo.py
+++ b/services/game_coordinator/tests/test_ramp_tempo.py
@@ -1,0 +1,353 @@
+"""
+Unit tests for ramp_tempo (#1117, #1103 MVP action 2): a scheduled tempo CURVE
+that fills the #1114 ``agent``-mode tempo seam.
+
+Covers:
+- parse_ramp_tempo_value: valid parse + bounds (target clamp, seconds cap, curve
+  vocabulary) and MALFORMED -> None (safe no-op, never dispatches garbage).
+- RampDescriptor.tempo_at: linear + ease interpolation reaches target over the
+  duration and HOLDS at target once complete.
+- handle_ramp_tempo: arms a descriptor anchored to the live tempo/clock; malformed
+  value is a no-op (descriptor unchanged).
+- _check_music_speed: drives the live tempo toward target via the SINGLE tempo
+  owner (ChangeTempo), holds at target, and suspends the natural schedule while a
+  ramp is active (no second writer).
+- handle_ramp_tempo_revert: drops the descriptor so the natural schedule resumes.
+- Agent-mode integration: with tempo_schedule_mode=agent the ramp drives pacing.
+- interventions.json / agent.json flag JSON is well-formed.
+
+Telemetry is disabled via conftest.
+"""
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+test_dir = Path(__file__).parent
+service_dir = test_dir.parent
+project_root = service_dir.parent.parent
+sys.path.insert(0, str(project_root))
+sys.path.insert(0, str(test_dir))
+
+from conftest import MockControllerManagerService, async_noop
+
+from services.game_coordinator.difficulty_handlers import (
+    handle_ramp_tempo,
+    handle_ramp_tempo_revert,
+    register_difficulty_handlers,
+)
+from services.game_coordinator.games.base import (
+    FAST_MUSIC_SPEED,
+    RAMP_CURVE_EASE,
+    RAMP_CURVE_LINEAR,
+    RAMP_TEMPO_MAX_SECONDS,
+    SLOW_MUSIC_SPEED,
+    TEMPO_MODE_AGENT,
+    Player,
+    RampDescriptor,
+    parse_ramp_tempo_value,
+)
+from services.game_coordinator.games.ffa import FFAGame
+from services.game_coordinator.interventions import (
+    INTERVENTION_SPECS,
+    InterventionContext,
+    InterventionManager,
+)
+
+INTERVENTIONS_JSON = project_root / "services" / "flagd" / "interventions.json"
+INTERVENTIONS_CI_JSON = project_root / "services" / "flagd" / "ci" / "interventions.json"
+AGENT_JSON = project_root / "services" / "flagd" / "agent.json"
+AGENT_CI_JSON = project_root / "services" / "flagd" / "ci" / "agent.json"
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures
+# --------------------------------------------------------------------------- #
+
+
+def make_game(sensitivity=2, num_players=2):
+    mock_cm = MockControllerManagerService(num_controllers=num_players)
+    mock_audio = AsyncMock()
+    game = FFAGame(
+        controller_manager_client=mock_cm,
+        event_publisher=async_noop,
+        audio_client=mock_audio,
+        game_id="test_ramp",
+        sensitivity=sensitivity,
+    )
+    game.music_track_id = "track_123"
+    game.music_speed = SLOW_MUSIC_SPEED
+    game.speed_up = True
+    game.gameplay_span = None
+    for i in range(num_players):
+        s = f"p{i + 1}"
+        game.players[s] = Player(serial=s, alive=True, color=(255, 0, 0))
+    return game
+
+
+def _spec(flag_key):
+    return next(s for s in INTERVENTION_SPECS if s.flag_key == flag_key)
+
+
+def make_ctx(value, game):
+    return InterventionContext(
+        spec=_spec("tempo_ramp"),
+        value=value,
+        payload="",
+        target_serial=None,
+        game=game,
+        objective="balanced",
+    )
+
+
+# --------------------------------------------------------------------------- #
+# parse_ramp_tempo_value
+# --------------------------------------------------------------------------- #
+
+
+def test_parse_valid_linear():
+    d = parse_ramp_tempo_value("1.3:8:linear")
+    assert d is not None
+    assert d.target_tempo == pytest.approx(1.3)
+    assert d.duration == pytest.approx(8.0)
+    assert d.curve == RAMP_CURVE_LINEAR
+
+
+def test_parse_valid_ease_with_whitespace():
+    d = parse_ramp_tempo_value("  1.1 : 5 : EASE ")
+    assert d is not None
+    assert d.target_tempo == pytest.approx(1.1)
+    assert d.curve == RAMP_CURVE_EASE
+
+
+def test_parse_clamps_target_to_tempo_range():
+    assert parse_ramp_tempo_value("9.9:5:linear").target_tempo == pytest.approx(FAST_MUSIC_SPEED)
+    assert parse_ramp_tempo_value("0.1:5:linear").target_tempo == pytest.approx(SLOW_MUSIC_SPEED)
+
+
+def test_parse_caps_duration():
+    assert parse_ramp_tempo_value("1.2:9999:linear").duration == pytest.approx(RAMP_TEMPO_MAX_SECONDS)
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        None,
+        "",
+        "none",
+        "NONE",
+        "1.3:8",  # too few fields
+        "1.3:8:linear:extra",  # too many fields
+        "1.3:8:spiral",  # unknown curve
+        "abc:8:linear",  # non-numeric target
+        "1.3:xyz:linear",  # non-numeric seconds
+        "1.3:0:linear",  # non-positive seconds
+        "1.3:-5:linear",  # negative seconds
+        "nan:8:linear",  # non-finite target
+        "1.3:inf:linear",  # non-finite seconds
+        42,  # non-string
+    ],
+)
+def test_parse_malformed_returns_none(bad):
+    assert parse_ramp_tempo_value(bad) is None
+
+
+# --------------------------------------------------------------------------- #
+# RampDescriptor interpolation
+# --------------------------------------------------------------------------- #
+
+
+def test_linear_interpolation_reaches_target_over_duration():
+    d = RampDescriptor(start_tempo=1.0, target_tempo=1.3, start_time=100.0, duration=10.0, curve=RAMP_CURVE_LINEAR)
+    assert d.tempo_at(100.0) == pytest.approx(1.0)  # start
+    assert d.tempo_at(105.0) == pytest.approx(1.15)  # midpoint, linear
+    assert d.tempo_at(110.0) == pytest.approx(1.3)  # end
+    assert d.tempo_at(200.0) == pytest.approx(1.3)  # held past end
+    assert d.tempo_at(50.0) == pytest.approx(1.0)  # before start
+    assert d.is_complete(110.0)
+    assert not d.is_complete(105.0)
+
+
+def test_ease_interpolation_is_smoothstep():
+    d = RampDescriptor(start_tempo=1.0, target_tempo=1.3, start_time=0.0, duration=10.0, curve=RAMP_CURVE_EASE)
+    # smoothstep hits the endpoints exactly and the midpoint equals linear at 0.5.
+    assert d.tempo_at(0.0) == pytest.approx(1.0)
+    assert d.tempo_at(10.0) == pytest.approx(1.3)
+    assert d.tempo_at(5.0) == pytest.approx(1.15)
+    # Early on it is slower than linear (ease-in): at 25% progress smoothstep<0.25.
+    linear_at_quarter = 1.0 + 0.3 * 0.25
+    assert d.tempo_at(2.5) < linear_at_quarter
+
+
+# --------------------------------------------------------------------------- #
+# handle_ramp_tempo / revert
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_handler_arms_descriptor_anchored_to_live_state():
+    game = make_game()
+    game.music_speed = 1.05
+    with patch("services.game_coordinator.difficulty_handlers.time.time", return_value=500.0):
+        await handle_ramp_tempo(make_ctx("1.3:8:linear", game))
+    assert game.tempo_ramp is not None
+    assert game.tempo_ramp.start_tempo == pytest.approx(1.05)  # anchored to live tempo
+    assert game.tempo_ramp.start_time == pytest.approx(500.0)
+    assert game.tempo_ramp.target_tempo == pytest.approx(1.3)
+
+
+@pytest.mark.asyncio
+async def test_handler_malformed_is_noop():
+    game = make_game()
+    game.tempo_ramp = None
+    await handle_ramp_tempo(make_ctx("garbage", game))
+    assert game.tempo_ramp is None  # unchanged: no garbage dispatched
+
+
+@pytest.mark.asyncio
+async def test_handler_no_game_does_not_raise():
+    await handle_ramp_tempo(make_ctx("1.3:8:linear", None))  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_revert_drops_descriptor():
+    game = make_game()
+    game.tempo_ramp = RampDescriptor(1.0, 1.3, 0.0, 8.0, RAMP_CURVE_LINEAR)
+    await handle_ramp_tempo_revert(make_ctx("none", game))
+    assert game.tempo_ramp is None
+
+
+@pytest.mark.asyncio
+async def test_revert_no_game_does_not_raise():
+    await handle_ramp_tempo_revert(make_ctx("none", None))
+
+
+# --------------------------------------------------------------------------- #
+# _check_music_speed drives the ramp (single tempo owner)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_check_music_speed_drives_ramp_toward_target_and_holds():
+    game = make_game()
+    game.music_speed = 1.0
+    base = 1000.0
+    game.tempo_ramp = RampDescriptor(
+        start_tempo=1.0, target_tempo=1.3, start_time=base, duration=10.0, curve=RAMP_CURVE_LINEAR
+    )
+
+    # Midway through the ramp the loop applies the interpolated tempo.
+    with patch("services.game_coordinator.games.base.time.time", return_value=base + 5.0):
+        await game._check_music_speed()
+    assert game.music_speed == pytest.approx(1.15)
+    game.audio_client.ChangeTempo.assert_called_once()
+
+    # Past the end it holds exactly at target...
+    game.audio_client.ChangeTempo.reset_mock()
+    with patch("services.game_coordinator.games.base.time.time", return_value=base + 50.0):
+        await game._check_music_speed()
+    assert game.music_speed == pytest.approx(1.3)
+    game.audio_client.ChangeTempo.assert_called_once()
+
+    # ...and a further tick at target is a no-op (already there, no churn).
+    game.audio_client.ChangeTempo.reset_mock()
+    with patch("services.game_coordinator.games.base.time.time", return_value=base + 60.0):
+        await game._check_music_speed()
+    game.audio_client.ChangeTempo.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_active_ramp_suspends_natural_schedule():
+    """While a ramp holds at target, the natural slow/fast schedule must not fire."""
+    game = make_game()
+    game.music_speed = 1.3
+    base = 2000.0
+    game.tempo_ramp = RampDescriptor(1.0, 1.3, base, 5.0, RAMP_CURVE_LINEAR)
+    game.change_time = base  # would normally trigger a scheduled change
+    with patch("services.game_coordinator.games.base.time.time", return_value=base + 100.0):
+        await game._check_music_speed()
+    # Held at target; the scheduled slow/fast hop did NOT run (no speed_up flip).
+    assert game.music_speed == pytest.approx(1.3)
+    game.audio_client.ChangeTempo.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_override_wins_over_ramp():
+    """A hard tempo_override takes precedence over a ramp (existing precedence)."""
+    game = make_game()
+    game.music_speed = 1.0
+    game.tempo_override = 1.2
+    game.tempo_ramp = RampDescriptor(1.0, 1.3, 0.0, 5.0, RAMP_CURVE_LINEAR)
+    await game._check_music_speed()
+    assert game.music_speed == pytest.approx(1.2)  # override target, not ramp
+
+
+# --------------------------------------------------------------------------- #
+# Agent-mode integration (#1114 seam)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_ramp_drives_pacing_in_agent_mode():
+    """With tempo_schedule_mode=agent the ramp drives the live tempo curve."""
+    game = make_game()
+    game.tempo_schedule_mode = TEMPO_MODE_AGENT
+    game.music_speed = 1.0
+    base = 3000.0
+    with patch("services.game_coordinator.difficulty_handlers.time.time", return_value=base):
+        await handle_ramp_tempo(make_ctx("1.3:8:linear", game))
+    with patch("services.game_coordinator.games.base.time.time", return_value=base + 4.0):
+        await game._check_music_speed()
+    assert game.music_speed == pytest.approx(1.15)  # halfway up the 8s linear ramp
+
+
+# --------------------------------------------------------------------------- #
+# Registration
+# --------------------------------------------------------------------------- #
+
+
+def test_register_wires_handler_and_revert():
+    mgr = InterventionManager(event_publisher=async_noop, get_game=lambda: None)
+    register_difficulty_handlers(mgr)
+    assert mgr._handlers["tempo_ramp"] is handle_ramp_tempo
+    assert mgr._revert_handlers["tempo_ramp"] is handle_ramp_tempo_revert
+
+
+# --------------------------------------------------------------------------- #
+# Spec + flag JSON well-formed
+# --------------------------------------------------------------------------- #
+
+
+def test_spec_registered():
+    spec = _spec("tempo_ramp")
+    assert spec.type_id == "ramp_tempo"
+    assert spec.value_kind == "string"
+    assert spec.none_value == "none"
+    assert not spec.edge_triggered
+    assert not spec.player_targeted
+
+
+@pytest.mark.parametrize("path", [INTERVENTIONS_JSON, INTERVENTIONS_CI_JSON])
+def test_interventions_json_well_formed(path):
+    data = json.loads(path.read_text())
+    flag = data["flags"]["tempo_ramp"]
+    assert flag["state"] == "ENABLED"
+    assert flag["defaultVariant"] == "none"
+    assert flag["variants"]["none"] == "none"
+    # Every non-neutral seed variant must itself parse to a valid descriptor.
+    for name, value in flag["variants"].items():
+        if name == "none":
+            continue
+        assert parse_ramp_tempo_value(value) is not None, f"{path}:{name}={value}"
+
+
+@pytest.mark.parametrize("path", [AGENT_JSON, AGENT_CI_JSON])
+def test_ramp_tempo_shadow_only_in_agent_json(path):
+    data = json.loads(path.read_text())
+    variants = data["flags"]["interventions_allowed"]["variants"]
+    assert "ramp_tempo" in variants["shadow_experimental"]
+    for real in ("ambient", "standard", "full"):
+        assert "ramp_tempo" not in variants[real], f"{path}: {real} must not include ramp_tempo"


### PR DESCRIPTION
Part of #1103, #1117

## What

Adds the **`ramp_tempo`** agent intervention — a scheduled tempo **CURVE** (ramp the music speed toward a target over N seconds) that fills the `agent`-mode tempo seam added by #1114. #1103 MVP action 2.

## Ramp mechanic & #1114 integration

- Agent emits one string directive `"<target>:<seconds>:<curve>"` (e.g. `"1.3:8:linear"`, curve ∈ {linear, ease}).
- `handle_ramp_tempo` parses + bounds-validates it, then records a `RampDescriptor` on `game.tempo_ramp` anchored to the **live** music_speed + clock.
- The existing 100ms `_check_music_speed` loop interpolates the live tempo toward the target each tick via a new `_apply_ramp_tempo` — the **same single tempo-owner seam** the override / `agent` mode uses (no competing tempo writer, no race) — and **holds at target** when complete. While a ramp is active the natural slow/fast schedule is suspended (mirrors `tempo_override`); a hard `tempo_override` still wins.
- When `tempo_schedule_mode=agent` (#1114) this curve **drives the schedule**: one budget charge buys a whole pacing arc instead of re-emitting discrete `adjust_music_tempo` steps.
- `handle_ramp_tempo_revert` drops the descriptor so the default rule resumes from the held tempo. Descriptor lives only on the game object — never persisted to `game.json`.

## Value schema & malformed-safety

`"<target>:<seconds>:<curve>"`, validated in **both** `writer.go` (`tempoRampOr`) and game-side `parse_ramp_tempo_value`:
- exactly 3 `:`-fields; target clamped to `[1.0, 1.3]`; seconds finite, `> 0`, capped at 60s; curve ∈ {linear, ease}.
- Malformed / `"none"` / `""` / non-string → safe no-op (descriptor unchanged; writer falls back to a safe default), never dispatches garbage.

## Shadow-only

`ramp_tempo` added to the `shadow_experimental` `interventions_allowed` variant **only** (`agent.json` + `ci/agent.json`); absent from `ambient`/`standard`/`full`. The allow-list is the load-bearing gate, proved by `TestRampTempoIsShadowOnly` (mirrors #1107) on both prod + CI configs.

## Tests

- game-coordinator `test_ramp_tempo.py` (35 tests): parse/bounds, linear+ease interpolation reaches target & holds, handler arming, `_check_music_speed` drive + hold + schedule suspension, override precedence, revert, agent-mode integration, malformed-safe, JSON well-formed. Full suite: **1077 passed**.
- agent: `gofmt` clean, `go build`/`go vet` clean, `go test ./... -race -count=1` all pass; golden prompt files regenerated (one impact-model line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)