### PR TITLE
test(menu): regression test for admin force-start with ghost controller (#551)

### DIFF
--- a/services/menu/tests/test_admin_handler.py
+++ b/services/menu/tests/test_admin_handler.py
@@ -493,6 +493,10 @@ class TestHandleForceStartFlagd:
         ready = {f"s{i}" for i in range(16)}
         mock_state_manager.ready_controllers = set(ready)
         mock_state_manager.connected_controllers = ready | {"ghost"}
+        # The all-ready gate is False while the ghost lingers (ready != connected).
+        # Pin it explicitly so this test fails the instant force-start regresses to
+        # honoring that gate (a default MagicMock is truthy and would mask it).
+        mock_state_manager.all_ready = MagicMock(return_value=False)
         handler._publish_event = AsyncMock()
         handler.exit = AsyncMock()
 

--- a/services/menu/tests/test_admin_handler.py
+++ b/services/menu/tests/test_admin_handler.py
@@ -474,6 +474,47 @@ class TestHandleForceStartFlagd:
         # ready (s1, s2) + admin (admin_serial), no duplicates.
         assert set(roster) == {"s1", "s2", "admin_serial"}
 
+    @pytest.mark.asyncio
+    async def test_force_start_not_blocked_by_ghost_controller(self, handler, mock_state_manager):
+        """Regression for #551: a ghost controller (the menu tracks more
+        connected controllers than are ready, e.g. after a missed DISCONNECT
+        during a gRPC GOAWAY) must NOT block admin force-start.
+
+        The normal trigger/auto path gates on all_ready() (ready == connected),
+        which stays False while a ghost lingers, so the game can never start
+        that way. Admin force-start is the operator's escape hatch: it must
+        bypass that gate entirely and launch with the real ready set rather
+        than waiting for the phantom controller to become ready.
+        """
+        mock_state_manager.current_game_mode.name = "JoustFFA"
+        # 16 ready, but the menu still tracks a 17th "ghost" as connected after a
+        # missed disconnect -> connected_count (17) != ready_count (16). The
+        # all-ready gate would refuse to start here.
+        ready = {f"s{i}" for i in range(16)}
+        mock_state_manager.ready_controllers = set(ready)
+        mock_state_manager.connected_controllers = ready | {"ghost"}
+        handler._publish_event = AsyncMock()
+        handler.exit = AsyncMock()
+
+        # force_all_start=False -> roster is the real ready set (+ admin if not
+        # already ready). The ghost is NOT ready, so it is excluded.
+        mock_gs_client = MagicMock()
+        mock_gs_client.get_boolean_value = MagicMock(return_value=False)
+
+        with (
+            patch("services.menu.handlers.admin.asyncio.sleep", new_callable=AsyncMock),
+            patch("lib.feature_flags.get_flag_client", return_value=mock_gs_client),
+        ):
+            await handler.handle_force_start("s0")
+
+        # The game must actually start despite the ready/connected mismatch.
+        handler.callbacks.start_game.assert_awaited_once()
+        roster = handler.callbacks.start_game.await_args.args[2]
+        # Started with the real ready set; the ghost is ignored. Admin (s0) is
+        # already ready, so no extra controller is appended.
+        assert set(roster) == ready
+        assert "ghost" not in roster
+
 
 # ============================================================================
 # Tier 1 — Core Lifecycle


### PR DESCRIPTION
Part of #551

## Investigation summary

#551 reports that admin force-start fails when the menu tracks a **ghost controller** (more controllers than the backend actually has, e.g. after a missed DISCONNECT during a gRPC GOAWAY — "16/17 ready").

I traced the full force-start / ready-check path on current `main` and found the reported symptom is **already addressed in two layers**, and the remaining true gap cannot be closed in the menu alone. So this PR adds the **missing regression test** rather than inventing a behavior change.

### Root cause of the original symptom
The all-ready gate lives in `services/menu/handlers/ready.py` (`_handle_trigger` / `on_enter`), which only starts when `StateManager.all_ready()` is true. `all_ready()` requires `ready_count == connected_count` (`state_manager.py:289`). A ghost stays in `connected_controllers` but never becomes READY, so that equality is never satisfied and the auto/trigger path can never start — exactly the "16/17, game does not start" symptom.

### What already fixes it
1. **Ghost reconciliation — #552 (commit `d5ab6ec3`).** Every CONNECT/DISCONNECT event now carries the backend's authoritative `connected_serials`; `controller_events.py::_reconcile_controllers` prunes any ghost the next time such an event arrives. This repairs the normal path. (#552's commit message references `#552`; the originating issue #551 stayed open and its `closingIssuesReferences` is empty.)
2. **Admin force-start already bypasses the gate.** `AdminModeHandler.handle_force_start` does **not** call `all_ready()`. It builds a roster from the ready set (or all connected when `force_all_start`) and routes it through `start_game -> _start_game`, which only requires `len(roster) >= 2` (`servicer.py:610`). So force-start starts the game regardless of the ready/connected mismatch.

### Residual gap (out of scope here)
During the window where a DISCONNECT was missed and **no** later connect/disconnect event has arrived, the menu cannot know which serial is the ghost — there is no synchronous backend roster-query RPC (`controller_manager.proto` exposes only the two streams + `RenameController`; `connected_serials` is piggybacked on events only). A cached roster would be stale-from-before-the-disconnect, so it wouldn't help. Fully resolving this would need a new query RPC + controller-manager work — explicitly outside this issue's menu scope.

## Change
Adds `test_force_start_not_blocked_by_ghost_controller` to `services/menu/tests/test_admin_handler.py`, mirroring the existing `TestHandleForceStartFlagd` patterns. It reproduces the issue scenario (16 ready, a 17th "ghost" connected -> `connected_count != ready_count`) and asserts force-start still launches via the coordinator start path with the real ready set, with the ghost excluded.

## Test results
- `services/menu`: 382 passed (146 in `test_admin_handler.py`, incl. the new test)
- `make lint`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)