### PR TITLE
fix(otel-collector): align memory_limiter below container ceiling to stop exit-137 OOM

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -193,7 +193,15 @@ services:
     deploy:
       resources:
         limits:
-          memory: 256m
+          # #1155: raised 256m -> 768m. At 256m the kernel OOM-killed the
+          # collector (exit 137) under sustained agent experiment-loop span
+          # volume before the memory_limiter (limit_mib was 512, ABOVE this
+          # ceiling) could ever shed load. The limiter is now aligned BELOW
+          # this ceiling (limit_mib=600, spike_limit_mib=150) per OTEL guidance
+          # (~80% / ~25%), so it backpressures at ~600m with ~168m headroom for
+          # off-heap/GC spikes instead of being OOM-killed. Keeps the #1140
+          # trace-correlation spans flowing. See services/otel-collector/config.yaml.
+          memory: 768m
           cpus: '0.5'
     logging: *default-logging
 

--- a/services/otel-collector/config.yaml
+++ b/services/otel-collector/config.yaml
@@ -138,19 +138,38 @@ receivers:
 
 processors:
   # Batch processor for better performance (traces/logs)
+  # #1155: shorter timeout + smaller batch flush sooner, lowering peak heap held
+  # by the trace/log pipelines under sustained agent experiment-loop span volume
+  # (4 paired shadow games/tick × decision/action/effect/experiment spans).
   batch:
-    timeout: 10s
-    send_batch_size: 1024
+    timeout: 5s
+    send_batch_size: 512
+    send_batch_max_size: 1024
 
   # Fast batch processor for sub-second metrics (Issue #105)
   batch/fast:
     timeout: 100ms
     send_batch_size: 1000
 
-  # Memory limiter to prevent OOM
+  # Memory limiter to prevent OOM (#1155).
+  #
+  # ROOT CAUSE of the exit-137 OOM-kills: limit_mib (512) was set ABOVE the
+  # container's `deploy.resources.limits.memory` ceiling (was 256 MiB) in
+  # docker-compose.yml. With no spike_limit_mib, the soft limit defaulted to
+  # 512 - 20% = ~410 MiB (the "~422 MiB" observed). Both the hard AND soft limit
+  # sat ABOVE the kernel cgroup ceiling, so the kernel OOM-killed the container
+  # long before the limiter could ever shed load — the limiter never engaged.
+  #
+  # FIX: the container ceiling is raised to 768 MiB in docker-compose.yml and the
+  # limiter is aligned BELOW it per OTEL guidance (limit_mib ~= 80% of container,
+  # spike_limit_mib ~= 25% of limit_mib). Now the limiter refuses/sheds data at
+  # ~600 MiB (soft ~450 MiB) — well under the 768 MiB cgroup ceiling — so under
+  # the agent experiment-loop span burst the collector backpressures instead of
+  # being OOM-killed, and keeps exporting the #1140 trace-correlation spans.
   memory_limiter:
     check_interval: 1s
-    limit_mib: 512
+    limit_mib: 600
+    spike_limit_mib: 150
 
   # Resource processors set service.namespace per pipeline.
   # The prometheusremotewrite exporter prefixes job labels with the namespace


### PR DESCRIPTION
Part of #1155.

## Root cause
`joustmania-otel-collector` OOM-killed (exit 137). Confirmed live on the dry-run stack via `docker inspect`: `ExitCode=137 OOMKilled=true`, cgroup `MemLimit=268435456` (= exactly **256 MiB**).

The `memory_limiter` processor had `limit_mib: 512` — **above** the container's `deploy.resources.limits.memory` ceiling of `256m`. With no `spike_limit_mib`, the soft limit defaulted to 512 − 20% = **~410 MiB** (the "~422 MiB" in the issue). Both the limiter's hard *and* soft thresholds sat above the kernel cgroup ceiling, so the kernel OOM-killed the container before the limiter could ever shed load. **The limiter never engaged** — the kernel always won (137). The #1140 `experiment.*` spans (4 paired shadow games/tick) push peak memory over 256 MiB.

## Fix (limiter aligned below container ceiling)
- **docker-compose.yml**: collector ceiling `256m` → `768m`.
- **config.yaml `memory_limiter`**: `limit_mib` `512` → `600`, add `spike_limit_mib: 150` (OTEL guidance ≈ 80% / ≈ 25% of container). Limiter now backpressures at ~600 MiB (soft ~450 MiB), with ~168 MiB headroom under the 768 MiB ceiling for off-heap/GC spikes.
- **config.yaml `batch`**: `timeout` `10s` → `5s`, `send_batch_size` `1024` → `512` (+ `send_batch_max_size: 1024`) so the trace/log pipelines flush sooner and hold less peak heap.

No sampling — the #1140 trace-correlation spans are preserved (demo needs them). Aggressive shadow-span sampling noted as a possible follow-up only.

## Verification
- `python3 -c "import yaml; yaml.safe_load(...)"` passes on both files (no dup keys).
- Live-restart of the shared collector was **denied by the sandbox** (shared infra). Verified by reasoning + live diagnostics instead: the dead container's confirmed 256 MiB cgroup limit vs the 512 MiB limiter is the exact misalignment fixed here. With the limiter (600/soft-450) now well under the 768 MiB ceiling, it sheds/backpressures before the kernel OOM-kills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)