### PR TITLE
feat(agent): partial_shield time-boxed handicap protection (#1129)

### DIFF
--- a/services/agent/actions/neutral_interventions.json
+++ b/services/agent/actions/neutral_interventions.json
@@ -46,6 +46,17 @@
       "defaultVariant": "none",
       "targeting": {}
     },
+    "partial_shield_seconds": {
+      "state": "ENABLED",
+      "variants": {
+        "none": "0",
+        "short": "3:2.0",
+        "default": "5:2.0",
+        "long": "10:2.0"
+      },
+      "defaultVariant": "none",
+      "targeting": {}
+    },
     "volume_override": {
       "state": "ENABLED",
       "variants": {

--- a/services/agent/actions/testdata/interventions.json
+++ b/services/agent/actions/testdata/interventions.json
@@ -57,6 +57,17 @@
       "defaultVariant": "none",
       "targeting": {}
     },
+    "partial_shield_seconds": {
+      "state": "ENABLED",
+      "variants": {
+        "none": "0",
+        "short": "3:2.0",
+        "default": "5:2.0",
+        "long": "10:2.0"
+      },
+      "defaultVariant": "none",
+      "targeting": {}
+    },
     "volume_override": {
       "state": "ENABLED",
       "variants": {

--- a/services/agent/actions/writer.go
+++ b/services/agent/actions/writer.go
@@ -48,6 +48,7 @@ const (
 	flagPlayerSensitivityFactor   = "player_sensitivity_factor"
 	flagPlayerHandicapFactor      = "player_handicap_factor" // #1107 (#1103 MVP action 1)
 	flagShieldSeconds             = "shield_seconds"
+	flagPartialShieldSeconds      = "partial_shield_seconds" // #1129 (#1103 Phase 2)
 	flagVolumeOverride            = "volume_override"
 	flagGlobalDifficultyFactor    = "global_difficulty_factor" // #766 F6
 	flagPacingProfile             = "pacing_profile"           // #766 F6
@@ -111,6 +112,18 @@ const (
 	// fast tempo over 8s, linear — used when a Decision carries no Value or a
 	// malformed one. Matches interventions.json "ramp_up".
 	defaultTempoRamp = "1.3:8:linear"
+	// defaultPartialShield is the safe fallback partial_shield directive (#1129):
+	// 5 seconds at the default ~2.0 boost — used when a Decision carries no Value
+	// or a malformed one. "<seconds>:<boost>" with boost at the [1.0,2.0] max.
+	defaultPartialShield = "5:2.0"
+)
+
+// partial_shield bounds (#1129) — mirror BaseGameMode's clamps so the writer
+// never emits a directive the game side would reject.
+const (
+	partialShieldMaxSeconds = 30.0
+	partialShieldBoostMin   = 1.0
+	partialShieldBoostMax   = 2.0
 )
 
 // tempoRampMaxSeconds bounds a single ramp's duration (mirrors base.py
@@ -405,6 +418,8 @@ func (w *Writer) mutate(doc *orderedDoc, d decision.Decision) error {
 		return w.setTargeted(doc, flagPlayerHandicapFactor, neutralDefault, d.TargetSerial, w.numOr(d.Value, defaultPlayerHandicap))
 	case decision.InterventionGrantShield:
 		return w.setTargeted(doc, flagShieldSeconds, neutralNone, d.TargetSerial, w.numOr(d.Value, defaultShieldSeconds))
+	case decision.InterventionPartialShield: // #1129 (#1103 Phase 2), shadow-only
+		return w.setTargetedString(doc, flagPartialShieldSeconds, neutralNone, d.TargetSerial, w.partialShieldOr(d.Value, defaultPartialShield))
 
 	// Probe-mode synthetic intervention: no game effect, but a dispatched success
 	// so probe mode (AGENT_PROBE_DECISIONS + the `probe` interventions_allowed
@@ -512,6 +527,77 @@ func (w *Writer) setTargeted(doc *orderedDoc, flagKey, neutral, serial string, v
 	return doc.putFlag(flagKey, f)
 }
 
+// setTargetedString writes a per-player STRING state-shaped flag via a flagd
+// targeting if-ladder keyed on targetingKey=serial (#1129 partial_shield). It is
+// the string sibling of setTargeted: each driven serial gets its own
+// "agent_<serial>" variant carrying a STRING value, the if-ladder maps serial ->
+// that variant, and unmatched serials fall through to the neutral defaultVariant.
+// Existing per-serial variants/branches are preserved (merge, not clobber).
+func (w *Writer) setTargetedString(doc *orderedDoc, flagKey, neutral, serial, value string) error {
+	if serial == "" {
+		return fmt.Errorf("targeted intervention on %q requires a target serial", flagKey)
+	}
+	f, err := doc.flag(flagKey)
+	if err != nil {
+		return err
+	}
+
+	variants := map[string]string{}
+	if _, err := f.get("variants", &variants); err != nil {
+		return err
+	}
+	variants[serialVariant(serial)] = value
+	if err := f.set("variants", variants); err != nil {
+		return err
+	}
+
+	names := make([]string, 0, len(variants))
+	for name := range variants {
+		names = append(names, name)
+	}
+	ladder := buildTargetingNames(names, neutral)
+	if ladder == nil {
+		f.delete("targeting")
+	} else if err := f.set("targeting", ladder); err != nil {
+		return err
+	}
+	if err := f.set("defaultVariant", neutral); err != nil {
+		return err
+	}
+	return doc.putFlag(flagKey, f)
+}
+
+// partialShieldOr validates a partial_shield directive "<seconds>" or
+// "<seconds>:<boost>" (#1129) and returns it, or def when v is empty/malformed/
+// out-of-bounds. Defensive sibling of tempoRampOr: the game-side parser
+// (lifecycle_handlers.parse_partial_shield_value) independently re-validates and
+// no-ops on garbage, but validating here keeps a malformed LLM value from ever
+// reaching the flag file. Bounds mirror the game side: seconds > 0 (capped),
+// boost in [1.0, 2.0] (default 2.0 when omitted).
+func (w *Writer) partialShieldOr(v, def string) string {
+	if v == "" {
+		return def
+	}
+	parts := strings.Split(strings.TrimSpace(v), ":")
+	if len(parts) < 1 || len(parts) > 2 {
+		w.log.Warn("agent.action_bad_value", "value", v, "fallback", def)
+		return def
+	}
+	seconds, serr := strconv.ParseFloat(strings.TrimSpace(parts[0]), 64)
+	if serr != nil || seconds <= 0 || seconds > partialShieldMaxSeconds {
+		w.log.Warn("agent.action_bad_value", "value", v, "fallback", def)
+		return def
+	}
+	if len(parts) == 2 {
+		boost, berr := strconv.ParseFloat(strings.TrimSpace(parts[1]), 64)
+		if berr != nil || boost < partialShieldBoostMin || boost > partialShieldBoostMax {
+			w.log.Warn("agent.action_bad_value", "value", v, "fallback", def)
+			return def
+		}
+	}
+	return v
+}
+
 // payloadOr returns v, or the default when v is empty.
 func (w *Writer) payloadOr(v, def string) string {
 	if v == "" {
@@ -597,8 +683,20 @@ func serialVariant(serial string) string { return "agent_" + serial }
 // so unmatched serials evaluate to defaultVariant anyway — explicit neutral
 // keeps the ladder self-describing.
 func buildTargeting(variants map[string]float64, neutral string) map[string]any {
-	serials := make([]string, 0)
+	names := make([]string, 0, len(variants))
 	for name := range variants {
+		names = append(names, name)
+	}
+	return buildTargetingNames(names, neutral)
+}
+
+// buildTargetingNames is the value-type-agnostic core of buildTargeting: it
+// renders the deterministic if-ladder from the set of "agent_<serial>" variant
+// NAMES (value type irrelevant — the ladder maps serial -> variant name). Used by
+// both setTargeted (float) and setTargetedString (string, #1129).
+func buildTargetingNames(variantNames []string, neutral string) map[string]any {
+	serials := make([]string, 0)
+	for _, name := range variantNames {
 		if s, ok := agentSerial(name); ok {
 			serials = append(serials, s)
 		}

--- a/services/agent/actions/writer_test.go
+++ b/services/agent/actions/writer_test.go
@@ -335,6 +335,62 @@ func TestSetPlayerHandicapDefaultValue(t *testing.T) {
 	}
 }
 
+// TestPartialShieldTargeted verifies the #1129 partial_shield writer case emits
+// the partial_shield_seconds flag as a per-serial targeted STRING state flag with
+// the neutral "none" fall-through, preserving the "<seconds>:<boost>" value.
+func TestPartialShieldTargeted(t *testing.T) {
+	w, path := newTestWriter(t)
+	if err := w.Apply(context.Background(), decision.Decision{Intervention: decision.InterventionPartialShield, TargetSerial: "AA", Value: "8:1.8"}); err != nil {
+		t.Fatalf("apply AA: %v", err)
+	}
+	if err := w.Apply(context.Background(), decision.Decision{Intervention: decision.InterventionPartialShield, TargetSerial: "BB", Value: "5"}); err != nil {
+		t.Fatalf("apply BB: %v", err)
+	}
+
+	assertTargetingResolves(t, path, flagPartialShieldSeconds, "AA", "agent_AA")
+	assertTargetingResolves(t, path, flagPartialShieldSeconds, "BB", "agent_BB")
+	assertTargetingResolves(t, path, flagPartialShieldSeconds, "ZZ", neutralNone)
+
+	variants := readFlag(t, path, flagPartialShieldSeconds)["variants"].(map[string]any)
+	if variants["agent_AA"].(string) != "8:1.8" {
+		t.Fatalf("agent_AA value = %v, want 8:1.8", variants["agent_AA"])
+	}
+	// Bare "<seconds>" form is preserved verbatim (boost defaults game-side).
+	if variants["agent_BB"].(string) != "5" {
+		t.Fatalf("agent_BB value = %v, want 5", variants["agent_BB"])
+	}
+	assertStructurallyValid(t, path)
+}
+
+// TestPartialShieldDefaultValue verifies an empty Value falls back to the writer's
+// safe default directive.
+func TestPartialShieldDefaultValue(t *testing.T) {
+	w, path := newTestWriter(t)
+	if err := w.Apply(context.Background(), decision.Decision{Intervention: decision.InterventionPartialShield, TargetSerial: "AA"}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if v := readFlag(t, path, flagPartialShieldSeconds)["variants"].(map[string]any)["agent_AA"].(string); v != defaultPartialShield {
+		t.Fatalf("default partial_shield value = %v, want %v", v, defaultPartialShield)
+	}
+}
+
+// TestPartialShieldMalformedFallsBackSafe verifies malformed directives degrade to
+// the safe default (never a garbage flag value): non-numeric, out-of-band boost,
+// non-positive seconds, and too-many fields all fall back.
+func TestPartialShieldMalformedFallsBackSafe(t *testing.T) {
+	for _, bad := range []string{"abc", "0", "-3", "5:9", "5:0.2", "5:2:1", "5:abc"} {
+		w, path := newTestWriter(t)
+		if err := w.Apply(context.Background(), decision.Decision{Intervention: decision.InterventionPartialShield, TargetSerial: "AA", Value: bad}); err != nil {
+			t.Fatalf("apply %q: %v", bad, err)
+		}
+		v := readFlag(t, path, flagPartialShieldSeconds)["variants"].(map[string]any)["agent_AA"].(string)
+		if v != defaultPartialShield {
+			t.Fatalf("malformed %q wrote %q, want safe default %q", bad, v, defaultPartialShield)
+		}
+		assertStructurallyValid(t, path)
+	}
+}
+
 func TestTargetedRequiresSerial(t *testing.T) {
 	w, _ := newTestWriter(t)
 	err := w.Apply(context.Background(), decision.Decision{Intervention: decision.InterventionAdjustPlayerSensitivity})

--- a/services/agent/decision/ratelimit.go
+++ b/services/agent/decision/ratelimit.go
@@ -52,8 +52,15 @@ const (
 	// "rein in"). SHADOW-game-only initially: allow-listed only via the
 	// `shadow_experimental` interventions_allowed variant (services/flagd/agent.json),
 	// never the real-facing ambient/standard/full variants.
-	InterventionSetPlayerHandicap       = "set_player_handicap"
-	InterventionGrantShield             = "grant_shield"
+	InterventionSetPlayerHandicap = "set_player_handicap"
+	InterventionGrantShield       = "grant_shield"
+	// InterventionPartialShield (#1129, #1103 Phase 2) is a per-player TIME-BOXED
+	// handicap boost ("<seconds>" or "<seconds>:<boost>") — much harder to die for
+	// N seconds but NOT immune (vs grant_shield's total grace_until immunity). It
+	// reuses the #1107 handicap mechanism. SHADOW-game-only initially: allow-listed
+	// only via the `shadow_experimental` interventions_allowed variant
+	// (services/flagd/agent.json), never the real-facing ambient/standard/full.
+	InterventionPartialShield           = "partial_shield"
 	InterventionAdjustGlobalSensitivity = "adjust_global_sensitivity"
 	InterventionAdjustGlobalDifficulty  = "adjust_global_difficulty"
 	InterventionSetPacingProfile        = "set_pacing_profile"
@@ -96,6 +103,7 @@ var interventionWeights = map[string]float64{
 	InterventionAdjustPlayerSensitivity: 1,
 	InterventionSetPlayerHandicap:       1, // #1107 (#1103 MVP action 1)
 	InterventionGrantShield:             1,
+	InterventionPartialShield:           1, // #1129 (#1103 Phase 2) — MEDIUM
 	InterventionAdjustGlobalDifficulty:  1, // #766 F6
 	InterventionSetPacingProfile:        1, // #766 F6
 	InterventionRampTempo:               1, // #1117 (#1103 MVP action 2)

--- a/services/agent/decision/shadow_gate_test.go
+++ b/services/agent/decision/shadow_gate_test.go
@@ -138,3 +138,39 @@ func TestRampTempoIsShadowOnly(t *testing.T) {
 		})
 	}
 }
+
+// TestPartialShieldIsShadowOnly is the load-bearing gating proof for #1129 (#1103
+// Phase 2): partial_shield MUST appear ONLY in the shadow_experimental variant of
+// interventions_allowed and MUST be absent from every real-facing variant
+// (ambient/standard/full). The allow-list is the enforcement gate, so absence from
+// the real variants means partial_shield is rejected for real games by
+// construction. Asserted on BOTH the production and CI flagd agent configs.
+func TestPartialShieldIsShadowOnly(t *testing.T) {
+	paths := []string{
+		filepath.Join("..", "..", "flagd", "agent.json"),
+		filepath.Join("..", "..", "flagd", "ci", "agent.json"),
+	}
+	for _, path := range paths {
+		t.Run(path, func(t *testing.T) {
+			variants := readInterventionsAllowed(t, path)
+
+			shadow, ok := variants["shadow_experimental"]
+			if !ok {
+				t.Fatalf("%s: missing shadow_experimental variant", path)
+			}
+			if !contains(shadow, InterventionPartialShield) {
+				t.Fatalf("%s: shadow_experimental must include %q", path, InterventionPartialShield)
+			}
+
+			for _, realVariant := range []string{"ambient", "standard", "full"} {
+				list, ok := variants[realVariant]
+				if !ok {
+					t.Fatalf("%s: missing expected real variant %q", path, realVariant)
+				}
+				if contains(list, InterventionPartialShield) {
+					t.Fatalf("%s: real variant %q must NOT include %q (shadow-only)", path, realVariant, InterventionPartialShield)
+				}
+			}
+		})
+	}
+}

--- a/services/agent/llm/prompt.go
+++ b/services/agent/llm/prompt.go
@@ -272,6 +272,9 @@ const genericModeFragment = `GAME MODE — not specified this cycle: reason only
 //     die; slower tempo = lower bar = easier to die.
 //   - grant_shield extends grace_until by shield_seconds (3/5/10s variants);
 //     while shielded the per-frame death check is skipped entirely.
+//   - partial_shield (#1129) instead raises the player's death threshold by up to
+//     ~2x via a time-boxed handicap for N seconds — much harder to die but NOT
+//     immune (clamped, finite threshold), the softer sibling of grant_shield.
 //   - eliminate_player is immediate + permanent (FFA); end_game ends the round;
 //     win = last player alive.
 //
@@ -298,6 +301,10 @@ Higher sensitivity level = higher bar = HARDER to die; slower tempo = lower bar
   - grant_shield: extends a player's grace window by ~3s (short) / 5s (default) /
     10s (long); during it they CANNOT be eliminated, then the EMA re-primes. Use
     to save a player about to be unfairly eliminated.
+  - partial_shield ("<seconds>" or "<seconds>:<boost>", boost 1.0-2.0 default
+    2.0): makes a player MUCH harder to eliminate (raises their death threshold by
+    up to ~2x via a time-boxed handicap) for N seconds, but NOT immune — a huge
+    spike can still kill them. A softer, less binary alternative to grant_shield.
   - eliminate_player: immediate and PERMANENT removal. end_game: ends the round
     now. Both are maximal, irreversible actions — last player alive wins.`
 

--- a/services/agent/llm/testdata/aggressive_3players.golden
+++ b/services/agent/llm/testdata/aggressive_3players.golden
@@ -65,6 +65,10 @@ Higher sensitivity level = higher bar = HARDER to die; slower tempo = lower bar
   - grant_shield: extends a player's grace window by ~3s (short) / 5s (default) /
     10s (long); during it they CANNOT be eliminated, then the EMA re-primes. Use
     to save a player about to be unfairly eliminated.
+  - partial_shield ("<seconds>" or "<seconds>:<boost>", boost 1.0-2.0 default
+    2.0): makes a player MUCH harder to eliminate (raises their death threshold by
+    up to ~2x via a time-boxed handicap) for N seconds, but NOT immune — a huge
+    spike can still kill them. A softer, less binary alternative to grant_shield.
   - eliminate_player: immediate and PERMANENT removal. end_game: ends the round
     now. Both are maximal, irreversible actions — last player alive wins.
 

--- a/services/agent/llm/testdata/balanced_3players.golden
+++ b/services/agent/llm/testdata/balanced_3players.golden
@@ -65,6 +65,10 @@ Higher sensitivity level = higher bar = HARDER to die; slower tempo = lower bar
   - grant_shield: extends a player's grace window by ~3s (short) / 5s (default) /
     10s (long); during it they CANNOT be eliminated, then the EMA re-primes. Use
     to save a player about to be unfairly eliminated.
+  - partial_shield ("<seconds>" or "<seconds>:<boost>", boost 1.0-2.0 default
+    2.0): makes a player MUCH harder to eliminate (raises their death threshold by
+    up to ~2x via a time-boxed handicap) for N seconds, but NOT immune — a huge
+    spike can still kill them. A softer, less binary alternative to grant_shield.
   - eliminate_player: immediate and PERMANENT removal. end_game: ends the round
     now. Both are maximal, irreversible actions — last player alive wins.
 

--- a/services/agent/llm/testdata/conservative_3players.golden
+++ b/services/agent/llm/testdata/conservative_3players.golden
@@ -65,6 +65,10 @@ Higher sensitivity level = higher bar = HARDER to die; slower tempo = lower bar
   - grant_shield: extends a player's grace window by ~3s (short) / 5s (default) /
     10s (long); during it they CANNOT be eliminated, then the EMA re-primes. Use
     to save a player about to be unfairly eliminated.
+  - partial_shield ("<seconds>" or "<seconds>:<boost>", boost 1.0-2.0 default
+    2.0): makes a player MUCH harder to eliminate (raises their death threshold by
+    up to ~2x via a time-boxed handicap) for N seconds, but NOT immune — a huge
+    spike can still kill them. A softer, less binary alternative to grant_shield.
   - eliminate_player: immediate and PERMANENT removal. end_game: ends the round
     now. Both are maximal, irreversible actions — last player alive wins.
 

--- a/services/agent/llm/testdata/empty_players.golden
+++ b/services/agent/llm/testdata/empty_players.golden
@@ -65,6 +65,10 @@ Higher sensitivity level = higher bar = HARDER to die; slower tempo = lower bar
   - grant_shield: extends a player's grace window by ~3s (short) / 5s (default) /
     10s (long); during it they CANNOT be eliminated, then the EMA re-primes. Use
     to save a player about to be unfairly eliminated.
+  - partial_shield ("<seconds>" or "<seconds>:<boost>", boost 1.0-2.0 default
+    2.0): makes a player MUCH harder to eliminate (raises their death threshold by
+    up to ~2x via a time-boxed handicap) for N seconds, but NOT immune — a huge
+    spike can still kill them. A softer, less binary alternative to grant_shield.
   - eliminate_player: immediate and PERMANENT removal. end_game: ends the round
     now. Both are maximal, irreversible actions — last player alive wins.
 

--- a/services/agent/llm/testdata/movement_3players.golden
+++ b/services/agent/llm/testdata/movement_3players.golden
@@ -65,6 +65,10 @@ Higher sensitivity level = higher bar = HARDER to die; slower tempo = lower bar
   - grant_shield: extends a player's grace window by ~3s (short) / 5s (default) /
     10s (long); during it they CANNOT be eliminated, then the EMA re-primes. Use
     to save a player about to be unfairly eliminated.
+  - partial_shield ("<seconds>" or "<seconds>:<boost>", boost 1.0-2.0 default
+    2.0): makes a player MUCH harder to eliminate (raises their death threshold by
+    up to ~2x via a time-boxed handicap) for N seconds, but NOT immune — a huge
+    spike can still kill them. A softer, less binary alternative to grant_shield.
   - eliminate_player: immediate and PERMANENT removal. end_game: ends the round
     now. Both are maximal, irreversible actions — last player alive wins.
 

--- a/services/agent/llm/testdata/timeline_3players.golden
+++ b/services/agent/llm/testdata/timeline_3players.golden
@@ -65,6 +65,10 @@ Higher sensitivity level = higher bar = HARDER to die; slower tempo = lower bar
   - grant_shield: extends a player's grace window by ~3s (short) / 5s (default) /
     10s (long); during it they CANNOT be eliminated, then the EMA re-primes. Use
     to save a player about to be unfairly eliminated.
+  - partial_shield ("<seconds>" or "<seconds>:<boost>", boost 1.0-2.0 default
+    2.0): makes a player MUCH harder to eliminate (raises their death threshold by
+    up to ~2x via a time-boxed handicap) for N seconds, but NOT immune — a huge
+    spike can still kill them. A softer, less binary alternative to grant_shield.
   - eliminate_player: immediate and PERMANENT removal. end_game: ends the round
     now. Both are maximal, irreversible actions — last player alive wins.
 

--- a/services/flagd/agent.json
+++ b/services/flagd/agent.json
@@ -82,7 +82,7 @@
         "ambient": "play_audio_cue,send_controller_effect,adjust_volume",
         "standard": "play_audio_cue,send_controller_effect,adjust_volume,adjust_music_tempo,set_pacing_profile,adjust_player_sensitivity,grant_shield",
         "full": "play_audio_cue,send_controller_effect,adjust_volume,adjust_music_tempo,set_pacing_profile,adjust_player_sensitivity,grant_shield,adjust_global_sensitivity,adjust_global_difficulty,eliminate_player,revive_player,end_game",
-        "shadow_experimental": "play_audio_cue,send_controller_effect,adjust_volume,adjust_music_tempo,set_pacing_profile,adjust_player_sensitivity,grant_shield,adjust_global_sensitivity,adjust_global_difficulty,eliminate_player,revive_player,end_game,set_player_handicap,ramp_tempo"
+        "shadow_experimental": "play_audio_cue,send_controller_effect,adjust_volume,adjust_music_tempo,set_pacing_profile,adjust_player_sensitivity,grant_shield,adjust_global_sensitivity,adjust_global_difficulty,eliminate_player,revive_player,end_game,set_player_handicap,ramp_tempo,partial_shield"
       },
       "defaultVariant": "ambient"
     },

--- a/services/flagd/ci/agent.json
+++ b/services/flagd/ci/agent.json
@@ -82,7 +82,7 @@
         "ambient": "play_audio_cue,send_controller_effect,adjust_volume",
         "standard": "play_audio_cue,send_controller_effect,adjust_volume,adjust_music_tempo,set_pacing_profile,adjust_player_sensitivity,grant_shield",
         "full": "play_audio_cue,send_controller_effect,adjust_volume,adjust_music_tempo,set_pacing_profile,adjust_player_sensitivity,grant_shield,adjust_global_sensitivity,adjust_global_difficulty,eliminate_player,revive_player,end_game",
-        "shadow_experimental": "play_audio_cue,send_controller_effect,adjust_volume,adjust_music_tempo,set_pacing_profile,adjust_player_sensitivity,grant_shield,adjust_global_sensitivity,adjust_global_difficulty,eliminate_player,revive_player,end_game,set_player_handicap,ramp_tempo"
+        "shadow_experimental": "play_audio_cue,send_controller_effect,adjust_volume,adjust_music_tempo,set_pacing_profile,adjust_player_sensitivity,grant_shield,adjust_global_sensitivity,adjust_global_difficulty,eliminate_player,revive_player,end_game,set_player_handicap,ramp_tempo,partial_shield"
       },
       "defaultVariant": "ambient"
     },

--- a/services/flagd/ci/interventions.json
+++ b/services/flagd/ci/interventions.json
@@ -57,6 +57,17 @@
       "defaultVariant": "none",
       "targeting": {}
     },
+    "partial_shield_seconds": {
+      "state": "ENABLED",
+      "variants": {
+        "none": "0",
+        "short": "3:2.0",
+        "default": "5:2.0",
+        "long": "10:2.0"
+      },
+      "defaultVariant": "none",
+      "targeting": {}
+    },
     "volume_override": {
       "state": "ENABLED",
       "variants": {

--- a/services/flagd/interventions.json
+++ b/services/flagd/interventions.json
@@ -57,6 +57,17 @@
       "defaultVariant": "none",
       "targeting": {}
     },
+    "partial_shield_seconds": {
+      "state": "ENABLED",
+      "variants": {
+        "none": "0",
+        "short": "3:2.0",
+        "default": "5:2.0",
+        "long": "10:2.0"
+      },
+      "defaultVariant": "none",
+      "targeting": {}
+    },
     "volume_override": {
       "state": "ENABLED",
       "variants": {

--- a/services/game_coordinator/games/base.py
+++ b/services/game_coordinator/games/base.py
@@ -539,6 +539,18 @@ class Player:
     # _compute_effective_thresholds. 1.0 = neutral (no effect). Shadow-game-only
     # initially via the interventions_allowed allow-list gate.
     handicap_factor: float = 1.0
+    # Time-boxed partial shield (#1129, #1103 Phase 2). When ``partial_shield_until``
+    # is in the future, ``partial_shield_boost`` acts as a TEMPORARY handicap
+    # override that COMPOSES with ``handicap_factor`` by taking the MAX of the two
+    # (so a standing set_player_handicap is never weakened, only strengthened for
+    # the window) — see ``_compute_effective_thresholds``. A large boost (~2.0)
+    # makes the player MUCH harder to eliminate but NOT immune (vs grant_shield's
+    # total grace_until immunity): the combined factor is still clamped [0.5, 2.0].
+    # On expiry the boost simply stops applying (no reset task needed) and the
+    # effective handicap falls back to the standing ``handicap_factor``. 0.0 / past
+    # deadline = inactive (no effect). Shadow-game-only via the allow-list gate.
+    partial_shield_until: float = 0.0
+    partial_shield_boost: float = 1.0
     # Per-player countdown span (created before countdown, ended after)
     _countdown_span: trace.Span | None = None
     # Health tracking (#571: controller health on player_lifecycle spans)
@@ -1533,7 +1545,18 @@ class BaseGameMode(ABC):
         # >1.0 raises the threshold (harder to die / "help"); <1.0 lowers it
         # (easier / "rein in"). At the neutral 1.0 this is a no-op, preserving the
         # prior behavior exactly.
-        handicap = max(0.5, min(2.0, player.handicap_factor))
+        # A time-boxed partial shield (#1129) takes the MAX with the standing
+        # handicap (it can only ever STRENGTHEN protection for its window, never
+        # weaken a standing set_player_handicap delta). Precedence: while the
+        # deadline is in the future the effective handicap is
+        # max(handicap_factor, partial_shield_boost); once it expires the boost
+        # silently drops out and the standing handicap_factor resumes. Still
+        # clamped [0.5, 2.0] below, so even a ~2.0 boost is "much harder to die",
+        # never truly immune (the deliberate distinction from grant_shield).
+        effective_handicap = player.handicap_factor
+        if time.time() < player.partial_shield_until:
+            effective_handicap = max(effective_handicap, player.partial_shield_boost)
+        handicap = max(0.5, min(2.0, effective_handicap))
         return warn * handicap, death * handicap
 
     def _record_player_analytics(
@@ -1935,6 +1958,93 @@ class BaseGameMode(ABC):
             player.span.add_event("shield_granted", attributes={"shield_seconds": seconds})
 
         # Visible pulse effect so the shield is observable on the controller.
+        if self.gameplay_stream:
+            from proto import controller_manager_pb2
+
+            trace_parent, trace_state = inject_trace_context(player.span)
+            effect_cmd = controller_manager_pb2.GameplayStreamControl(
+                game_effect=controller_manager_pb2.GameEffectCommand(
+                    serial=serial,
+                    effect=controller_manager_pb2.GAME_EFFECT_PULSE,
+                    trace_parent=trace_parent,
+                    trace_state=trace_state,
+                )
+            )
+            await self.gameplay_stream.write(effect_cmd)
+
+        return True
+
+    # Partial-shield defaults (#1129, #1103 Phase 2). Boost is clamped to the same
+    # upper bound as handicap_factor so a partial shield is "much harder to die"
+    # but never immune; seconds are capped so a single arming can't last forever.
+    PARTIAL_SHIELD_DEFAULT_BOOST = 2.0
+    PARTIAL_SHIELD_BOOST_MIN = 1.0
+    PARTIAL_SHIELD_BOOST_MAX = 2.0
+    PARTIAL_SHIELD_MAX_SECONDS = 30.0
+
+    async def grant_partial_shield(self, serial: str, seconds: float, boost: float | None = None) -> bool:
+        """
+        Grant a time-boxed PARTIAL shield to a player (#1129, #1103 Phase 2).
+
+        Unlike :meth:`grant_shield` (total immunity via ``grace_until`` that skips
+        the death check entirely), a partial shield only raises the player's
+        effective death/warning threshold for ``seconds`` by applying a temporary
+        ``handicap`` boost — making them MUCH harder to eliminate but NOT immune: a
+        genuinely huge spike can still exceed the (still-finite) boosted threshold.
+        It reuses the #1107 per-player handicap mechanism: while the deadline is in
+        the future, ``_compute_effective_thresholds`` takes ``max(handicap_factor,
+        partial_shield_boost)`` (so it never weakens a standing set_player_handicap
+        delta, only strengthens it for the window), still clamped [0.5, 2.0].
+
+        Time-box semantics mirror ``grant_shield``: extend-not-shorten on the
+        deadline. A new arming only ever lengthens an active window (and never
+        lowers an active boost); a shorter/weaker request is a no-op extension. On
+        expiry the boost silently drops out — no reset task needed — and the
+        standing ``handicap_factor`` resumes.
+
+        Args:
+            serial: Controller serial number.
+            seconds: Shield duration in seconds. Non-positive is a no-op (False);
+                capped at ``PARTIAL_SHIELD_MAX_SECONDS``.
+            boost: Handicap boost while active; clamped
+                [``PARTIAL_SHIELD_BOOST_MIN``, ``PARTIAL_SHIELD_BOOST_MAX``].
+                Defaults to ``PARTIAL_SHIELD_DEFAULT_BOOST`` (~2.0).
+
+        Returns:
+            True if a partial shield was armed/extended, False if the player is
+            unknown/dead or the duration was non-positive.
+        """
+        if seconds <= 0:
+            return False
+
+        player = self.players.get(serial)
+        if not player or not player.alive:
+            return False
+
+        seconds = min(seconds, self.PARTIAL_SHIELD_MAX_SECONDS)
+        if boost is None:
+            boost = self.PARTIAL_SHIELD_DEFAULT_BOOST
+        boost = max(self.PARTIAL_SHIELD_BOOST_MIN, min(self.PARTIAL_SHIELD_BOOST_MAX, boost))
+
+        new_until = time.time() + seconds
+        # Extend-not-shorten / strengthen-not-weaken: keep whichever active window
+        # is longer and whichever active boost is higher, so repeated arming never
+        # reduces in-flight protection.
+        if time.time() < player.partial_shield_until:
+            new_until = max(new_until, player.partial_shield_until)
+            boost = max(boost, player.partial_shield_boost)
+        player.partial_shield_until = new_until
+        player.partial_shield_boost = boost
+        logger.info(f"Partial shield armed for {serial}: boost={boost:.2f} for {seconds:.1f}s (until={new_until:.2f})")
+
+        if player.span:
+            player.span.add_event(
+                "partial_shield_armed",
+                attributes={"partial_shield_seconds": seconds, "partial_shield_boost": boost},
+            )
+
+        # Visible pulse effect so the partial shield is observable (same mechanism
+        # as grant_shield's pulse).
         if self.gameplay_stream:
             from proto import controller_manager_pb2
 

--- a/services/game_coordinator/interventions.py
+++ b/services/game_coordinator/interventions.py
@@ -208,6 +208,22 @@ INTERVENTION_SPECS: tuple[InterventionSpec, ...] = (
         none_value=0,
     ),
     InterventionSpec(
+        flag_key="partial_shield_seconds",
+        type_id="partial_shield",
+        weight=WEIGHT_MEDIUM,
+        edge_triggered=False,
+        player_targeted=True,
+        # STRING value "<seconds>" or "<seconds>:<boost>" (#1129, #1103 Phase 2):
+        # a TIME-BOXED handicap boost (much harder to die, but NOT immune — vs
+        # grant_shield's total grace_until immunity). The handler parses both
+        # forms; malformed values are a safe no-op. "0" (and "none"/empty) means
+        # no partial shield. SHADOW-game-only initially: allow-listed ONLY via the
+        # `shadow_experimental` interventions_allowed variant (the load-bearing
+        # gate), never the real-facing ambient/standard/full variants.
+        value_kind="string",
+        none_value="0",
+    ),
+    InterventionSpec(
         flag_key="volume_override",
         type_id="adjust_volume",
         weight=WEIGHT_SOFT,
@@ -1241,13 +1257,13 @@ class InterventionManager:
     def resolve_player_targets(
         self,
         flag_key: str,
-        default: float,
+        default,
         game: object,
         *,
         value_kind: str = "float",
         battery_gate: bool = True,
         game_id: str = "",
-    ) -> dict[str, float]:
+    ) -> dict:
         """Evaluate a per-player targeted flag for every active player serial.
 
         For each active serial in ``game.players`` the flag is evaluated with an
@@ -1269,7 +1285,9 @@ class InterventionManager:
             default: Neutral value returned for serials with no targeting match
                 (e.g. 1.0 for sensitivity factor, 0 for shield seconds).
             game: Live game whose ``players`` dict supplies the active serials.
-            value_kind: ``"float"`` or ``"int"`` (flag value type).
+            value_kind: ``"float"``, ``"int"`` or ``"string"`` (flag value type).
+                ``"string"`` (#1129 partial_shield) returns raw per-serial strings
+                for the handler to parse; float/int return coerced numbers.
             battery_gate: If True, drop serials below the battery threshold.
             game_id: Owning session's game id, added as ``gameId`` to the context
                 (#838). Empty string adds no ``gameId`` (legacy primary path).
@@ -1278,7 +1296,7 @@ class InterventionManager:
             ``{serial: value}`` for every active serial that should be acted on.
             Battery-gated serials are omitted entirely.
         """
-        result: dict[str, float] = {}
+        result: dict = {}
         client = self._interventions_client
         serials = _active_player_serials(game)
         threshold = self._battery_threshold() if battery_gate else None
@@ -1290,12 +1308,15 @@ class InterventionManager:
                     continue  # battery guard: skip low-battery controllers
 
             if client is None:
-                value: float = default
+                value = default
             else:
                 ctx = self._session_context(game_id, targeting_key=serial)
                 try:
                     if value_kind == "int":
                         value = float(client.get_integer_value(flag_key, int(default), ctx))
+                    elif value_kind == "string":
+                        # Raw string returned for the handler to parse (#1129).
+                        value = str(client.get_string_value(flag_key, str(default), ctx))
                     else:
                         value = float(client.get_float_value(flag_key, float(default), ctx))
                 except Exception as e:  # one bad serial must not drop the rest

--- a/services/game_coordinator/lifecycle_handlers.py
+++ b/services/game_coordinator/lifecycle_handlers.py
@@ -44,6 +44,82 @@ ELIMINATE_ACCEL = 0.0
 # Neutral shield value (no shield). Matches shield_seconds none variant.
 SHIELD_NONE = 0.0
 
+# Partial-shield (#1129, #1103 Phase 2) value parsing. Value is a STRING
+# "<seconds>" or "<seconds>:<boost>"; bounds mirror BaseGameMode's clamps so a
+# malformed value degrades to a safe no-op rather than dispatching garbage.
+PARTIAL_SHIELD_NONE_VALUES = frozenset({"", "0", "0.0", "none", "off"})
+PARTIAL_SHIELD_DEFAULT_BOOST = 2.0
+PARTIAL_SHIELD_BOOST_MIN = 1.0
+PARTIAL_SHIELD_BOOST_MAX = 2.0
+PARTIAL_SHIELD_MAX_SECONDS = 30.0
+
+
+def parse_partial_shield_value(value: object) -> tuple[float, float] | None:
+    """Parse a partial_shield value into ``(seconds, boost)`` or ``None``.
+
+    Accepts ``"<seconds>"`` or ``"<seconds>:<boost>"``. Returns ``None`` for the
+    neutral / empty / malformed forms (caller treats ``None`` as a safe no-op):
+    non-numeric fields, seconds <= 0, or boost outside a sane band. Bounds are
+    clamped (seconds capped at ``PARTIAL_SHIELD_MAX_SECONDS``, boost to
+    [``PARTIAL_SHIELD_BOOST_MIN``, ``PARTIAL_SHIELD_BOOST_MAX``]) so the resolved
+    pair is always safe to pass to ``grant_partial_shield``.
+    """
+    text = str(value).strip().lower()
+    if text in PARTIAL_SHIELD_NONE_VALUES:
+        return None
+    parts = text.split(":")
+    if len(parts) > 2:
+        return None
+    try:
+        seconds = float(parts[0])
+        boost = float(parts[1]) if len(parts) == 2 else PARTIAL_SHIELD_DEFAULT_BOOST
+    except ValueError:
+        return None
+    if seconds <= 0:
+        return None
+    seconds = min(seconds, PARTIAL_SHIELD_MAX_SECONDS)
+    boost = max(PARTIAL_SHIELD_BOOST_MIN, min(PARTIAL_SHIELD_BOOST_MAX, boost))
+    return seconds, boost
+
+
+async def handle_partial_shield(ctx: InterventionContext, manager: InterventionManager) -> None:
+    """Arm per-player TIME-BOXED partial shields via per-serial targeting (#1129).
+
+    Mirrors :func:`handle_shield_seconds`: resolves the STRING flag once per active
+    serial via the manager's reusable ``resolve_player_targets`` helper, parses
+    each value with :func:`parse_partial_shield_value` (malformed / neutral -> safe
+    skip), and arms a time-boxed handicap boost via ``game.grant_partial_shield``.
+    Unlike ``grant_shield`` (total grace_until immunity), this only raises the
+    player's death threshold for the window — much harder to die, NOT immune.
+    Reverting to none requires no action: the boost simply stops applying when its
+    deadline passes (``_compute_effective_thresholds`` reads it live each frame).
+    """
+    game = ctx.game
+    if game is None:
+        logger.debug("partial_shield: no live game, ignoring")
+        return
+
+    values = manager.resolve_player_targets(
+        flag_key=ctx.spec.flag_key,
+        default="0",
+        game=game,
+        value_kind="string",
+        battery_gate=True,
+        game_id=ctx.game_id,
+    )
+
+    grant = getattr(game, "grant_partial_shield", None)
+    if not callable(grant):
+        logger.debug("partial_shield: game has no grant_partial_shield, ignoring")
+        return
+
+    for serial, raw in values.items():
+        parsed = parse_partial_shield_value(raw)
+        if parsed is None:
+            continue  # neutral / malformed: safe no-op for this serial
+        seconds, boost = parsed
+        await grant(serial, seconds, boost)
+
 
 async def handle_shield_seconds(ctx: InterventionContext, manager: InterventionManager) -> None:
     """Grant per-player shields via per-serial targeting resolution (N3).
@@ -151,6 +227,11 @@ def register_lifecycle_handlers(manager: InterventionManager) -> None:
     manager.register_handler(
         "shield_seconds",
         lambda ctx: handle_shield_seconds(ctx, manager),
+    )
+    # partial_shield (#1129) also needs the manager for the targeting helper.
+    manager.register_handler(
+        "partial_shield_seconds",
+        lambda ctx: handle_partial_shield(ctx, manager),
     )
     manager.register_handler("eliminate_player", handle_eliminate_player)
     manager.register_handler("revive_player", handle_revive_player)

--- a/services/game_coordinator/tests/test_base_helpers.py
+++ b/services/game_coordinator/tests/test_base_helpers.py
@@ -341,6 +341,146 @@ class TestComputeEffectiveThresholds:
         assert warn_c == pytest.approx(warn_n)
         assert death_c == pytest.approx(death_n)
 
+    # --- #1129: time-boxed partial_shield boost in the threshold path ---- #
+
+    def test_partial_shield_active_boosts_threshold(self, game):
+        """An active partial shield raises the threshold via its boost."""
+        from lib.types import Sensitivity
+
+        game.sensitivity = Sensitivity.MEDIUM
+        game.music_speed = SLOW_MUSIC_SPEED
+        neutral = Player(serial="t", sensitivity_factor=1.0, handicap_factor=1.0)
+        shielded = Player(
+            serial="t",
+            sensitivity_factor=1.0,
+            handicap_factor=1.0,
+            partial_shield_until=time.time() + 5.0,
+            partial_shield_boost=2.0,
+        )
+        _, death_n = game._compute_effective_thresholds(neutral)
+        _, death_s = game._compute_effective_thresholds(shielded)
+        assert death_s == pytest.approx(death_n * 2.0)
+
+    def test_partial_shield_expired_is_noop(self, game):
+        """A partial shield whose deadline has passed leaves thresholds at the
+        standing handicap (no reset task needed — it simply stops applying)."""
+        from lib.types import Sensitivity
+
+        game.sensitivity = Sensitivity.MEDIUM
+        game.music_speed = SLOW_MUSIC_SPEED
+        plain = Player(serial="t", sensitivity_factor=1.0, handicap_factor=1.0)
+        expired = Player(
+            serial="t",
+            sensitivity_factor=1.0,
+            handicap_factor=1.0,
+            partial_shield_until=time.time() - 1.0,  # already past
+            partial_shield_boost=2.0,
+        )
+        assert game._compute_effective_thresholds(expired) == pytest.approx(game._compute_effective_thresholds(plain))
+
+    def test_partial_shield_takes_max_with_standing_handicap(self, game):
+        """While active, the effective handicap is max(handicap_factor, boost):
+        a partial shield never WEAKENS a standing set_player_handicap delta."""
+        from lib.types import Sensitivity
+
+        game.sensitivity = Sensitivity.MEDIUM
+        game.music_speed = SLOW_MUSIC_SPEED
+        # Standing handicap 1.8 (help), weaker shield boost 1.2 -> max keeps 1.8.
+        p = Player(
+            serial="t",
+            sensitivity_factor=1.0,
+            handicap_factor=1.8,
+            partial_shield_until=time.time() + 5.0,
+            partial_shield_boost=1.2,
+        )
+        ref = Player(serial="t", sensitivity_factor=1.0, handicap_factor=1.8)
+        assert game._compute_effective_thresholds(p) == pytest.approx(game._compute_effective_thresholds(ref))
+
+    def test_partial_shield_clamped_not_immune(self, game):
+        """Even a maxed boost is clamped to 2.0 — never immune (the point vs
+        grant_shield): the boosted death threshold stays finite."""
+        from lib.types import Sensitivity
+
+        game.sensitivity = Sensitivity.MEDIUM
+        game.music_speed = SLOW_MUSIC_SPEED
+        p = Player(
+            serial="t",
+            sensitivity_factor=1.0,
+            handicap_factor=1.0,
+            partial_shield_until=time.time() + 5.0,
+            partial_shield_boost=2.0,
+        )
+        _, death = game._compute_effective_thresholds(p)
+        assert death > 0 and death != float("inf")
+
+
+# ========================================================================
+# grant_partial_shield primitive (#1129)
+# ========================================================================
+
+
+class TestGrantPartialShield:
+    """Tests for the BaseGameMode.grant_partial_shield time-boxed primitive."""
+
+    @pytest.fixture
+    def game(self):
+        mock_cm = MockControllerManagerService(num_controllers=2)
+        game = FFAGame(
+            controller_manager_client=mock_cm,
+            event_publisher=async_noop,
+            audio_client=None,
+            game_id="test_partial_shield",
+        )
+        game.players["AA"] = Player(serial="AA", alive=True)
+        return game
+
+    @pytest.mark.asyncio
+    async def test_arms_boost_and_deadline(self, game):
+        ok = await game.grant_partial_shield("AA", 5.0, 1.8)
+        assert ok is True
+        p = game.players["AA"]
+        assert p.partial_shield_boost == pytest.approx(1.8)
+        assert p.partial_shield_until > time.time()
+
+    @pytest.mark.asyncio
+    async def test_default_boost_when_omitted(self, game):
+        await game.grant_partial_shield("AA", 5.0)
+        assert game.players["AA"].partial_shield_boost == pytest.approx(game.PARTIAL_SHIELD_DEFAULT_BOOST)
+
+    @pytest.mark.asyncio
+    async def test_boost_clamped_to_band(self, game):
+        await game.grant_partial_shield("AA", 5.0, 9.0)
+        assert game.players["AA"].partial_shield_boost == pytest.approx(game.PARTIAL_SHIELD_BOOST_MAX)
+        await game.grant_partial_shield("AA", 5.0, 0.1)
+        # extend-not-shorten / strengthen-not-weaken keeps the higher (max) boost.
+        assert game.players["AA"].partial_shield_boost == pytest.approx(game.PARTIAL_SHIELD_BOOST_MAX)
+
+    @pytest.mark.asyncio
+    async def test_seconds_capped(self, game):
+        await game.grant_partial_shield("AA", 9999.0)
+        assert game.players["AA"].partial_shield_until <= time.time() + game.PARTIAL_SHIELD_MAX_SECONDS + 1.0
+
+    @pytest.mark.asyncio
+    async def test_nonpositive_seconds_noop(self, game):
+        assert await game.grant_partial_shield("AA", 0.0) is False
+        assert await game.grant_partial_shield("AA", -3.0) is False
+        assert game.players["AA"].partial_shield_until == 0.0
+
+    @pytest.mark.asyncio
+    async def test_unknown_or_dead_player_noop(self, game):
+        assert await game.grant_partial_shield("ZZ", 5.0) is False
+        game.players["AA"].alive = False
+        assert await game.grant_partial_shield("AA", 5.0) is False
+
+    @pytest.mark.asyncio
+    async def test_extend_not_shorten(self, game):
+        await game.grant_partial_shield("AA", 30.0, 2.0)
+        far = game.players["AA"].partial_shield_until
+        # A shorter, weaker re-arming must not reduce the active window/boost.
+        await game.grant_partial_shield("AA", 1.0, 1.1)
+        assert game.players["AA"].partial_shield_until == pytest.approx(far)
+        assert game.players["AA"].partial_shield_boost == pytest.approx(2.0)
+
 
 # ========================================================================
 # _process_controller_state (player name capture)

--- a/services/game_coordinator/tests/test_lifecycle_interventions.py
+++ b/services/game_coordinator/tests/test_lifecycle_interventions.py
@@ -45,8 +45,10 @@ from services.game_coordinator.interventions import (
 from services.game_coordinator.lifecycle_handlers import (
     ELIMINATE_REASON,
     handle_eliminate_player,
+    handle_partial_shield,
     handle_revive_player,
     handle_shield_seconds,
+    parse_partial_shield_value,
     register_lifecycle_handlers,
 )
 
@@ -116,6 +118,9 @@ class TargetingFlagClient:
 
     def get_integer_value(self, _key, default, ctx=None):
         return int(self._resolve(ctx, default))
+
+    def get_string_value(self, _key, default, ctx=None):
+        return str(self._resolve(ctx, default))
 
 
 class _AgentStub:
@@ -240,6 +245,76 @@ class TestShieldSecondsHandler:
 
 
 # --------------------------------------------------------------------------- #
+# partial_shield: value parser (#1129)
+# --------------------------------------------------------------------------- #
+class TestParsePartialShieldValue:
+    def test_seconds_only_defaults_boost(self):
+        assert parse_partial_shield_value("5") == (5.0, 2.0)
+
+    def test_seconds_and_boost(self):
+        assert parse_partial_shield_value("8:1.8") == (8.0, 1.8)
+
+    def test_seconds_capped(self):
+        secs, _ = parse_partial_shield_value("9999")
+        assert secs == 30.0
+
+    def test_boost_clamped(self):
+        assert parse_partial_shield_value("5:9")[1] == 2.0
+        assert parse_partial_shield_value("5:0.1")[1] == 1.0
+
+    @pytest.mark.parametrize(
+        "bad",
+        ["", "0", "none", "off", "-3", "abc", "5:abc", "5:2:1", "  ", "x:y"],
+    )
+    def test_malformed_or_neutral_is_none(self, bad):
+        assert parse_partial_shield_value(bad) is None
+
+
+# --------------------------------------------------------------------------- #
+# partial_shield handler (#1129)
+# --------------------------------------------------------------------------- #
+class TestPartialShieldHandler:
+    @pytest.mark.asyncio
+    async def test_arms_only_targeted_serials(self):
+        game = make_ffa_game(num_players=3)
+        mgr, _ = make_manager(game=game)
+        # p1 gets an 8s/1.8 boost; p2/p3 resolve to neutral "0".
+        mgr._interventions_client = TargetingFlagClient(default="0", per_serial={"p1": "8:1.8"})
+
+        await handle_partial_shield(make_ctx("partial_shield_seconds", "8:1.8", game), mgr)
+
+        assert game.players["p1"].partial_shield_until > time.time()
+        assert game.players["p1"].partial_shield_boost == pytest.approx(1.8)
+        assert game.players["p2"].partial_shield_until == 0.0
+        assert game.players["p3"].partial_shield_until == 0.0
+
+    @pytest.mark.asyncio
+    async def test_malformed_value_is_safe_noop(self):
+        game = make_ffa_game(num_players=1)
+        mgr, _ = make_manager(game=game)
+        mgr._interventions_client = TargetingFlagClient(default="0", per_serial={"p1": "garbage"})
+
+        await handle_partial_shield(make_ctx("partial_shield_seconds", "garbage", game), mgr)
+        assert game.players["p1"].partial_shield_until == 0.0
+
+    @pytest.mark.asyncio
+    async def test_battery_gated_serial_skipped(self):
+        game = make_ffa_game(num_players=2)
+        mgr, _ = make_manager(game=game, battery={"p1": 90, "p2": 5}, threshold=20)
+        mgr._interventions_client = TargetingFlagClient(default="0", per_serial={"p1": "5", "p2": "5"})
+
+        await handle_partial_shield(make_ctx("partial_shield_seconds", "5", game), mgr)
+        assert game.players["p1"].partial_shield_until > 0.0
+        assert game.players["p2"].partial_shield_until == 0.0
+
+    @pytest.mark.asyncio
+    async def test_no_live_game_is_noop(self):
+        mgr, _ = make_manager(game=None)
+        mgr._interventions_client = TargetingFlagClient(default="0")
+        await handle_partial_shield(make_ctx("partial_shield_seconds", "5", None), mgr)  # no raise
+
+
+# --------------------------------------------------------------------------- #
 # eliminate_player handler
 # --------------------------------------------------------------------------- #
 class TestEliminatePlayerHandler:
@@ -344,9 +419,14 @@ class TestRevivePlayer:
 # registration wiring
 # --------------------------------------------------------------------------- #
 class TestRegistration:
-    def test_register_lifecycle_handlers_wires_all_three(self):
+    def test_register_lifecycle_handlers_wires_all(self):
         mgr, _ = make_manager()
         register_lifecycle_handlers(mgr)
-        for flag in ("shield_seconds", "eliminate_player", "revive_player"):
+        for flag in (
+            "shield_seconds",
+            "partial_shield_seconds",
+            "eliminate_player",
+            "revive_player",
+        ):
             handler = mgr._handlers[flag]
             assert handler is not mgr._noop_handler


### PR DESCRIPTION
## Summary

Adds `partial_shield` — a richer agent-specific protective intervention than the binary `grant_shield`. Where `grant_shield` makes a player TOTALLY immune (skips the death check via `grace_until`), `partial_shield` applies a TIME-BOXED handicap boost (~2.0) that raises the player's death threshold a lot for N seconds: much harder to eliminate, but a genuinely huge spike can still kill them. The handicap clamp `[0.5,2.0]` keeps the threshold finite — never immune. This is the deliberate distinction from `grant_shield`, and it reuses the merged #1107 per-player handicap mechanism.

## The timed-handicap mechanic & composition with set_player_handicap

- New `Player.partial_shield_until` / `partial_shield_boost`. While the deadline is in the future, `_compute_effective_thresholds` uses `max(handicap_factor, partial_shield_boost)` as the effective handicap (then the existing `[0.5,2.0]` clamp). On expiry the boost simply stops applying — no reset task — and the standing `handicap_factor` resumes.
- **Precedence / composition**: `partial_shield` is a time-boxed OVERRIDE that can only STRENGTHEN protection. Because it takes the `max` with the standing `handicap_factor`, it never WEAKENS a `set_player_handicap` delta; once it expires, the standing handicap is untouched.
- `BaseGameMode.grant_partial_shield(serial, seconds, boost)` mirrors `grant_shield`'s time-box (extend-not-shorten + strengthen-not-weaken, visible pulse).

## Value schema & malformed-safety

`"<seconds>"` or `"<seconds>:<boost>"` (boost `[1.0,2.0]`, default 2.0; seconds `>0`, capped 30s). Validated in BOTH `writer.go` (`partialShieldOr`) and the Python handler (`parse_partial_shield_value`); any malformed value degrades to a safe no-op / safe default — never a garbage flag write.

## Shadow-only proof (string variant)

Appended `,partial_shield` to the `shadow_experimental` `interventions_allowed` STRING variant in `agent.json` + `ci/agent.json` only (the load-bearing allow-list gate is now a comma-separated string since #1127). It is absent from `ambient`/`standard`/`full`. `TestPartialShieldIsShadowOnly` asserts this on both configs (mirrors #1107/#1117).

## Wiring

- `decision.InterventionPartialShield`, MEDIUM weight in BOTH `ratelimit.go` and `interventions.py`.
- `writer.go` case (`setTargetedString` — new string sibling of `setTargeted`, sharing a name-based ladder builder).
- `resolve_player_targets` gained a `"string"` value kind.
- One-line impact-model fragment in `prompt.go` (goldens regenerated, +4 lines each).

No `game.json` persistence; default-safe (no shield armed / absent flag = no effect).

## Tests
- Game: threshold boost/expiry/max-vs-standing/clamp-not-immune; `grant_partial_shield` primitive (arm, default/clamped boost, capped seconds, non-positive/dead/unknown no-op, extend-not-shorten); parser + handler malformed-safety + battery-gate. Full `game_coordinator` suite: 1111 passed. ruff clean.
- Agent: `gofmt`/`go build`/`go vet` clean; `go test ./... -race` green; new writer + shadow-gate tests.

Part of #1103, #1129

🤖 Generated with [Claude Code](https://claude.com/claude-code)