### PR TITLE
fix(ci): stop concurrency-cancelled runs posting CI Complete: FAILURE (#1086)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,19 @@ jobs:
     name: Detect changes
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    # #1086: only the `ci-full` label should drive a fresh full run when added to
+    # an EXISTING PR. Adding any OTHER label (e.g. `bug`) to a PR must not spawn a
+    # redundant heavy CI run on an already-tested SHA. `opened`/`synchronize`/
+    # `reopened`/`push`/`workflow_dispatch` always proceed; a `labeled` action
+    # proceeds only when the added label is `ci-full`. (The create-PR-with-
+    # `ci-full` double fire is still handled by the concurrency group + the
+    # ci-complete `!cancelled()` guard below — both the opened and the labeled
+    # run are legitimate there; the cancelled one simply posts no blocking
+    # status.) NOTE: for pull_request events the trigger type is in
+    # `github.event.action` (event_name is always `pull_request`).
+    if: >-
+      github.event.action != 'labeled' ||
+      github.event.label.name == 'ci-full'
     outputs:
       lib: ${{ steps.f.outputs.lib }}
       rust: ${{ steps.f.outputs.rust }}
@@ -703,7 +716,7 @@ jobs:
   # Final status check job for branch protection
   # This job depends on all other jobs and provides a single status check
   # that represents the entire CI pipeline's health.
-  # Skipped jobs (path filter) keep this green; failures/cancellations fail it.
+  # Skipped jobs (path filter) keep this green; failures fail it.
   ci-complete:
     name: CI Complete
     runs-on: ubuntu-latest
@@ -721,7 +734,19 @@ jobs:
       - docker-build
       - docker-build-extra
       - retag-skipped
-    if: always()
+    # #1086: was `always()`. Creating a PR with a label (`gh pr create --label
+    # ci-full`) fires BOTH the `opened` and `labeled` pull_request events, so two
+    # runs start on the same SHA; the `concurrency` group below cancels the
+    # older one. Under `always()` that CANCELLED run still ran ci-complete, and
+    # the step concluded FAILURE (cancelled `needs`) — posting a stale
+    # `CI Complete: FAILURE` status that blocked auto-merge even though the
+    # surviving run was green. `!cancelled()` makes a concurrency-superseded run
+    # SKIP ci-complete entirely (posts no blocking status), so only the
+    # surviving run's status counts. Genuine job failures are NOT cancellations,
+    # so `!cancelled()` is still true on failure and the step below still
+    # exit-1's — real failures keep blocking. Per-job `cancelled` results (e.g. a
+    # single timed-out job in an otherwise-live run) are still caught below.
+    if: ${{ !cancelled() }}
     steps:
       - name: Check all jobs passed
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -746,7 +746,19 @@ jobs:
     # so `!cancelled()` is still true on failure and the step below still
     # exit-1's — real failures keep blocking. Per-job `cancelled` results (e.g. a
     # single timed-out job in an otherwise-live run) are still caught below.
-    if: ${{ !cancelled() }}
+    #
+    # The second clause guards the label-gate cascade: on a non-`ci-full`
+    # `labeled` event the `changes` job is skipped (see its `if`), so every real
+    # check is skipped too. WITHOUT this clause ci-complete would still run with
+    # all-`skipped` needs and post `CI Complete: success` on the head SHA —
+    # which, under the repo's latest-status-wins ruleset (strict checks OFF),
+    # would OVERWRITE a prior real `CI Complete: FAILURE` on that same SHA and
+    # unblock a red merge with no re-run. Skipping ci-complete on those events
+    # means a label-only change posts NO status, so the SHA's prior real result
+    # stands. (Adding `ci-full` itself runs the full pipeline normally.)
+    if: >-
+      ${{ !cancelled() &&
+      (github.event.action != 'labeled' || github.event.label.name == 'ci-full') }}
     steps:
       - name: Check all jobs passed
         env:


### PR DESCRIPTION
Part of #1086

## Root cause (confirmed)
`gh pr create --label ci-full` (what our subagents always do) fires BOTH the `opened` and `labeled` pull_request webhook events near-simultaneously → two CI runs start on the same SHA. The workflow `concurrency` group (`cancel-in-progress` on PRs) cancels the older run. Because `ci-complete` was guarded with `if: always()`, the **cancelled** run still executed `ci-complete`, its step treats a `cancelled` result in `needs.*` as failure (`exit 1`), and that posts a `CI Complete: FAILURE` commit status. Since both runs share the SHA/context, that stale FAILURE becomes the latest `CI Complete` status and blocks branch-protection / auto-merge even though the surviving run is green.

## The fix (workflow only — `.github/workflows/ci.yml`)
1. **`ci-complete`: `if: always()` → `if: ${{ !cancelled() && (github.event.action != 'labeled' || github.event.label.name == 'ci-full') }}` (load-bearing).**
   - `!cancelled()`: a run cancelled by concurrency supersession **skips `ci-complete` entirely** and posts no `CI Complete` status, so only the surviving run's status counts. A genuine job failure is NOT a cancellation, so `!cancelled()` stays true and the gate still `exit 1`s on failure — real failures keep blocking. The step body still flags any per-job `cancelled` result inside an otherwise-live run (e.g. a single timed-out job).
   - label clause: on a non-`ci-full` `labeled` event the `changes` job (and thus every real check) is skipped, so `ci-complete` must NOT post a green status — otherwise, under the repo's latest-status-wins required-status ruleset (strict checks OFF), that green would overwrite a prior real `CI Complete: FAILURE` on the same SHA and unblock a red merge. This clause makes a label-only change post NO status, so the SHA's prior real result stands.
2. **`changes`: skip `labeled` events unless the label is `ci-full`.** Adding an unrelated label (e.g. `bug`) to an already-tested PR no longer spawns a redundant heavy run. `opened`/`synchronize`/`reopened`/`push`/`workflow_dispatch` are unaffected. (For `pull_request` events the trigger type lives in `github.event.action`; `github.event_name` is always `pull_request`.)

The `ci-full` label functionality and the `labeled` trigger are preserved: adding `ci-full` to an existing PR still forces a full run.

## Event matrix
| Event | Real CI runs | `CI Complete` status outcome |
|-------|--------------|------------------------------|
| **PR opened WITH `ci-full`** | 2 (`opened` + `labeled:ci-full`) | concurrency cancels one; cancelled run **skips** ci-complete (no status). Survivor reports the real result. ✅ no stale FAILURE |
| **PR opened WITHOUT label** | 1 (`opened`) | single run reports real result. ✅ |
| **`ci-full` added later** | 1 (`labeled:ci-full`) | full pipeline runs, reports real result. ✅ feature preserved |
| **Other label added later** (e.g. `bug`) | 0 (`changes` skipped → cascade skip) | ci-complete **skipped** (label clause false) → **posts NO status**; the SHA's prior real `CI Complete` stands. ✅ cannot mask a prior FAILURE |
| **synchronize (new push)** | 1; cancels any in-flight run for the PR | superseded in-flight run **skips** ci-complete (no status); newest push reports real result. ✅ |
| **reopened** | 1 | single run reports real result. ✅ |
| **push to main / workflow_dispatch** | 1 | full checks; `cancel-in-progress` is false for non-PR so main runs never cancel each other. ✅ |

In no scenario does a concurrency-cancelled run post a blocking `CI Complete: FAILURE`, and no label-only event can overwrite a prior real status.

## Verification
- `python -c "import yaml; yaml.safe_load(...)"` → valid YAML, no duplicate keys; both `if` expressions parse.
- `actionlint .github/workflows/ci.yml` → clean (no errors).
- This PR is created WITHOUT `--label` (per #1086 workaround) so it doesn't trigger the very bug while the fix is still unmerged. Adding `ci-full` to THIS PR after merge-readiness is the live regression test.

## ⚠️ Needs careful human review — changes CI gating
This changes the required `CI Complete` status semantics (cancelled / non-`ci-full`-label events → no status instead of fail/success) and adds a label-event gate. Recommend confirming on a deliberately-red test PR + non-`ci-full` label-add that the prior FAILURE is NOT overwritten. Real failure paths are unchanged: failures still set `!cancelled()` true and `exit 1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)