### PR TITLE
feat(agent): retro→game linkage + experiment-lifecycle spans (#1140 B+C)

### DIFF
--- a/services/agent/decision/retro_capture.go
+++ b/services/agent/decision/retro_capture.go
@@ -287,8 +287,24 @@ func (rc *RetroCoordinator) OnGameEnd(c gamecontext.GameContext) {
 	attrs = append(attrs, rc.outcomeAttributes(c)...)
 	attrs = append(attrs, rc.experimentAttributes(c)...)
 
-	_, span := rc.Tracer.Start(context.Background(), SpanLLMRetro,
-		trace.WithAttributes(attrs...))
+	// #1140 Slice B: the retro is post-game / async, so it stays a ROOT span (no
+	// parent — there is no inbound RPC context at game end), but it is no longer
+	// ORPHANED from the game it reflects on. When the finished session carries a
+	// valid game-coordinator trace_id (GameContext.GameTraceID, #1133), add the SAME
+	// span Link the agent.decision span uses (gameTraceLink, package-level in this
+	// package), so agent.llm.retro is navigable to the originating game trace in
+	// Jaeger. The trace_id is also stamped as a plain span attribute (mirroring
+	// runDecision) so it stays queryable as a tag on backends that don't surface Link
+	// attributes in search. An empty/invalid id yields no Link and no attribute —
+	// graceful fallback, the span is byte-identical to before.
+	startOpts := []trace.SpanStartOption{trace.WithAttributes(attrs...)}
+	startOpts = append(startOpts, gameTraceLink(c.GameTraceID)...)
+	if c.GameTraceID != "" {
+		startOpts = append(startOpts,
+			trace.WithAttributes(attribute.String(AttrGameTraceID, c.GameTraceID)))
+	}
+
+	_, span := rc.Tracer.Start(context.Background(), SpanLLMRetro, startOpts...)
 	span.End()
 
 	rc.Log.Info("agent.llm.retro_captured",

--- a/services/agent/decision/retro_trace_link_test.go
+++ b/services/agent/decision/retro_trace_link_test.go
@@ -1,0 +1,117 @@
+package decision
+
+import (
+	"testing"
+
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/joustmania/agent/gamecontext"
+)
+
+// #1140 Slice B: the post-game agent.llm.retro span stays a ROOT span but is no
+// longer orphaned from the game — when the finished session carries a valid game
+// trace_id (GameContext.GameTraceID, #1133) the retro span carries an OTel Link to
+// that game trace (the same gameTraceLink primitive the agent.decision span uses).
+// Absent/invalid trace_id -> no Link, no error (graceful fallback). The link
+// complements, does not replace, the game.id attribute.
+
+// endedSessionWithTrace is a finished-game GameContext carrying a game trace_id.
+func endedSessionWithTrace(traceID string) gamecontext.GameContext {
+	c := endedSession()
+	c.GameTraceID = traceID
+	return c
+}
+
+// TestRetroSpan_LinksToGameTrace: a valid GameTraceID yields exactly one Link on the
+// agent.llm.retro span whose target trace_id is that game trace, the link carries
+// game.trace_id as an attribute, and the span itself stamps game.trace_id as a
+// queryable tag. The retro stays a root span (no parent).
+func TestRetroSpan_LinksToGameTrace(t *testing.T) {
+	const gameTrace = "4bf92f3577b34da6a3ce929d0e0e4736" // valid 16-byte hex trace id
+
+	rc, sr := recordingRetro(t, retroFlagSnapshot())
+	rc.OnGameEnd(endedSessionWithTrace(gameTrace))
+
+	spans := spansByName(sr.Ended(), SpanLLMRetro)
+	if len(spans) != 1 {
+		t.Fatalf("agent.llm.retro spans = %d, want 1", len(spans))
+	}
+	span := spans[0]
+
+	// Root span: no parent (post-game / async).
+	if span.Parent().IsValid() {
+		t.Error("agent.llm.retro must remain a root span (no parent)")
+	}
+
+	links := span.Links()
+	if len(links) != 1 {
+		t.Fatalf("agent.llm.retro links = %d, want 1", len(links))
+	}
+	wantTID, _ := trace.TraceIDFromHex(gameTrace)
+	if got := links[0].SpanContext.TraceID(); got != wantTID {
+		t.Errorf("link trace_id = %s, want %s", got, wantTID)
+	}
+	if !links[0].SpanContext.TraceID().IsValid() {
+		t.Error("link trace_id must be valid")
+	}
+	// The trace id is stamped on the link as a queryable attribute.
+	var foundLinkAttr bool
+	for _, kv := range links[0].Attributes {
+		if string(kv.Key) == AttrGameTraceID && kv.Value.AsString() == gameTrace {
+			foundLinkAttr = true
+		}
+	}
+	if !foundLinkAttr {
+		t.Errorf("link must carry %s=%s", AttrGameTraceID, gameTrace)
+	}
+	// The trace id is ALSO a plain span attribute (searchable on backends that don't
+	// surface link attributes).
+	if v, ok := attrValue(span, AttrGameTraceID); !ok || v.AsString() != gameTrace {
+		t.Errorf("span %s = %q (present=%v), want %q", AttrGameTraceID, v.AsString(), ok, gameTrace)
+	}
+}
+
+// TestRetroSpan_NoLinkWhenTraceAbsent: a finished game with no GameTraceID (a shadow
+// game, or any game before the correlation signal arrives) emits the retro span with
+// NO Link and NO game.trace_id attribute — graceful fallback, byte-identical to
+// before #1140. The game.id attribute is still present.
+func TestRetroSpan_NoLinkWhenTraceAbsent(t *testing.T) {
+	rc, sr := recordingRetro(t, retroFlagSnapshot())
+	rc.OnGameEnd(endedSession()) // no GameTraceID
+
+	spans := spansByName(sr.Ended(), SpanLLMRetro)
+	if len(spans) != 1 {
+		t.Fatalf("agent.llm.retro spans = %d, want 1", len(spans))
+	}
+	span := spans[0]
+	if n := len(span.Links()); n != 0 {
+		t.Errorf("agent.llm.retro links = %d, want 0 (no game trace_id)", n)
+	}
+	if _, ok := attrValue(span, AttrGameTraceID); ok {
+		t.Error("game.trace_id attribute must be absent when no game trace_id is present")
+	}
+	if v, ok := attrValue(span, AttrGameID); !ok || v.AsString() == "" {
+		t.Error("game.id attribute must survive even without a link")
+	}
+}
+
+// TestRetroSpan_NoLinkWhenTraceInvalid: a malformed/garbage trace_id must NOT produce
+// a Link and must NOT panic — the span is created as if no trace_id were present.
+func TestRetroSpan_NoLinkWhenTraceInvalid(t *testing.T) {
+	for _, bad := range []string{
+		"not-hex",                          // unparseable
+		"00000000000000000000000000000000", // all-zero (invalid trace id)
+		"abc",                              // wrong length
+	} {
+		rc, sr := recordingRetro(t, retroFlagSnapshot())
+		rc.OnGameEnd(endedSessionWithTrace(bad))
+
+		spans := spansByName(sr.Ended(), SpanLLMRetro)
+		if len(spans) != 1 {
+			t.Fatalf("GameTraceID=%q: agent.llm.retro spans = %d, want 1", bad, len(spans))
+		}
+		if n := len(spans[0].Links()); n != 0 {
+			t.Errorf("GameTraceID=%q: links = %d, want 0 (invalid id yields no link)", bad, n)
+		}
+	}
+}

--- a/services/agent/decision/telemetry.go
+++ b/services/agent/decision/telemetry.go
@@ -404,5 +404,55 @@ const (
 // in Jaeger. Present only on dispatched (applied) decisions that schedule a follow-up.
 const AttrDecisionInterventionID = "decision.intervention_id"
 
+// Experiment / cohort lifecycle spans (#1140 Slice C). Before this the entire
+// "learn from games" loop (experiment_loop.go) was LOG-ONLY — the retro/experiment
+// phase was invisible in traces. These spans make that loop an actual trace, in the
+// established dot-notation namespace, each carrying experiment.id / arm / fitness
+// attributes and (where a game trace_id is in scope) a span Link to the originating
+// game trace (the same #1133 link-from-hex primitive gameTraceLink uses). They are
+// OBSERVABILITY ONLY: they wrap the existing fitness/verdict/conclusion computations
+// without changing verdict math, fitness computation, promotion gating, or the loop's
+// control flow.
+const (
+	// SpanExperimentFitness wraps the per-shadow-game fitness scalar computation in
+	// onGameEnd: the gameFitnessFunc that scores one finished experiment game into the
+	// [0,1] sample the cohort aggregator folds. Carries experiment.id / arm / game.id /
+	// objective + the resulting experiment.fitness, Linked to the game trace.
+	SpanExperimentFitness = "experiment.fitness"
+	// SpanExperimentEvaluate wraps one experiment-conclusion: folding a concluded
+	// shadow game into its arm (ConcludeGame) and the resulting lifecycle status.
+	// Carries experiment.id / game.id / the resulting experiment.status, Linked to the
+	// game trace. It is the parent of any experiment.verdict span.
+	SpanExperimentEvaluate = "experiment.evaluate"
+	// SpanExperimentVerdict is the paired-difference decision span: emitted under
+	// experiment.evaluate when the conclusion produced a rolling verdict (the #979
+	// min-N + effect-size comparison the registry computed). Carries the verdict
+	// outcome / delta / significance. It records the verdict, it does NOT compute it
+	// (the registry owns the math) — observability only.
+	SpanExperimentVerdict = "experiment.verdict"
+)
+
+// Custom attribute keys for the experiment-lifecycle spans (#1140 Slice C). They
+// reuse the established experiment.* vocabulary (AttrExperimentID / AttrExperimentArm /
+// AttrExperimentFitness, defined in retro_capture.go) and add the conclusion-status
+// and verdict keys. No cross-session player identity is ever stamped — only
+// experiment.id / arm / game.id (the no-player-identity constraint, #23).
+const (
+	// AttrExperimentStatus is the experiment lifecycle status that resulted from
+	// folding a game (e.g. "running" / "concluded"), recorded on experiment.evaluate.
+	AttrExperimentStatus = "experiment.status"
+	// AttrExperimentObjective is the experiment's fitness objective
+	// (endurance/balanced/accelerate) the per-game fitness was scored against,
+	// recorded on experiment.fitness.
+	AttrExperimentObjective = "experiment.objective"
+	// AttrVerdictOutcome / AttrVerdictDelta / AttrVerdictSignificant carry the rolling
+	// paired-difference verdict the registry computed: the outcome label
+	// ("inconclusive"/"promote"/"discard"), the experimental-minus-control delta, and
+	// whether it cleared the significance bar. Recorded on experiment.verdict.
+	AttrVerdictOutcome     = "verdict.outcome"
+	AttrVerdictDelta       = "verdict.delta"
+	AttrVerdictSignificant = "verdict.significant"
+)
+
 // instrumentationName scopes the agent's tracer.
 const instrumentationName = "github.com/joustmania/agent"

--- a/services/agent/experiment_loop.go
+++ b/services/agent/experiment_loop.go
@@ -10,6 +10,10 @@ import (
 	"sync"
 	"time"
 
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
 	"github.com/joustmania/agent/decision"
 	"github.com/joustmania/agent/experiment"
 	"github.com/joustmania/agent/experiment/journal"
@@ -109,6 +113,14 @@ type experimentLoop struct {
 	spawner  *shadowSpawner
 	flags    *flags.Flags
 	log      *slog.Logger
+
+	// tracer emits the #1140 Slice C experiment-lifecycle spans (experiment.fitness /
+	// experiment.evaluate / experiment.verdict) so the otherwise log-only "learn from
+	// games" loop is an actual trace. Defaulted to the agent's tracer in
+	// buildExperimentLoop; tests inject a recording tracer. A nil tracer is treated as
+	// a no-op (the loop never panics on a span emission), so test wiring that does not
+	// set it leaves behavior unchanged.
+	tracer trace.Tracer
 
 	// fitnessStore is the finalized-per-game fitness store (#965/#1017): onGameEnd
 	// records every concluded game's settled fitness here, keyed by game_id, for
@@ -293,6 +305,7 @@ func buildExperimentLoop(
 		spawner:        spawner,
 		flags:          flagsClient,
 		log:            logger,
+		tracer:         otel.Tracer(experimentInstrumentationName),
 		fitnessStore:   fitnessStore,
 		expDefaults:    expDefaults,
 		seed:           seedIntentFromEnv(),
@@ -672,13 +685,27 @@ func (e *experimentLoop) onGameEnd(gc gamecontext.GameContext) {
 	if cv, ok := e.registry.CompactView(gc.ExperimentID); ok {
 		objective = cv.Intent.Objective
 	}
-	fitness := e.fitness(gc, objective)
+
+	// #1140 Slice C: emit the experiment-lifecycle spans around the EXISTING fitness /
+	// conclusion computations — observability only, no change to the values computed,
+	// their order, or the loop's control flow. Each span is Linked to the originating
+	// game trace (the #1133 link-from-hex pattern, replicated here as
+	// experimentGameTraceLink) so the experiment phase is navigable to the game it
+	// aggregates.
+	gameLink := experimentGameTraceLink(gc.GameTraceID)
+
+	// experiment.fitness: the per-shadow-game fitness scalar the cohort aggregator folds.
+	fitness := e.scoreGameFitness(gc, objective, gameLink)
 	// Record the SHADOW game's finalized fitness keyed by game_id (#965) so the M7-7
 	// StoreMeasurer can read a validation batch's fitness back. This is the same
 	// scalar ConcludeGame folds into the cohort journal — captured for the validation
 	// path too.
 	e.recordFinalizedFitness(gc, objective, fitness, duration)
-	status, err := e.registry.ConcludeGame(context.Background(), gc.SessionID, fitness, duration)
+
+	// experiment.evaluate: fold the concluded game into its arm and observe the
+	// resulting lifecycle status; experiment.verdict (a child) records the rolling
+	// paired-difference verdict the registry computed, when one is present.
+	status, err := e.concludeWithSpan(gc, fitness, duration, gameLink)
 	if err != nil {
 		e.log.Warn("experiment: conclude game failed", "game_id", gc.SessionID, "error", err)
 		return
@@ -686,6 +713,124 @@ func (e *experimentLoop) onGameEnd(gc gamecontext.GameContext) {
 	if status == experiment.StatusRunning {
 		// A freed in-flight slot; refill it (respecting the kill-switch).
 		e.allocateIfEnabled(context.Background())
+	}
+}
+
+// scoreGameFitness computes one finished experiment game's fitness scalar (the
+// existing gameFitnessFunc) inside the #1140 experiment.fitness span. The span is
+// OBSERVABILITY ONLY — it wraps the SAME e.fitness(gc, objective) call and returns
+// its result unchanged. It carries the experiment correlation (id / arm / game.id /
+// objective) and the resulting experiment.fitness, and Links to the game trace when
+// one is in scope. A nil tracer (test wiring) is a no-op: the fitness call runs
+// directly with no span.
+func (e *experimentLoop) scoreGameFitness(gc gamecontext.GameContext, objective string, gameLink []trace.SpanStartOption) float64 {
+	if e.tracer == nil {
+		return e.fitness(gc, objective)
+	}
+	attrs := []attribute.KeyValue{
+		attribute.String(decision.AttrExperimentID, gc.ExperimentID),
+		attribute.String(decision.AttrGameID, gc.SessionID),
+	}
+	if gc.Arm != "" {
+		attrs = append(attrs, attribute.String(decision.AttrExperimentArm, gc.Arm))
+	}
+	if objective != "" {
+		attrs = append(attrs, attribute.String(decision.AttrExperimentObjective, objective))
+	}
+	opts := append([]trace.SpanStartOption{trace.WithAttributes(attrs...)}, gameLink...)
+	_, span := e.tracer.Start(context.Background(), decision.SpanExperimentFitness, opts...)
+	defer span.End()
+
+	fitness := e.fitness(gc, objective)
+	span.SetAttributes(attribute.Float64(decision.AttrExperimentFitness, fitness))
+	return fitness
+}
+
+// concludeWithSpan folds the concluded game into its arm (the existing
+// registry.ConcludeGame) inside the #1140 experiment.evaluate span and, when the
+// conclusion produced a rolling verdict, emits a child experiment.verdict span. Both
+// are OBSERVABILITY ONLY — the fold, the status, and the verdict are exactly what the
+// registry computes; the spans record them, they do not change them. experiment.evaluate
+// Links to the game trace. A nil tracer (test wiring) is a no-op: ConcludeGame runs
+// directly with no span. The returned (status, err) are passed straight through.
+func (e *experimentLoop) concludeWithSpan(gc gamecontext.GameContext, fitness, duration float64, gameLink []trace.SpanStartOption) (experiment.Status, error) {
+	if e.tracer == nil {
+		return e.registry.ConcludeGame(context.Background(), gc.SessionID, fitness, duration)
+	}
+	attrs := []attribute.KeyValue{
+		attribute.String(decision.AttrExperimentID, gc.ExperimentID),
+		attribute.String(decision.AttrGameID, gc.SessionID),
+	}
+	if gc.Arm != "" {
+		attrs = append(attrs, attribute.String(decision.AttrExperimentArm, gc.Arm))
+	}
+	opts := append([]trace.SpanStartOption{trace.WithAttributes(attrs...)}, gameLink...)
+	ctx, span := e.tracer.Start(context.Background(), decision.SpanExperimentEvaluate, opts...)
+	defer span.End()
+
+	status, err := e.registry.ConcludeGame(ctx, gc.SessionID, fitness, duration)
+	span.SetAttributes(attribute.String(decision.AttrExperimentStatus, string(status)))
+
+	// experiment.verdict (child): record the rolling paired-difference verdict the
+	// registry computed, when the conclusion produced one. We READ it back via
+	// CompactView — the registry owns the math; this span only surfaces the result.
+	if err == nil {
+		e.recordVerdictSpan(ctx, gc.ExperimentID)
+	}
+	return status, err
+}
+
+// recordVerdictSpan emits the #1140 experiment.verdict span carrying the rolling
+// paired-difference verdict (outcome / delta / significance) the registry computed
+// for the experiment, read back via CompactView. It is OBSERVABILITY ONLY — it
+// computes nothing. The span is emitted only when a verdict is actually present
+// (a conclusion that has not yet produced one adds no empty span). The ctx is the
+// experiment.evaluate span's context, so the verdict span nests under it.
+func (e *experimentLoop) recordVerdictSpan(ctx context.Context, experimentID string) {
+	cv, ok := e.registry.CompactView(experimentID)
+	if !ok || cv.Verdict == nil {
+		return
+	}
+	v := cv.Verdict
+	_, span := e.tracer.Start(ctx, decision.SpanExperimentVerdict, trace.WithAttributes(
+		attribute.String(decision.AttrExperimentID, experimentID),
+		attribute.String(decision.AttrVerdictOutcome, v.Outcome),
+		attribute.Float64(decision.AttrVerdictDelta, v.Delta),
+		attribute.Bool(decision.AttrVerdictSignificant, v.Significant),
+	))
+	span.End()
+}
+
+// experimentInstrumentationName scopes the experiment loop's tracer. It matches the
+// decision package's instrumentationName literal so all agent spans share one
+// instrumentation scope in Jaeger.
+const experimentInstrumentationName = "github.com/joustmania/agent"
+
+// experimentGameTraceLink replicates the #1133 gameTraceLink primitive (which is
+// package-private to the decision package) for the experiment loop: when gameTraceID
+// is a valid hex trace_id, it returns a single trace.WithLinks option whose Link
+// targets a remote, sampled SpanContext reconstructed from that trace_id, so an
+// experiment-lifecycle span LINKS to the originating game trace (navigable in Jaeger).
+// The Link carries the trace_id as an attribute. An empty or unparseable id yields NO
+// option — graceful fallback, no Link, no error — exactly like gameTraceLink.
+func experimentGameTraceLink(gameTraceID string) []trace.SpanStartOption {
+	if gameTraceID == "" {
+		return nil
+	}
+	tid, err := trace.TraceIDFromHex(gameTraceID)
+	if err != nil || !tid.IsValid() {
+		return nil
+	}
+	sc := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    tid,
+		TraceFlags: trace.FlagsSampled,
+		Remote:     true,
+	})
+	return []trace.SpanStartOption{
+		trace.WithLinks(trace.Link{
+			SpanContext: sc,
+			Attributes:  []attribute.KeyValue{attribute.String(decision.AttrGameTraceID, gameTraceID)},
+		}),
 	}
 }
 

--- a/services/agent/experiment_spans_test.go
+++ b/services/agent/experiment_spans_test.go
@@ -1,0 +1,272 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/joustmania/agent/decision"
+	"github.com/joustmania/agent/experiment"
+	"github.com/joustmania/agent/gamecontext"
+	"github.com/joustmania/agent/promote"
+)
+
+// #1140 Slice C: the experiment / fitness / verdict learning loop was log-only —
+// invisible in traces. onGameEnd now wraps the EXISTING fitness + conclusion
+// computations in experiment.fitness / experiment.evaluate / experiment.verdict
+// spans (observability only — no change to the values, their order, or the loop's
+// control flow), each Linked to the originating game trace when one is in scope.
+
+// expSpan_findByName returns the recorded spans with the given name.
+func expSpan_findByName(spans []sdktrace.ReadOnlySpan, name string) []sdktrace.ReadOnlySpan {
+	var out []sdktrace.ReadOnlySpan
+	for _, s := range spans {
+		if s.Name() == name {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func expSpan_attr(s sdktrace.ReadOnlySpan, key string) (string, bool) {
+	for _, kv := range s.Attributes() {
+		if string(kv.Key) == key {
+			return kv.Value.Emit(), true
+		}
+	}
+	return "", false
+}
+
+// gcWithTrace mirrors gcFor but stamps a game trace_id so the experiment spans can be
+// asserted to Link to the originating game trace.
+func gcWithTrace(gameID, experimentID, arm, traceID string) gamecontext.GameContext {
+	gc := gcFor(gameID, experimentID, arm)
+	gc.GameTraceID = traceID
+	return gc
+}
+
+// recordingExperimentLoop builds a loop wired with a recording tracer plus a real
+// registry, declares + starts one experiment, and returns the loop, span recorder,
+// the recording spawner, and the experiment id.
+func recordingExperimentLoop(t *testing.T) (*experimentLoop, *tracetest.SpanRecorder, *recordingSpawner, string) {
+	t.Helper()
+	spawner := &recordingSpawner{}
+	realDef := &recordingRealDefault{}
+	github := &recordingGitHub{}
+	// Safe-default resolver (mode=issue, local, kill-switch off) — the verdict path is
+	// exercised without any real-player write, exactly like the safe-default E2E test.
+	resolve := func(context.Context) promote.Config {
+		return promote.Config{Mode: promote.ModeIssue, Target: promote.TargetLocal, Enabled: false}
+	}
+	loop := buildLoopForTest(t, spawner, resolve, realDef, github, armFitness())
+
+	sr := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+	loop.tracer = tp.Tracer("test")
+
+	id, err := loop.registry.Declare(experiment.Intent{
+		FlagKey: "invincibility_seconds", ExperimentalValue: 6.0, Objective: "balanced", TargetNPerArm: 3,
+	})
+	if err != nil {
+		t.Fatalf("declare: %v", err)
+	}
+	if err := loop.registry.Start(context.Background(), id); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	return loop, sr, spawner, id
+}
+
+// TestExperimentSpans_FitnessAndEvaluateEmitted: concluding a single shadow game
+// emits one experiment.fitness span and one experiment.evaluate span, each carrying
+// the experiment correlation (id / arm / game.id) and a Link to the game trace, and
+// experiment.fitness carries the computed fitness scalar.
+func TestExperimentSpans_FitnessAndEvaluateEmitted(t *testing.T) {
+	loop, sr, spawner, expID := recordingExperimentLoop(t)
+	const gameTrace = "4bf92f3577b34da6a3ce929d0e0e4736"
+
+	// Allocate one game so the registry binds it to the experiment, then conclude the
+	// ACTUAL bound game (using the spawner's recorded gameID) so ConcludeGame folds it.
+	loop.registry.AllocateAndSpawn(context.Background())
+	rec := spawner.drain()
+	if len(rec) == 0 {
+		t.Fatal("expected the registry to allocate one shadow game")
+	}
+	c := rec[0]
+	loop.onGameEnd(gcWithTrace(c.gameID, c.experimentID, c.arm, gameTrace))
+
+	ended := sr.Ended()
+
+	fit := expSpan_findByName(ended, decision.SpanExperimentFitness)
+	if len(fit) != 1 {
+		t.Fatalf("experiment.fitness spans = %d, want 1", len(fit))
+	}
+	if v, ok := expSpan_attr(fit[0], decision.AttrExperimentID); !ok || v != expID {
+		t.Errorf("experiment.fitness %s = %q, want %q", decision.AttrExperimentID, v, expID)
+	}
+	if v, ok := expSpan_attr(fit[0], decision.AttrExperimentArm); !ok || v != c.arm {
+		t.Errorf("experiment.fitness %s = %q, want %q", decision.AttrExperimentArm, v, c.arm)
+	}
+	if _, ok := expSpan_attr(fit[0], decision.AttrExperimentFitness); !ok {
+		t.Errorf("experiment.fitness must carry %s", decision.AttrExperimentFitness)
+	}
+	assertLinksToTrace(t, fit[0], gameTrace, "experiment.fitness")
+
+	eval := expSpan_findByName(ended, decision.SpanExperimentEvaluate)
+	if len(eval) != 1 {
+		t.Fatalf("experiment.evaluate spans = %d, want 1", len(eval))
+	}
+	if v, ok := expSpan_attr(eval[0], decision.AttrExperimentStatus); !ok || v == "" {
+		t.Errorf("experiment.evaluate must carry a non-empty %s, got %q", decision.AttrExperimentStatus, v)
+	}
+	assertLinksToTrace(t, eval[0], gameTrace, "experiment.evaluate")
+}
+
+// TestExperimentSpans_VerdictEmitted: running enough conclusions to reach a rolling
+// verdict emits an experiment.verdict span carrying the outcome / delta / significance
+// the registry computed, nested under an experiment.evaluate span.
+func TestExperimentSpans_VerdictEmitted(t *testing.T) {
+	loop, sr, spawner, expID := recordingExperimentLoop(t)
+
+	// Conclude enough games per arm (TargetNPerArm=3) for the #979 verdict to settle.
+	concludeCohort(t, loop, spawner, 4)
+
+	ended := sr.Ended()
+	verdicts := expSpan_findByName(ended, decision.SpanExperimentVerdict)
+	if len(verdicts) == 0 {
+		t.Fatalf("expected at least one experiment.verdict span once a verdict settles, got 0")
+	}
+	last := verdicts[len(verdicts)-1]
+	if v, ok := expSpan_attr(last, decision.AttrVerdictOutcome); !ok || v == "" {
+		t.Errorf("experiment.verdict must carry a non-empty %s", decision.AttrVerdictOutcome)
+	}
+	if _, ok := expSpan_attr(last, decision.AttrVerdictDelta); !ok {
+		t.Errorf("experiment.verdict must carry %s", decision.AttrVerdictDelta)
+	}
+	if v, ok := expSpan_attr(last, decision.AttrExperimentID); !ok || v != expID {
+		t.Errorf("experiment.verdict %s = %q, want %q", decision.AttrExperimentID, v, expID)
+	}
+	// The verdict span nests under an experiment.evaluate span (shares its trace).
+	evals := expSpan_findByName(ended, decision.SpanExperimentEvaluate)
+	if len(evals) == 0 {
+		t.Fatal("expected experiment.evaluate spans to parent the verdict")
+	}
+	var nested bool
+	for _, ev := range evals {
+		if ev.SpanContext().TraceID() == last.SpanContext().TraceID() {
+			nested = true
+		}
+	}
+	if !nested {
+		t.Error("experiment.verdict must nest under an experiment.evaluate span (same trace)")
+	}
+}
+
+// TestExperimentSpans_NoLinkWhenTraceAbsent: a concluded game with no GameTraceID
+// (the common shadow-game case) still emits the spans, but with NO Link — graceful
+// fallback, no panic.
+func TestExperimentSpans_NoLinkWhenTraceAbsent(t *testing.T) {
+	loop, sr, spawner, _ := recordingExperimentLoop(t)
+
+	loop.registry.AllocateAndSpawn(context.Background())
+	rec := spawner.drain()
+	if len(rec) == 0 {
+		t.Fatal("expected the registry to allocate one shadow game")
+	}
+	c := rec[0]
+	loop.onGameEnd(gcFor(c.gameID, c.experimentID, c.arm)) // no GameTraceID
+
+	ended := sr.Ended()
+	for _, name := range []string{decision.SpanExperimentFitness, decision.SpanExperimentEvaluate} {
+		spans := expSpan_findByName(ended, name)
+		if len(spans) != 1 {
+			t.Fatalf("%s spans = %d, want 1", name, len(spans))
+		}
+		if n := len(spans[0].Links()); n != 0 {
+			t.Errorf("%s links = %d, want 0 (no game trace_id)", name, n)
+		}
+	}
+}
+
+// TestExperimentSpans_FitnessValueUnchanged: the experiment.fitness span is pure
+// observability — the scalar recorded on the span MUST equal the bare gameFitnessFunc
+// result, proving the span does not alter the computed fitness.
+func TestExperimentSpans_FitnessValueUnchanged(t *testing.T) {
+	loop, sr, spawner, _ := recordingExperimentLoop(t)
+
+	loop.registry.AllocateAndSpawn(context.Background())
+	rec := spawner.drain()
+	if len(rec) == 0 {
+		t.Fatal("expected the registry to allocate one shadow game")
+	}
+	c := rec[0]
+	gc := gcFor(c.gameID, c.experimentID, c.arm)
+
+	want := armFitness()(gc, "balanced")
+	loop.onGameEnd(gc)
+
+	fit := expSpan_findByName(sr.Ended(), decision.SpanExperimentFitness)
+	if len(fit) != 1 {
+		t.Fatalf("experiment.fitness spans = %d, want 1", len(fit))
+	}
+	got, ok := fitnessAttrFloat(fit[0])
+	if !ok {
+		t.Fatalf("experiment.fitness must carry %s", decision.AttrExperimentFitness)
+	}
+	if got != want {
+		t.Errorf("recorded fitness = %v, want %v (span must not change the computed value)", got, want)
+	}
+}
+
+// fitnessAttrFloat extracts the experiment.fitness float64 attribute.
+func fitnessAttrFloat(s sdktrace.ReadOnlySpan) (float64, bool) {
+	for _, kv := range s.Attributes() {
+		if string(kv.Key) == decision.AttrExperimentFitness {
+			return kv.Value.AsFloat64(), true
+		}
+	}
+	return 0, false
+}
+
+// assertLinksToTrace asserts the span carries exactly one Link to the given game
+// trace_id with the trace_id attribute.
+func assertLinksToTrace(t *testing.T, s sdktrace.ReadOnlySpan, gameTrace, spanName string) {
+	t.Helper()
+	links := s.Links()
+	if len(links) != 1 {
+		t.Fatalf("%s links = %d, want 1", spanName, len(links))
+	}
+	wantTID, _ := trace.TraceIDFromHex(gameTrace)
+	if got := links[0].SpanContext.TraceID(); got != wantTID {
+		t.Errorf("%s link trace_id = %s, want %s", spanName, got, wantTID)
+	}
+	var found bool
+	for _, kv := range links[0].Attributes {
+		if string(kv.Key) == decision.AttrGameTraceID && kv.Value.AsString() == gameTrace {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("%s link must carry %s=%s", spanName, decision.AttrGameTraceID, gameTrace)
+	}
+}
+
+// TestExperimentGameTraceLink_Direct unit-tests the replicated #1133 link primitive:
+// valid -> one option, empty/invalid -> nil (graceful fallback).
+func TestExperimentGameTraceLink_Direct(t *testing.T) {
+	if got := experimentGameTraceLink(""); got != nil {
+		t.Errorf("experimentGameTraceLink(empty) = %v, want nil", got)
+	}
+	if got := experimentGameTraceLink("zzzz"); got != nil {
+		t.Errorf("experimentGameTraceLink(invalid) = %v, want nil", got)
+	}
+	if got := experimentGameTraceLink("00000000000000000000000000000000"); got != nil {
+		t.Errorf("experimentGameTraceLink(all-zero) = %v, want nil", got)
+	}
+	if got := experimentGameTraceLink("4bf92f3577b34da6a3ce929d0e0e4736"); len(got) != 1 {
+		t.Errorf("experimentGameTraceLink(valid) = %d options, want 1", len(got))
+	}
+}


### PR DESCRIPTION
Part of #1088, #1140 (Slices B+C: retro linkage + experiment-lifecycle spans)

## Slice B — retro linkage
`agent.llm.retro` (retro_capture.go) was created with `context.Background()` → a fully orphaned root, tied to the game only by the `game.id` attribute. It stays a **root** span (it is post-game / async, with no inbound RPC context), but it is now **navigable to the game**: when the finished session carries a valid `GameContext.GameTraceID` (#1133), the span gets the same OTel Link the `agent.decision` span uses (`gameTraceLink`, package-level in the `decision` package — called directly), plus a plain `game.trace_id` span attribute for backends that don't surface link attributes in search. Empty/invalid id → no link, no attribute (graceful, byte-identical to before).

## Slice C — experiment-lifecycle spans
The experiment/fitness/verdict loop was entirely log-only. `onGameEnd` now wraps the **existing** computations (no reordering, no math change) in three spans:

| Span | Where emitted | Carries | Game correlation |
|------|---------------|---------|------------------|
| `experiment.fitness` | `scoreGameFitness` (wraps the per-shadow-game `e.fitness(gc, objective)` call) | experiment.id, arm, game.id, objective, experiment.fitness | **Link** to game trace |
| `experiment.evaluate` | `concludeWithSpan` (wraps `registry.ConcludeGame`) | experiment.id, arm, game.id, experiment.status (resulting lifecycle status) | **Link** to game trace |
| `experiment.verdict` | `recordVerdictSpan`, child of `experiment.evaluate` | experiment.id, verdict.outcome, verdict.delta, verdict.significant | nested under evaluate (read back via `CompactView`) |

The verdict math, fitness computation, and promotion gating live in the `experiment` package (untouched) — these spans only **record** what the registry computes. The loop gained a `tracer` field (defaulted via `otel.Tracer(...)`, nil = no-op). Since `gameTraceLink` is package-private to `decision`, the link-from-hex pattern is replicated as `experimentGameTraceLink` in the loop (same nil-on-invalid behavior).

No cross-session player identity is stamped — only experiment.id / arm / game.id (#23).

## Files
- `services/agent/decision/retro_capture.go` — retro link site
- `services/agent/decision/telemetry.go` — new `SpanExperiment*` + `AttrExperimentStatus`/`AttrExperimentObjective`/`AttrVerdict*` consts
- `services/agent/experiment_loop.go` — tracer field + the three span helpers
- `services/agent/decision/retro_trace_link_test.go`, `services/agent/experiment_spans_test.go` — tests

## Verify
`gofmt -l .` clean, `go build ./...`, `go vet ./...`, `go test ./... -race -count=1` all green. Tests assert: retro span links to the game trace when present (and no link/attr when absent/invalid), the three experiment spans emit with the right names/attributes, the verdict span nests under evaluate, links are present/absent correctly, and the recorded fitness equals the bare `gameFitnessFunc` result (no behavior change).