### PR TITLE
feat(agent): honor rollout.strategy — skip count ladder on immediate

### DIFF
--- a/services/agent/decision/infra_loop.go
+++ b/services/agent/decision/infra_loop.go
@@ -134,6 +134,14 @@ const DefaultRolloutCooldown = 30 * time.Second
 // decision span when the loop expands (e.g. 3 after advancing none→one→three).
 const AttrRolloutControllerCount = "rollout.controller_count"
 
+// rolloutStrategyImmediate is the controller-manager strategy under which ALL
+// controllers are routed to the target backend at once (no progressive cohort).
+// The current_controller_count ladder is meaningless under it, so the loop
+// observes only — it never climbs the ladder or writes flag flips that would
+// correspond to no routing change (#829). It mirrors the "immediate" literal in
+// services/controller_manager/multiplexer/rollout_router.py.
+const rolloutStrategyImmediate = "immediate"
+
 // InfraLoop runs the progressive-rollout expansion controller (#734). On each
 // infra observe cycle it gates on controller freshness, evaluates Bluetooth
 // fitness against the live fitness.bluetooth.* thresholds, reads the OBSERVED
@@ -302,7 +310,19 @@ func (l *InfraLoop) OnInfraEvaluate(ctx context.Context, snap infracontext.Infra
 		l.rollbackInFlight = false
 	}
 
+	// Under strategy=immediate the controller-manager routes ALL controllers to
+	// the target at once, so the count ladder is meaningless: climbing it would
+	// only write flag flips and emit "expand" decisions that correspond to no
+	// routing change (#829). Observe only — record action="none" and skip the
+	// expand/rollback decision entirely. Absent/empty strategy (older
+	// controller-manager spans) is NOT immediate, so it falls through to the
+	// progressive ladder unchanged — no regression.
+	immediate := snap.Window.RolloutStrategy == rolloutStrategyImmediate
+
 	switch {
+	case immediate:
+		// Observe-only: action remains RemediationNone, no write, no ladder climb.
+
 	case fit.Evaluated && fit.Passing:
 		// Fitness passes → climb the ladder if eligible (PR E expansion).
 		if l.rollout != nil {

--- a/services/agent/decision/infra_loop_test.go
+++ b/services/agent/decision/infra_loop_test.go
@@ -88,6 +88,13 @@ func infraSnap(target string, stage int, now time.Time, hz float64) infracontext
 	}
 }
 
