### PR TITLE
fix(agent): retro prompt — per-player arcs + physics grounding, drop phantom flags (#1158)

### DIFF
--- a/services/agent/decision/retro_capture.go
+++ b/services/agent/decision/retro_capture.go
@@ -13,6 +13,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/joustmania/agent/gamecontext"
+	"github.com/joustmania/agent/gamesummary"
 	"github.com/joustmania/agent/llm"
 )
 
@@ -252,10 +253,27 @@ func (rc *RetroCoordinator) OnGameEnd(c gamecontext.GameContext) {
 		return
 	}
 
+	// #1158: build the per-game narrative Summary from the SAME finished-game
+	// snapshot and feed it to the retro, so the prompt renders the rich per-player
+	// PlayerArc stanzas (survival / elimination-offset / movement sparkline /
+	// activity / near-death) the agent already derives — not a flat terminal
+	// snapshot. We call gamesummary.BuildSummary DIRECTLY rather than reusing the
+	// gamesummary.Coordinator's Observer seam: that seam is a one-way PUSH sink
+	// (Observer.Record(Summary)) the Coordinator fires to a registered window store,
+	// with no way to pull the Summary back here, and the retro path holds no
+	// reference to the Coordinator. BuildSummary is a documented PURE fold over the
+	// snapshot (no clock/disk/network), so calling it here with the same injected
+	// now() is cheap and deterministic, and keeps the retro self-contained — the two
+	// once-per-game components stay decoupled. The injected now() matches BuildRetro's
+	// Now so the Summary's GeneratedAt and the prompt's captured_at agree.
+	retroNow := now()
+	summary := gamesummary.BuildSummary(c, gamesummary.BuildOptions{Now: retroNow})
+
 	prompt := llm.BuildRetro(llm.RetroInput{
 		Snapshot: snapshot,
 		Context:  c,
-		Now:      now(),
+		Summary:  summary,
+		Now:      retroNow,
 	})
 
 	// #1080: resolve the inference attribution through the SAME shared resolver the

