### PR TITLE
feat(agent): pre-warm inference + OLLAMA_KEEP_ALIVE docs (#1130)

### DIFF
--- a/docs/agent-inference-gateway.md
+++ b/docs/agent-inference-gateway.md
@@ -82,7 +82,11 @@ Where the gateway reaches Ollama is `OLLAMA_BASE_URL` (default
 > *not* `host.docker.internal`. See
 > [`agent-ollama-host-runbook.md`](agent-ollama-host-runbook.md) for the full
 > checklist — both the gateway's `OLLAMA_BASE_URL` and the Ollama-direct
-> `AGENT_INFERENCE_BASE_URL` need it.
+> `AGENT_INFERENCE_BASE_URL` need it. That runbook (§4) also covers
+> `OLLAMA_KEEP_ALIVE` and the agent's startup pre-warm (#1130): set
+> `OLLAMA_KEEP_ALIVE=-1` on whichever Ollama the gateway proxies so the model
+> stays resident instead of unloading after ~5 min idle and re-paying the
+> ~30-100s cold load.
 
 ## The Anthropic key — gateway-only, optional
 

--- a/docs/agent-ollama-host-runbook.md
+++ b/docs/agent-ollama-host-runbook.md
@@ -106,6 +106,82 @@ docker compose logs agent | grep -E 'agent\.evaluate|no_backend_available' | tai
 **model** problem, not networking — confirm `AGENT_INFERENCE_MODEL` matches a
 tag from `/api/tags` exactly (e.g. `gemma3:4b`, not `gemma4`).
 
+## 4. Keep the model resident: `OLLAMA_KEEP_ALIVE` (cold-start, #1130)
+
+Reachability gets the LLM *called*; this makes it *fast*. Verification runs
+(#1098/#1124) measured the agent proposer's **first** call at **~97-109s** — that
+is the model cold-load, not the round-trip. Worse, **Ollama unloads an idle model
+after ~5 minutes** by default (`keep_alive`), so the agent's bursty, intermittent
+traffic re-pays that ~30-100s cold load again and again, and live `mode=llm`
+decisions feel slow or flaky even when everything is wired correctly.
+
+Two cheap levers fix this; use **both**.
+
+### Lever 1 (host-side, primary): keep the model loaded
+
+Set `OLLAMA_KEEP_ALIVE` on the **host Ollama** so the model stays resident across
+the agent's duty cycle instead of unloading after ~5 min idle:
+
+```bash
+# Linux/macOS host (systemd): keep the model loaded indefinitely
+sudo systemctl edit ollama        # add: [Service]\nEnvironment="OLLAMA_KEEP_ALIVE=-1"
+sudo systemctl restart ollama
+
+# Or for a foreground run:
+OLLAMA_HOST=0.0.0.0 OLLAMA_KEEP_ALIVE=-1 ollama serve
+```
+
+```powershell
+# Windows host (Ollama as a Windows app): set a user env var, then restart Ollama
+setx OLLAMA_KEEP_ALIVE "-1"
+# quit Ollama from the tray and relaunch so it picks up the new value
+```
+
+Values:
+
+| `OLLAMA_KEEP_ALIVE` | Effect |
+|---------------------|--------|
+| `-1` | Keep the model loaded **indefinitely** (until Ollama restarts) — best for a dedicated demo box |
+| `30m` (or any duration) | Keep loaded for that idle window — a middle ground if the box also serves other workloads |
+| unset (`5m` default) | Unloads after ~5 min idle — re-pays the cold load on bursty agent traffic (the symptom) |
+
+> This is a **host Ollama** setting, not agent config — set it where `ollama
+> serve` runs (alongside `OLLAMA_HOST` in §1). The agent has no way to override
+> the server's unload policy.
+
+Confirm the model is loaded and not about to expire:
+
+```bash
+ollama ps        # UNTIL column should read "Forever" (-1) or a future time, not seconds away
+```
+
+### Lever 2 (agent-side, automatic): startup pre-warm (#1130)
+
+When `AGENT_INFERENCE_BACKEND=openai`, the agent fires **one** best-effort
+throwaway warmup `Infer` (a tiny `"ping"` prompt) in a background goroutine at
+startup, so the model is already loading before the first *real*
+decision/proposal — moving the ~100s cold load off the hot path. It is:
+
+- **default-on** for the openai backend, **no-op** for the stub default (no
+  behavior change when no real backend is configured);
+- **best-effort / non-fatal**: a failure is logged at `Warn` and never blocks or
+  crashes startup;
+- **bounded** by the configured inference timeout (`AGENT_INFERENCE_TIMEOUT_SECONDS`,
+  #1079) so it can't hang forever.
+
+Disable it (e.g. to keep startup logs quiet on a box without Ollama) with
+`AGENT_INFERENCE_PREWARM=false`. Watch it in the logs:
+
+```bash
+docker compose logs agent | grep -i 'pre-warm' | tail
+# "Inference pre-warm started ..." then "... succeeded; model resident" (elapsed_ms ≈ the cold load)
+```
+
+The pre-warm pays the cold load **once at startup**; `OLLAMA_KEEP_ALIVE` then
+*keeps* it paid for the rest of the duty cycle. Pre-warm without keep-alive still
+goes cold after 5 min idle; keep-alive without pre-warm still eats the first
+real call. Set both.
+
 ## Why the agent doesn't just crash
 
 The inference tier is **probed** (a TCP dial of the `AGENT_INFERENCE_BASE_URL`

--- a/services/agent/inference_prewarm.go
+++ b/services/agent/inference_prewarm.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/joustmania/agent/inference"
+	"github.com/joustmania/agent/llm"
+)
+
+// warmupPromptText is the tiny throwaway prompt fired at startup to load the
+// model. Its content is irrelevant — the result is discarded — so it is kept as
+// short as possible to minimise the work the model does on this one call.
+const warmupPromptText = "ping"
+
+// prewarmEnabled reports whether the startup model pre-warm should run for a real
+// backend. It reads AGENT_INFERENCE_PREWARM: any value other than an explicit
+// "false"/"0"/"off"/"no" (case-insensitive) leaves it ON, so the default-on
+// behavior holds when the var is unset. The toggle only ever gates the openai
+// path — the stub backend never warms regardless (see prewarmInference).
+func prewarmEnabled() bool {
+	v := strings.ToLower(strings.TrimSpace(getEnv("AGENT_INFERENCE_PREWARM", "")))
+	if v == "" {
+		return true
+	}
+	if b, err := strconv.ParseBool(v); err == nil {
+		return b
+	}
+	switch v {
+	case "off", "no":
+		return false
+	default:
+		return true
+	}
+}
+
+// prewarmInference fires ONE best-effort throwaway Infer call in a BACKGROUND
+// goroutine so the host Ollama model is resident before the first real
+// decision/proposal eats the ~30-100s cold load (#1130). It is wired only when a
+// REAL backend is configured (AGENT_INFERENCE_BACKEND=openai): the stub default
+// passes a nil delegate, so this no-ops and the byte-identical default startup is
+// preserved. The call is:
+//   - non-blocking: it runs in its own goroutine, so startup is never delayed;
+//   - best-effort / non-fatal: any failure is logged at Warn and NEVER crashes or
+//     blocks the agent — it serves regardless of the warmup outcome;
+//   - bounded: the goroutine's context carries warmupTimeout (the configured
+//     inference timeout) so it can never hang forever, and it is also tied to the
+//     parent ctx so shutdown cancels an in-flight warmup.
+//
+// The prompt mirrors the llm.Prompt shape every other Infer call uses, with a
+// minimal User string. The model name is set for attribution only.
+func prewarmInference(ctx context.Context, delegate inferFunc, model string, warmupTimeout time.Duration) {
+	if delegate == nil {
+		return // stub backend: no warmup, unchanged default behavior.
+	}
+	if !prewarmEnabled() {
+		slog.Info("Inference pre-warm disabled via AGENT_INFERENCE_PREWARM (#1130)")
+		return
+	}
+	if warmupTimeout <= 0 {
+		warmupTimeout = inference.DefaultTimeout
+	}
+	slog.Info("Inference pre-warm started (best-effort, background) (#1130)",
+		"model", model, "timeout", warmupTimeout)
+	go func() {
+		warmCtx, cancel := context.WithTimeout(ctx, warmupTimeout)
+		defer cancel()
+		start := time.Now()
+		_, err := delegate(warmCtx, llm.Prompt{
+			User:  warmupPromptText,
+			Model: model,
+		})
+		elapsedMs := time.Since(start).Milliseconds()
+		if err != nil {
+			slog.Warn("Inference pre-warm failed (non-fatal; agent serves regardless) (#1130)",
+				"model", model, "elapsed_ms", elapsedMs, "error", err)
+			return
+		}
+		slog.Info("Inference pre-warm succeeded; model resident (#1130)",
+			"model", model, "elapsed_ms", elapsedMs)
+	}()
+}

--- a/services/agent/inference_prewarm_test.go
+++ b/services/agent/inference_prewarm_test.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/joustmania/agent/llm"
+)
+
+// inference_prewarm_test.go covers the #1130 startup model pre-warm: it fires
+// exactly one background Infer for a real backend, skips entirely for the stub
+// (nil delegate), never blocks startup, and swallows errors (best-effort).
+
+// waitForCount spins until the atomic reaches want or the deadline elapses,
+// covering the background goroutine's eventual call without a fixed sleep.
+func waitForCount(t *testing.T, c *atomic.Int64, want int64) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if c.Load() == want {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatalf("Infer call count = %d, want %d", c.Load(), want)
+}
+
+func TestPrewarmInference_StubBackendNoOp(t *testing.T) {
+	// nil delegate (stub default) must not warm at all.
+	prewarmInference(context.Background(), nil, "phi4-mini", time.Second)
+	// Nothing to assert beyond "did not panic / did not block" — a nil delegate
+	// means there is no call to count. The other tests cover the real path.
+}
+
+func TestPrewarmInference_RealBackendFiresOnce(t *testing.T) {
+	t.Setenv("AGENT_INFERENCE_PREWARM", "") // default-on
+
+	var calls atomic.Int64
+	var gotPrompt llm.Prompt
+	delegate := func(_ context.Context, p llm.Prompt) (string, error) {
+		gotPrompt = p
+		calls.Add(1)
+		return "pong", nil
+	}
+
+	prewarmInference(context.Background(), delegate, "gemma3:4b", time.Second)
+	waitForCount(t, &calls, 1)
+
+	if calls.Load() != 1 {
+		t.Errorf("Infer called %d times, want exactly 1", calls.Load())
+	}
+	if gotPrompt.User == "" {
+		t.Error("warmup prompt User is empty; want a minimal prompt")
+	}
+	if gotPrompt.Model != "gemma3:4b" {
+		t.Errorf("warmup prompt Model = %q, want gemma3:4b", gotPrompt.Model)
+	}
+}
+
+func TestPrewarmInference_SwallowsErrors(t *testing.T) {
+	t.Setenv("AGENT_INFERENCE_PREWARM", "")
+
+	var calls atomic.Int64
+	delegate := func(context.Context, llm.Prompt) (string, error) {
+		calls.Add(1)
+		return "", errors.New("backend unreachable")
+	}
+
+	// A failing backend must not panic or block — the helper returns immediately
+	// (goroutine) and the error is logged, not propagated.
+	prewarmInference(context.Background(), delegate, "phi4-mini", time.Second)
+	waitForCount(t, &calls, 1)
+}
+
+func TestPrewarmInference_DoesNotBlock(t *testing.T) {
+	t.Setenv("AGENT_INFERENCE_PREWARM", "")
+
+	release := make(chan struct{})
+	delegate := func(ctx context.Context, _ llm.Prompt) (string, error) {
+		<-release // block until the test releases it
+		return "ok", nil
+	}
+
+	done := make(chan struct{})
+	go func() {
+		prewarmInference(context.Background(), delegate, "phi4-mini", 5*time.Second)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// prewarmInference returned promptly even though Infer is still blocked.
+	case <-time.After(time.Second):
+		t.Fatal("prewarmInference blocked on the backend call; want background/non-blocking")
+	}
+	close(release) // let the goroutine finish cleanly
+}
+
+func TestPrewarmInference_DisabledByEnv(t *testing.T) {
+	t.Setenv("AGENT_INFERENCE_PREWARM", "false")
+
+	var calls atomic.Int64
+	delegate := func(context.Context, llm.Prompt) (string, error) {
+		calls.Add(1)
+		return "", nil
+	}
+
+	prewarmInference(context.Background(), delegate, "phi4-mini", time.Second)
+	// Give any (incorrectly-spawned) goroutine a chance to run before asserting.
+	time.Sleep(50 * time.Millisecond)
+	if calls.Load() != 0 {
+		t.Errorf("Infer called %d times with prewarm disabled, want 0", calls.Load())
+	}
+}
+
+func TestPrewarmEnabled(t *testing.T) {
+	cases := map[string]bool{
+		"":      true,
+		"true":  true,
+		"1":     true,
+		"on":    true,
+		"yes":   true,
+		"false": false,
+		"0":     false,
+		"off":   false,
+		"no":    false,
+		"FALSE": false,
+		"junk":  true, // unknown -> fail safe to ON
+	}
+	for val, want := range cases {
+		t.Setenv("AGENT_INFERENCE_PREWARM", val)
+		if got := prewarmEnabled(); got != want {
+			t.Errorf("prewarmEnabled() with %q = %v, want %v", val, got, want)
+		}
+	}
+}

--- a/services/agent/main.go
+++ b/services/agent/main.go
@@ -576,6 +576,14 @@ func main() {
 		"model", inferModel,
 		"api_key_set", getEnv("AGENT_INFERENCE_API_KEY", "") != "",
 	)
+	// Inference cold-start pre-warm (#1130). When a REAL backend is configured
+	// (inferDelegate != nil, AGENT_INFERENCE_BACKEND=openai), fire ONE best-effort
+	// throwaway Infer in the background so the host Ollama model is resident before
+	// the first real decision/proposal pays the ~30-100s cold load. No-op for the
+	// stub default (nil delegate) → byte-identical startup. Bounded by the configured
+	// inference timeout, non-blocking, non-fatal — see prewarmInference.
+	prewarmInference(ctx, inferDelegate, inferModel,
+		secondsEnv("AGENT_INFERENCE_TIMEOUT_SECONDS", inference.DefaultTimeout))
 	legacyEndpoints := decision.Endpoints{
 		Cloud:     getEnv("AGENT_CLOUD_ENDPOINT", ""),                    // #742 credential-blocked: empty = permanently unreachable
 		Jetson:    getEnv("AGENT_JETSON_ENDPOINT", "jetson:11434"),       // #738 Ollama on the Jetson; unresolvable in dev


### PR DESCRIPTION
## What

Two cheap levers to cut inference cold-start (#1130). Verification runs measured the proposer's first model call at ~97-109s (cold load), and Ollama unloads an idle model after ~5min — so bursty agent traffic re-pays the cold load and live `mode=llm` is slow/intermittent.

### 1. Agent startup pre-warm (`services/agent`)
When `AGENT_INFERENCE_BACKEND=openai`, `main.go` fires ONE best-effort throwaway `"ping"` `Infer` in a **background goroutine** at startup (new `inference_prewarm.go`), so the host Ollama model loads before the first real decision/proposal. It is:
- **non-blocking** — own goroutine; startup is never delayed;
- **best-effort / non-fatal** — failure logged at `Warn`, never crashes/blocks startup;
- **bounded** — context with the configured inference timeout (`AGENT_INFERENCE_TIMEOUT_SECONDS`, #1079);
- a **no-op for the stub default** (nil delegate) → byte-identical startup, no behavior change.

`AGENT_INFERENCE_PREWARM=false` opts out (default-on for openai). Outcome is logged (started / succeeded in Xms / failed: reason). No changes to decisions, gating, game-coordinator, interventions, or base.py.

### 2. `OLLAMA_KEEP_ALIVE` docs
`docs/agent-ollama-host-runbook.md` §4: set host-side `OLLAMA_KEEP_ALIVE` (`-1` to keep loaded indefinitely, or `30m`) so the model stays resident past the ~5min idle unload, cross-referenced to the cold-start findings; plus a note on the agent-side pre-warm and why you want both. `docs/agent-inference-gateway.md` notes the same for the gateway's Ollama.

## Tests
`inference_prewarm_test.go`: fires-once (correct minimal prompt + model attribution), stub-skip (nil delegate no-ops), error-swallow, non-blocking, env-disable, and the toggle parser. `gofmt`/`go build`/`go vet`/`go test ./... -race -count=1` all green.

Closes #1130