+// infraSnapStrategy is infraSnap with the observed rollout strategy set (#829).
+func infraSnapStrategy(target string, stage int, now time.Time, hz float64, strategy string) infracontext.InfraContext {
+	snap := infraSnap(target, stage, now, hz)
+	snap.Window.RolloutStrategy = strategy
+	return snap
+}
+
 // newInfraLoop builds a loop with a fake clock, fake rollout actuator, default
 // thresholds, an always-pass gate, and a recording tracer.
 func newInfraLoop(t *testing.T, rollout RolloutActuator, clock *time.Time) (*InfraLoop, *tracetest.SpanRecorder) {
@@ -160,6 +167,80 @@ func TestInfraLoop_ExpandsWhenPassing(t *testing.T) {
 	}
 	if v, _ := spanStr(spans[0], AttrFitnessViolations); v != "" {
 		t.Errorf("fitness.violations = %q, want empty", v)
+	}
+}
+
+// TestInfraLoop_ImmediateStrategySkipsLadder is the #829 guarantee: under
+// strategy=immediate the controller-manager routes ALL controllers at once, so
+// the count ladder is meaningless. Even with passing fitness at stage 0 (which
+// would otherwise expand to "one"), the loop must NOT write and must record
+// remediation.action="none" — but still emit the observe span.
+func TestInfraLoop_ImmediateStrategySkipsLadder(t *testing.T) {
+	clock := time.Unix(1000, 0)
+	rollout := &fakeRollout{}
+	l, sr := newInfraLoop(t, rollout, &clock)
+
+	l.OnInfraEvaluate(context.Background(), infraSnapStrategy("rust", 0, clock, 30, "immediate"))
+
+	if got := rollout.calls(); len(got) != 0 {
+		t.Fatalf("writes = %v, want none under strategy=immediate (no ladder climb)", got)
+	}
+	spans := infraSpans(sr)
+	if len(spans) != 1 {
+		t.Fatalf("got %d spans, want 1 (immediate still observes)", len(spans))
+	}
+	if v, _ := spanStr(spans[0], AttrRemediationAction); v != RemediationNone {
+		t.Errorf("remediation.action = %q, want %q (observe-only under immediate)", v, RemediationNone)
+	}
+	// The expand-destination attribute must be absent (no expand happened).
+	if _, ok := spanInt(spans[0], AttrRolloutControllerCount); ok {
+		t.Errorf("rollout.controller_count present, want absent (no expand under immediate)")
+	}
+	// The observed strategy is surfaced on the span for the operator.
+	if v, ok := spanStr(spans[0], AttrBluetoothRolloutStrategy); !ok || v != "immediate" {
+		t.Errorf("bluetooth.rollout_strategy = %q (ok=%v), want %q", v, ok, "immediate")
+	}
+}
+
+// TestInfraLoop_ProgressiveStrategyClimbsLadder is the explicit-progressive
+// counterpart: strategy="progressive" behaves exactly like the ladder path.
+func TestInfraLoop_ProgressiveStrategyClimbsLadder(t *testing.T) {
+	clock := time.Unix(1000, 0)
+	rollout := &fakeRollout{}
+	l, _ := newInfraLoop(t, rollout, &clock)
+
+	l.OnInfraEvaluate(context.Background(), infraSnapStrategy("rust", 0, clock, 30, "progressive"))
+
+	if got := rollout.calls(); len(got) != 1 || got[0] != "one" {
+		t.Fatalf("writes = %v, want [one] under strategy=progressive", got)
+	}
+}
+
+// TestInfraLoop_AbsentStrategyClimbsLadder is the graceful-default guarantee
+// (#829): an older controller-manager that omits bluetooth.rollout_strategy
+// produces an empty strategy, which must behave exactly as before — the
+// progressive ladder climbs. No regression.
+func TestInfraLoop_AbsentStrategyClimbsLadder(t *testing.T) {
+	clock := time.Unix(1000, 0)
+	rollout := &fakeRollout{}
+	l, sr := newInfraLoop(t, rollout, &clock)
+
+	// infraSnap leaves RolloutStrategy == "" (attribute absent on the span).
+	l.OnInfraEvaluate(context.Background(), infraSnap("rust", 0, clock, 30))
+
+	if got := rollout.calls(); len(got) != 1 || got[0] != "one" {
+		t.Fatalf("writes = %v, want [one] when strategy absent (progressive ladder as before)", got)
+	}
+	spans := infraSpans(sr)
+	if len(spans) != 1 {
+		t.Fatalf("got %d spans, want 1", len(spans))
+	}
+	if v, _ := spanStr(spans[0], AttrRemediationAction); v != RemediationExpand {
+		t.Errorf("remediation.action = %q, want %q (absent strategy → ladder)", v, RemediationExpand)
+	}
+	// Strategy is present-but-empty on the span (schema-complete unknown).
+	if v, ok := spanStr(spans[0], AttrBluetoothRolloutStrategy); !ok || v != "" {
+		t.Errorf("bluetooth.rollout_strategy = %q (ok=%v), want present-but-empty", v, ok)
 	}
 }
 

--- a/services/agent/decision/infra_telemetry.go
+++ b/services/agent/decision/infra_telemetry.go
@@ -53,6 +53,12 @@ const (
 	AttrBluetoothActiveControllers = "bluetooth.active_controllers"
 	AttrBluetoothTargetBackend     = "bluetooth.target_backend"
 	AttrBluetoothRolloutCount      = "bluetooth.rollout_count"
+	// AttrBluetoothRolloutStrategy is the observed controller-manager rollout
+	// strategy ("off"/"immediate"/"progressive"), surfaced on the decision span so
+	// a Jaeger consumer can see WHY an immediate-strategy cycle observed only
+	// (action="none") instead of climbing the ladder (#829). Present-but-empty when
+	// the producing controller-manager omits it (older than #829).
+	AttrBluetoothRolloutStrategy = "bluetooth.rollout_strategy"
 )
 
 // infraDecisionAttrs is the input bundle for the single span-attribute builder.
