### PR TITLE
feat(agent): span Links from agent.decision to the game trace (#1133)

### DIFF
--- a/services/agent/decision/decision.go
+++ b/services/agent/decision/decision.go
@@ -908,8 +908,19 @@ func (l *Loop) runDecision(ctx context.Context, snapshot flags.Snapshot, c gamec
 	cost := interventionCost(d.Intervention)
 	reason, blocked := l.evaluatePermission(snapshot, c, d, now, cost)
 
-	dCtx, dSpan := l.Tracer.Start(ctx, SpanDecision,
-		trace.WithAttributes(decisionAttributes(state, d, blocked, reason, c.GameKind, c.SessionID)...))
+	// Trace correlation Phase 2 (#1133): when the game-coordinator's root game-span
+	// trace_id is known (ingested from the game_trace_correlation signal into
+	// GameContext.GameTraceID), add an OTel span LINK from this agent.decision span to
+	// that game trace. A Link (not parent-child) because the relationship is async /
+	// cross-trace: the agent's decision is its own root trace that REFERENCES the game.
+	// This complements — does not replace — the #1095 game.id attribute (still emitted
+	// via decisionAttributes). gameTraceLink returns no options when the id is absent or
+	// invalid, so the span is created exactly as before (graceful fallback, no error).
+	startOpts := []trace.SpanStartOption{
+		trace.WithAttributes(decisionAttributes(state, d, blocked, reason, c.GameKind, c.SessionID)...),
+	}
+	startOpts = append(startOpts, gameTraceLink(c.GameTraceID)...)
+	dCtx, dSpan := l.Tracer.Start(ctx, SpanDecision, startOpts...)
 	defer dSpan.End()
 
 	// The interventions.allowed evaluation as a feature_flag.* span event
@@ -1120,6 +1131,39 @@ func (l *Loop) shouldLog() bool {
 	}
 	l.lastLog = t
 	return true
+}
+
+// gameTraceLink builds the trace-correlation span option for #1133: when gameTraceID
+// is a valid hex trace_id (ingested into GameContext from the game_trace_correlation
+// signal), it returns a single trace.WithLinks option whose Link targets a remote
+// SpanContext reconstructed from that trace_id, so the agent.decision span LINKS to the
+// originating game trace (navigable in Jaeger). The Link has no span_id — we correlate
+// to the game's TRACE, not one specific span in it — so the SpanContext carries only the
+// trace_id and is marked Remote + Sampled; it still validates (a non-zero trace_id is
+// sufficient for IsValid on a remote link target). An empty or unparseable id yields NO
+// option, so the span is created exactly as before: graceful fallback, no Link, no error.
+//
+// The trace_id is also stamped as a plain attribute on the Link so backends that do not
+// render Links keep the correlation id queryable.
+func gameTraceLink(gameTraceID string) []trace.SpanStartOption {
+	if gameTraceID == "" {
+		return nil
+	}
+	tid, err := trace.TraceIDFromHex(gameTraceID)
+	if err != nil || !tid.IsValid() {
+		return nil
+	}
+	sc := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    tid,
+		TraceFlags: trace.FlagsSampled,
+		Remote:     true,
+	})
+	return []trace.SpanStartOption{
+		trace.WithLinks(trace.Link{
+			SpanContext: sc,
+			Attributes:  []attribute.KeyValue{attribute.String(AttrGameTraceID, gameTraceID)},
+		}),
+	}
 }
 
 // decisionAttributes builds the complete #724 + #729 decision-span schema for

--- a/services/agent/decision/decision.go
+++ b/services/agent/decision/decision.go
@@ -920,6 +920,12 @@ func (l *Loop) runDecision(ctx context.Context, snapshot flags.Snapshot, c gamec
 		trace.WithAttributes(decisionAttributes(state, d, blocked, reason, c.GameKind, c.SessionID)...),
 	}
 	startOpts = append(startOpts, gameTraceLink(c.GameTraceID)...)
+	if c.GameTraceID != "" {
+		// Also stamp the originating trace_id as a span ATTRIBUTE (not only the Link
+		// attribute), so it is searchable as a span tag in Jaeger even on backends
+		// that don't surface Link attributes in search (#1133 review).
+		startOpts = append(startOpts, trace.WithAttributes(attribute.String(AttrGameTraceID, c.GameTraceID)))
+	}
 	dCtx, dSpan := l.Tracer.Start(ctx, SpanDecision, startOpts...)
 	defer dSpan.End()
 