--- a/services/agent/llm/retro.go
+++ b/services/agent/llm/retro.go
@@ -78,9 +78,14 @@ func BuildRetro(in RetroInput) RetroPrompt {
 // game-physics + mode grounding (#1158: the SAME physicalModel + modePromptFragment
 // the in-game buildSystem got via #1091, so the offline analyst reasons within the
 // real mechanics and cannot hallucinate combat/respawn/init-only "calibration
-// flags"), the REAL next-game lever vocabulary (the intervention allow-list — the
+// flags"), the REAL intervention-type vocabulary (the intervention allow-list — the
 // agent has no init-time calibration surface; it only ever acts through
 // interventions), the smallest-change policy, and the JSON response contract.
+//
+// #1160 review fix: the allow-list is the agent's REACTIVE in-game vocabulary, not a
+// game-setup surface — so the analyst recommends which of these intervention TYPES to
+// ENABLE / EMPHASIZE (or de-emphasize) for the next session, not how the next game
+// opens or is paced.
 //
 // #1158 fix B: the four phantom flags this prompt previously enumerated
 // (global_difficulty_factor / pacing_profile / threshold_table / objective_variant)
@@ -88,18 +93,28 @@ func BuildRetro(in RetroInput) RetroPrompt {
 // exist in NO flagd source; global_difficulty_factor and pacing_profile DO exist but
 // only as game_coordinator (interventions domain) flags the agent writes INDIRECTLY
 // via the adjust_global_difficulty / set_pacing_profile INTERVENTIONS — there is no
-// agent-side "read at game INIT" calibration surface. So the analyst recommends
-// LEVERS from the live intervention allow-list (the agent's only acting surface),
-// framed as how the NEXT game should open / be paced. The former objective_variant
-// enum collided with the in-game objective_served enum; the retro's advisory goal
-// field is renamed session_focus to remove the collision.
+// agent-side "read at game INIT" calibration surface. So the analyst recommends from
+// the live intervention allow-list (the agent's only acting surface). The former
+// objective_variant enum collided with the in-game objective_served enum; the retro's
+// advisory goal field is renamed session_focus to remove the collision.
+//
+// #1160 review fix: the allow-list is the set of REAL-TIME REACTIVE in-game actions
+// (with the full / shadow_experimental variants it includes eliminate_player /
+// revive_player / end_game / send_controller_effect). Recommending the next game
+// "OPEN by eliminating a player" is incoherent — those are reactions, not setup. So
+// the recommendation surface is reframed: the analyst recommends which intervention
+// TYPES the agent should ENABLE or EMPHASIZE (weight up) — and which to de-emphasize
+// — for the next session, i.e. tuning the agent's reactive vocabulary and emphasis,
+// NOT the game's opening configuration. Under that framing the whole allow-list,
+// reactive actions included, reads coherently. Still advisory / recorded-only /
+// human-reviewed.
 func buildRetroSystem(mode string, allowed []string) string {
 	var b strings.Builder
 	b.WriteString(`You are the JoustMania post-game analyst. A physical movement party game has just
-ended. You receive a full session summary and must suggest how the NEXT game should
-be set up and paced to make it more fun. You are NOT controlling a live game — you
-make at most a handful of recommendations, which a human reviews. Suggestions are
-RECORDED ONLY and never auto-applied.
+ended. You receive a full session summary and must suggest how the agent should TUNE
+its in-game reactions for the NEXT session to make play more fun. You are NOT
+controlling a live game — you make at most a handful of recommendations, which a
+human reviews. Suggestions are RECORDED ONLY and never auto-applied.
 
 `)
 	// Physics + current-mode grounding (#1158), shared verbatim with the in-game
@@ -112,30 +127,35 @@ RECORDED ONLY and never auto-applied.
 	b.WriteString(`
 
 YOUR RECOMMENDATION SURFACE — the agent has NO init-time "calibration flags"; it
-only ever acts through INTERVENTIONS. So recommend how the next game should OPEN and
-be PACED using these same levers (only those the live allow-list below permits):
+only ever acts through INTERVENTIONS, and these are REAL-TIME REACTIVE in-game
+actions, not a game-setup or opening configuration. So do NOT recommend how the next
+game opens or is paced. Instead, recommend which of these intervention TYPES the
+agent should ENABLE or EMPHASIZE (weight up) — and which to de-emphasize — for the
+next session, tuning its reactive vocabulary and emphasis (only those the live
+allow-list below permits):
 `)
 	b.WriteString("  " + joinInterventions(allowed))
 	b.WriteString(`
 
-POLICY: suggest the SMALLEST change that addresses an observed problem, grounded in
-the session evidence below (who faded when, who was near death, the engagement
-trend). If the session looked healthy, return an empty suggestions list. Do not
-invent levers outside the allow-list above.
+POLICY: suggest the SMALLEST tuning change that addresses an observed problem,
+grounded in the session evidence below (who faded when, who was near death, the
+engagement trend) — e.g. enable or weight up an intervention type that would have
+helped, or de-emphasize one that over-fired. If the session looked healthy, return an
+empty suggestions list. Do not invent intervention types outside the allow-list above.
 
 RESPONSE CONTRACT — reply with EXACTLY ONE JSON object, no prose, matching:
 {
   "session_assessment": "<one short sentence: how did this game go?>",
   "suggestions": [
     {
-      "lever": "<one of the allow-list levers above>",
-      "value": "<the suggested next-game value/direction as a string>",
-      "reason": "<one short sentence tying the change to session evidence>"
+      "intervention_type": "<one of the allow-list intervention types above>",
+      "emphasis": "<one of: enable, weight_up, weight_down, disable>",
+      "reason": "<one short sentence tying the tuning change to session evidence>"
     }
   ],
-  "session_focus": "<one of: endurance, balanced, accelerate, chaos — the goal the next game should lean toward>"
+  "session_focus": "<one of: endurance, balanced, accelerate, chaos — the goal the next session should lean toward>"
 }
-If no tweak is warranted, return "suggestions": [].`)
+If no tuning is warranted, return "suggestions": [].`)
 	return b.String()
 }
 

--- a/services/agent/llm/retro.go
+++ b/services/agent/llm/retro.go
@@ -24,11 +24,13 @@ package llm
 import (
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/joustmania/agent/flags"
 	"github.com/joustmania/agent/gamecontext"
+	"github.com/joustmania/agent/gamesummary"
 )
 
 // RetroPrompt is the System/User prompt pair the agent would send to the offline
@@ -45,77 +47,113 @@ type RetroPrompt struct {
 type RetroInput struct {
 	Snapshot flags.Snapshot
 	Context  gamecontext.GameContext
-	Now      time.Time // injected for determinism — BuildRetro must never read the wall clock
+	// Summary is the already-built per-game narrative (#1158). The retro renders the
+	// rich per-player PlayerArc stanzas (survival / elimination-offset / sparkline /
+	// activity / near-death) the agent ALREADY computes in gamesummary.BuildSummary,
+	// instead of re-deriving a flat terminal snapshot. It is built by the caller from
+	// the SAME finished-game GameContext (gamesummary.BuildSummary is a pure fold), so
+	// no clock/disk is touched here and the prompt stays deterministic (PlayerArcs are
+	// serial-sorted, all offsets relative to game start). A zero Summary (no arcs)
+	// falls back to the room-level outcome block alone.
+	Summary gamesummary.Summary
+	Now     time.Time // injected for determinism — BuildRetro must never read the wall clock
 }
-
-// Calibration-surface flag names the analyst may suggest. These are the #766
-// calibration flags read at game INIT (docs/research/722-intervention-surface.md
-// §11) — NOT the in-game intervention allow-list. They are listed here once so
-// the System prompt and the contract-presence test share a single source.
-const (
-	calibDifficultyFactor = "global_difficulty_factor"
-	calibPacingProfile    = "pacing_profile"
-	calibThresholdTable   = "threshold_table"
-	calibObjectiveVariant = "objective_variant"
-)
 
 // BuildRetro renders the deterministic retrospective prompt for one finished
 // session. The same RetroInput (with a fixed Now) always yields a byte-identical
-// RetroPrompt.
+// RetroPrompt. The System prompt is grounded in the SAME physics + mode mechanics
+// the in-game prompt uses (#1158: physicalModel + modePromptFragment), and the
+// suggestion vocabulary is the REAL intervention allow-list — there are no
+// init-time "calibration flags"; the agent only ever acts through interventions.
 func BuildRetro(in RetroInput) RetroPrompt {
+	mode := stringOrUnknown(in.Context.Session.GameMode)
 	return RetroPrompt{
-		System: buildRetroSystem(),
-		User:   buildRetroUser(in.Context, in.Now),
+		System: buildRetroSystem(mode, in.Snapshot.InterventionsAllowed),
+		User:   buildRetroUser(in.Context, in.Summary, in.Now),
 		Model:  in.Snapshot.Capability.Model,
 	}
 }
 
 // buildRetroSystem renders the System prompt: the post-game analyst role, the
-// calibration surface as the suggestion vocabulary, the smallest-change policy,
-// and the JSON response contract. It takes no input — the calibration surface is
-// fixed, so the System prompt is constant (the session evidence lives in User).
-func buildRetroSystem() string {
-	return `You are the JoustMania post-game analyst. A physical movement party game has just
-ended. You receive a full session summary and must suggest CALIBRATION TWEAKS that
-would make the NEXT game more fun. You are NOT controlling a live game — you make
-at most a handful of recommendations, which a human reviews. Suggestions are
+// game-physics + mode grounding (#1158: the SAME physicalModel + modePromptFragment
+// the in-game buildSystem got via #1091, so the offline analyst reasons within the
+// real mechanics and cannot hallucinate combat/respawn/init-only "calibration
+// flags"), the REAL next-game lever vocabulary (the intervention allow-list — the
+// agent has no init-time calibration surface; it only ever acts through
+// interventions), the smallest-change policy, and the JSON response contract.
+//
+// #1158 fix B: the four phantom flags this prompt previously enumerated
+// (global_difficulty_factor / pacing_profile / threshold_table / objective_variant)
+// are GONE. Verified against the real schema: threshold_table and objective_variant
+// exist in NO flagd source; global_difficulty_factor and pacing_profile DO exist but
+// only as game_coordinator (interventions domain) flags the agent writes INDIRECTLY
+// via the adjust_global_difficulty / set_pacing_profile INTERVENTIONS — there is no
+// agent-side "read at game INIT" calibration surface. So the analyst recommends
+// LEVERS from the live intervention allow-list (the agent's only acting surface),
+// framed as how the NEXT game should open / be paced. The former objective_variant
+// enum collided with the in-game objective_served enum; the retro's advisory goal
+// field is renamed session_focus to remove the collision.
+func buildRetroSystem(mode string, allowed []string) string {
+	var b strings.Builder
+	b.WriteString(`You are the JoustMania post-game analyst. A physical movement party game has just
+ended. You receive a full session summary and must suggest how the NEXT game should
+be set up and paced to make it more fun. You are NOT controlling a live game — you
+make at most a handful of recommendations, which a human reviews. Suggestions are
 RECORDED ONLY and never auto-applied.
 
-CALIBRATION SURFACE — you may ONLY suggest changes to these flags. Each is read at
-game INIT:
+`)
+	// Physics + current-mode grounding (#1158), shared verbatim with the in-game
+	// prompt (#1091): the analyst must reason within the game's actual mechanics —
+	// motion-controlled, tempo-scaled elimination, no health/damage/combat — so it
+	// never invents mechanics the system does not have.
+	b.WriteString(physicalModel)
+	b.WriteString("\n\n")
+	b.WriteString(modePromptFragment(mode))
+	b.WriteString(`
 
-  ` + calibDifficultyFactor + `   (float, ~0.5..1.5; 1.0 = current) — scales overall
-                             movement demand for the next game.
-  ` + calibPacingProfile + `             (enum: "relaxed" | "standard" | "intense") — the
-                             music-schedule preset that shapes round tempo.
-  ` + calibThresholdTable + `            (named death/warning threshold table, e.g.
-                             "easy" | "standard" | "hard").
-  ` + calibObjectiveVariant + `          (enum: endurance | balanced | accelerate | chaos) —
-                             the session goal weighting for the next game.
+YOUR RECOMMENDATION SURFACE — the agent has NO init-time "calibration flags"; it
+only ever acts through INTERVENTIONS. So recommend how the next game should OPEN and
+be PACED using these same levers (only those the live allow-list below permits):
+`)
+	b.WriteString("  " + joinInterventions(allowed))
+	b.WriteString(`
 
-POLICY: suggest the SMALLEST change that addresses an observed problem. If the
-session looked healthy, return an empty suggestions list. Do not invent flags
-outside the calibration surface.
+POLICY: suggest the SMALLEST change that addresses an observed problem, grounded in
+the session evidence below (who faded when, who was near death, the engagement
+trend). If the session looked healthy, return an empty suggestions list. Do not
+invent levers outside the allow-list above.
 
 RESPONSE CONTRACT — reply with EXACTLY ONE JSON object, no prose, matching:
 {
   "session_assessment": "<one short sentence: how did this game go?>",
   "suggestions": [
     {
-      "flag": "<one of: ` + calibDifficultyFactor + `, ` + calibPacingProfile + `, ` + calibThresholdTable + `, ` + calibObjectiveVariant + `>",
-      "value": "<the suggested value as a string>",
+      "lever": "<one of the allow-list levers above>",
+      "value": "<the suggested next-game value/direction as a string>",
       "reason": "<one short sentence tying the change to session evidence>"
     }
-  ]
+  ],
+  "session_focus": "<one of: endurance, balanced, accelerate, chaos — the goal the next game should lean toward>"
 }
-If no tweak is warranted, return "suggestions": [].`
+If no tweak is warranted, return "suggestions": [].`)
+	return b.String()
 }
 
 // buildRetroUser renders the User message: the session header, the derived
-// outcome (duration, final active players, elimination order, winner), and the
-// per-player end-state sorted by serial. Now is rendered as the captured_at
-// timestamp in UTC RFC3339.
-func buildRetroUser(ctx gamecontext.GameContext, now time.Time) string {
+// outcome (duration, final active players, elimination order, winner), the
+// room-level engagement TREND, and the per-player ARC stanzas (#1158). Now is
+// rendered as the captured_at timestamp in UTC RFC3339.
+//
+// #1158 fix A: the per-player section is now built from the rich PlayerArc the
+// agent ALREADY computes in gamesummary.BuildSummary (survival_seconds /
+// elimination_offset_seconds / movement_sparkline / activity / final_intensity /
+// near_death_ratio + offset), instead of re-deriving a flat terminal snapshot that
+// dropped most of those values. Arcs are serial-sorted and offset-based, so the
+// stanza block stays deterministic. The room-level outcome / timeline / engagement
+// trend / speed blocks remain as context. When the Summary carries no arcs (a
+// pre-#1158 caller that never built one, or a game with no players), the stanza
+// block falls back to "(none)" and the rest of the prompt is unchanged.
+func buildRetroUser(ctx gamecontext.GameContext, summary gamesummary.Summary, now time.Time) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "SESSION RETROSPECTIVE (session=%s, kind=%s, mode=%s, captured_at=%s)\n",
 		ctx.SessionID, gameKindOrUnknown(ctx.GameKind), stringOrUnknown(ctx.Session.GameMode), now.UTC().Format(time.RFC3339))
@@ -135,35 +173,85 @@ func buildRetroUser(ctx gamecontext.GameContext, now time.Time) string {
 	writeTimeline(&b, ctx, now)
 	// #1082: the game-speed track the per-player proximity tracks are read against.
 	writeSpeedTrack(&b, ctx)
+	// #1158: the room-level engagement trend (active-count + mean-intensity over the
+	// game), straight off the Summary the agent already derived, kept as the
+	// session-wide context the per-player arcs read against.
+	writeEngagementTrend(&b, summary.EngagementTrend)
 
-	b.WriteString("\nPlayers (sorted by serial; \"unknown\" = signal never observed):\n")
-	if len(ctx.Players) == 0 {
+	// #1158: per-player ARC stanzas from the already-built Summary, replacing the old
+	// flat snapshot. Arcs are serial-sorted by BuildSummary, so the block is
+	// deterministic.
+	b.WriteString("\nPlayer arcs (sorted by serial; offsets relative to game start; \"unknown\" = never observed):\n")
+	if len(summary.PlayerArcs) == 0 {
 		b.WriteString("  (none)")
 		return b.String()
 	}
-
-	lines := make([]string, 0, len(serials))
-	for _, serial := range serials {
-		p := ctx.Players[serial]
-		lines = append(lines, fmt.Sprintf(
-			"  %s: outcome=%s battery_pct=%s skill=%s movement_intensity=%s movement_variance=%s",
-			serial,
-			playerOutcome(serial, ctx.Session.EliminationSequence),
-			floatPtrOrUnknown(p.BatteryPct),
-			floatPtrOrUnknown(p.SkillLevel),
-			floatPtrOrUnknown(p.MovementIntensity),
-			floatPtrOrUnknown(p.MovementVariance),
-		))
-		// #1082: the per-player movement TIME-SERIES line — sparkline + activity +
-		// proximity-to-death — so the analyst sees WHO was active/idle/erratic and WHO
-		// was close to death over the game, not just the end-state snapshot. The
-		// "→elim" marker fires for an eliminated player who crossed the threshold.
-		if track := renderPlayerTrack(p, ctx, now, eliminated(serial, ctx.Session.EliminationSequence)); track != "" {
-			lines = append(lines, track)
+	for i, arc := range summary.PlayerArcs {
+		if i > 0 {
+			b.WriteString("\n")
 		}
+		writePlayerArc(&b, arc, ctx.Session.EliminationSequence)
 	}
-	b.WriteString(strings.Join(lines, "\n"))
 	return b.String()
+}
+
+// writeEngagementTrend renders the room-level engagement series the Summary
+// derived from the #916 timeline (#1158): each down-sampled (offset, active,
+// mean-intensity) point, oldest-first, so the analyst sees how the WHOLE room's
+// engagement moved over the game. Omitted entirely when the trend is empty (keeps
+// the no-narrative prompt compact).
+func writeEngagementTrend(b *strings.Builder, trend []gamesummary.EngagementPoint) {
+	if len(trend) == 0 {
+		return
+	}
+	b.WriteString("\nEngagement trend (room; offset_seconds: active / mean_intensity; oldest first):\n")
+	for _, pt := range trend {
+		fmt.Fprintf(b, "  +%ss: active=%s mean_intensity=%s\n",
+			strconv.FormatFloat(pt.OffsetSeconds, 'f', 0, 64),
+			intPtrOrUnknown(pt.ActivePlayers),
+			floatPtrOrUnknown(pt.MeanIntensity))
+	}
+}
+
+// writePlayerArc renders one PlayerArc as a multi-field stanza (#1158): the
+// outcome + survival/elimination timing, the movement TIME-SERIES (sparkline +
+// activity), the closest call to the death threshold and when it happened, and the
+// final-state aggregates. Every field falls back to the "unknown" literal when the
+// arc never observed it, so a never-seen player renders honestly rather than
+// fabricating zeros. Pure over the arc + elimination sequence — no clock.
+func writePlayerArc(b *strings.Builder, arc gamesummary.PlayerArc, eliminationSequence []string) {
+	fmt.Fprintf(b, "  %s: outcome=%s survival_seconds=%s elimination_offset_seconds=%s\n",
+		arc.Serial,
+		playerOutcome(arc.Serial, eliminationSequence),
+		floatPtrOrUnknown(arc.SurvivalSeconds),
+		floatPtrOrUnknown(arc.EliminationOffsetSeconds))
+	fmt.Fprintf(b, "    movement=%s activity=%s\n",
+		sparklineOrUnknown(arc.MovementSparkline),
+		stringValueOrUnknown(arc.Activity))
+	fmt.Fprintf(b, "    near_death_ratio=%s near_death_offset_seconds=%s\n",
+		floatPtrOrUnknown(arc.NearDeathRatio),
+		floatPtrOrUnknown(arc.NearDeathOffsetSeconds))
+	fmt.Fprintf(b, "    final_intensity=%s final_skill=%s",
+		floatPtrOrUnknown(arc.FinalIntensity),
+		floatPtrOrUnknown(arc.FinalSkill))
+}
+
+// sparklineOrUnknown renders a movement sparkline string, or the "unknown" literal
+// when empty (the player had no movement history) — mirroring stringOrUnknown for
+// the non-pointer Summary string fields.
+func sparklineOrUnknown(s string) string {
+	if s == "" {
+		return unknown
+	}
+	return s
+}
+
+// stringValueOrUnknown renders a plain string field, or "unknown" when empty.
+func stringValueOrUnknown(s string) string {
+	if s == "" {
+		return unknown
+	}
+	return s
 }
 
 // sortedSerials returns the player serials sorted ascending. Sorting (not map

--- a/services/agent/llm/retro_test.go
+++ b/services/agent/llm/retro_test.go
@@ -35,6 +35,23 @@ func retroSnapshot() flags.Snapshot {
 	}
 }
 
+// retroFullSnapshot is retroSnapshot with the production `full` intervention
+// allow-list (#1160 review fix): it includes the REAL-TIME REACTIVE actions
+// eliminate_player / revive_player / end_game / send_controller_effect, so the golden
+// shows the reframed recommendation surface ("which intervention TYPES to enable /
+// emphasize for the next session") reading coherently with reactive actions present —
+// not the old incoherent "open the next game by eliminating a player" framing.
+func retroFullSnapshot() flags.Snapshot {
+	s := retroSnapshot()
+	s.InterventionsAllowed = []string{
+		"play_audio_cue", "send_controller_effect", "adjust_volume",
+		"adjust_music_tempo", "set_pacing_profile", "adjust_player_sensitivity",
+		"grant_shield", "adjust_global_sensitivity", "adjust_global_difficulty",
+		"eliminate_player", "revive_player", "end_game",
+	}
+	return s
+}
+
 // retroThreePlayers: two eliminations and one survivor (the winner). Mixes real
 // and never-observed signals like the in-game three-player context.
 func retroThreePlayers() gamecontext.GameContext {
@@ -172,6 +189,15 @@ func retroCases() []retroCase {
 			context:  retroMovementContext(),
 		},
 		{
+			// #1160 review fix: the production `full` allow-list, which includes the
+			// reactive actions eliminate_player / revive_player / end_game. The golden
+			// makes the reframed recommendation surface visible and coherent with those
+			// real-time actions present (not "open the next game by eliminating a player").
+			name:     "retro_full_allowlist",
+			snapshot: retroFullSnapshot(),
+			context:  retroMovementContext(),
+		},
+		{
 			// No players, nil session signals: every field renders "unknown"/[].
 			name:     "retro_empty",
 			snapshot: retroSnapshot(),
@@ -305,13 +331,49 @@ func TestRetroDeterminism(t *testing.T) {
 }
 
 // TestRetroContractKeys: the System prompt names every response-contract key, so
-// it cannot drift from the documented surface (#1158: lever/session_focus, not the
-// old phantom-flag "flag" enum).
+// it cannot drift from the documented surface (#1160: intervention_type/emphasis/
+// session_focus — the reframed tuning surface, not the old lever/value setup framing).
 func TestRetroContractKeys(t *testing.T) {
 	sys := BuildRetro(RetroInput{Snapshot: retroSnapshot(), Context: retroThreePlayers(), Now: fixedNow}).System
-	for _, key := range []string{"session_assessment", "suggestions", "lever", "value", "reason", "session_focus"} {
+	for _, key := range []string{"session_assessment", "suggestions", "intervention_type", "emphasis", "reason", "session_focus"} {
 		if !strings.Contains(sys, `"`+key+`"`) {
 			t.Errorf("system prompt missing response-contract key %q", key)
+		}
+	}
+}
+
+// TestRetroSystemReframedTuning asserts the #1160 review fix: the recommendation
+// surface frames the allow-list as intervention TYPES to ENABLE/EMPHASIZE for the
+// next session (tuning the agent's reactive vocabulary), NOT how the next game OPENS
+// or is PACED. With the production `full` allow-list (eliminate_player / revive_player
+// / end_game present) the old "open the next game by eliminating a player" framing was
+// incoherent; the reframed prose must be present and the setup framing gone.
+func TestRetroSystemReframedTuning(t *testing.T) {
+	sys := BuildRetro(RetroInput{Snapshot: retroFullSnapshot(), Context: retroMovementContext(), Now: fixedNow}).System
+	// The reframed tuning surface must be present.
+	for _, want := range []string{
+		"intervention TYPES",
+		"ENABLE or EMPHASIZE",
+		"REAL-TIME REACTIVE in-game",
+	} {
+		if !strings.Contains(sys, want) {
+			t.Errorf("retro system prompt missing reframed tuning wording %q", want)
+		}
+	}
+	// The old setup/opening framing must be gone.
+	for _, gone := range []string{
+		"how the next game should OPEN",
+		"should OPEN and\nbe PACED",
+		"next-game value/direction",
+	} {
+		if strings.Contains(sys, gone) {
+			t.Errorf("retro system prompt still uses old setup framing %q", gone)
+		}
+	}
+	// The full reactive allow-list must still be rendered verbatim (data unchanged).
+	for _, lever := range []string{"eliminate_player", "revive_player", "end_game", "send_controller_effect"} {
+		if !strings.Contains(sys, lever) {
+			t.Errorf("retro system prompt dropped reactive intervention type %q from the full allow-list", lever)
 		}
 	}
 }

--- a/services/agent/llm/retro_test.go
+++ b/services/agent/llm/retro_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/joustmania/agent/flags"
 	"github.com/joustmania/agent/gamecontext"
+	"github.com/joustmania/agent/gamesummary"
 )
 
 // retroSnapshot is the shared flag snapshot for the retro golden scenarios. Only
@@ -21,6 +22,14 @@ func retroSnapshot() flags.Snapshot {
 			"balanced":  0.7,
 			"chaos":     0.1,
 			"endurance": 0.1,
+		},
+		// #1158: the retro System prompt now renders the REAL intervention allow-list
+		// as the recommendation surface (no phantom calibration flags), so the golden
+		// snapshot carries a representative "standard" variant allow-list.
+		InterventionsAllowed: []string{
+			"play_audio_cue", "send_controller_effect", "adjust_volume",
+			"adjust_music_tempo", "set_pacing_profile", "adjust_player_sensitivity",
+			"grant_shield",
 		},
 		Capability: flags.Capability{Model: "phi4-mini"},
 	}
@@ -209,7 +218,12 @@ func TestRetroGolden(t *testing.T) {
 			got := renderRetroGolden(BuildRetro(RetroInput{
 				Snapshot: tc.snapshot,
 				Context:  tc.context,
-				Now:      fixedNow,
+				// #1158: build the per-game Summary the same way retro_capture.go does —
+				// a pure fold over the finished-game snapshot with the injected Now — so
+				// the golden exercises the per-player ARC stanzas (PlayerArc), not the old
+				// flat terminal snapshot.
+				Summary: gamesummary.BuildSummary(tc.context, gamesummary.BuildOptions{Now: fixedNow}),
+				Now:     fixedNow,
 			}))
 			path := filepath.Join("testdata", tc.name+".golden")
 			if *update {
@@ -276,9 +290,11 @@ func TestWinnerSerial(t *testing.T) {
 // TestRetroDeterminism: identical input yields byte-identical output regardless
 // of player map insertion order.
 func TestRetroDeterminism(t *testing.T) {
+	ctx := retroThreePlayers()
 	in := RetroInput{
 		Snapshot: retroSnapshot(),
-		Context:  retroThreePlayers(),
+		Context:  ctx,
+		Summary:  gamesummary.BuildSummary(ctx, gamesummary.BuildOptions{Now: fixedNow}),
 		Now:      fixedNow,
 	}
 	first := BuildRetro(in)
@@ -288,20 +304,89 @@ func TestRetroDeterminism(t *testing.T) {
 	}
 }
 
-// TestRetroContractKeys: the System prompt names every response-contract key and
-// every calibration flag, so it cannot drift from the documented surface.
+// TestRetroContractKeys: the System prompt names every response-contract key, so
+// it cannot drift from the documented surface (#1158: lever/session_focus, not the
+// old phantom-flag "flag" enum).
 func TestRetroContractKeys(t *testing.T) {
 	sys := BuildRetro(RetroInput{Snapshot: retroSnapshot(), Context: retroThreePlayers(), Now: fixedNow}).System
-	for _, key := range []string{"session_assessment", "suggestions", "flag", "value", "reason"} {
+	for _, key := range []string{"session_assessment", "suggestions", "lever", "value", "reason", "session_focus"} {
 		if !strings.Contains(sys, `"`+key+`"`) {
 			t.Errorf("system prompt missing response-contract key %q", key)
 		}
 	}
-	for _, flag := range []string{
-		calibDifficultyFactor, calibPacingProfile, calibThresholdTable, calibObjectiveVariant,
+}
+
+// TestRetroSystemNoPhantomFlags asserts the four phantom calibration flags the
+// pre-#1158 prompt invented are GONE from the System prompt — none are real
+// agent-readable init flags (threshold_table / objective_variant exist nowhere;
+// global_difficulty_factor / pacing_profile are game_coordinator intervention-domain
+// flags the agent only writes INDIRECTLY via interventions, never reads at INIT).
+// The retro must recommend REAL intervention levers, not phantom flags.
+func TestRetroSystemNoPhantomFlags(t *testing.T) {
+	sys := BuildRetro(RetroInput{Snapshot: retroSnapshot(), Context: retroThreePlayers(), Now: fixedNow}).System
+	// threshold_table / objective_variant / global_difficulty_factor exist in no
+	// agent-readable init surface and must be absent outright.
+	for _, phantom := range []string{
+		"global_difficulty_factor", "threshold_table", "objective_variant",
 	} {
-		if !strings.Contains(sys, flag) {
-			t.Errorf("system prompt missing calibration flag %q", flag)
+		if strings.Contains(sys, phantom) {
+			t.Errorf("system prompt still cites phantom calibration flag %q", phantom)
+		}
+	}
+	// The bare "pacing_profile" calibration flag is phantom; the legitimate
+	// set_pacing_profile INTERVENTION (which contains it) is allowed. So scrub the
+	// real lever name first, then assert the bare flag name is gone.
+	scrubbed := strings.ReplaceAll(sys, "set_pacing_profile", "")
+	if strings.Contains(scrubbed, "pacing_profile") {
+		t.Errorf("system prompt still cites phantom calibration flag \"pacing_profile\" (not as set_pacing_profile)")
+	}
+	// The old calibration-surface framing ("read at game INIT") must be gone.
+	if strings.Contains(sys, "read at\ngame INIT") || strings.Contains(sys, "CALIBRATION SURFACE") {
+		t.Errorf("system prompt still frames an init-time calibration surface")
+	}
+	// The renamed advisory goal field must not collide with the in-game objective_served.
+	if strings.Contains(sys, "objective_served") {
+		t.Errorf("retro system prompt should use session_focus, not the in-game objective_served")
+	}
+}
+
+// TestRetroSystemPhysicsGrounding asserts the System prompt carries the SAME
+// physics + FFA-mode grounding the in-game prompt got (#1091), so the offline
+// analyst reasons within the real mechanics (#1158 fix B).
+func TestRetroSystemPhysicsGrounding(t *testing.T) {
+	sys := BuildRetro(RetroInput{Snapshot: retroSnapshot(), Context: retroThreePlayers(), Now: fixedNow}).System
+	for _, want := range []string{
+		"HOW THE GAME PHYSICALLY WORKS:",
+		"GAME MODE — FFA",
+		// a real lever from the allow-list, proving the recommendation surface is real.
+		"adjust_music_tempo",
+	} {
+		if !strings.Contains(sys, want) {
+			t.Errorf("retro system prompt missing grounding %q", want)
+		}
+	}
+}
+
+// TestRetroUserPerPlayerArcs asserts the User prompt renders the rich per-player
+// ARC fields from the Summary (#1158 fix A), not the old flat terminal snapshot.
+func TestRetroUserPerPlayerArcs(t *testing.T) {
+	ctx := retroMovementContext()
+	user := BuildRetro(RetroInput{
+		Snapshot: retroSnapshot(),
+		Context:  ctx,
+		Summary:  gamesummary.BuildSummary(ctx, gamesummary.BuildOptions{Now: fixedNow}),
+		Now:      fixedNow,
+	}).User
+	for _, want := range []string{
+		"Player arcs",
+		"survival_seconds=",
+		"elimination_offset_seconds=",
+		"near_death_ratio=",
+		"final_intensity=",
+		"Engagement trend (room",
+	} {
+		if !strings.Contains(user, want) {
+			t.Errorf("retro user prompt missing per-player arc field %q in:\n%s", want, user)
 		}
 	}
 }

--- a/services/agent/llm/testdata/retro_3players.golden
+++ b/services/agent/llm/testdata/retro_3players.golden
@@ -2,37 +2,64 @@
 phi4-mini
 === SYSTEM ===
 You are the JoustMania post-game analyst. A physical movement party game has just
-ended. You receive a full session summary and must suggest CALIBRATION TWEAKS that
-would make the NEXT game more fun. You are NOT controlling a live game — you make
-at most a handful of recommendations, which a human reviews. Suggestions are
+ended. You receive a full session summary and must suggest how the NEXT game should
+be set up and paced to make it more fun. You are NOT controlling a live game — you
+make at most a handful of recommendations, which a human reviews. Suggestions are
 RECORDED ONLY and never auto-applied.
 
-CALIBRATION SURFACE — you may ONLY suggest changes to these flags. Each is read at
-game INIT:
+HOW THE GAME PHYSICALLY WORKS:
+  - Each player holds a PS Move controller that streams its acceleration
+    magnitude — a movement-intensity reading. There is NO health, NO damage,
+    and players do NOT attack each other; they compete only on movement control.
+  - A player is eliminated when their (smoothed) movement intensity exceeds the
+    current effective death threshold. Hold still enough and you survive.
+  - Music tempo / game speed sets how much movement is tolerated: the effective
+    threshold is interpolated by tempo. SLOW tempo => low threshold (move gently
+    or you're out); FAST tempo => higher threshold (more movement allowed). The
+    User snapshot's music_tempo + death_threshold and the game-speed track are
+    this reference frame — read each player's intensity against them.
+  - A brief ~0.3s startup grace at spawn keeps initial spikes from insta-killing.
 
-  global_difficulty_factor   (float, ~0.5..1.5; 1.0 = current) — scales overall
-                             movement demand for the next game.
-  pacing_profile             (enum: "relaxed" | "standard" | "intense") — the
-                             music-schedule preset that shapes round tempo.
-  threshold_table            (named death/warning threshold table, e.g.
-                             "easy" | "standard" | "hard").
-  objective_variant          (enum: endurance | balanced | accelerate | chaos) —
-                             the session goal weighting for the next game.
+GAME MODE — FFA (Free-For-All), last player standing:
+  - ELIMINATION IS PERMANENT. When a player crosses the tempo-scaled threshold
+    they are out for the rest of the game — there is NO respawn, NO revive, and
+    NO "downed" or "dead-player" state to interact with. Do not reason about
+    reviving, reusing, or re-engaging eliminated players; they are simply gone.
+  - The round ends when one player remains (the winner) — or all remaining
+    players are eliminated together.
+  - Effective FFA levers (only those also in the allow-list below may be used):
+    pace the difficulty for the whole room by shifting music tempo / game
+    speed (which moves everyone's threshold), nudge global or per-player
+    sensitivity, grant a short per-player movement-grace shield to a player about
+    to be unfairly eliminated, and play audio cues / controller effects to steer
+    the room. note: death_grace_period_seconds governs post-death respawn grace
+    and has NO effect in FFA (no respawns) — it is not a lever here.
+  - set_player_handicap: per-player multiplier on that player's death threshold
+    (>1 = higher threshold = harder to eliminate / "help"; <1 = lower = easier /
+    "rein in"), clamped 0.5-2.0; COMPOSES WITH (does not replace) per-player
+    sensitivity, so use it for continuous rubber-banding toward fairness.
 
-POLICY: suggest the SMALLEST change that addresses an observed problem. If the
-session looked healthy, return an empty suggestions list. Do not invent flags
-outside the calibration surface.
+YOUR RECOMMENDATION SURFACE — the agent has NO init-time "calibration flags"; it
+only ever acts through INTERVENTIONS. So recommend how the next game should OPEN and
+be PACED using these same levers (only those the live allow-list below permits):
+  play_audio_cue, send_controller_effect, adjust_volume, adjust_music_tempo, set_pacing_profile, adjust_player_sensitivity, grant_shield
+
+POLICY: suggest the SMALLEST change that addresses an observed problem, grounded in
+the session evidence below (who faded when, who was near death, the engagement
+trend). If the session looked healthy, return an empty suggestions list. Do not
+invent levers outside the allow-list above.
 
 RESPONSE CONTRACT — reply with EXACTLY ONE JSON object, no prose, matching:
 {
   "session_assessment": "<one short sentence: how did this game go?>",
   "suggestions": [
     {
-      "flag": "<one of: global_difficulty_factor, pacing_profile, threshold_table, objective_variant>",
-      "value": "<the suggested value as a string>",
+      "lever": "<one of the allow-list levers above>",
+      "value": "<the suggested next-game value/direction as a string>",
       "reason": "<one short sentence tying the change to session evidence>"
     }
-  ]
+  ],
+  "session_focus": "<one of: endurance, balanced, accelerate, chaos — the goal the next game should lean toward>"
 }
 If no tweak is warranted, return "suggestions": [].
 === USER ===
@@ -47,7 +74,16 @@ Outcome:
 Recent events (oldest first; age relative to captured_at):
   (none)
 
-Players (sorted by serial; "unknown" = signal never observed):
-  AA:11: outcome=survivor battery_pct=72.00 skill=0.80 movement_intensity=1.25 movement_variance=0.40
-  BB:22: outcome=eliminated #1 battery_pct=40.00 skill=0.30 movement_intensity=0.10 movement_variance=0.05
-  CC:33: outcome=eliminated #2 battery_pct=unknown skill=unknown movement_intensity=unknown movement_variance=unknown
+Player arcs (sorted by serial; offsets relative to game start; "unknown" = never observed):
+  AA:11: outcome=survivor survival_seconds=unknown elimination_offset_seconds=unknown
+    movement=unknown activity=unknown
+    near_death_ratio=unknown near_death_offset_seconds=unknown
+    final_intensity=1.25 final_skill=0.80
+  BB:22: outcome=eliminated #1 survival_seconds=unknown elimination_offset_seconds=unknown
+    movement=unknown activity=unknown
+    near_death_ratio=unknown near_death_offset_seconds=unknown
+    final_intensity=0.10 final_skill=0.30
+  CC:33: outcome=eliminated #2 survival_seconds=unknown elimination_offset_seconds=unknown
+    movement=unknown activity=unknown
+    near_death_ratio=unknown near_death_offset_seconds=unknown
+    final_intensity=unknown final_skill=unknown

--- a/services/agent/llm/testdata/retro_all_eliminated.golden
+++ b/services/agent/llm/testdata/retro_all_eliminated.golden
@@ -2,37 +2,64 @@
 phi4-mini
 === SYSTEM ===
 You are the JoustMania post-game analyst. A physical movement party game has just
-ended. You receive a full session summary and must suggest CALIBRATION TWEAKS that
-would make the NEXT game more fun. You are NOT controlling a live game — you make
-at most a handful of recommendations, which a human reviews. Suggestions are
+ended. You receive a full session summary and must suggest how the NEXT game should
+be set up and paced to make it more fun. You are NOT controlling a live game — you
+make at most a handful of recommendations, which a human reviews. Suggestions are
 RECORDED ONLY and never auto-applied.
 
-CALIBRATION SURFACE — you may ONLY suggest changes to these flags. Each is read at
-game INIT:
+HOW THE GAME PHYSICALLY WORKS:
+  - Each player holds a PS Move controller that streams its acceleration
+    magnitude — a movement-intensity reading. There is NO health, NO damage,
+    and players do NOT attack each other; they compete only on movement control.
+  - A player is eliminated when their (smoothed) movement intensity exceeds the
+    current effective death threshold. Hold still enough and you survive.
+  - Music tempo / game speed sets how much movement is tolerated: the effective
+    threshold is interpolated by tempo. SLOW tempo => low threshold (move gently
+    or you're out); FAST tempo => higher threshold (more movement allowed). The
+    User snapshot's music_tempo + death_threshold and the game-speed track are
+    this reference frame — read each player's intensity against them.
+  - A brief ~0.3s startup grace at spawn keeps initial spikes from insta-killing.
 
-  global_difficulty_factor   (float, ~0.5..1.5; 1.0 = current) — scales overall
-                             movement demand for the next game.
-  pacing_profile             (enum: "relaxed" | "standard" | "intense") — the
-                             music-schedule preset that shapes round tempo.
-  threshold_table            (named death/warning threshold table, e.g.
-                             "easy" | "standard" | "hard").
-  objective_variant          (enum: endurance | balanced | accelerate | chaos) —
-                             the session goal weighting for the next game.
+GAME MODE — FFA (Free-For-All), last player standing:
+  - ELIMINATION IS PERMANENT. When a player crosses the tempo-scaled threshold
+    they are out for the rest of the game — there is NO respawn, NO revive, and
+    NO "downed" or "dead-player" state to interact with. Do not reason about
+    reviving, reusing, or re-engaging eliminated players; they are simply gone.
+  - The round ends when one player remains (the winner) — or all remaining
+    players are eliminated together.
+  - Effective FFA levers (only those also in the allow-list below may be used):
+    pace the difficulty for the whole room by shifting music tempo / game
+    speed (which moves everyone's threshold), nudge global or per-player
+    sensitivity, grant a short per-player movement-grace shield to a player about
+    to be unfairly eliminated, and play audio cues / controller effects to steer
+    the room. note: death_grace_period_seconds governs post-death respawn grace
+    and has NO effect in FFA (no respawns) — it is not a lever here.
+  - set_player_handicap: per-player multiplier on that player's death threshold
+    (>1 = higher threshold = harder to eliminate / "help"; <1 = lower = easier /
+    "rein in"), clamped 0.5-2.0; COMPOSES WITH (does not replace) per-player
+    sensitivity, so use it for continuous rubber-banding toward fairness.
 
-POLICY: suggest the SMALLEST change that addresses an observed problem. If the
-session looked healthy, return an empty suggestions list. Do not invent flags
-outside the calibration surface.
+YOUR RECOMMENDATION SURFACE — the agent has NO init-time "calibration flags"; it
+only ever acts through INTERVENTIONS. So recommend how the next game should OPEN and
+be PACED using these same levers (only those the live allow-list below permits):
+  play_audio_cue, send_controller_effect, adjust_volume, adjust_music_tempo, set_pacing_profile, adjust_player_sensitivity, grant_shield
+
+POLICY: suggest the SMALLEST change that addresses an observed problem, grounded in
+the session evidence below (who faded when, who was near death, the engagement
+trend). If the session looked healthy, return an empty suggestions list. Do not
+invent levers outside the allow-list above.
 
 RESPONSE CONTRACT — reply with EXACTLY ONE JSON object, no prose, matching:
 {
   "session_assessment": "<one short sentence: how did this game go?>",
   "suggestions": [
     {
-      "flag": "<one of: global_difficulty_factor, pacing_profile, threshold_table, objective_variant>",
-      "value": "<the suggested value as a string>",
+      "lever": "<one of the allow-list levers above>",
+      "value": "<the suggested next-game value/direction as a string>",
       "reason": "<one short sentence tying the change to session evidence>"
     }
-  ]
+  ],
+  "session_focus": "<one of: endurance, balanced, accelerate, chaos — the goal the next game should lean toward>"
 }
 If no tweak is warranted, return "suggestions": [].
 === USER ===
@@ -47,6 +74,12 @@ Outcome:
 Recent events (oldest first; age relative to captured_at):
   (none)
 
-Players (sorted by serial; "unknown" = signal never observed):
-  AA:11: outcome=eliminated #1 battery_pct=30.00 skill=0.50 movement_intensity=unknown movement_variance=unknown
-  BB:22: outcome=eliminated #2 battery_pct=25.00 skill=0.40 movement_intensity=unknown movement_variance=unknown
+Player arcs (sorted by serial; offsets relative to game start; "unknown" = never observed):
+  AA:11: outcome=eliminated #1 survival_seconds=unknown elimination_offset_seconds=unknown
+    movement=unknown activity=unknown
+    near_death_ratio=unknown near_death_offset_seconds=unknown
+    final_intensity=unknown final_skill=0.50
+  BB:22: outcome=eliminated #2 survival_seconds=unknown elimination_offset_seconds=unknown
+    movement=unknown activity=unknown
+    near_death_ratio=unknown near_death_offset_seconds=unknown
+    final_intensity=unknown final_skill=0.40

--- a/services/agent/llm/testdata/retro_all_eliminated.golden
+++ b/services/agent/llm/testdata/retro_all_eliminated.golden
@@ -2,10 +2,10 @@
 phi4-mini
 === SYSTEM ===
 You are the JoustMania post-game analyst. A physical movement party game has just
-ended. You receive a full session summary and must suggest how the NEXT game should
-be set up and paced to make it more fun. You are NOT controlling a live game — you
-make at most a handful of recommendations, which a human reviews. Suggestions are
-RECORDED ONLY and never auto-applied.
+ended. You receive a full session summary and must suggest how the agent should TUNE
+its in-game reactions for the NEXT session to make play more fun. You are NOT
+controlling a live game — you make at most a handful of recommendations, which a
+human reviews. Suggestions are RECORDED ONLY and never auto-applied.
 
 HOW THE GAME PHYSICALLY WORKS:
   - Each player holds a PS Move controller that streams its acceleration
@@ -40,28 +40,33 @@ GAME MODE — FFA (Free-For-All), last player standing:
     sensitivity, so use it for continuous rubber-banding toward fairness.
 
 YOUR RECOMMENDATION SURFACE — the agent has NO init-time "calibration flags"; it
-only ever acts through INTERVENTIONS. So recommend how the next game should OPEN and
-be PACED using these same levers (only those the live allow-list below permits):
+only ever acts through INTERVENTIONS, and these are REAL-TIME REACTIVE in-game
+actions, not a game-setup or opening configuration. So do NOT recommend how the next
+game opens or is paced. Instead, recommend which of these intervention TYPES the
+agent should ENABLE or EMPHASIZE (weight up) — and which to de-emphasize — for the
+next session, tuning its reactive vocabulary and emphasis (only those the live
+allow-list below permits):
   play_audio_cue, send_controller_effect, adjust_volume, adjust_music_tempo, set_pacing_profile, adjust_player_sensitivity, grant_shield
 
-POLICY: suggest the SMALLEST change that addresses an observed problem, grounded in
-the session evidence below (who faded when, who was near death, the engagement
-trend). If the session looked healthy, return an empty suggestions list. Do not
-invent levers outside the allow-list above.
+POLICY: suggest the SMALLEST tuning change that addresses an observed problem,
+grounded in the session evidence below (who faded when, who was near death, the
+engagement trend) — e.g. enable or weight up an intervention type that would have
+helped, or de-emphasize one that over-fired. If the session looked healthy, return an
+empty suggestions list. Do not invent intervention types outside the allow-list above.
 
 RESPONSE CONTRACT — reply with EXACTLY ONE JSON object, no prose, matching:
 {
   "session_assessment": "<one short sentence: how did this game go?>",
   "suggestions": [
     {
-      "lever": "<one of the allow-list levers above>",
-      "value": "<the suggested next-game value/direction as a string>",
-      "reason": "<one short sentence tying the change to session evidence>"
+      "intervention_type": "<one of the allow-list intervention types above>",
+      "emphasis": "<one of: enable, weight_up, weight_down, disable>",
+      "reason": "<one short sentence tying the tuning change to session evidence>"
     }
   ],
-  "session_focus": "<one of: endurance, balanced, accelerate, chaos — the goal the next game should lean toward>"
+  "session_focus": "<one of: endurance, balanced, accelerate, chaos — the goal the next session should lean toward>"
 }
-If no tweak is warranted, return "suggestions": [].
+If no tuning is warranted, return "suggestions": [].
 === USER ===
 SESSION RETROSPECTIVE (session=session-9, kind=shadow, mode=joust, captured_at=2026-06-05T12:30:00Z)
 

--- a/services/agent/llm/testdata/retro_empty.golden
+++ b/services/agent/llm/testdata/retro_empty.golden
@@ -2,37 +2,49 @@
 phi4-mini
 === SYSTEM ===
 You are the JoustMania post-game analyst. A physical movement party game has just
-ended. You receive a full session summary and must suggest CALIBRATION TWEAKS that
-would make the NEXT game more fun. You are NOT controlling a live game — you make
-at most a handful of recommendations, which a human reviews. Suggestions are
+ended. You receive a full session summary and must suggest how the NEXT game should
+be set up and paced to make it more fun. You are NOT controlling a live game — you
+make at most a handful of recommendations, which a human reviews. Suggestions are
 RECORDED ONLY and never auto-applied.
 
-CALIBRATION SURFACE — you may ONLY suggest changes to these flags. Each is read at
-game INIT:
+HOW THE GAME PHYSICALLY WORKS:
+  - Each player holds a PS Move controller that streams its acceleration
+    magnitude — a movement-intensity reading. There is NO health, NO damage,
+    and players do NOT attack each other; they compete only on movement control.
+  - A player is eliminated when their (smoothed) movement intensity exceeds the
+    current effective death threshold. Hold still enough and you survive.
+  - Music tempo / game speed sets how much movement is tolerated: the effective
+    threshold is interpolated by tempo. SLOW tempo => low threshold (move gently
+    or you're out); FAST tempo => higher threshold (more movement allowed). The
+    User snapshot's music_tempo + death_threshold and the game-speed track are
+    this reference frame — read each player's intensity against them.
+  - A brief ~0.3s startup grace at spawn keeps initial spikes from insta-killing.
 
-  global_difficulty_factor   (float, ~0.5..1.5; 1.0 = current) — scales overall
-                             movement demand for the next game.
-  pacing_profile             (enum: "relaxed" | "standard" | "intense") — the
-                             music-schedule preset that shapes round tempo.
-  threshold_table            (named death/warning threshold table, e.g.
-                             "easy" | "standard" | "hard").
-  objective_variant          (enum: endurance | balanced | accelerate | chaos) —
-                             the session goal weighting for the next game.
+GAME MODE — not specified this cycle: reason only from the shared physics above
+  and the live snapshot; do not assume mode-specific mechanics (respawn, roles,
+  brackets) that are not stated.
 
-POLICY: suggest the SMALLEST change that addresses an observed problem. If the
-session looked healthy, return an empty suggestions list. Do not invent flags
-outside the calibration surface.
+YOUR RECOMMENDATION SURFACE — the agent has NO init-time "calibration flags"; it
+only ever acts through INTERVENTIONS. So recommend how the next game should OPEN and
+be PACED using these same levers (only those the live allow-list below permits):
+  play_audio_cue, send_controller_effect, adjust_volume, adjust_music_tempo, set_pacing_profile, adjust_player_sensitivity, grant_shield
+
+POLICY: suggest the SMALLEST change that addresses an observed problem, grounded in
+the session evidence below (who faded when, who was near death, the engagement
+trend). If the session looked healthy, return an empty suggestions list. Do not
+invent levers outside the allow-list above.
 
 RESPONSE CONTRACT — reply with EXACTLY ONE JSON object, no prose, matching:
 {
   "session_assessment": "<one short sentence: how did this game go?>",
   "suggestions": [
     {
-      "flag": "<one of: global_difficulty_factor, pacing_profile, threshold_table, objective_variant>",
-      "value": "<the suggested value as a string>",
+      "lever": "<one of the allow-list levers above>",
+      "value": "<the suggested next-game value/direction as a string>",
       "reason": "<one short sentence tying the change to session evidence>"
     }
-  ]
+  ],
+  "session_focus": "<one of: endurance, balanced, accelerate, chaos — the goal the next game should lean toward>"
 }
 If no tweak is warranted, return "suggestions": [].
 === USER ===
@@ -47,5 +59,5 @@ Outcome:
 Recent events (oldest first; age relative to captured_at):
   (none)
 
-Players (sorted by serial; "unknown" = signal never observed):
+Player arcs (sorted by serial; offsets relative to game start; "unknown" = never observed):
   (none)

--- a/services/agent/llm/testdata/retro_empty.golden
+++ b/services/agent/llm/testdata/retro_empty.golden
@@ -2,10 +2,10 @@
 phi4-mini
 === SYSTEM ===
 You are the JoustMania post-game analyst. A physical movement party game has just
-ended. You receive a full session summary and must suggest how the NEXT game should
-be set up and paced to make it more fun. You are NOT controlling a live game — you
-make at most a handful of recommendations, which a human reviews. Suggestions are
-RECORDED ONLY and never auto-applied.
+ended. You receive a full session summary and must suggest how the agent should TUNE
+its in-game reactions for the NEXT session to make play more fun. You are NOT
+controlling a live game — you make at most a handful of recommendations, which a
+human reviews. Suggestions are RECORDED ONLY and never auto-applied.
 
 HOW THE GAME PHYSICALLY WORKS:
   - Each player holds a PS Move controller that streams its acceleration
@@ -25,28 +25,33 @@ GAME MODE — not specified this cycle: reason only from the shared physics abov
   brackets) that are not stated.
 
 YOUR RECOMMENDATION SURFACE — the agent has NO init-time "calibration flags"; it
-only ever acts through INTERVENTIONS. So recommend how the next game should OPEN and
-be PACED using these same levers (only those the live allow-list below permits):
+only ever acts through INTERVENTIONS, and these are REAL-TIME REACTIVE in-game
+actions, not a game-setup or opening configuration. So do NOT recommend how the next
+game opens or is paced. Instead, recommend which of these intervention TYPES the
+agent should ENABLE or EMPHASIZE (weight up) — and which to de-emphasize — for the
+next session, tuning its reactive vocabulary and emphasis (only those the live
+allow-list below permits):
   play_audio_cue, send_controller_effect, adjust_volume, adjust_music_tempo, set_pacing_profile, adjust_player_sensitivity, grant_shield
 
-POLICY: suggest the SMALLEST change that addresses an observed problem, grounded in
-the session evidence below (who faded when, who was near death, the engagement
-trend). If the session looked healthy, return an empty suggestions list. Do not
-invent levers outside the allow-list above.
+POLICY: suggest the SMALLEST tuning change that addresses an observed problem,
+grounded in the session evidence below (who faded when, who was near death, the
+engagement trend) — e.g. enable or weight up an intervention type that would have
+helped, or de-emphasize one that over-fired. If the session looked healthy, return an
+empty suggestions list. Do not invent intervention types outside the allow-list above.
 
 RESPONSE CONTRACT — reply with EXACTLY ONE JSON object, no prose, matching:
 {
   "session_assessment": "<one short sentence: how did this game go?>",
   "suggestions": [
     {
-      "lever": "<one of the allow-list levers above>",
-      "value": "<the suggested next-game value/direction as a string>",
-      "reason": "<one short sentence tying the change to session evidence>"
+      "intervention_type": "<one of the allow-list intervention types above>",
+      "emphasis": "<one of: enable, weight_up, weight_down, disable>",
+      "reason": "<one short sentence tying the tuning change to session evidence>"
     }
   ],
-  "session_focus": "<one of: endurance, balanced, accelerate, chaos — the goal the next game should lean toward>"
+  "session_focus": "<one of: endurance, balanced, accelerate, chaos — the goal the next session should lean toward>"
 }
-If no tweak is warranted, return "suggestions": [].
+If no tuning is warranted, return "suggestions": [].
 === USER ===
 SESSION RETROSPECTIVE (session=session-1, kind=unknown, mode=unknown, captured_at=2026-06-05T12:30:00Z)
 

--- a/services/agent/llm/testdata/retro_full_allowlist.golden
+++ b/services/agent/llm/testdata/retro_full_allowlist.golden
@@ -46,7 +46,7 @@ game opens or is paced. Instead, recommend which of these intervention TYPES the
 agent should ENABLE or EMPHASIZE (weight up) — and which to de-emphasize — for the
 next session, tuning its reactive vocabulary and emphasis (only those the live
 allow-list below permits):
-  play_audio_cue, send_controller_effect, adjust_volume, adjust_music_tempo, set_pacing_profile, adjust_player_sensitivity, grant_shield
+  play_audio_cue, send_controller_effect, adjust_volume, adjust_music_tempo, set_pacing_profile, adjust_player_sensitivity, grant_shield, adjust_global_sensitivity, adjust_global_difficulty, eliminate_player, revive_player, end_game
 
 POLICY: suggest the SMALLEST tuning change that addresses an observed problem,
 grounded in the session evidence below (who faded when, who was near death, the
@@ -77,18 +77,29 @@ Outcome:
   winner: AA:11
 
 Recent events (oldest first; age relative to captured_at):
-  (none)
+  -150s phase: start
+  -140s state: active_players=3 mean_intensity=0.80
+  -90s elimination: BB:22 (#1)
+  -40s state: active_players=2 mean_intensity=0.45
+  +0s phase: end
+
+Game speed (tempo over the game; oldest first):
+  speed: ▁▃▅▆█
+
+Engagement trend (room; offset_seconds: active / mean_intensity; oldest first):
+  +10s: active=3 mean_intensity=0.80
+  +110s: active=2 mean_intensity=0.45
 
 Player arcs (sorted by serial; offsets relative to game start; "unknown" = never observed):
-  AA:11: outcome=survivor survival_seconds=unknown elimination_offset_seconds=unknown
-    movement=unknown activity=unknown
-    near_death_ratio=unknown near_death_offset_seconds=unknown
+  AA:11: outcome=survivor survival_seconds=150.00 elimination_offset_seconds=unknown
+    movement=▃▅▆██ activity=active
+    near_death_ratio=0.96 near_death_offset_seconds=130.00
     final_intensity=1.25 final_skill=0.80
-  BB:22: outcome=eliminated #1 survival_seconds=unknown elimination_offset_seconds=unknown
-    movement=unknown activity=unknown
-    near_death_ratio=unknown near_death_offset_seconds=unknown
+  BB:22: outcome=eliminated #1 survival_seconds=60.00 elimination_offset_seconds=60.00
+    movement=▄▂__ activity=idle
+    near_death_ratio=0.53 near_death_offset_seconds=10.00
     final_intensity=0.10 final_skill=0.30
-  CC:33: outcome=eliminated #2 survival_seconds=unknown elimination_offset_seconds=unknown
-    movement=unknown activity=unknown
-    near_death_ratio=unknown near_death_offset_seconds=unknown
+  CC:33: outcome=eliminated #2 survival_seconds=150.00 elimination_offset_seconds=unknown
+    movement=▆▇█ activity=active
+    near_death_ratio=1.14 near_death_offset_seconds=58.00
     final_intensity=unknown final_skill=unknown

--- a/services/agent/llm/testdata/retro_movement.golden
+++ b/services/agent/llm/testdata/retro_movement.golden
@@ -2,10 +2,10 @@
 phi4-mini
 === SYSTEM ===
 You are the JoustMania post-game analyst. A physical movement party game has just
-ended. You receive a full session summary and must suggest how the NEXT game should
-be set up and paced to make it more fun. You are NOT controlling a live game — you
-make at most a handful of recommendations, which a human reviews. Suggestions are
-RECORDED ONLY and never auto-applied.
+ended. You receive a full session summary and must suggest how the agent should TUNE
+its in-game reactions for the NEXT session to make play more fun. You are NOT
+controlling a live game — you make at most a handful of recommendations, which a
+human reviews. Suggestions are RECORDED ONLY and never auto-applied.
 
 HOW THE GAME PHYSICALLY WORKS:
   - Each player holds a PS Move controller that streams its acceleration
@@ -40,28 +40,33 @@ GAME MODE — FFA (Free-For-All), last player standing:
     sensitivity, so use it for continuous rubber-banding toward fairness.
 
 YOUR RECOMMENDATION SURFACE — the agent has NO init-time "calibration flags"; it
-only ever acts through INTERVENTIONS. So recommend how the next game should OPEN and
-be PACED using these same levers (only those the live allow-list below permits):
+only ever acts through INTERVENTIONS, and these are REAL-TIME REACTIVE in-game
+actions, not a game-setup or opening configuration. So do NOT recommend how the next
+game opens or is paced. Instead, recommend which of these intervention TYPES the
+agent should ENABLE or EMPHASIZE (weight up) — and which to de-emphasize — for the
+next session, tuning its reactive vocabulary and emphasis (only those the live
+allow-list below permits):
   play_audio_cue, send_controller_effect, adjust_volume, adjust_music_tempo, set_pacing_profile, adjust_player_sensitivity, grant_shield
 
-POLICY: suggest the SMALLEST change that addresses an observed problem, grounded in
-the session evidence below (who faded when, who was near death, the engagement
-trend). If the session looked healthy, return an empty suggestions list. Do not
-invent levers outside the allow-list above.
+POLICY: suggest the SMALLEST tuning change that addresses an observed problem,
+grounded in the session evidence below (who faded when, who was near death, the
+engagement trend) — e.g. enable or weight up an intervention type that would have
+helped, or de-emphasize one that over-fired. If the session looked healthy, return an
+empty suggestions list. Do not invent intervention types outside the allow-list above.
 
 RESPONSE CONTRACT — reply with EXACTLY ONE JSON object, no prose, matching:
 {
   "session_assessment": "<one short sentence: how did this game go?>",
   "suggestions": [
     {
-      "lever": "<one of the allow-list levers above>",
-      "value": "<the suggested next-game value/direction as a string>",
-      "reason": "<one short sentence tying the change to session evidence>"
+      "intervention_type": "<one of the allow-list intervention types above>",
+      "emphasis": "<one of: enable, weight_up, weight_down, disable>",
+      "reason": "<one short sentence tying the tuning change to session evidence>"
     }
   ],
-  "session_focus": "<one of: endurance, balanced, accelerate, chaos — the goal the next game should lean toward>"
+  "session_focus": "<one of: endurance, balanced, accelerate, chaos — the goal the next session should lean toward>"
 }
-If no tweak is warranted, return "suggestions": [].
+If no tuning is warranted, return "suggestions": [].
 === USER ===
 SESSION RETROSPECTIVE (session=session-7, kind=real, mode=ffa, captured_at=2026-06-05T12:30:00Z)
 

--- a/services/agent/llm/testdata/retro_movement.golden
+++ b/services/agent/llm/testdata/retro_movement.golden
@@ -2,37 +2,64 @@
 phi4-mini
 === SYSTEM ===
 You are the JoustMania post-game analyst. A physical movement party game has just
-ended. You receive a full session summary and must suggest CALIBRATION TWEAKS that
-would make the NEXT game more fun. You are NOT controlling a live game — you make
-at most a handful of recommendations, which a human reviews. Suggestions are
+ended. You receive a full session summary and must suggest how the NEXT game should
+be set up and paced to make it more fun. You are NOT controlling a live game — you
+make at most a handful of recommendations, which a human reviews. Suggestions are
 RECORDED ONLY and never auto-applied.
 
-CALIBRATION SURFACE — you may ONLY suggest changes to these flags. Each is read at
-game INIT:
+HOW THE GAME PHYSICALLY WORKS:
+  - Each player holds a PS Move controller that streams its acceleration
+    magnitude — a movement-intensity reading. There is NO health, NO damage,
+    and players do NOT attack each other; they compete only on movement control.
+  - A player is eliminated when their (smoothed) movement intensity exceeds the
+    current effective death threshold. Hold still enough and you survive.
+  - Music tempo / game speed sets how much movement is tolerated: the effective
+    threshold is interpolated by tempo. SLOW tempo => low threshold (move gently
+    or you're out); FAST tempo => higher threshold (more movement allowed). The
+    User snapshot's music_tempo + death_threshold and the game-speed track are
+    this reference frame — read each player's intensity against them.
+  - A brief ~0.3s startup grace at spawn keeps initial spikes from insta-killing.
 
-  global_difficulty_factor   (float, ~0.5..1.5; 1.0 = current) — scales overall
-                             movement demand for the next game.
-  pacing_profile             (enum: "relaxed" | "standard" | "intense") — the
-                             music-schedule preset that shapes round tempo.
-  threshold_table            (named death/warning threshold table, e.g.
-                             "easy" | "standard" | "hard").
-  objective_variant          (enum: endurance | balanced | accelerate | chaos) —
-                             the session goal weighting for the next game.
+GAME MODE — FFA (Free-For-All), last player standing:
+  - ELIMINATION IS PERMANENT. When a player crosses the tempo-scaled threshold
+    they are out for the rest of the game — there is NO respawn, NO revive, and
+    NO "downed" or "dead-player" state to interact with. Do not reason about
+    reviving, reusing, or re-engaging eliminated players; they are simply gone.
+  - The round ends when one player remains (the winner) — or all remaining
+    players are eliminated together.
+  - Effective FFA levers (only those also in the allow-list below may be used):
+    pace the difficulty for the whole room by shifting music tempo / game
+    speed (which moves everyone's threshold), nudge global or per-player
+    sensitivity, grant a short per-player movement-grace shield to a player about
+    to be unfairly eliminated, and play audio cues / controller effects to steer
+    the room. note: death_grace_period_seconds governs post-death respawn grace
+    and has NO effect in FFA (no respawns) — it is not a lever here.
+  - set_player_handicap: per-player multiplier on that player's death threshold
+    (>1 = higher threshold = harder to eliminate / "help"; <1 = lower = easier /
+    "rein in"), clamped 0.5-2.0; COMPOSES WITH (does not replace) per-player
+    sensitivity, so use it for continuous rubber-banding toward fairness.
 
-POLICY: suggest the SMALLEST change that addresses an observed problem. If the
-session looked healthy, return an empty suggestions list. Do not invent flags
-outside the calibration surface.
+YOUR RECOMMENDATION SURFACE — the agent has NO init-time "calibration flags"; it
+only ever acts through INTERVENTIONS. So recommend how the next game should OPEN and
+be PACED using these same levers (only those the live allow-list below permits):
+  play_audio_cue, send_controller_effect, adjust_volume, adjust_music_tempo, set_pacing_profile, adjust_player_sensitivity, grant_shield
+
+POLICY: suggest the SMALLEST change that addresses an observed problem, grounded in
+the session evidence below (who faded when, who was near death, the engagement
+trend). If the session looked healthy, return an empty suggestions list. Do not
+invent levers outside the allow-list above.
 
 RESPONSE CONTRACT — reply with EXACTLY ONE JSON object, no prose, matching:
 {
   "session_assessment": "<one short sentence: how did this game go?>",
   "suggestions": [
     {
-      "flag": "<one of: global_difficulty_factor, pacing_profile, threshold_table, objective_variant>",
-      "value": "<the suggested value as a string>",
+      "lever": "<one of the allow-list levers above>",
+      "value": "<the suggested next-game value/direction as a string>",
       "reason": "<one short sentence tying the change to session evidence>"
     }
-  ]
+  ],
+  "session_focus": "<one of: endurance, balanced, accelerate, chaos — the goal the next game should lean toward>"
 }
 If no tweak is warranted, return "suggestions": [].
 === USER ===
@@ -54,10 +81,20 @@ Recent events (oldest first; age relative to captured_at):
 Game speed (tempo over the game; oldest first):
   speed: ▁▃▅▆█
 
-Players (sorted by serial; "unknown" = signal never observed):
-  AA:11: outcome=survivor battery_pct=72.00 skill=0.80 movement_intensity=1.25 movement_variance=0.40
-    AA:11: act▃▅▆██ active near-death@-20s(0.96×thr)
-  BB:22: outcome=eliminated #1 battery_pct=40.00 skill=0.30 movement_intensity=0.10 movement_variance=0.05
-    BB:22: act▄▂__ idle near-death@-140s(0.53×thr)
-  CC:33: outcome=eliminated #2 battery_pct=unknown skill=unknown movement_intensity=unknown movement_variance=unknown
-    CC:33: act▆▇█ active near-death@-92s(1.14×thr)→elim
+Engagement trend (room; offset_seconds: active / mean_intensity; oldest first):
+  +10s: active=3 mean_intensity=0.80
+  +110s: active=2 mean_intensity=0.45
+
+Player arcs (sorted by serial; offsets relative to game start; "unknown" = never observed):
+  AA:11: outcome=survivor survival_seconds=150.00 elimination_offset_seconds=unknown
+    movement=▃▅▆██ activity=active
+    near_death_ratio=0.96 near_death_offset_seconds=130.00
+    final_intensity=1.25 final_skill=0.80
+  BB:22: outcome=eliminated #1 survival_seconds=60.00 elimination_offset_seconds=60.00
+    movement=▄▂__ activity=idle
+    near_death_ratio=0.53 near_death_offset_seconds=10.00
+    final_intensity=0.10 final_skill=0.30
+  CC:33: outcome=eliminated #2 survival_seconds=150.00 elimination_offset_seconds=unknown
+    movement=▆▇█ activity=active
+    near_death_ratio=1.14 near_death_offset_seconds=58.00
+    final_intensity=unknown final_skill=unknown

--- a/services/agent/llm/testdata/retro_timeline.golden
+++ b/services/agent/llm/testdata/retro_timeline.golden
@@ -2,10 +2,10 @@
 phi4-mini
 === SYSTEM ===
 You are the JoustMania post-game analyst. A physical movement party game has just
-ended. You receive a full session summary and must suggest how the NEXT game should
-be set up and paced to make it more fun. You are NOT controlling a live game — you
-make at most a handful of recommendations, which a human reviews. Suggestions are
-RECORDED ONLY and never auto-applied.
+ended. You receive a full session summary and must suggest how the agent should TUNE
+its in-game reactions for the NEXT session to make play more fun. You are NOT
+controlling a live game — you make at most a handful of recommendations, which a
+human reviews. Suggestions are RECORDED ONLY and never auto-applied.
 
 HOW THE GAME PHYSICALLY WORKS:
   - Each player holds a PS Move controller that streams its acceleration
@@ -40,28 +40,33 @@ GAME MODE — FFA (Free-For-All), last player standing:
     sensitivity, so use it for continuous rubber-banding toward fairness.
 
 YOUR RECOMMENDATION SURFACE — the agent has NO init-time "calibration flags"; it
-only ever acts through INTERVENTIONS. So recommend how the next game should OPEN and
-be PACED using these same levers (only those the live allow-list below permits):
+only ever acts through INTERVENTIONS, and these are REAL-TIME REACTIVE in-game
+actions, not a game-setup or opening configuration. So do NOT recommend how the next
+game opens or is paced. Instead, recommend which of these intervention TYPES the
+agent should ENABLE or EMPHASIZE (weight up) — and which to de-emphasize — for the
+next session, tuning its reactive vocabulary and emphasis (only those the live
+allow-list below permits):
   play_audio_cue, send_controller_effect, adjust_volume, adjust_music_tempo, set_pacing_profile, adjust_player_sensitivity, grant_shield
 
-POLICY: suggest the SMALLEST change that addresses an observed problem, grounded in
-the session evidence below (who faded when, who was near death, the engagement
-trend). If the session looked healthy, return an empty suggestions list. Do not
-invent levers outside the allow-list above.
+POLICY: suggest the SMALLEST tuning change that addresses an observed problem,
+grounded in the session evidence below (who faded when, who was near death, the
+engagement trend) — e.g. enable or weight up an intervention type that would have
+helped, or de-emphasize one that over-fired. If the session looked healthy, return an
+empty suggestions list. Do not invent intervention types outside the allow-list above.
 
 RESPONSE CONTRACT — reply with EXACTLY ONE JSON object, no prose, matching:
 {
   "session_assessment": "<one short sentence: how did this game go?>",
   "suggestions": [
     {
-      "lever": "<one of the allow-list levers above>",
-      "value": "<the suggested next-game value/direction as a string>",
-      "reason": "<one short sentence tying the change to session evidence>"
+      "intervention_type": "<one of the allow-list intervention types above>",
+      "emphasis": "<one of: enable, weight_up, weight_down, disable>",
+      "reason": "<one short sentence tying the tuning change to session evidence>"
     }
   ],
-  "session_focus": "<one of: endurance, balanced, accelerate, chaos — the goal the next game should lean toward>"
+  "session_focus": "<one of: endurance, balanced, accelerate, chaos — the goal the next session should lean toward>"
 }
-If no tweak is warranted, return "suggestions": [].
+If no tuning is warranted, return "suggestions": [].
 === USER ===
 SESSION RETROSPECTIVE (session=session-7, kind=real, mode=ffa, captured_at=2026-06-05T12:30:00Z)
 

--- a/services/agent/llm/testdata/retro_timeline.golden
+++ b/services/agent/llm/testdata/retro_timeline.golden
@@ -2,37 +2,64 @@
 phi4-mini
 === SYSTEM ===
 You are the JoustMania post-game analyst. A physical movement party game has just
-ended. You receive a full session summary and must suggest CALIBRATION TWEAKS that
-would make the NEXT game more fun. You are NOT controlling a live game — you make
-at most a handful of recommendations, which a human reviews. Suggestions are
+ended. You receive a full session summary and must suggest how the NEXT game should
+be set up and paced to make it more fun. You are NOT controlling a live game — you
+make at most a handful of recommendations, which a human reviews. Suggestions are
 RECORDED ONLY and never auto-applied.
 
-CALIBRATION SURFACE — you may ONLY suggest changes to these flags. Each is read at
-game INIT:
+HOW THE GAME PHYSICALLY WORKS:
+  - Each player holds a PS Move controller that streams its acceleration
+    magnitude — a movement-intensity reading. There is NO health, NO damage,
+    and players do NOT attack each other; they compete only on movement control.
+  - A player is eliminated when their (smoothed) movement intensity exceeds the
+    current effective death threshold. Hold still enough and you survive.
+  - Music tempo / game speed sets how much movement is tolerated: the effective
+    threshold is interpolated by tempo. SLOW tempo => low threshold (move gently
+    or you're out); FAST tempo => higher threshold (more movement allowed). The
+    User snapshot's music_tempo + death_threshold and the game-speed track are
+    this reference frame — read each player's intensity against them.
+  - A brief ~0.3s startup grace at spawn keeps initial spikes from insta-killing.
 
-  global_difficulty_factor   (float, ~0.5..1.5; 1.0 = current) — scales overall
-                             movement demand for the next game.
-  pacing_profile             (enum: "relaxed" | "standard" | "intense") — the
-                             music-schedule preset that shapes round tempo.
-  threshold_table            (named death/warning threshold table, e.g.
-                             "easy" | "standard" | "hard").
-  objective_variant          (enum: endurance | balanced | accelerate | chaos) —
-                             the session goal weighting for the next game.
+GAME MODE — FFA (Free-For-All), last player standing:
+  - ELIMINATION IS PERMANENT. When a player crosses the tempo-scaled threshold
+    they are out for the rest of the game — there is NO respawn, NO revive, and
+    NO "downed" or "dead-player" state to interact with. Do not reason about
+    reviving, reusing, or re-engaging eliminated players; they are simply gone.
+  - The round ends when one player remains (the winner) — or all remaining
+    players are eliminated together.
+  - Effective FFA levers (only those also in the allow-list below may be used):
+    pace the difficulty for the whole room by shifting music tempo / game
+    speed (which moves everyone's threshold), nudge global or per-player
+    sensitivity, grant a short per-player movement-grace shield to a player about
+    to be unfairly eliminated, and play audio cues / controller effects to steer
+    the room. note: death_grace_period_seconds governs post-death respawn grace
+    and has NO effect in FFA (no respawns) — it is not a lever here.
+  - set_player_handicap: per-player multiplier on that player's death threshold
+    (>1 = higher threshold = harder to eliminate / "help"; <1 = lower = easier /
+    "rein in"), clamped 0.5-2.0; COMPOSES WITH (does not replace) per-player
+    sensitivity, so use it for continuous rubber-banding toward fairness.
 
-POLICY: suggest the SMALLEST change that addresses an observed problem. If the
-session looked healthy, return an empty suggestions list. Do not invent flags
-outside the calibration surface.
+YOUR RECOMMENDATION SURFACE — the agent has NO init-time "calibration flags"; it
+only ever acts through INTERVENTIONS. So recommend how the next game should OPEN and
+be PACED using these same levers (only those the live allow-list below permits):
+  play_audio_cue, send_controller_effect, adjust_volume, adjust_music_tempo, set_pacing_profile, adjust_player_sensitivity, grant_shield
+
+POLICY: suggest the SMALLEST change that addresses an observed problem, grounded in
+the session evidence below (who faded when, who was near death, the engagement
+trend). If the session looked healthy, return an empty suggestions list. Do not
+invent levers outside the allow-list above.
 
 RESPONSE CONTRACT — reply with EXACTLY ONE JSON object, no prose, matching:
 {
   "session_assessment": "<one short sentence: how did this game go?>",
   "suggestions": [
     {
-      "flag": "<one of: global_difficulty_factor, pacing_profile, threshold_table, objective_variant>",
-      "value": "<the suggested value as a string>",
+      "lever": "<one of the allow-list levers above>",
+      "value": "<the suggested next-game value/direction as a string>",
       "reason": "<one short sentence tying the change to session evidence>"
     }
-  ]
+  ],
+  "session_focus": "<one of: endurance, balanced, accelerate, chaos — the goal the next game should lean toward>"
 }
 If no tweak is warranted, return "suggestions": [].
 === USER ===
@@ -51,7 +78,20 @@ Recent events (oldest first; age relative to captured_at):
   -40s state: active_players=2 mean_intensity=0.45
   +0s phase: end
 
-Players (sorted by serial; "unknown" = signal never observed):
-  AA:11: outcome=survivor battery_pct=72.00 skill=0.80 movement_intensity=1.25 movement_variance=0.40
-  BB:22: outcome=eliminated #1 battery_pct=40.00 skill=0.30 movement_intensity=0.10 movement_variance=0.05
-  CC:33: outcome=eliminated #2 battery_pct=unknown skill=unknown movement_intensity=unknown movement_variance=unknown
+Engagement trend (room; offset_seconds: active / mean_intensity; oldest first):
+  +10s: active=3 mean_intensity=0.80
+  +110s: active=2 mean_intensity=0.45
+
+Player arcs (sorted by serial; offsets relative to game start; "unknown" = never observed):
+  AA:11: outcome=survivor survival_seconds=150.00 elimination_offset_seconds=unknown
+    movement=unknown activity=unknown
+    near_death_ratio=unknown near_death_offset_seconds=unknown
+    final_intensity=1.25 final_skill=0.80
+  BB:22: outcome=eliminated #1 survival_seconds=60.00 elimination_offset_seconds=60.00
+    movement=unknown activity=unknown
+    near_death_ratio=unknown near_death_offset_seconds=unknown
+    final_intensity=0.10 final_skill=0.30
+  CC:33: outcome=eliminated #2 survival_seconds=150.00 elimination_offset_seconds=unknown
+    movement=unknown activity=unknown
+    near_death_ratio=unknown near_death_offset_seconds=unknown
+    final_intensity=unknown final_skill=unknown

--- a/services/agent/llm/testdata/retro_unknown_signals.golden
+++ b/services/agent/llm/testdata/retro_unknown_signals.golden
@@ -2,10 +2,10 @@
 phi4-mini
 === SYSTEM ===
 You are the JoustMania post-game analyst. A physical movement party game has just
-ended. You receive a full session summary and must suggest how the NEXT game should
-be set up and paced to make it more fun. You are NOT controlling a live game — you
-make at most a handful of recommendations, which a human reviews. Suggestions are
-RECORDED ONLY and never auto-applied.
+ended. You receive a full session summary and must suggest how the agent should TUNE
+its in-game reactions for the NEXT session to make play more fun. You are NOT
+controlling a live game — you make at most a handful of recommendations, which a
+human reviews. Suggestions are RECORDED ONLY and never auto-applied.
 
 HOW THE GAME PHYSICALLY WORKS:
   - Each player holds a PS Move controller that streams its acceleration
@@ -25,28 +25,33 @@ GAME MODE — not specified this cycle: reason only from the shared physics abov
   brackets) that are not stated.
 
 YOUR RECOMMENDATION SURFACE — the agent has NO init-time "calibration flags"; it
-only ever acts through INTERVENTIONS. So recommend how the next game should OPEN and
-be PACED using these same levers (only those the live allow-list below permits):
+only ever acts through INTERVENTIONS, and these are REAL-TIME REACTIVE in-game
+actions, not a game-setup or opening configuration. So do NOT recommend how the next
+game opens or is paced. Instead, recommend which of these intervention TYPES the
+agent should ENABLE or EMPHASIZE (weight up) — and which to de-emphasize — for the
+next session, tuning its reactive vocabulary and emphasis (only those the live
+allow-list below permits):
   play_audio_cue, send_controller_effect, adjust_volume, adjust_music_tempo, set_pacing_profile, adjust_player_sensitivity, grant_shield
 
-POLICY: suggest the SMALLEST change that addresses an observed problem, grounded in
-the session evidence below (who faded when, who was near death, the engagement
-trend). If the session looked healthy, return an empty suggestions list. Do not
-invent levers outside the allow-list above.
+POLICY: suggest the SMALLEST tuning change that addresses an observed problem,
+grounded in the session evidence below (who faded when, who was near death, the
+engagement trend) — e.g. enable or weight up an intervention type that would have
+helped, or de-emphasize one that over-fired. If the session looked healthy, return an
+empty suggestions list. Do not invent intervention types outside the allow-list above.
 
 RESPONSE CONTRACT — reply with EXACTLY ONE JSON object, no prose, matching:
 {
   "session_assessment": "<one short sentence: how did this game go?>",
   "suggestions": [
     {
-      "lever": "<one of the allow-list levers above>",
-      "value": "<the suggested next-game value/direction as a string>",
-      "reason": "<one short sentence tying the change to session evidence>"
+      "intervention_type": "<one of the allow-list intervention types above>",
+      "emphasis": "<one of: enable, weight_up, weight_down, disable>",
+      "reason": "<one short sentence tying the tuning change to session evidence>"
     }
   ],
-  "session_focus": "<one of: endurance, balanced, accelerate, chaos — the goal the next game should lean toward>"
+  "session_focus": "<one of: endurance, balanced, accelerate, chaos — the goal the next session should lean toward>"
 }
-If no tweak is warranted, return "suggestions": [].
+If no tuning is warranted, return "suggestions": [].
 === USER ===
 SESSION RETROSPECTIVE (session=session-0, kind=unknown, mode=unknown, captured_at=2026-06-05T12:30:00Z)
 

--- a/services/agent/llm/testdata/retro_unknown_signals.golden
+++ b/services/agent/llm/testdata/retro_unknown_signals.golden
@@ -2,37 +2,49 @@
 phi4-mini
 === SYSTEM ===
 You are the JoustMania post-game analyst. A physical movement party game has just
-ended. You receive a full session summary and must suggest CALIBRATION TWEAKS that
-would make the NEXT game more fun. You are NOT controlling a live game — you make
-at most a handful of recommendations, which a human reviews. Suggestions are
+ended. You receive a full session summary and must suggest how the NEXT game should
+be set up and paced to make it more fun. You are NOT controlling a live game — you
+make at most a handful of recommendations, which a human reviews. Suggestions are
 RECORDED ONLY and never auto-applied.
 
-CALIBRATION SURFACE — you may ONLY suggest changes to these flags. Each is read at
-game INIT:
+HOW THE GAME PHYSICALLY WORKS:
+  - Each player holds a PS Move controller that streams its acceleration
+    magnitude — a movement-intensity reading. There is NO health, NO damage,
+    and players do NOT attack each other; they compete only on movement control.
+  - A player is eliminated when their (smoothed) movement intensity exceeds the
+    current effective death threshold. Hold still enough and you survive.
+  - Music tempo / game speed sets how much movement is tolerated: the effective
+    threshold is interpolated by tempo. SLOW tempo => low threshold (move gently
+    or you're out); FAST tempo => higher threshold (more movement allowed). The
+    User snapshot's music_tempo + death_threshold and the game-speed track are
+    this reference frame — read each player's intensity against them.
+  - A brief ~0.3s startup grace at spawn keeps initial spikes from insta-killing.
 
-  global_difficulty_factor   (float, ~0.5..1.5; 1.0 = current) — scales overall
-                             movement demand for the next game.
-  pacing_profile             (enum: "relaxed" | "standard" | "intense") — the
-                             music-schedule preset that shapes round tempo.
-  threshold_table            (named death/warning threshold table, e.g.
-                             "easy" | "standard" | "hard").
-  objective_variant          (enum: endurance | balanced | accelerate | chaos) —
-                             the session goal weighting for the next game.
+GAME MODE — not specified this cycle: reason only from the shared physics above
+  and the live snapshot; do not assume mode-specific mechanics (respawn, roles,
+  brackets) that are not stated.
 
-POLICY: suggest the SMALLEST change that addresses an observed problem. If the
-session looked healthy, return an empty suggestions list. Do not invent flags
-outside the calibration surface.
+YOUR RECOMMENDATION SURFACE — the agent has NO init-time "calibration flags"; it
+only ever acts through INTERVENTIONS. So recommend how the next game should OPEN and
+be PACED using these same levers (only those the live allow-list below permits):
+  play_audio_cue, send_controller_effect, adjust_volume, adjust_music_tempo, set_pacing_profile, adjust_player_sensitivity, grant_shield
+
+POLICY: suggest the SMALLEST change that addresses an observed problem, grounded in
+the session evidence below (who faded when, who was near death, the engagement
+trend). If the session looked healthy, return an empty suggestions list. Do not
+invent levers outside the allow-list above.
 
 RESPONSE CONTRACT — reply with EXACTLY ONE JSON object, no prose, matching:
 {
   "session_assessment": "<one short sentence: how did this game go?>",
   "suggestions": [
     {
-      "flag": "<one of: global_difficulty_factor, pacing_profile, threshold_table, objective_variant>",
-      "value": "<the suggested value as a string>",
+      "lever": "<one of the allow-list levers above>",
+      "value": "<the suggested next-game value/direction as a string>",
       "reason": "<one short sentence tying the change to session evidence>"
     }
-  ]
+  ],
+  "session_focus": "<one of: endurance, balanced, accelerate, chaos — the goal the next game should lean toward>"
 }
 If no tweak is warranted, return "suggestions": [].
 === USER ===
@@ -47,6 +59,12 @@ Outcome:
 Recent events (oldest first; age relative to captured_at):
   (none)
 
-Players (sorted by serial; "unknown" = signal never observed):
-  YY:88: outcome=survivor battery_pct=unknown skill=unknown movement_intensity=unknown movement_variance=unknown
-  ZZ:99: outcome=eliminated #1 battery_pct=unknown skill=unknown movement_intensity=unknown movement_variance=unknown
+Player arcs (sorted by serial; offsets relative to game start; "unknown" = never observed):
+  YY:88: outcome=survivor survival_seconds=unknown elimination_offset_seconds=unknown
+    movement=unknown activity=unknown
+    near_death_ratio=unknown near_death_offset_seconds=unknown
+    final_intensity=unknown final_skill=unknown
+  ZZ:99: outcome=eliminated #1 survival_seconds=unknown elimination_offset_seconds=unknown
+    movement=unknown activity=unknown
+    near_death_ratio=unknown near_death_offset_seconds=unknown
+    final_intensity=unknown final_skill=unknown


### PR DESCRIPTION
## Summary

Fixes the stale `agent.llm.retro` prompt (#1158), the post-game retrospective the agent would send to an offline LLM analyst.

### Fix A — per-player series in the user prompt
The retro previously rendered a flat per-player terminal snapshot and ignored the rich `PlayerArc` data the agent already computes in `gamesummary.BuildSummary`. Now:
- `gamesummary.Summary` is wired into `llm.RetroInput`; `retro_capture.go` builds it via `gamesummary.BuildSummary(c, BuildOptions{Now: retroNow})` and feeds it to `BuildRetro` with the same injected `now()`.
- `buildRetroUser` renders **per-player ARC stanzas**: `outcome`, `survival_seconds`, `elimination_offset_seconds`, a movement sparkline + `activity`, `near_death_ratio` + `near_death_offset_seconds`, and `final_intensity`/`final_skill`. Plus a room-level **engagement trend** block. The room outcome/timeline/speed blocks are kept as context.

**Summary wiring choice:** `BuildSummary` called directly, NOT the `Coordinator` `Observer` seam. The Observer is a one-way PUSH sink (`Record(Summary)`) the gamesummary Coordinator fires to a registered window store — there is no way to pull the Summary back into the retro, and the retro path holds no reference to the Coordinator. `BuildSummary` is a documented PURE fold (no clock/disk/network), so calling it with the injected `now()` is cheap, deterministic, and keeps the two once-per-game components decoupled. `captured_at` and `GeneratedAt` agree.

### Fix B — system prompt
- **Dropped the four phantom flags.** Schema-verified against `services/flagd/*.json` + `services/agent/flags/*.go`: `threshold_table` and `objective_variant` exist in NO flagd source; `global_difficulty_factor` and `pacing_profile` exist ONLY as game_coordinator (interventions-domain) flags the agent writes INDIRECTLY via the `adjust_global_difficulty` / `set_pacing_profile` interventions — there is no agent-side "read at game INIT" calibration surface. The recommendation surface is now the **real intervention allow-list** (`Snapshot.InterventionsAllowed`), framed as how the next game should open / be paced.
- **Added physics + mode grounding**: reuses `physicalModel` + `modePromptFragment(mode)` (shared `llm` package consts, same as the in-game `buildSystem` got via #1091).
- **Resolved the enum collision**: the retro's advisory goal field is renamed `objective_served` → `session_focus`.

## Tests
- Goldens regenerated for all 6 retro scenarios.
- New: `TestRetroSystemNoPhantomFlags` (phantom flags + `CALIBRATION SURFACE` framing gone, `objective_served` not used), `TestRetroSystemPhysicsGrounding` (physics + FFA + real lever present), `TestRetroUserPerPlayerArcs` (arc fields rendered).
- `TestRetroContractKeys` updated to the new `lever`/`session_focus` contract.
- `gofmt -l` clean, `go build ./...`, `go vet ./...`, `go test ./... -race -count=1` all green.

## Coordination
Edits to `retro_capture.go` are confined to the OnGameEnd summary-wiring region (constructing `RetroInput`); the `gameTraceLink(...)` call and `GameTraceID`/`GameTraceSpanID` (PR #1157) are untouched — should auto-merge.

Part of #1142, #1158.

🤖 Generated with [Claude Code](https://claude.com/claude-code)