@@ -112,6 +118,9 @@ func infraDecisionAttributes(in infraDecisionAttrs) []attribute.KeyValue {
 		// Window context that always exists on an active-rollout cycle.
 		attribute.String(AttrBluetoothTargetBackend, in.snap.Window.TargetBackend),
 		attribute.Int(AttrBluetoothRolloutCount, in.snap.Window.RolloutCount),
+		// Observed strategy (present-but-empty when omitted by an older producer)
+		// so a consumer can see why an immediate cycle observed only (#829).
+		attribute.String(AttrBluetoothRolloutStrategy, in.snap.Window.RolloutStrategy),
 	}
 	// Optional window signals: recorded only when observed (a missing signal
 	// contributes no attribute rather than a fabricated zero).

--- a/services/agent/infracontext/extract_spans.go
+++ b/services/agent/infracontext/extract_spans.go
@@ -24,6 +24,7 @@ const (
 	AttrActiveControllers = "bluetooth.active_controllers"
 	AttrTargetBackend     = "bluetooth.target_backend"
 	AttrRolloutCount      = "bluetooth.rollout_count"
+	AttrRolloutStrategy   = "bluetooth.rollout_strategy"
 
 	// Per-sample event attributes. AttrDroppedEventsPct and AttrMovementUpdateHz
 	// are reused at the per-serial scope.
@@ -107,6 +108,9 @@ func windowFromAttrs(attrs pcommon.Map) WindowSignals {
 	}
 	if v, ok := intAttr(attrs, AttrRolloutCount); ok {
 		w.RolloutCount = v
+	}
+	if v, ok := attrs.Get(AttrRolloutStrategy); ok {
+		w.RolloutStrategy = v.AsString()
 	}
 	return w
 }

--- a/services/agent/infracontext/extract_spans_test.go
+++ b/services/agent/infracontext/extract_spans_test.go
@@ -64,11 +64,18 @@ func TestApplySpans_FullHealthSpan(t *testing.T) {
 		{serial: "A", hz: 60, droppedPct: 0.0, adapter: "python"},
 		{serial: "B", hz: 55, droppedPct: 0.2, adapter: "rust"},
 	}, false)
+	// strategy attribute (#829) — set directly; healthSpan has no slot for it.
+	td.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).
+		Attributes().PutStr(AttrRolloutStrategy, "progressive")
 
 	if !s.ApplySpans(td) {
 		t.Fatal("expected health span to be recognized")
 	}
 	snap := s.Snapshot()
