### PR TITLE
fix(agent): make interventions_allowed a STRING flag so the agent's allow-list gate resolves (#1127)

### DIFF
--- a/services/agent/README.md
+++ b/services/agent/README.md
@@ -472,9 +472,12 @@ model**, applied in order:
      the M4 LLM path lands. They are passed along the `llm` path stub.
 4. **Permission** (constrains which actions dispatch, and how fast) — applied to
    each candidate decision in this order, blocking with an attributed reason:
-   - `interventions_allowed` (object → `[]string`): the allow-list gate (#727).
-     A decision whose intervention is not on the list is blocked
-     (`reason=not_allowed`). An empty allow-list dispatches nothing.
+   - `interventions_allowed` (string of comma-separated ids → `[]string`): the
+     allow-list gate (#727). A decision whose intervention is not on the list is
+     blocked (`reason=not_allowed`). An empty allow-list dispatches nothing. It is
+     a STRING flag (not a LIST/object flag): the flagd RPC resolver the agent uses
+     silently TYPE_MISMATCHes a top-level LIST flag to its empty default, which
+     would block every intervention (#1127); a string is read cleanly.
    - `policy.battery_threshold` (int %, default 20): a **player-targeted**
      decision is blocked (`reason=battery_threshold`) when the target player's
      battery is below the threshold — a low-battery controller signals unreliable

--- a/services/agent/decision/shadow_gate_test.go
+++ b/services/agent/decision/shadow_gate_test.go
@@ -4,15 +4,20 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
 // agentFlagDoc is the minimal shape needed to read interventions_allowed variants
-// from a flagd agent flag file.
+// from a flagd agent flag file. Each variant value is held as RawMessage because
+// interventions_allowed migrated from a LIST flag to a STRING flag of
+// comma-separated ids (#1127 — the flagd RPC list-flag trap), so a variant may be
+// either a JSON array (legacy) or a comma-separated string. readInterventionsAllowed
+// normalizes both into []string.
 type agentFlagDoc struct {
 	Flags struct {
 		InterventionsAllowed struct {
-			Variants map[string][]string `json:"variants"`
+			Variants map[string]json.RawMessage `json:"variants"`
 		} `json:"interventions_allowed"`
 	} `json:"flags"`
 }
@@ -27,11 +32,36 @@ func readInterventionsAllowed(t *testing.T, path string) map[string][]string {
 	if err := json.Unmarshal(raw, &doc); err != nil {
 		t.Fatalf("unmarshal %s: %v", path, err)
 	}
-	v := doc.Flags.InterventionsAllowed.Variants
-	if len(v) == 0 {
+	if len(doc.Flags.InterventionsAllowed.Variants) == 0 {
 		t.Fatalf("%s: interventions_allowed has no variants", path)
 	}
-	return v
+	out := make(map[string][]string, len(doc.Flags.InterventionsAllowed.Variants))
+	for name, rawVal := range doc.Flags.InterventionsAllowed.Variants {
+		out[name] = parseAllowedVariant(t, path, name, rawVal)
+	}
+	return out
+}
+
+// parseAllowedVariant decodes one interventions_allowed variant value, accepting
+// either the STRING form ("a,b,c"; #1127) or the legacy JSON-array form.
+func parseAllowedVariant(t *testing.T, path, name string, rawVal json.RawMessage) []string {
+	t.Helper()
+	var asString string
+	if err := json.Unmarshal(rawVal, &asString); err == nil {
+		ids := make([]string, 0)
+		for _, tok := range strings.Split(asString, ",") {
+			if s := strings.TrimSpace(tok); s != "" {
+				ids = append(ids, s)
+			}
+		}
+		return ids
+	}
+	var asList []string
+	if err := json.Unmarshal(rawVal, &asList); err == nil {
+		return asList
+	}
+	t.Fatalf("%s: interventions_allowed variant %q has unexpected shape: %s", path, name, rawVal)
+	return nil
 }
 
 // TestSetPlayerHandicapIsShadowOnly is the load-bearing gating proof for #1107

--- a/services/agent/flags/flags.go
+++ b/services/agent/flags/flags.go
@@ -19,6 +19,7 @@ package flags
 import (
 	"context"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/open-feature/go-sdk/openfeature"
@@ -846,21 +847,41 @@ func (f *Flags) objectives(ctx context.Context) map[string]float64 {
 	return weights
 }
 
-// interventionsAllowed resolves the allow-list object into []string. The flag's
-// variants are JSON arrays, surfaced as []any of strings. An empty or
-// unparseable result yields an empty list (dispatch nothing).
+// interventionsAllowed resolves the allow-list into []string. The flag is a
+// STRING flag whose variants are comma-separated intervention ids (e.g.
+// "play_audio_cue,grant_shield"); `none` is the empty string. It is deliberately
+// NOT a LIST/object flag: top-level LIST flags hit the flagd RPC resolver's
+// get_object_value TYPE_MISMATCH and silently fall back to the passed default —
+// for an allow-list that default is empty, so the gate would block EVERY
+// intervention even when a non-`none` variant is active (#1127). A STRING flag is
+// read cleanly by the RPC resolver, so the agent honors the live variant; the
+// game_coordinator (in-process resolver) reads the same string and parses it
+// identically. An empty or unreadable value yields an empty list (dispatch
+// nothing) — fail-closed.
 func (f *Flags) interventionsAllowed(ctx context.Context) []string {
-	raw, err := f.client.ObjectValue(ctx, keyInterventionsAllowed, []any{}, openfeature.EvaluationContext{})
+	raw, err := f.client.StringValue(ctx, keyInterventionsAllowed, "", openfeature.EvaluationContext{})
 	if err != nil {
 		f.log.Debug("flags.interventions_allowed fell back to empty", "error", err)
 		return nil
 	}
-	list, ok := toStringSlice(raw)
-	if !ok {
-		f.log.Warn("flags.interventions_allowed had unexpected shape, blocking all", "value", raw)
+	return parseCSVList(raw)
+}
+
+// parseCSVList splits a comma-separated flag value into a slice of trimmed,
+// non-empty tokens. The empty string (the `none` variant) yields nil — an empty
+// allow-list, the fail-closed default.
+func parseCSVList(raw string) []string {
+	parts := strings.Split(raw, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if s := strings.TrimSpace(p); s != "" {
+			out = append(out, s)
+		}
+	}
+	if len(out) == 0 {
 		return nil
 	}
-	return list
+	return out
 }
 
 // llmGate resolves the three LLM-call-gate flags (#847) for one cycle. Each falls

--- a/services/agent/flags/flags_test.go
+++ b/services/agent/flags/flags_test.go
@@ -79,6 +79,10 @@ func TestEvaluate_FlagdShape(t *testing.T) {
 			keyMode:          "llm",
 			keyModel:         "claude",
 			keyPromptVariant: "aggressive",
+			// interventions_allowed is a STRING flag: comma-separated ids (#1127),
+			// read cleanly by the flagd RPC resolver (a LIST flag TYPE_MISMATCHes
+			// there and silently blocks every intervention).
+			keyInterventionsAllowed: "play_audio_cue,grant_shield",
 		},
 		ints: map[string]int64{
 			keyBatteryThreshold:            30,
@@ -96,8 +100,7 @@ func TestEvaluate_FlagdShape(t *testing.T) {
 		},
 		objects: map[string]any{
 			// flagd surfaces object flags as map[string]any / []any.
-			keyObjectives:           map[string]any{"endurance": 0.7, "chaos": 0.3},
-			keyInterventionsAllowed: []any{"play_audio_cue", "grant_shield"},
+			keyObjectives: map[string]any{"endurance": 0.7, "chaos": 0.3},
 		},
 	}
 	f := New(stub, nil)
@@ -288,8 +291,7 @@ func TestEvaluate_DefaultsOnError(t *testing.T) {
 
 func TestEvaluate_UnexpectedObjectShapeFallsBack(t *testing.T) {
 	stub := stubEvaluator{objects: map[string]any{
-		keyObjectives:           "not-a-map",
-		keyInterventionsAllowed: map[string]any{"unexpected": true},
+		keyObjectives: "not-a-map",
 	}}
 	f := New(stub, nil)
 	got := f.Evaluate(context.Background())
@@ -297,9 +299,49 @@ func TestEvaluate_UnexpectedObjectShapeFallsBack(t *testing.T) {
 	if !reflect.DeepEqual(got.Objectives, map[string]float64{"endurance": 1.0}) {
 		t.Errorf("Objectives = %v, want default on bad shape", got.Objectives)
 	}
-	if len(got.InterventionsAllowed) != 0 {
-		t.Errorf("InterventionsAllowed = %v, want empty on bad shape", got.InterventionsAllowed)
-	}
+}
+
+// TestInterventionsAllowed_StringFlag pins the #1127 fix: interventions_allowed
+// is a STRING flag (comma-separated ids), NOT a LIST/object flag. A LIST flag
+// read via the flagd RPC resolver's ObjectValue silently TYPE_MISMATCHes to its
+// passed default — for an allow-list that empty default blocks EVERY
+// intervention even with a non-`none` variant active. Reading the string variant
+// must resolve to the full id list so a permitted intervention can dispatch.
+func TestInterventionsAllowed_StringFlag(t *testing.T) {
+	t.Run("non-none variant resolves to full list", func(t *testing.T) {
+		stub := stubEvaluator{strings: map[string]string{
+			// the shadow_experimental variant, comma-separated as in agent.json.
+			keyInterventionsAllowed: "play_audio_cue,grant_shield,ramp_tempo",
+		}}
+		got := New(stub, nil).Evaluate(context.Background())
+		want := []string{"play_audio_cue", "grant_shield", "ramp_tempo"}
+		if !reflect.DeepEqual(got.InterventionsAllowed, want) {
+			t.Fatalf("InterventionsAllowed = %v, want %v", got.InterventionsAllowed, want)
+		}
+		// A permitted intervention passes the allow-list gate (NOT blocked).
+		if !got.Permits("grant_shield") {
+			t.Errorf("grant_shield should be allowed under a non-none variant")
+		}
+	})
+
+	t.Run("none variant (empty string) blocks all", func(t *testing.T) {
+		stub := stubEvaluator{strings: map[string]string{keyInterventionsAllowed: ""}}
+		got := New(stub, nil).Evaluate(context.Background())
+		if len(got.InterventionsAllowed) != 0 {
+			t.Errorf("InterventionsAllowed = %v, want empty for the none variant", got.InterventionsAllowed)
+		}
+		if got.Permits("grant_shield") {
+			t.Errorf("grant_shield must be blocked when allow-list is empty (fail-closed)")
+		}
+	})
+
+	t.Run("unreadable flag fails closed", func(t *testing.T) {
+		stub := stubEvaluator{errs: map[string]error{keyInterventionsAllowed: errors.New("flagd down")}}
+		got := New(stub, nil).Evaluate(context.Background())
+		if len(got.InterventionsAllowed) != 0 {
+			t.Errorf("InterventionsAllowed = %v, want empty on read error (fail-closed)", got.InterventionsAllowed)
+		}
+	})
 }
 
 // TestEvaluate_LLMGate_FlagdShape: the three #847 gate flags resolve through the

--- a/services/agent/flags/provider_test.go
+++ b/services/agent/flags/provider_test.go
@@ -46,8 +46,9 @@ func TestEvaluate_WithInMemoryProvider(t *testing.T) {
 		keyInterventionsAllowed: {
 			State:          memprovider.Enabled,
 			DefaultVariant: "ambient",
+			// STRING flag: comma-separated ids (#1127), read via StringValue.
 			Variants: map[string]any{
-				"ambient": []any{"play_audio_cue", "adjust_volume"},
+				"ambient": "play_audio_cue,adjust_volume",
 			},
 		},
 		keyBatteryThreshold: {

--- a/services/flagd/agent.json
+++ b/services/flagd/agent.json
@@ -77,54 +77,12 @@
     "interventions_allowed": {
       "state": "ENABLED",
       "variants": {
-        "none": [],
-        "probe": [
-          "noop"
-        ],
-        "ambient": [
-          "play_audio_cue",
-          "send_controller_effect",
-          "adjust_volume"
-        ],
-        "standard": [
-          "play_audio_cue",
-          "send_controller_effect",
-          "adjust_volume",
-          "adjust_music_tempo",
-          "set_pacing_profile",
-          "adjust_player_sensitivity",
-          "grant_shield"
-        ],
-        "full": [
-          "play_audio_cue",
-          "send_controller_effect",
-          "adjust_volume",
-          "adjust_music_tempo",
-          "set_pacing_profile",
-          "adjust_player_sensitivity",
-          "grant_shield",
-          "adjust_global_sensitivity",
-          "adjust_global_difficulty",
-          "eliminate_player",
-          "revive_player",
-          "end_game"
-        ],
-        "shadow_experimental": [
-          "play_audio_cue",
-          "send_controller_effect",
-          "adjust_volume",
-          "adjust_music_tempo",
-          "set_pacing_profile",
-          "adjust_player_sensitivity",
-          "grant_shield",
-          "adjust_global_sensitivity",
-          "adjust_global_difficulty",
-          "eliminate_player",
-          "revive_player",
-          "end_game",
-          "set_player_handicap",
-          "ramp_tempo"
-        ]
+        "none": "",
+        "probe": "noop",
+        "ambient": "play_audio_cue,send_controller_effect,adjust_volume",
+        "standard": "play_audio_cue,send_controller_effect,adjust_volume,adjust_music_tempo,set_pacing_profile,adjust_player_sensitivity,grant_shield",
+        "full": "play_audio_cue,send_controller_effect,adjust_volume,adjust_music_tempo,set_pacing_profile,adjust_player_sensitivity,grant_shield,adjust_global_sensitivity,adjust_global_difficulty,eliminate_player,revive_player,end_game",
+        "shadow_experimental": "play_audio_cue,send_controller_effect,adjust_volume,adjust_music_tempo,set_pacing_profile,adjust_player_sensitivity,grant_shield,adjust_global_sensitivity,adjust_global_difficulty,eliminate_player,revive_player,end_game,set_player_handicap,ramp_tempo"
       },
       "defaultVariant": "ambient"
     },

--- a/services/flagd/ci/agent.json
+++ b/services/flagd/ci/agent.json
@@ -77,54 +77,12 @@
     "interventions_allowed": {
       "state": "ENABLED",
       "variants": {
-        "none": [],
-        "probe": [
-          "noop"
-        ],
-        "ambient": [
-          "play_audio_cue",
-          "send_controller_effect",
-          "adjust_volume"
-        ],
-        "standard": [
-          "play_audio_cue",
-          "send_controller_effect",
-          "adjust_volume",
-          "adjust_music_tempo",
-          "set_pacing_profile",
-          "adjust_player_sensitivity",
-          "grant_shield"
-        ],
-        "full": [
-          "play_audio_cue",
-          "send_controller_effect",
-          "adjust_volume",
-          "adjust_music_tempo",
-          "set_pacing_profile",
-          "adjust_player_sensitivity",
-          "grant_shield",
-          "adjust_global_sensitivity",
-          "adjust_global_difficulty",
-          "eliminate_player",
-          "revive_player",
-          "end_game"
-        ],
-        "shadow_experimental": [
-          "play_audio_cue",
-          "send_controller_effect",
-          "adjust_volume",
-          "adjust_music_tempo",
-          "set_pacing_profile",
-          "adjust_player_sensitivity",
-          "grant_shield",
-          "adjust_global_sensitivity",
-          "adjust_global_difficulty",
-          "eliminate_player",
-          "revive_player",
-          "end_game",
-          "set_player_handicap",
-          "ramp_tempo"
-        ]
+        "none": "",
+        "probe": "noop",
+        "ambient": "play_audio_cue,send_controller_effect,adjust_volume",
+        "standard": "play_audio_cue,send_controller_effect,adjust_volume,adjust_music_tempo,set_pacing_profile,adjust_player_sensitivity,grant_shield",
+        "full": "play_audio_cue,send_controller_effect,adjust_volume,adjust_music_tempo,set_pacing_profile,adjust_player_sensitivity,grant_shield,adjust_global_sensitivity,adjust_global_difficulty,eliminate_player,revive_player,end_game",
+        "shadow_experimental": "play_audio_cue,send_controller_effect,adjust_volume,adjust_music_tempo,set_pacing_profile,adjust_player_sensitivity,grant_shield,adjust_global_sensitivity,adjust_global_difficulty,eliminate_player,revive_player,end_game,set_player_handicap,ramp_tempo"
       },
       "defaultVariant": "ambient"
     },

--- a/services/game_coordinator/interventions.py
+++ b/services/game_coordinator/interventions.py
@@ -1306,12 +1306,19 @@ class InterventionManager:
         return result
 
     def _allowed_types(self) -> set[str]:
+        # interventions_allowed is a STRING flag whose value is a comma-separated
+        # list of intervention ids (`none` == ""). It used to be a LIST/object
+        # flag, but the agent's flagd RPC resolver silently TYPE_MISMATCHes
+        # get_object_value on a top-level LIST flag and falls back to its empty
+        # default, blocking EVERY intervention even with a non-`none` variant
+        # active (#1127). Both sides now read a string and parse it identically;
+        # the coordinator's in-process resolver reads the string cleanly too.
         if self._agent_client is None:
             return set()
         try:
-            value = self._agent_client.get_object_value("interventions_allowed", [], EvaluationContext())
-            if isinstance(value, list):
-                return set(value)
+            value = self._agent_client.get_string_value("interventions_allowed", "", EvaluationContext())
+            if isinstance(value, str):
+                return {token.strip() for token in value.split(",") if token.strip()}
         except Exception as e:
             logger.debug(f"InterventionManager: interventions_allowed read failed: {e}")
         return set()

--- a/services/game_coordinator/tests/test_battery_provider.py
+++ b/services/game_coordinator/tests/test_battery_provider.py
@@ -108,7 +108,8 @@ def _wire_manager(provider, *, threshold=20, budget=10, game=None):
     mgr._interventions_client = FakeFlagClient()
     mgr._agent_client = FakeFlagClient(
         {
-            "interventions_allowed": list(ALL_TYPES),
+            # interventions_allowed is a STRING flag: comma-separated ids (#1127).
+            "interventions_allowed": ",".join(sorted(ALL_TYPES)),
             "policy.max_interventions_per_minute": budget,
             "policy.battery_threshold": threshold,
         }

--- a/services/game_coordinator/tests/test_difficulty_interventions.py
+++ b/services/game_coordinator/tests/test_difficulty_interventions.py
@@ -553,9 +553,13 @@ class _ScalarFlagClient:
 
 
 class _AllowAllAgent:
-    def get_object_value(self, key, default, _ctx=None):
+    def get_string_value(self, key, default, _ctx=None):
+        # interventions_allowed is a STRING flag: comma-separated ids (#1127).
         if key == "interventions_allowed":
-            return ["adjust_music_tempo", "adjust_global_sensitivity", "adjust_player_sensitivity"]
+            return "adjust_music_tempo,adjust_global_sensitivity,adjust_player_sensitivity"
+        return default
+
+    def get_object_value(self, key, default, _ctx=None):
         return default
 
     def get_integer_value(self, key, default, _ctx=None):

--- a/services/game_coordinator/tests/test_f6_intervention_levers.py
+++ b/services/game_coordinator/tests/test_f6_intervention_levers.py
@@ -309,9 +309,14 @@ class _AgentStub:
             return 20
         return default
 
-    def get_object_value(self, key, default, _ctx=None):
+    def get_string_value(self, key, default, _ctx=None):
+        # interventions_allowed is a STRING flag: comma-separated ids (#1127).
+        # Call sites still pass a list; join it here to match the flag format.
         if key == "interventions_allowed":
-            return self._allowed
+            return ",".join(self._allowed)
+        return default
+
+    def get_object_value(self, key, default, _ctx=None):
         return default
 
 

--- a/services/game_coordinator/tests/test_gameid_routing.py
+++ b/services/game_coordinator/tests/test_gameid_routing.py
@@ -91,9 +91,13 @@ class AgentStub:
             return 20
         return default
 
-    def get_object_value(self, key, default, _ctx=None):
+    def get_string_value(self, key, default, _ctx=None):
+        # interventions_allowed is a STRING flag: comma-separated ids (#1127).
         if key == "interventions_allowed":
-            return list(ALL_TYPES)
+            return ",".join(sorted(ALL_TYPES))
+        return default
+
+    def get_object_value(self, key, default, _ctx=None):
         return default
 
 

--- a/services/game_coordinator/tests/test_intervention_handlers.py
+++ b/services/game_coordinator/tests/test_intervention_handlers.py
@@ -91,7 +91,8 @@ def make_manager(*, interventions=None, game=None, end_game_fn=None, budget=20):
         events.append((event_type, data))
 
     agent_values = {
-        "interventions_allowed": list(ALL_TYPES),
+        # interventions_allowed is a STRING flag: comma-separated ids (#1127).
+        "interventions_allowed": ",".join(sorted(ALL_TYPES)),
         "policy.max_interventions_per_minute": budget,
         "policy.battery_threshold": 20,
     }

--- a/services/game_coordinator/tests/test_interventions.py
+++ b/services/game_coordinator/tests/test_interventions.py
@@ -106,7 +106,8 @@ def make_manager(
         events.append((event_type, data))
 
     agent_values = {
-        "interventions_allowed": list(ALL_TYPES) if allowed is None else allowed,
+        # interventions_allowed is a STRING flag: comma-separated ids (#1127).
+        "interventions_allowed": ",".join(sorted(ALL_TYPES)) if allowed is None else allowed,
         # Agent-owned per-game budget (NOT read by the coordinator backstop).
         "policy.max_interventions_per_minute": 2,
         # Coordinator-owned generous global backstop (what _refresh_budget reads).
@@ -297,7 +298,7 @@ async def test_state_flag_revert_to_none_not_dispatched():
 async def test_allowed_membership_blocks():
     mgr, events = make_manager(
         interventions={"eliminate_player": "1:ctrl_a"},
-        allowed=["play_audio_cue"],  # eliminate not allowed
+        allowed="play_audio_cue",  # eliminate not allowed
     )
     with patch("services.game_coordinator.metrics.interventions_total"):
         await mgr.evaluate_all()
@@ -361,13 +362,13 @@ async def test_blocked_intervention_does_not_consume_backstop_budget():
     clock = Clock()
     mgr, _ = make_manager(
         interventions={"eliminate_player": "1:ctrl_a"},
-        allowed=["eliminate_player"],
+        allowed="eliminate_player",
         backstop=2,
         time_fn=clock,
     )
     # block eliminate via membership by removing it AFTER constructing? Instead
     # verify the rate limiter directly: a not-allowed type returns before check.
-    mgr._agent_client.set("interventions_allowed", [])  # now nothing allowed
+    mgr._agent_client.set("interventions_allowed", "")  # now nothing allowed
     with patch("services.game_coordinator.metrics.interventions_total"):
         await mgr.evaluate_all()  # blocked (not allowed) -> no reservation
     assert mgr._rate_limiter.current_weight() == pytest.approx(0.0)

--- a/services/game_coordinator/tests/test_ramp_tempo.py
+++ b/services/game_coordinator/tests/test_ramp_tempo.py
@@ -348,6 +348,16 @@ def test_interventions_json_well_formed(path):
 def test_ramp_tempo_shadow_only_in_agent_json(path):
     data = json.loads(path.read_text())
     variants = data["flags"]["interventions_allowed"]["variants"]
-    assert "ramp_tempo" in variants["shadow_experimental"]
+
+    # interventions_allowed migrated from a LIST flag to a STRING flag of
+    # comma-separated ids (#1127, the flagd RPC list-flag trap). Parse either
+    # shape into a set of ids so the membership assertion is exact (not a
+    # substring match that could false-positive on shared prefixes).
+    def ids(variant):
+        if isinstance(variant, str):
+            return {tok.strip() for tok in variant.split(",") if tok.strip()}
+        return set(variant)
+
+    assert "ramp_tempo" in ids(variants["shadow_experimental"])
     for real in ("ambient", "standard", "full"):
-        assert "ramp_tempo" not in variants[real], f"{path}: {real} must not include ramp_tempo"
+        assert "ramp_tempo" not in ids(variants[real]), f"{path}: {real} must not include ramp_tempo"

--- a/services/menu/handlers/admin.py
+++ b/services/menu/handlers/admin.py
@@ -1317,8 +1317,12 @@ class AdminModeHandler:
         if client is None:
             return file_level
         try:
-            default_value = writer.get_variant_value(AGENT_POLICY_FLAG, file_level) if file_level else []
-            resolved = client.get_object_value(AGENT_POLICY_FLAG, default_value)
+            # interventions_allowed is a STRING flag (comma-separated ids; #1127),
+            # so resolve it with the string getter and match the string value back
+            # to a variant name. Reading it via get_object_value would TYPE_MISMATCH
+            # to the passed default and break the live-level reconciliation.
+            default_value = writer.get_variant_value(AGENT_POLICY_FLAG, file_level) if file_level else ""
+            resolved = self._resolve_flag_value(client, AGENT_POLICY_FLAG, default_value)
             matched = writer.match_variant_for_value(AGENT_POLICY_FLAG, resolved)
             return matched or file_level
         except Exception as e:

--- a/tests/integration/test_parallel_intervention_flow.py
+++ b/tests/integration/test_parallel_intervention_flow.py
@@ -707,13 +707,15 @@ async def test_parallel_interventions(flag_files, docker_compose, headless_clean
     # Wait until flagd actually SERVES the permission flip before any scenario
     # writes (#894: condition poll, not a fixed settle).
     with open(AGENT_PATH) as fh:
+        # interventions_allowed is a STRING flag: comma-separated ids (#1127),
+        # so probe it with the string getter and compare the served string.
         expected_full = json.load(fh)["flags"]["interventions_allowed"]["variants"]["full"]
     from openfeature.evaluation_context import EvaluationContext
 
     with flagd_probe_client(docker_compose, "agent") as flag_client:
         assert await async_poll_until(
-            lambda: flag_client.get_object_value(
-                "interventions_allowed", None, EvaluationContext()
+            lambda: flag_client.get_string_value(
+                "interventions_allowed", "", EvaluationContext()
             )
             == expected_full,
             rewrite=lambda: set_interventions_allowed("full"),


### PR DESCRIPTION
Closes #1127

## Root cause (confirmed)
`interventions_allowed` was a top-level **LIST/object** flagd flag. The agent resolves flags through the flagd **RPC resolver** (`services/agent/flags/provider.go`, `WithRPCResolver()` on port 8013). A top-level LIST flag read via `ObjectValue` silently **TYPE_MISMATCHes** under the RPC resolver and falls back to the *passed default* — for the allow-list that default is the empty list `[]any{}`. So every `agent.decision` resolved `interventions.allowed=none` and blocked `not_allowed`, even with `defaultVariant=shadow_experimental` (ENABLED, no targeting). The agent could **never** apply an intervention.

This is the object-flag sibling of the known #894/#903 numeric-flag trap. The two existing LIST declarer knobs were kept as ENV for exactly this reason — `interventions_allowed` fell into the trap.

The **game_coordinator** read it correctly only because it uses the **in-process resolver** (port 8015, `lib/feature_flags.py` `ResolverType.IN_PROCESS`), which reads LIST flags. So the two readers silently disagreed.

## Fix (Option A — string variant)
Why A: the agent's Go provider is RPC-only; wiring a second in-process provider just for one flag (B) is invasive, and the coordinator's correct in-process read (C) can't be mirrored into the agent's RPC path. A STRING flag is read cleanly by **both** resolvers and stays live-tunable — matching the codebase's established "work around the RPC trap with a typed getter" philosophy.

`interventions_allowed` is now a **STRING** flag whose variants are comma-separated intervention ids (`none` == `""`). The variant set (none/probe/ambient/standard/full/shadow_experimental) and their membership are unchanged semantically.

## Both readers now agree on the format
- **Agent** (`services/agent/flags/flags.go`): `interventionsAllowed()` reads `StringValue` + `parseCSVList` (trim, drop empties).
- **Coordinator** (`services/game_coordinator/interventions.py`): `_allowed_types()` reads `get_string_value` + `split(",")`.
- **Menu admin** (`services/menu/handlers/admin.py`): `_current_agent_level()` resolves via the string getter so the on-device kill-switch level reconciliation still works.

## Fail-closed preserved
An absent / unreadable / empty `interventions_allowed` still yields an **empty** allow-list (dispatch nothing). The fix makes a *present non-none* variant resolve; it does not make a resolution failure fail open.

## Tests
- `services/agent/flags/flags_test.go` — `TestInterventionsAllowed_StringFlag`: a non-`none` variant resolves to its full id list and `Permits("grant_shield")` is true (passes the gate); the `none`/empty-string variant and an unreadable flag both resolve empty (fail-closed).
- Coordinator intervention tests (`test_interventions.py` etc.) exercise the allow-list membership gate against the string format — a permitted intervention is **not** blocked `not_allowed`.
- `shadow_gate_test.go` + `test_ramp_tempo.py` parse either the new string shape **or** the legacy list shape, so the shadow-only gating proofs hold across both `agent.json` files.

## Verification
- `services/agent`: `gofmt -l .` clean, `go build ./...`, `go vet ./...`, `go test ./... -race -count=1` all green.
- `services/game_coordinator`: `uv run --extra test pytest` — 1082 passed.
- `services/menu`: full suite — 381 passed.
- `make lint` — all checks passed. Both `agent.json` files validated as JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)