### PR TITLE
feat(dashboard): use agent_decisions_total for applied-vs-blocked panel

### DIFF
--- a/services/grafana/dashboards/agent-operations.json
+++ b/services/grafana/dashboards/agent-operations.json
@@ -264,7 +264,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "Agent ActionSink flag-write outcomes per minute: result=ok means an intervention was successfully written to the interventions flag file; result=error means the agent could not apply it (e.g. flagd file unreachable). This is the queryable applied-vs-blocked signal today; the richer per-type agent_interventions_applied_total / agent_decisions_total breakdown lands with #790. Source: agent_intervention_writes_total.",
+      "description": "Agent decision outcomes per minute. 'applied' = decisions that dispatched (blocked=false); the remaining series are decisions blocked before dispatch, split by reason (not_allowed = interventions disabled by policy; battery_threshold = target controller below battery floor; rate_limit = per-minute intervention budget exhausted). Source: agent_decisions_total{blocked,block_reason} (#1115).",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -316,22 +316,7 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "error"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "red",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "ok"
+              "options": "applied"
             },
             "properties": [
               {
@@ -371,12 +356,21 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum by (result) (rate(agent_intervention_writes_total[5m])) * 60",
-          "legendFormat": "{{result}}",
+          "expr": "sum(rate(agent_decisions_total{blocked=\"false\"}[5m])) * 60",
+          "legendFormat": "applied",
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (block_reason) (rate(agent_decisions_total{blocked=\"true\"}[5m])) * 60",
+          "legendFormat": "{{block_reason}}",
+          "refId": "B"
         }
       ],
-      "title": "Interventions Applied vs Blocked (flag-write outcome)",
+      "title": "Interventions Applied vs Blocked",
       "type": "timeseries"
     },
     {


### PR DESCRIPTION
Upgrades the #1113 Agent Operations dashboard's "Interventions Applied vs Blocked" panel to use the real `agent_decisions_total{blocked,block_reason}` metric (merged #1115, verified emitting live #1124), replacing the `agent_intervention_writes_total{result}` flag-write substitute that #791 documented as a forward-compat placeholder.

## Changes (services/grafana/dashboards/agent-operations.json)
- **Applied** series: `sum(rate(agent_decisions_total{blocked="false"}[5m])) * 60`
- **Blocked by reason** series: `sum by (block_reason) (rate(agent_decisions_total{blocked="true"}[5m])) * 60`, legend `{{block_reason}}` (not_allowed / battery_threshold / rate_limit)
- Updated panel description to reference the real `agent_decisions_total` (#1115); dropped the #790-pending forward-compat note.
- Replaced the now-meaningless `ok`/`error` color overrides with a single green override for `applied`.

## Validation (live, status:success)
- `action` / `blocked` / `block_reason` confirmed as the live label names (already underscore-free).
- All three PromQL queries returned `status:success` against `/prometheus/api/v1/query`.

Part of #789, #790

🤖 Generated with [Claude Code](https://claude.com/claude-code)