+
+	if snap.Window.RolloutStrategy != "progressive" {
+		t.Fatalf("rollout_strategy = %q, want progressive", snap.Window.RolloutStrategy)
+	}
 
 	if snap.Window.EventGapMs == nil || *snap.Window.EventGapMs != 42.5 {
 		t.Fatalf("event_gap_ms = %v, want 42.5", snap.Window.EventGapMs)
@@ -121,6 +128,11 @@ func TestApplySpans_PartialAttrs(t *testing.T) {
 	}
 	if snap.Window.MovementUpdateHz != nil {
 		t.Fatalf("movement_update_hz = %v, want nil (absent)", snap.Window.MovementUpdateHz)
+	}
+	// Graceful default (#829): an older controller-manager omits the strategy
+	// attribute → empty string, which the loop treats as "behave as before".
+	if snap.Window.RolloutStrategy != "" {
+		t.Fatalf("rollout_strategy = %q, want empty (absent)", snap.Window.RolloutStrategy)
 	}
 	if snap.Window.ActiveControllers != nil {
 		t.Fatalf("active_controllers = %v, want nil (absent)", snap.Window.ActiveControllers)

--- a/services/agent/infracontext/model.go
+++ b/services/agent/infracontext/model.go
@@ -63,6 +63,15 @@ type WindowSignals struct {
 	// RolloutCount is the current_controller_count under rollout, 0 when off.
 	// Source: bluetooth.rollout_count.
 	RolloutCount int
+
+	// RolloutStrategy is the controller-manager's active rollout strategy —
+	// "off" | "immediate" | "progressive" — surfaced so the agent can skip its
+	// count ladder under "immediate" (where the controller-manager routes ALL
+	// controllers at once and the ladder is meaningless). Empty when the
+	// producing controller-manager is older than #829 and omits the attribute;
+	// callers treat "" as "behave as before" (the progressive ladder).
+	// Source: bluetooth.rollout_strategy.
+	RolloutStrategy string
 }
 
 // InfraContext is the full accumulated infrastructure view: the latest window

--- a/services/controller_manager/discovery_loop.py
+++ b/services/controller_manager/discovery_loop.py
@@ -751,6 +751,18 @@ class DiscoveryLoop:
             except Exception:
                 logger.debug("Failed to read rollout summary for health span", exc_info=True)
 
+        # Active rollout strategy ("off"/"immediate"/"progressive"). The agent
+        # reads this to skip its count ladder under "immediate" routing. Empty
+        # on any error so a flagd outage never breaks span emission; the agent
+        # treats absence as "behave as before" (progressive ladder).
+        rollout_strategy = ""
+        rollout_strategy_fn = getattr(self.backend, "rollout_strategy", None)
+        if rollout_strategy_fn is not None:
+            try:
+                rollout_strategy = rollout_strategy_fn()
+            except Exception:
+                logger.debug("Failed to read rollout strategy for health span", exc_info=True)
+
         # --- Span: periodic root span, like controller.discover ---------------
         with tracer.start_as_current_span("controller.bluetooth_health") as span:
             span.set_attribute("bluetooth.event_gap_ms", float(signals["event_gap_ms"]))
@@ -759,6 +771,7 @@ class DiscoveryLoop:
             span.set_attribute("bluetooth.active_controllers", int(signals["active_controllers"]))
             span.set_attribute("bluetooth.target_backend", target_backend)
             span.set_attribute("bluetooth.rollout_count", int(rollout_count))
+            span.set_attribute("bluetooth.rollout_strategy", rollout_strategy)
 
             # One event per active serial with per-serial signals.
             for serial, s in signals["per_serial"].items():

--- a/services/controller_manager/multiplexer/multiplexer_backend.py
+++ b/services/controller_manager/multiplexer/multiplexer_backend.py
@@ -314,6 +314,16 @@ class MultiplexerBackend(ControllerBackend):
         """
         return self._rollout_router.current_target()
 
+    def rollout_strategy(self) -> str:
+        """Active rollout ``strategy`` string for telemetry.
+
+        Public seam for the bluetooth-health span so the agent can see whether
+        the controller-manager is routing ``immediate`` / ``progressive`` /
+        ``off``. Delegates to the RolloutRouter, which degrades to ``""`` on any
+        flag error.
+        """
+        return self._rollout_router.current_strategy()
+
     def _cleanup_stale_state(self, seen: dict[str, ControllerIOAdapter]) -> None:
         """Remove centralized state for controllers no longer present."""
         stale = set(self._led_colors.keys()) - set(seen.keys())

--- a/services/controller_manager/multiplexer/rollout_router.py
+++ b/services/controller_manager/multiplexer/rollout_router.py
@@ -70,6 +70,25 @@ class RolloutRouter:
             logger.debug("RolloutRouter.current_target failed; reporting off", exc_info=True)
             return "", 0
 
+    def current_strategy(self) -> str:
+        """Return the active rollout ``strategy`` string for telemetry.
+
+        One of ``"off"`` | ``"immediate"`` | ``"progressive"`` (or any future
+        value flagd returns). Degrades to ``""`` on any evaluation error so a
+        flagd outage never breaks span emission; callers treat ``""`` as "no
+        strategy observed" and fall back to their default behavior.
+        """
+        try:
+            from openfeature.evaluation_context import EvaluationContext
+
+            from lib.feature_flags import get_flag_client
+
+            client = get_flag_client(_DOMAIN)
+            return client.get_string_value("strategy", "off", EvaluationContext())
+        except Exception:
+            logger.debug("RolloutRouter.current_strategy failed; reporting empty", exc_info=True)
+            return ""
+
     def target_for(self, serial: str, all_serials: list[str]) -> str | None:
         """Return the rollout target adapter_type for ``serial``, or None.
 

--- a/services/controller_manager/tests/test_bluetooth_health.py
+++ b/services/controller_manager/tests/test_bluetooth_health.py
@@ -186,6 +186,7 @@ class TestSpanEmission:
         backend = MagicMock()
         backend.get_adapter_type.return_value = "unstable"
         backend.rollout_summary.return_value = ("unstable", 3)
+        backend.rollout_strategy.return_value = "progressive"
         loop = _make_loop(backend)
         loop._window_start = 0.0
         _feed(loop, "AA", [{"n": i} if i % 5 != 0 else None for i in range(10)], dt=0.01)
@@ -201,6 +202,7 @@ class TestSpanEmission:
         assert a["bluetooth.dropped_events_pct"] == 0.2
         assert a["bluetooth.target_backend"] == "unstable"
         assert a["bluetooth.rollout_count"] == 3
+        assert a["bluetooth.rollout_strategy"] == "progressive"
         assert isinstance(a["bluetooth.event_gap_ms"], float)
         assert isinstance(a["bluetooth.movement_update_hz"], float)
 

--- a/services/controller_manager/tests/test_rollout_router.py
+++ b/services/controller_manager/tests/test_rollout_router.py
@@ -134,3 +134,27 @@ class TestCurrentTarget:
         router = RolloutRouter()
         with patch("lib.feature_flags.get_flag_client", side_effect=RuntimeError("flagd down")):
             assert router.current_target() == ("", 0)
+
+
+def _strategy(**kw):
+    router = RolloutRouter()
+    with patch("lib.feature_flags.get_flag_client", return_value=_client(**kw)):
+        return router.current_strategy()
+
+
+class TestCurrentStrategy:
+    """Strategy string surfaced on the bluetooth-health span (#829)."""
+
+    def test_off(self):
+        assert _strategy(strategy="off") == "off"
+
+    def test_immediate(self):
+        assert _strategy(strategy="immediate") == "immediate"
+
+    def test_progressive(self):
+        assert _strategy(strategy="progressive") == "progressive"
+
+    def test_flag_client_error_reports_empty(self):
+        router = RolloutRouter()
+        with patch("lib.feature_flags.get_flag_client", side_effect=RuntimeError("flagd down")):
+            assert router.current_strategy() == ""


### PR DESCRIPTION
## Summary

Under `strategy=immediate` the controller-manager routes ALL controllers to the target backend at once, but the agent kept climbing the `current_controller_count` ladder — writing meaningless flag flips and emitting `expand` decision spans that corresponded to no routing change. This wires the strategy through to the agent so it observes only under `immediate`.

## Controller-manager
- `RolloutRouter.current_strategy()` surfaces the active strategy (`off`/`immediate`/`progressive`), fail-soft to `""` on any flag error.
- `MultiplexerBackend.rollout_strategy()` is a public telemetry seam delegating to it.
- The `controller.bluetooth_health` span now carries `bluetooth.rollout_strategy`.

## Agent
- `infracontext.WindowSignals.RolloutStrategy` is extracted from the span.
- `InfraLoop.OnInfraEvaluate`: when `strategy == "immediate"`, the decision skips the expand/rollback ladder entirely — records `remediation.action="none"`, no write, no ladder climb — while still emitting the observe span.
- The observed strategy is surfaced on the decision span (`bluetooth.rollout_strategy`).

## Graceful default
If the attribute is absent/empty (an older controller-manager that predates this change), `RolloutStrategy == ""`, which is **not** `immediate`, so the loop falls through to the existing progressive ladder unchanged. `off`/`progressive` strategies are unchanged.

## Tests
- controller-manager: `TestCurrentStrategy` (off/immediate/progressive/error→empty) + `bluetooth.rollout_strategy` asserted on the health span. Full suite: 688 passed.
- agent: immediate → no write + `action="none"` + no `rollout.controller_count`; progressive → climbs; absent → climbs (graceful default); span extraction full + absent→empty. `gofmt`/`go build`/`go vet`/`go test -race` all green.

Part of #734, #829.

🤖 Generated with [Claude Code](https://claude.com/claude-code)