@@ -1143,8 +1149,9 @@ func (l *Loop) shouldLog() bool {
 // sufficient for IsValid on a remote link target). An empty or unparseable id yields NO
 // option, so the span is created exactly as before: graceful fallback, no Link, no error.
 //
-// The trace_id is also stamped as a plain attribute on the Link so backends that do not
-// render Links keep the correlation id queryable.
+// The trace_id is also stamped as a plain attribute on the Link; the caller additionally
+// stamps it as a span attribute (see runDecision) so it stays queryable as a span tag on
+// backends that don't surface Link attributes in search.
 func gameTraceLink(gameTraceID string) []trace.SpanStartOption {
 	if gameTraceID == "" {
 		return nil

--- a/services/agent/decision/telemetry.go
+++ b/services/agent/decision/telemetry.go
@@ -211,11 +211,12 @@ const (
 	AttrSessionID = "session.id"
 	AttrGameID    = "game.id"
 	// AttrGameTraceID is the hex trace_id of the originating game-coordinator trace
-	// (#1133, Phase 2 of #1088). Carried as an attribute on the OTel Link the
-	// agent.decision span adds to that game trace (gameTraceLink) — so even a backend
-	// that does not render Links keeps the correlation id queryable on the span, and a
-	// reader sees WHICH trace the link points at. Empty/absent when no valid game
-	// trace_id was ingested (graceful fallback: no link is added at all).
+	// (#1133, Phase 2 of #1088). Stamped in TWO places when a valid game trace_id is
+	// ingested: (1) as an attribute on the OTel Link the agent.decision span adds to
+	// that game trace (gameTraceLink), and (2) as a plain attribute on the decision
+	// span itself — so it is searchable as a span tag in Jaeger even on backends that
+	// don't surface Link attributes in search. Empty/absent when no valid game
+	// trace_id was ingested (graceful fallback: no link and no attribute are added).
 	AttrGameTraceID = "game.trace_id"
 	// AttrEnabled is the existence-layer kill switch (agent.enabled). Lifted from
 	// the cycle's LayerState onto every decision span (including the disabled

--- a/services/agent/decision/telemetry.go
+++ b/services/agent/decision/telemetry.go
@@ -210,6 +210,13 @@ const (
 	// two concurrent games' decision traces are independently attributable.
 	AttrSessionID = "session.id"
 	AttrGameID    = "game.id"
+	// AttrGameTraceID is the hex trace_id of the originating game-coordinator trace
+	// (#1133, Phase 2 of #1088). Carried as an attribute on the OTel Link the
+	// agent.decision span adds to that game trace (gameTraceLink) — so even a backend
+	// that does not render Links keeps the correlation id queryable on the span, and a
+	// reader sees WHICH trace the link points at. Empty/absent when no valid game
+	// trace_id was ingested (graceful fallback: no link is added at all).
+	AttrGameTraceID = "game.trace_id"
 	// AttrEnabled is the existence-layer kill switch (agent.enabled). Lifted from
 	// the cycle's LayerState onto every decision span (including the disabled
 	// kill-switch span) so a trace shows whether the agent was live (#729).

--- a/services/agent/decision/trace_link_test.go
+++ b/services/agent/decision/trace_link_test.go
@@ -1,0 +1,126 @@
+package decision
+
+import (
+	"context"
+	"testing"
+
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/joustmania/agent/flags"
+	"github.com/joustmania/agent/gamecontext"
+)
+
+// trace-correlation Phase 2 (#1133): when the coordinator's game-span trace_id is
+// known (ingested into GameContext.GameTraceID), the agent.decision span carries an
+// OTel Link to that trace; absent/invalid -> no Link, no error. The #1095 game.id
+// attribute stays in every case (Links complement, do not replace, the attribute).
+
+func linkSnapshot() flags.Snapshot {
+	return flags.Snapshot{
+		Enabled:              true,
+		Mode:                 "rules",
+		InterventionsAllowed: []string{"grant_shield"},
+		Policy:               flags.Policy{MaxInterventionsPerMinute: 10},
+	}
+}
+
+func decisionSpan(t *testing.T, ctx gamecontext.GameContext) (linkCount int, linkedTrace string, gameIDAttr string, present bool) {
+	t.Helper()
+	l, sr := recordingLoop(t, linkSnapshot(), []Decision{{Intervention: "grant_shield", Reason: "x"}})
+	l.OnEvaluate(context.Background(), ctx, testTrigger())
+	dec := spansByName(sr.Ended(), SpanDecision)[0]
+	links := dec.Links()
+	if v, ok := attrValue(dec, AttrGameID); ok {
+		gameIDAttr, present = v.AsString(), true
+	}
+	if len(links) == 1 {
+		return 1, links[0].SpanContext.TraceID().String(), gameIDAttr, present
+	}
+	return len(links), "", gameIDAttr, present
+}
+
+// TestDecisionSpan_LinksToGameTrace: a valid GameTraceID yields exactly one Link on
+// the agent.decision span whose target trace_id is that game trace, AND the link
+// carries game.trace_id as an attribute. The #1095 game.id attribute is still present.
+func TestDecisionSpan_LinksToGameTrace(t *testing.T) {
+	const gameTrace = "4bf92f3577b34da6a3ce929d0e0e4736" // valid 16-byte hex trace id
+	const gameID = "game_abc123def456"
+
+	l, sr := recordingLoop(t, linkSnapshot(), []Decision{{Intervention: "grant_shield", Reason: "x"}})
+	l.OnEvaluate(context.Background(), gamecontext.GameContext{
+		SessionID:   gameID,
+		GameKind:    "real",
+		GameTraceID: gameTrace,
+	}, testTrigger())
+
+	dec := spansByName(sr.Ended(), SpanDecision)[0]
+	links := dec.Links()
+	if len(links) != 1 {
+		t.Fatalf("agent.decision links = %d, want 1", len(links))
+	}
+	wantTID, _ := trace.TraceIDFromHex(gameTrace)
+	if got := links[0].SpanContext.TraceID(); got != wantTID {
+		t.Errorf("link trace_id = %s, want %s", got, wantTID)
+	}
+	// The link target must validate so Jaeger renders it as navigable.
+	if !links[0].SpanContext.TraceID().IsValid() {
+		t.Error("link trace_id must be valid")
+	}
+	// The trace id is also stamped on the link as a queryable attribute.
+	var foundAttr bool
+	for _, kv := range links[0].Attributes {
+		if string(kv.Key) == AttrGameTraceID && kv.Value.AsString() == gameTrace {
+			foundAttr = true
+		}
+	}
+	if !foundAttr {
+		t.Errorf("link must carry %s=%s", AttrGameTraceID, gameTrace)
+	}
+	// Phase 1 (#1095) game.id attribute is untouched by the Link.
+	if v, ok := attrValue(dec, AttrGameID); !ok || v.AsString() != gameID {
+		t.Errorf("game.id = %q (present=%v), want %q", v.AsString(), ok, gameID)
+	}
+}
+
+// TestDecisionSpan_NoLinkWhenTraceAbsent: shadow games (or any game before the
+// correlation signal arrives) have no GameTraceID — the span is created with NO Link
+// and NO error, and the game.id attribute is still present (graceful fallback).
+func TestDecisionSpan_NoLinkWhenTraceAbsent(t *testing.T) {
+	n, _, gameID, present := decisionSpan(t, gamecontext.GameContext{SessionID: "game_noTrace", GameKind: "shadow"})
+	if n != 0 {
+		t.Fatalf("agent.decision links = %d, want 0 (no game trace_id)", n)
+	}
+	if !present || gameID != "game_noTrace" {
+		t.Errorf("game.id = %q (present=%v), want %q present — attribute must survive even without a link", gameID, present, "game_noTrace")
+	}
+}
+
+// TestDecisionSpan_NoLinkWhenTraceInvalid: a malformed/garbage trace_id (e.g. an
+// unparseable or all-zero id) must NOT produce a Link and must NOT panic — the span is
+// created exactly as if no trace_id were present.
+func TestDecisionSpan_NoLinkWhenTraceInvalid(t *testing.T) {
+	for _, bad := range []string{
+		"not-hex",                          // unparseable
+		"00000000000000000000000000000000", // all-zero (invalid trace id)
+		"abc",                              // wrong length
+	} {
+		n, _, _, _ := decisionSpan(t, gamecontext.GameContext{SessionID: "g", GameTraceID: bad})
+		if n != 0 {
+			t.Errorf("GameTraceID=%q: links = %d, want 0 (invalid id yields no link)", bad, n)
+		}
+	}
+}
+
+// TestGameTraceLink_Direct unit-tests the helper in isolation: valid -> one link
+// option, empty/invalid -> nil so the span is started unchanged.
+func TestGameTraceLink_Direct(t *testing.T) {
+	if got := gameTraceLink(""); got != nil {
+		t.Errorf("gameTraceLink(empty) = %v, want nil", got)
+	}
+	if got := gameTraceLink("zzzz"); got != nil {
+		t.Errorf("gameTraceLink(invalid) = %v, want nil", got)
+	}
+	if got := gameTraceLink("4bf92f3577b34da6a3ce929d0e0e4736"); len(got) != 1 {
+		t.Errorf("gameTraceLink(valid) = %d options, want 1", len(got))
+	}
+}

--- a/services/agent/gamecontext/extract_metrics.go
+++ b/services/agent/gamecontext/extract_metrics.go
@@ -22,6 +22,14 @@ const (
 	metricDeathsTotal    = "game_player_deaths_total"    // live
 	metricPeakAccel      = "game_player_peak_accel"      // live (whole-game aggregate + game_id carrier)
 
+	// Trace-correlation signal (#1133, Phase 2 of #1088). A dedicated low-rate
+	// per-game gauge (value always 1 while the game span is live) whose payload is its
+	// labels: game_id + the game span's hex game_trace_id. The agent reads game_trace_id
+	// here so the decision loop can add an OTel span LINK from agent.decision to the
+	// originating game trace — the agent otherwise has no parent context (it consumes
+	// game state only as metrics). Falls back gracefully (no link) when absent/unsampled.
+	metricTraceCorrelation = "game_trace_correlation"
+
 	// Game-speed / threshold reference frame (#1082). All three are SESSION-level
 	// gauges the coordinator already emits (no serial label): game_music_tempo is
 	// the applied game speed (1.0=slow..~1.3=fast); the effective thresholds are the
@@ -49,6 +57,10 @@ const (
 	attrMode     = "mode"
 	attrGameID   = "game_id"
 	attrGameKind = "game_kind"
+	// attrGameTraceID is the coordinator root game-span trace_id carried on the
+	// dedicated game_trace_correlation signal (#1133). Hex string; empty when the
+	// game span was unsampled.
+	attrGameTraceID = "game_trace_id"
 	// Experiment attribution (#975, epic #982): finer-grained labels WITHIN a
 	// shadow game. Carried on the LOW-RATE lifecycle metrics (game_active,
 	// game_active_players, game_duration_seconds) the same way game_kind is —
@@ -79,6 +91,10 @@ type gameLabels struct {
 	// a cohort is reconstructed by grouping partitions that share an ExperimentID.
 	ExperimentID string
 	Arm          string
+	// GameTraceID carries the coordinator's root game-span trace_id (#1133) when the
+	// signal is the dedicated game_trace_correlation gauge — empty on every other
+	// signal. Like ExperimentID/Arm it is partition ENRICHMENT, not a routing key.
+	GameTraceID string
 }
 
 // gameIDOf reads the game_id datapoint label; empty when absent.
@@ -113,6 +129,14 @@ func armOf(attrs pcommon.Map) string {
 	return ""
 }
 
+// gameTraceIDOf reads the game_trace_id datapoint label (#1133); empty when absent.
+func gameTraceIDOf(attrs pcommon.Map) string {
+	if v, ok := attrs.Get(attrGameTraceID); ok {
+		return v.AsString()
+	}
+	return ""
+}
+
 // metricGameLabels resolves the game identity labels on a metric datapoint.
 func metricGameLabels(attrs pcommon.Map) gameLabels {
 	return gameLabels{
@@ -120,6 +144,7 @@ func metricGameLabels(attrs pcommon.Map) gameLabels {
 		GameKind:     gameKindOf(attrs),
 		ExperimentID: experimentIDOf(attrs),
 		Arm:          armOf(attrs),
+		GameTraceID:  gameTraceIDOf(attrs),
 	}
 }
 
@@ -295,6 +320,13 @@ func (s *Store) applyDataPoint(name string, dp pmetric.NumberDataPoint) bool {
 		s.SetGameActive(v == 1)
 		s.adoptGame(labels)
 		return true
+	case metricTraceCorrelation:
+		// Dedicated trace-correlation signal (#1133): value is always 1; the payload is
+		// the labels (game_id + game_trace_id). Route through adoptGame so the
+		// game_trace_id enriches the same partition the multiplexer selected on game_id;
+		// SetGameTraceID ignores an empty id, so a malformed datapoint is a safe no-op.
+		s.adoptGame(labels)
+		return labels.GameTraceID != "" || labels.GameID != ""
 	case metricGameMode:
 		// game_current_mode is a primary/legacy signal: it NEVER carries game_id,
 		// so it is deliberately not routed through adoptGame.
@@ -342,4 +374,5 @@ func (s *Store) adoptGame(labels gameLabels) {
 	s.SetGameKind(labels.GameKind)
 	s.SetExperimentID(labels.ExperimentID)
 	s.SetArm(labels.Arm)
+	s.SetGameTraceID(labels.GameTraceID) // #1133: empty on all but game_trace_correlation
 }

--- a/services/agent/gamecontext/extract_metrics_test.go
+++ b/services/agent/gamecontext/extract_metrics_test.go
@@ -255,6 +255,47 @@ func TestApplyMetrics_MovementVarianceAggregateRetained(t *testing.T) {
 	}
 }
 
+// TestApplyMetrics_AdoptsGameTraceID verifies the #1133 trace-correlation signal:
+// game_trace_correlation carries game_id + game_trace_id and adopts both into the
+// context so the decision loop can link agent.decision to the originating game trace.
+func TestApplyMetrics_AdoptsGameTraceID(t *testing.T) {
+	s := newTestStore()
+	const tid = "4bf92f3577b34da6a3ce929d0e0e4736"
+	if !s.ApplyMetrics(metricsWith(metricTraceCorrelation, 1, map[string]string{
+		attrGameID:      "game-99",
+		attrGameKind:    "real",
+		attrGameTraceID: tid,
+	})) {
+		t.Fatal("game_trace_correlation carrying game_trace_id must apply")
+	}
+	snap := s.Snapshot()
+	if snap.SessionID != "game-99" {
+		t.Fatalf("SessionID = %q, want game-99 (adopted from game_id)", snap.SessionID)
+	}
+	if snap.GameTraceID != tid {
+		t.Fatalf("GameTraceID = %q, want %q", snap.GameTraceID, tid)
+	}
+}
+
+// TestApplyMetrics_TraceCorrelationWithoutTraceIDIsSafe documents the fallback:
+// a correlation datapoint missing game_trace_id still routes its game_id but leaves
+// GameTraceID empty (no link will be added) — no error.
+func TestApplyMetrics_TraceCorrelationWithoutTraceIDIsSafe(t *testing.T) {
+	s := newTestStore()
+	if !s.ApplyMetrics(metricsWith(metricTraceCorrelation, 1, map[string]string{
+		attrGameID: "game-100",
+	})) {
+		t.Fatal("correlation datapoint with only game_id must still contribute it")
+	}
+	snap := s.Snapshot()
+	if snap.SessionID != "game-100" {
+		t.Fatalf("SessionID = %q, want game-100", snap.SessionID)
+	}
+	if snap.GameTraceID != "" {
+		t.Fatalf("GameTraceID = %q, want empty (no game_trace_id label)", snap.GameTraceID)
+	}
+}
+
 func TestApplyMetrics_MissingSerialSkipped(t *testing.T) {
 	s := newTestStore()
 	if s.ApplyMetrics(metricsWith(metricAccelMagnitude, 1.2, nil)) {

--- a/services/agent/gamecontext/model.go
+++ b/services/agent/gamecontext/model.go
@@ -142,9 +142,18 @@ type GameContext struct {
 	// partitions by ExperimentID; the Multiplexer still partitions on game_id.
 	ExperimentID string
 	Arm          string
-	Session      SessionSignals
-	Players      map[string]*PlayerSignals
-	UpdatedAt    time.Time
+	// GameTraceID is the hex trace_id of the coordinator's root game span for this
+	// session (#1133, Phase 2 of #1088). Source: the game_trace_id datapoint label on
+	// the dedicated game_trace_correlation gauge the coordinator emits while the game
+	// span is live. The agent has no parent trace context (it consumes game state only
+	// as metrics), so this id is what lets the decision loop add an OTel span LINK from
+	// agent.decision to the originating game trace — navigable in Jaeger, not merely a
+	// shared game.id attribute (Phase 1). Empty when not yet observed or the game span
+	// was unsampled; an empty value means "no link" (graceful fallback, no error).
+	GameTraceID string
+	Session     SessionSignals
+	Players     map[string]*PlayerSignals
+	UpdatedAt   time.Time
 
 	// Timeline is a bounded, oldest-first slice of the partition's recent rolling
 	// narrative (#916): periodic state deltas, eliminations, and session phase

--- a/services/agent/gamecontext/store.go
+++ b/services/agent/gamecontext/store.go
@@ -523,6 +523,22 @@ func (s *Store) SetExperimentID(id string) {
 	s.touchSession()
 }
 
+// SetGameTraceID records the coordinator's root game-span trace_id (#1133) from
+// the game_trace_id label on the game_trace_correlation signal. An empty id is
+// ignored so an unlabeled signal never clobbers a previously observed trace id —
+// exactly like SetGameKind. The decision loop reads this to add a span Link from
+// agent.decision to the originating game trace; it is validated there, so an
+// invalid value stored here simply yields no Link (graceful fallback).
+func (s *Store) SetGameTraceID(id string) {
+	if id == "" {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.ctx.GameTraceID = id
+	s.touchSession()
+}
+
 // SetArm records the experiment arm ("experimental"/"control", #975) from the
 // arm datapoint label or the experiment.arm span attribute. An empty arm is
 // ignored so an unlabeled signal never clobbers a previously observed arm.
@@ -764,6 +780,7 @@ func (s *Store) EvictStale() {
 		s.ctx.GameKind = ""
 		s.ctx.ExperimentID = ""
 		s.ctx.Arm = ""
+		s.ctx.GameTraceID = "" // drop the finished game's trace link (#1133)
 		s.elimOrder = make(map[string]int)
 		s.endedAt = time.Time{}
 		s.ctx.UpdatedAt = now

--- a/services/game_coordinator/game_session.py
+++ b/services/game_coordinator/game_session.py
@@ -28,6 +28,8 @@ import threading
 import time
 from contextlib import suppress
 
+from opentelemetry import trace
+
 from lib.feature_flags import (
     GAME_KIND_REAL as EVAL_GAME_KIND_REAL,
 )
@@ -96,6 +98,11 @@ class GameSession:
         self.game_start_time = time.time()
         self.game_state = game_coordinator_pb2.GameState.STARTING
         self.current_game = None
+        # Hex trace_id of this session's root game span (#1133). Captured once the
+        # span exists in _run_game and exposed as the game_trace_correlation gauge's
+        # game_trace_id label so the agent can link agent.decision -> this game trace.
+        # Empty until the span opens; used at retire to remove the exact gauge series.
+        self.game_trace_id = ""
 
         # Per-session loop runs in its own thread with its own GrpcClientManager.
         self.clients = GrpcClientManager()
@@ -132,6 +139,13 @@ class GameSession:
         ):
             with suppress(KeyError, ValueError):
                 gauge.remove(*labels)
+
+        # The trace-correlation gauge (#1133) carries a different label tuple
+        # (game_kind, game_id, game_trace_id) and was only set when the span was
+        # sampled (game_trace_id non-empty), so remove it separately and only then.
+        if self.game_trace_id:
+            with suppress(KeyError, ValueError):
+                metrics.game_trace_correlation.remove(self.game_kind, self.game_id, self.game_trace_id)
 
     def on_event_state_sync(self, event_type: str) -> None:
         """EventBus state-sync callback bound to THIS session's state (#775).
@@ -239,6 +253,21 @@ class GameSession:
             game_span.set_attribute("experiment.id", self.experiment_id)
             game_span.set_attribute("experiment.arm", self.arm)
             game_span.set_attribute("player.count", len(self.players))
+
+            # Trace-correlation signal (#1133): capture THIS game span's trace_id and
+            # publish it as the game_trace_correlation gauge so the agent can read it
+            # off the metric stream and link agent.decision -> this game trace. A
+            # non-recording span (sampler dropped it, or telemetry off) reports the
+            # all-zero invalid trace id; skip the gauge in that case so the agent never
+            # tries to link to an invalid trace. Set to 1 while live; removed at retire.
+            span_ctx = game_span.get_span_context()
+            if span_ctx.trace_id != 0:
+                self.game_trace_id = trace.format_trace_id(span_ctx.trace_id)
+                metrics.game_trace_correlation.labels(
+                    game_kind=self.game_kind,
+                    game_id=self.game_id,
+                    game_trace_id=self.game_trace_id,
+                ).set(1)
 
             try:
                 # Check if gRPC clients are available

--- a/services/game_coordinator/metrics.py
+++ b/services/game_coordinator/metrics.py
@@ -40,6 +40,34 @@ current_game_mode = Gauge(
     ["mode"],  # 'ffa', 'teams_simple', 'teams_random', 'nonstop_joust', 'none'
 )
 
+# Trace-correlation signal (#1133, Phase 2 of #1088). A dedicated, low-rate
+# per-game gauge whose VALUE is always 1 while the game's root span is live; its
+# payload is the labels. It carries the game span's hex trace_id as game_trace_id
+# alongside game_id so the agent — which consumes game state only as METRICS (no
+# parent trace context) — can read the originating game trace_id during ingest and
+# add an OTel span LINK from agent.decision to that trace (navigable in Jaeger),
+# not merely a shared game.id attribute (Phase 1, #1095).
+#
+# Why a dedicated signal and not an exemplar (the OTLP-native alternative the issue
+# asked us to evaluate FIRST): the coordinator's gauges go through
+# lib.otel_metrics, which uses the OTel SDK's create_observable_gauge + a flush-time
+# callback yielding metrics.Observation(value, labels). Observable gauges expose NO
+# API to attach exemplars (exemplars are auto-sampled by the SDK for sum/histogram
+# aggregations from the active span at record time — there is no active span at the
+# async callback flush, and the Observation API takes no exemplar). So the exemplar
+# path is not feasible end-to-end in this stack; this dedicated attribute-carrying
+# signal is the documented Approach B.
+#
+# Cardinality: game_trace_id is 1:1 with game_id (one trace per game), so it
+# multiplies NO series beyond the already-unbounded game_id. Like the other
+# per-game gauges it is SET to 1 inside the live game span and REMOVED at retire
+# (clear_metrics, #1018) so the series does not accumulate.
+game_trace_correlation = Gauge(
+    "game_trace_correlation",
+    "Correlation marker tying a live game_id to its root span trace_id (always 1 while live)",
+    ["game_kind", "game_id", "game_trace_id"],
+)
+
 game_duration_seconds = Gauge(
     "game_duration_seconds",
     "Duration of current game in seconds",

--- a/services/game_coordinator/tests/test_game_session.py
+++ b/services/game_coordinator/tests/test_game_session.py
@@ -26,17 +26,30 @@ from proto import game_coordinator_pb2
 from services.game_coordinator.game_session import GAME_KIND_PRIMARY, GAME_KIND_SHADOW, GameSession
 
 
+class MockSpanContext:
+    """Mock SpanContext exposing trace_id (#1133 correlation gauge reads it)."""
+
+    def __init__(self, trace_id):
+        self.trace_id = trace_id
+
+
 class MockSpan:
     """Mock OpenTelemetry span supporting set_attribute + context manager."""
 
-    def __init__(self):
+    def __init__(self, trace_id=0x4BF92F3577B34DA6A3CE929D0E0E4736):
         self.attributes = {}
+        # Non-zero trace_id by default so the #1133 correlation gauge fires; a test
+        # can pass trace_id=0 to exercise the unsampled-span fallback (no gauge).
+        self._span_context = MockSpanContext(trace_id)
 
     def set_attribute(self, key, value):
         self.attributes[key] = value
 
     def add_event(self, name, attributes=None):
         pass
+
+    def get_span_context(self):
+        return self._span_context
 
     def __enter__(self):
         return self
@@ -76,8 +89,8 @@ def _make_session(game_kind=GAME_KIND_PRIMARY, experiment_id="", arm=""):
     return session
 
 
-def _tracer_mock():
-    mock_span = MockSpan()
+def _tracer_mock(trace_id=0x4BF92F3577B34DA6A3CE929D0E0E4736):
+    mock_span = MockSpan(trace_id=trace_id)
     mock_tracer = MagicMock()
     mock_tracer.start_as_current_span.return_value.__enter__ = MagicMock(return_value=mock_span)
     mock_tracer.start_as_current_span.return_value.__exit__ = MagicMock(return_value=False)
@@ -346,6 +359,51 @@ class TestGameSessionLoop:
     @patch("services.game_coordinator.game_session.metrics")
     @patch("services.game_coordinator.game_session.GameFactory")
     @patch("services.game_coordinator.game_session.tracer")
+    async def test_loop_emits_trace_correlation_gauge(self, mock_tracer_mod, mock_factory, mock_metrics):
+        """#1133: while the game span is live the loop publishes game_trace_correlation
+        carrying game_id + the span's hex trace_id, so the agent can link
+        agent.decision -> this game trace. The hex id is captured onto the session."""
+        from opentelemetry import trace as ot_trace
+
+        session = _make_session(game_kind=GAME_KIND_SHADOW)
+        trace_id = 0x4BF92F3577B34DA6A3CE929D0E0E4736
+        mock_tracer_mod.start_as_current_span = _tracer_mock(trace_id=trace_id).start_as_current_span
+        mock_game = MagicMock()
+        mock_game.run = AsyncMock()
+        mock_factory.create_game.return_value = mock_game
+
+        await session._run_game_loop_async()
+
+        expected_hex = ot_trace.format_trace_id(trace_id)
+        assert session.game_trace_id == expected_hex
+        mock_metrics.game_trace_correlation.labels.assert_any_call(
+            game_kind=GAME_KIND_SHADOW, game_id="game_abc123", game_trace_id=expected_hex
+        )
+        mock_metrics.game_trace_correlation.labels.return_value.set.assert_any_call(1)
+
+    @pytest.mark.asyncio
+    @patch("services.game_coordinator.game_session.metrics")
+    @patch("services.game_coordinator.game_session.GameFactory")
+    @patch("services.game_coordinator.game_session.tracer")
+    async def test_loop_skips_trace_correlation_for_unsampled_span(self, mock_tracer_mod, mock_factory, mock_metrics):
+        """#1133 fallback: an unsampled/non-recording span reports the all-zero invalid
+        trace id; the loop must NOT emit the correlation gauge (no link to an invalid
+        trace) and must leave game_trace_id empty — no crash."""
+        session = _make_session(game_kind=GAME_KIND_SHADOW)
+        mock_tracer_mod.start_as_current_span = _tracer_mock(trace_id=0).start_as_current_span
+        mock_game = MagicMock()
+        mock_game.run = AsyncMock()
+        mock_factory.create_game.return_value = mock_game
+
+        await session._run_game_loop_async()
+
+        assert session.game_trace_id == ""
+        mock_metrics.game_trace_correlation.labels.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("services.game_coordinator.game_session.metrics")
+    @patch("services.game_coordinator.game_session.GameFactory")
+    @patch("services.game_coordinator.game_session.tracer")
     async def test_shadow_loop_does_not_reset_players_alive(self, mock_tracer_mod, mock_factory, mock_metrics):
         """A shadow session ending must not reset the global players_alive gauge."""
         session = _make_session(game_kind=GAME_KIND_SHADOW)
@@ -443,6 +501,31 @@ class TestGameSessionClearMetrics:
 
         expected = (GAME_KIND_PRIMARY, "game_abc123", "", "")
         mock_metrics.active_game.remove.assert_called_once_with(*expected)
+
+    @patch("services.game_coordinator.game_session.metrics")
+    def test_clear_metrics_removes_trace_correlation_when_set(self, mock_metrics):
+        """#1133: the trace-correlation gauge (labels game_kind, game_id,
+        game_trace_id) is removed at retire ONLY when a trace id was captured —
+        otherwise it was never set."""
+        session = _make_session(game_kind=GAME_KIND_SHADOW)
+        session.game_trace_id = "4bf92f3577b34da6a3ce929d0e0e4736"
+
+        session.clear_metrics()
+
+        mock_metrics.game_trace_correlation.remove.assert_called_once_with(
+            GAME_KIND_SHADOW, "game_abc123", "4bf92f3577b34da6a3ce929d0e0e4736"
+        )
+
+    @patch("services.game_coordinator.game_session.metrics")
+    def test_clear_metrics_skips_trace_correlation_when_unset(self, mock_metrics):
+        """#1133: an unsampled span never set the correlation gauge, so retire must
+        not try to remove a series that was never created."""
+        session = _make_session(game_kind=GAME_KIND_SHADOW)
+        # game_trace_id stays "" (default) — span was never sampled.
+
+        session.clear_metrics()
+
+        mock_metrics.game_trace_correlation.remove.assert_not_called()
 
     def test_clear_metrics_idempotent_on_missing_series(self):
         """A double-retire (or never-started session) must not raise — the gauge


### PR DESCRIPTION
## What

Phase 2 of trace correlation (#1088): make an `agent.decision` trace **navigable** to the originating game-coordinator trace via OTel span **Links** — not merely filterable by the shared `game.id` attribute Phase 1 (#1095) added. Closes #1133.

## Feasibility finding: exemplars (Approach A) are NOT feasible here

The issue asked to evaluate metric exemplars first. They do not work end-to-end in this stack:

- The coordinator's per-game gauges go through `lib.otel_metrics`, which uses the OTel SDK's `create_observable_gauge` + a flush-time callback yielding `metrics.Observation(value, labels)`. **Observable gauges expose no API to attach exemplars** — the SDK auto-samples exemplars only for sum/histogram aggregations from the active span at *record* time, and there is no active span at the async callback flush. The `Observation` API takes no exemplar.
- So neither the emit side nor the agent ingest side (`extract_metrics.go` reads `NumberDataPoint`s with no exemplars on these gauges) can carry an exemplar trace_id.

Implemented **Approach B (dedicated correlation signal)** instead.

## Coordinator side (kept out of base.py threshold/handicap/tempo logic)

- New low-rate per-game gauge `game_trace_correlation{game_kind, game_id, game_trace_id}`, set to `1` inside the live game span in `game_session.py` — the one place the game span's `trace_id` is available. A non-recording/unsampled span (all-zero trace id) is **skipped** (no gauge, no bogus link target).
- Removed at retire in `clear_metrics` (#1018 series hygiene). `game_trace_id` is 1:1 with `game_id`, so **no new series multiplication**.

## Agent side

- `extract_metrics.go` recognizes `game_trace_correlation`, reads `game_trace_id`, and `adoptGame` → `SetGameTraceID` stores it on `GameContext.GameTraceID` (reset on session reset, like `GameKind`).
- `decision.go` adds a `trace.WithLinks` option (`gameTraceLink` helper) from the `agent.decision` span to a remote `SpanContext` reconstructed from the hex trace_id, with `game.trace_id` stamped on the Link as a queryable attribute.
- **Graceful fallback**: empty / invalid / unparseable / all-zero trace_id → no Link, no error (shadow games without a coordinator trace fall back cleanly). The #1095 `game.id` attribute is unchanged — Links complement, do not replace it.

**No decision/gate behavior change; base.py threshold/handicap/tempo logic untouched.**

## Tests

- Agent: `agent.decision` Link present (valid id) / absent (no id) / no-link-on-invalid; `gameTraceLink` helper unit test; gamecontext ingest adopts trace_id + safe fallback when label missing.
- Coordinator: gauge emitted (sampled span) / skipped (unsampled span); `clear_metrics` removes the series only when one was set.
- Full suites green: agent `go test ./... -race`, coordinator `pytest` (1115 passed), `make lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)