### PR TITLE
fix(trace): re-root game span + carry span_id in correlation link (#1157)

### DIFF
--- a/services/agent/decision/decision.go
+++ b/services/agent/decision/decision.go
@@ -949,12 +949,16 @@ func (l *Loop) runDecision(ctx context.Context, snapshot flags.Snapshot, c gamec
 	startOpts := []trace.SpanStartOption{
 		trace.WithAttributes(decisionAttributes(state, d, blocked, reason, c.GameKind, c.SessionID)...),
 	}
-	startOpts = append(startOpts, gameTraceLink(c.GameTraceID)...)
+	startOpts = append(startOpts, gameTraceLink(c.GameTraceID, c.GameTraceSpanID)...)
 	if c.GameTraceID != "" {
 		// Also stamp the originating trace_id as a span ATTRIBUTE (not only the Link
 		// attribute), so it is searchable as a span tag in Jaeger even on backends
 		// that don't surface Link attributes in search (#1133 review).
 		startOpts = append(startOpts, trace.WithAttributes(attribute.String(AttrGameTraceID, c.GameTraceID)))
+	}
+	if c.GameTraceSpanID != "" {
+		// Likewise stamp the originating span_id as a searchable span attribute (#1157).
+		startOpts = append(startOpts, trace.WithAttributes(attribute.String(AttrGameTraceSpanID, c.GameTraceSpanID)))
 	}
 	dCtx, dSpan := l.Tracer.Start(ctx, SpanDecision, startOpts...)
 	defer dSpan.End()
@@ -1155,36 +1159,46 @@ func (l *Loop) shouldLog() bool {
 	return true
 }
 
-// gameTraceLink builds the trace-correlation span option for #1133: when gameTraceID
-// is a valid hex trace_id (ingested into GameContext from the game_trace_correlation
-// signal), it returns a single trace.WithLinks option whose Link targets a remote
-// SpanContext reconstructed from that trace_id, so the agent.decision span LINKS to the
-// originating game trace (navigable in Jaeger). The Link has no span_id — we correlate
-// to the game's TRACE, not one specific span in it — so the SpanContext carries only the
-// trace_id and is marked Remote + Sampled; it still validates (a non-zero trace_id is
-// sufficient for IsValid on a remote link target). An empty or unparseable id yields NO
-// option, so the span is created exactly as before: graceful fallback, no Link, no error.
+// gameTraceLink builds the trace-correlation span option for #1133/#1157: when
+// gameTraceID is a valid hex trace_id AND gameTraceSpanID is a valid hex span_id
+// (both ingested into GameContext from the game_trace_correlation signal), it
+// returns a single trace.WithLinks option whose Link targets a remote SpanContext
+// reconstructed from BOTH ids. That makes the agent.decision span LINK to the
+// originating game's root span (not merely its trace), so Jaeger's uiFind
+// highlights the actual game-start span (#1157) instead of an all-zero span id
+// under the trace. The SpanContext is marked Remote + Sampled.
 //
-// The trace_id is also stamped as a plain attribute on the Link; the caller additionally
-// stamps it as a span attribute (see runDecision) so it stays queryable as a span tag on
-// backends that don't surface Link attributes in search.
-func gameTraceLink(gameTraceID string) []trace.SpanStartOption {
-	if gameTraceID == "" {
+// An empty/unparseable trace_id OR span_id yields NO option, so the span is created
+// exactly as before: graceful fallback, no Link, no error. Pre-#1157 emitters (or
+// an unsampled game span) carry an empty span_id and therefore produce no Link —
+// the same as a missing trace_id. Both ids are also stamped as plain attributes on
+// the Link; the caller additionally stamps them as span attributes (see runDecision)
+// so they stay queryable as span tags on backends that don't surface Link attributes.
+func gameTraceLink(gameTraceID, gameTraceSpanID string) []trace.SpanStartOption {
+	if gameTraceID == "" || gameTraceSpanID == "" {
 		return nil
 	}
 	tid, err := trace.TraceIDFromHex(gameTraceID)
 	if err != nil || !tid.IsValid() {
 		return nil
 	}
+	sid, err := trace.SpanIDFromHex(gameTraceSpanID)
+	if err != nil || !sid.IsValid() {
+		return nil
+	}
 	sc := trace.NewSpanContext(trace.SpanContextConfig{
 		TraceID:    tid,
+		SpanID:     sid,
 		TraceFlags: trace.FlagsSampled,
 		Remote:     true,
 	})
 	return []trace.SpanStartOption{
 		trace.WithLinks(trace.Link{
 			SpanContext: sc,
-			Attributes:  []attribute.KeyValue{attribute.String(AttrGameTraceID, gameTraceID)},
+			Attributes: []attribute.KeyValue{
+				attribute.String(AttrGameTraceID, gameTraceID),
+				attribute.String(AttrGameTraceSpanID, gameTraceSpanID),
+			},
 		}),
 	}
 }

--- a/services/agent/decision/retro_capture.go
+++ b/services/agent/decision/retro_capture.go
@@ -316,7 +316,7 @@ func (rc *RetroCoordinator) OnGameEnd(c gamecontext.GameContext) {
 	// attributes in search. An empty/invalid id yields no Link and no attribute —
 	// graceful fallback, the span is byte-identical to before.
 	startOpts := []trace.SpanStartOption{trace.WithAttributes(attrs...)}
-	startOpts = append(startOpts, gameTraceLink(c.GameTraceID)...)
+	startOpts = append(startOpts, gameTraceLink(c.GameTraceID, c.GameTraceSpanID)...)
 	if c.GameTraceID != "" {
 		startOpts = append(startOpts,
 			trace.WithAttributes(attribute.String(AttrGameTraceID, c.GameTraceID)))

--- a/services/agent/decision/retro_trace_link_test.go
+++ b/services/agent/decision/retro_trace_link_test.go
@@ -15,10 +15,14 @@ import (
 // Absent/invalid trace_id -> no Link, no error (graceful fallback). The link
 // complements, does not replace, the game.id attribute.
 
-// endedSessionWithTrace is a finished-game GameContext carrying a game trace_id.
+const retroGameSpanID = "051581bf3cb55c13" // valid 8-byte hex span id (#1157)
+
+// endedSessionWithTrace is a finished-game GameContext carrying a game trace_id
+// (paired with a valid span_id, #1157, so a valid trace alone produces a link).
 func endedSessionWithTrace(traceID string) gamecontext.GameContext {
 	c := endedSession()
 	c.GameTraceID = traceID
+	c.GameTraceSpanID = retroGameSpanID
 	return c
 }
 
@@ -54,15 +58,29 @@ func TestRetroSpan_LinksToGameTrace(t *testing.T) {
 	if !links[0].SpanContext.TraceID().IsValid() {
 		t.Error("link trace_id must be valid")
 	}
-	// The trace id is stamped on the link as a queryable attribute.
-	var foundLinkAttr bool
+	// #1157: the retro link now targets the actual game-start span.
+	wantSID, _ := trace.SpanIDFromHex(retroGameSpanID)
+	if got := links[0].SpanContext.SpanID(); got != wantSID {
+		t.Errorf("link span_id = %s, want %s", got, wantSID)
+	}
+	if !links[0].SpanContext.SpanID().IsValid() {
+		t.Error("link span_id must be valid")
+	}
+	// Both ids are stamped on the link as queryable attributes.
+	var foundTraceAttr, foundSpanAttr bool
 	for _, kv := range links[0].Attributes {
 		if string(kv.Key) == AttrGameTraceID && kv.Value.AsString() == gameTrace {
-			foundLinkAttr = true
+			foundTraceAttr = true
+		}
+		if string(kv.Key) == AttrGameTraceSpanID && kv.Value.AsString() == retroGameSpanID {
+			foundSpanAttr = true
 		}
 	}
-	if !foundLinkAttr {
+	if !foundTraceAttr {
 		t.Errorf("link must carry %s=%s", AttrGameTraceID, gameTrace)
+	}
+	if !foundSpanAttr {
+		t.Errorf("link must carry %s=%s", AttrGameTraceSpanID, retroGameSpanID)
 	}
 	// The trace id is ALSO a plain span attribute (searchable on backends that don't
 	// surface link attributes).

--- a/services/agent/decision/telemetry.go
+++ b/services/agent/decision/telemetry.go
@@ -218,6 +218,12 @@ const (
 	// don't surface Link attributes in search. Empty/absent when no valid game
 	// trace_id was ingested (graceful fallback: no link and no attribute are added).
 	AttrGameTraceID = "game.trace_id"
+	// AttrGameTraceSpanID is the hex span_id of the originating game-coordinator
+	// root game span (#1157, follow-up to #1133). Stamped in the SAME two places as
+	// AttrGameTraceID (the gameTraceLink Link attribute + a plain span attribute) so
+	// the Link references the actual game-start span and the span_id is searchable
+	// as a span tag. Empty/absent when no valid game span_id was ingested.
+	AttrGameTraceSpanID = "game.trace_span_id"
 	// AttrEnabled is the existence-layer kill switch (agent.enabled). Lifted from
 	// the cycle's LayerState onto every decision span (including the disabled
 	// kill-switch span) so a trace shows whether the agent was live (#729).

--- a/services/agent/decision/trace_link_test.go
+++ b/services/agent/decision/trace_link_test.go
@@ -10,10 +10,13 @@ import (
 	"github.com/joustmania/agent/gamecontext"
 )
 
-// trace-correlation Phase 2 (#1133): when the coordinator's game-span trace_id is
-// known (ingested into GameContext.GameTraceID), the agent.decision span carries an
-// OTel Link to that trace; absent/invalid -> no Link, no error. The #1095 game.id
+// trace-correlation Phase 2 (#1133/#1157): when the coordinator's game-span
+// trace_id AND span_id are known (ingested into GameContext.GameTraceID /
+// GameTraceSpanID), the agent.decision span carries an OTel Link to that game's
+// root span; either id absent/invalid -> no Link, no error. The #1095 game.id
 // attribute stays in every case (Links complement, do not replace, the attribute).
+
+const linkGameSpanID = "051581bf3cb55c13" // valid 8-byte hex span id
 
 func linkSnapshot() flags.Snapshot {
 	return flags.Snapshot{
@@ -48,9 +51,10 @@ func TestDecisionSpan_LinksToGameTrace(t *testing.T) {
 
 	l, sr := recordingLoop(t, linkSnapshot(), []Decision{{Intervention: "grant_shield", Reason: "x"}})
 	l.OnEvaluate(context.Background(), gamecontext.GameContext{
-		SessionID:   gameID,
-		GameKind:    "real",
-		GameTraceID: gameTrace,
+		SessionID:       gameID,
+		GameKind:        "real",
+		GameTraceID:     gameTrace,
+		GameTraceSpanID: linkGameSpanID,
 	}, testTrigger())
 
 	dec := spansByName(sr.Ended(), SpanDecision)[0]
@@ -62,19 +66,33 @@ func TestDecisionSpan_LinksToGameTrace(t *testing.T) {
 	if got := links[0].SpanContext.TraceID(); got != wantTID {
 		t.Errorf("link trace_id = %s, want %s", got, wantTID)
 	}
+	// #1157: the link now targets the actual game-start span, not just the trace.
+	wantSID, _ := trace.SpanIDFromHex(linkGameSpanID)
+	if got := links[0].SpanContext.SpanID(); got != wantSID {
+		t.Errorf("link span_id = %s, want %s", got, wantSID)
+	}
 	// The link target must validate so Jaeger renders it as navigable.
 	if !links[0].SpanContext.TraceID().IsValid() {
 		t.Error("link trace_id must be valid")
 	}
-	// The trace id is also stamped on the link as a queryable attribute.
-	var foundAttr bool
+	if !links[0].SpanContext.SpanID().IsValid() {
+		t.Error("link span_id must be valid")
+	}
+	// Both ids are stamped on the link as queryable attributes.
+	var foundTraceAttr, foundSpanAttr bool
 	for _, kv := range links[0].Attributes {
 		if string(kv.Key) == AttrGameTraceID && kv.Value.AsString() == gameTrace {
-			foundAttr = true
+			foundTraceAttr = true
+		}
+		if string(kv.Key) == AttrGameTraceSpanID && kv.Value.AsString() == linkGameSpanID {
+			foundSpanAttr = true
 		}
 	}
-	if !foundAttr {
+	if !foundTraceAttr {
 		t.Errorf("link must carry %s=%s", AttrGameTraceID, gameTrace)
+	}
+	if !foundSpanAttr {
+		t.Errorf("link must carry %s=%s", AttrGameTraceSpanID, linkGameSpanID)
 	}
 	// Phase 1 (#1095) game.id attribute is untouched by the Link.
 	if v, ok := attrValue(dec, AttrGameID); !ok || v.AsString() != gameID {
@@ -99,28 +117,56 @@ func TestDecisionSpan_NoLinkWhenTraceAbsent(t *testing.T) {
 // unparseable or all-zero id) must NOT produce a Link and must NOT panic — the span is
 // created exactly as if no trace_id were present.
 func TestDecisionSpan_NoLinkWhenTraceInvalid(t *testing.T) {
+	const validTrace = "4bf92f3577b34da6a3ce929d0e0e4736"
 	for _, bad := range []string{
 		"not-hex",                          // unparseable
 		"00000000000000000000000000000000", // all-zero (invalid trace id)
 		"abc",                              // wrong length
 	} {
-		n, _, _, _ := decisionSpan(t, gamecontext.GameContext{SessionID: "g", GameTraceID: bad})
+		// Pair the bad trace_id with a valid span_id so the trace_id is solely
+		// what suppresses the link.
+		n, _, _, _ := decisionSpan(t, gamecontext.GameContext{SessionID: "g", GameTraceID: bad, GameTraceSpanID: linkGameSpanID})
 		if n != 0 {
 			t.Errorf("GameTraceID=%q: links = %d, want 0 (invalid id yields no link)", bad, n)
 		}
 	}
 }
 
-// TestGameTraceLink_Direct unit-tests the helper in isolation: valid -> one link
-// option, empty/invalid -> nil so the span is started unchanged.
+// TestDecisionSpan_NoLinkWhenSpanIDMissingOrInvalid (#1157): a valid game trace_id
+// is no longer sufficient on its own — without a valid span_id the link target
+// would carry an all-zero span_id, so the loop emits NO link (graceful fallback).
+func TestDecisionSpan_NoLinkWhenSpanIDMissingOrInvalid(t *testing.T) {
+	const validTrace = "4bf92f3577b34da6a3ce929d0e0e4736"
+	for _, badSpan := range []string{
+		"",                 // pre-#1157 emitter / unsampled span
+		"zz",               // unparseable
+		"0000000000000000", // all-zero (invalid span id)
+		"abc",              // wrong length
+	} {
+		n, _, _, _ := decisionSpan(t, gamecontext.GameContext{SessionID: "g", GameTraceID: validTrace, GameTraceSpanID: badSpan})
+		if n != 0 {
+			t.Errorf("GameTraceSpanID=%q: links = %d, want 0 (missing/invalid span_id yields no link)", badSpan, n)
+		}
+	}
+}
+
+// TestGameTraceLink_Direct unit-tests the helper in isolation: a valid (trace,span)
+// pair -> one link option; any empty/invalid id -> nil so the span is started unchanged.
 func TestGameTraceLink_Direct(t *testing.T) {
-	if got := gameTraceLink(""); got != nil {
-		t.Errorf("gameTraceLink(empty) = %v, want nil", got)
+	const validTrace = "4bf92f3577b34da6a3ce929d0e0e4736"
+	if got := gameTraceLink("", linkGameSpanID); got != nil {
+		t.Errorf("gameTraceLink(empty trace) = %v, want nil", got)
 	}
-	if got := gameTraceLink("zzzz"); got != nil {
-		t.Errorf("gameTraceLink(invalid) = %v, want nil", got)
+	if got := gameTraceLink(validTrace, ""); got != nil {
+		t.Errorf("gameTraceLink(empty span) = %v, want nil", got)
 	}
-	if got := gameTraceLink("4bf92f3577b34da6a3ce929d0e0e4736"); len(got) != 1 {
+	if got := gameTraceLink("zzzz", linkGameSpanID); got != nil {
+		t.Errorf("gameTraceLink(invalid trace) = %v, want nil", got)
+	}
+	if got := gameTraceLink(validTrace, "zz"); got != nil {
+		t.Errorf("gameTraceLink(invalid span) = %v, want nil", got)
+	}
+	if got := gameTraceLink(validTrace, linkGameSpanID); len(got) != 1 {
 		t.Errorf("gameTraceLink(valid) = %d options, want 1", len(got))
 	}
 }

--- a/services/agent/gamecontext/extract_metrics.go
+++ b/services/agent/gamecontext/extract_metrics.go
@@ -61,6 +61,10 @@ const (
 	// dedicated game_trace_correlation signal (#1133). Hex string; empty when the
 	// game span was unsampled.
 	attrGameTraceID = "game_trace_id"
+	// attrGameTraceSpanID is the coordinator root game-span span_id carried on the
+	// same game_trace_correlation signal (#1157). Hex string; empty when the game
+	// span was unsampled.
+	attrGameTraceSpanID = "game_trace_span_id"
 	// Experiment attribution (#975, epic #982): finer-grained labels WITHIN a
 	// shadow game. Carried on the LOW-RATE lifecycle metrics (game_active,
 	// game_active_players, game_duration_seconds) the same way game_kind is —
@@ -95,6 +99,9 @@ type gameLabels struct {
 	// signal is the dedicated game_trace_correlation gauge — empty on every other
 	// signal. Like ExperimentID/Arm it is partition ENRICHMENT, not a routing key.
 	GameTraceID string
+	// GameTraceSpanID carries the coordinator's root game-span span_id (#1157),
+	// likewise only on the game_trace_correlation gauge and likewise enrichment.
+	GameTraceSpanID string
 }
 
 // gameIDOf reads the game_id datapoint label; empty when absent.
@@ -137,14 +144,23 @@ func gameTraceIDOf(attrs pcommon.Map) string {
 	return ""
 }
 
+// gameTraceSpanIDOf reads the game_trace_span_id datapoint label (#1157); empty when absent.
+func gameTraceSpanIDOf(attrs pcommon.Map) string {
+	if v, ok := attrs.Get(attrGameTraceSpanID); ok {
+		return v.AsString()
+	}
+	return ""
+}
+
 // metricGameLabels resolves the game identity labels on a metric datapoint.
 func metricGameLabels(attrs pcommon.Map) gameLabels {
 	return gameLabels{
-		GameID:       gameIDOf(attrs),
-		GameKind:     gameKindOf(attrs),
-		ExperimentID: experimentIDOf(attrs),
-		Arm:          armOf(attrs),
-		GameTraceID:  gameTraceIDOf(attrs),
+		GameID:          gameIDOf(attrs),
+		GameKind:        gameKindOf(attrs),
+		ExperimentID:    experimentIDOf(attrs),
+		Arm:             armOf(attrs),
+		GameTraceID:     gameTraceIDOf(attrs),
+		GameTraceSpanID: gameTraceSpanIDOf(attrs),
 	}
 }
 
@@ -374,5 +390,6 @@ func (s *Store) adoptGame(labels gameLabels) {
 	s.SetGameKind(labels.GameKind)
 	s.SetExperimentID(labels.ExperimentID)
 	s.SetArm(labels.Arm)
-	s.SetGameTraceID(labels.GameTraceID) // #1133: empty on all but game_trace_correlation
+	s.SetGameTraceID(labels.GameTraceID)         // #1133: empty on all but game_trace_correlation
+	s.SetGameTraceSpanID(labels.GameTraceSpanID) // #1157: ditto
 }

--- a/services/agent/gamecontext/extract_metrics_test.go
+++ b/services/agent/gamecontext/extract_metrics_test.go
@@ -255,16 +255,19 @@ func TestApplyMetrics_MovementVarianceAggregateRetained(t *testing.T) {
 	}
 }
 
-// TestApplyMetrics_AdoptsGameTraceID verifies the #1133 trace-correlation signal:
-// game_trace_correlation carries game_id + game_trace_id and adopts both into the
-// context so the decision loop can link agent.decision to the originating game trace.
+// TestApplyMetrics_AdoptsGameTraceID verifies the #1133/#1157 trace-correlation
+// signal: game_trace_correlation carries game_id + game_trace_id + game_trace_span_id
+// and adopts all into the context so the decision loop can link agent.decision to the
+// originating game's root span.
 func TestApplyMetrics_AdoptsGameTraceID(t *testing.T) {
 	s := newTestStore()
 	const tid = "4bf92f3577b34da6a3ce929d0e0e4736"
+	const sid = "051581bf3cb55c13"
 	if !s.ApplyMetrics(metricsWith(metricTraceCorrelation, 1, map[string]string{
-		attrGameID:      "game-99",
-		attrGameKind:    "real",
-		attrGameTraceID: tid,
+		attrGameID:          "game-99",
+		attrGameKind:        "real",
+		attrGameTraceID:     tid,
+		attrGameTraceSpanID: sid,
 	})) {
 		t.Fatal("game_trace_correlation carrying game_trace_id must apply")
 	}
@@ -275,11 +278,14 @@ func TestApplyMetrics_AdoptsGameTraceID(t *testing.T) {
 	if snap.GameTraceID != tid {
 		t.Fatalf("GameTraceID = %q, want %q", snap.GameTraceID, tid)
 	}
+	if snap.GameTraceSpanID != sid {
+		t.Fatalf("GameTraceSpanID = %q, want %q", snap.GameTraceSpanID, sid)
+	}
 }
 
 // TestApplyMetrics_TraceCorrelationWithoutTraceIDIsSafe documents the fallback:
-// a correlation datapoint missing game_trace_id still routes its game_id but leaves
-// GameTraceID empty (no link will be added) — no error.
+// a correlation datapoint missing game_trace_id/game_trace_span_id still routes its
+// game_id but leaves both empty (no link will be added) — no error.
 func TestApplyMetrics_TraceCorrelationWithoutTraceIDIsSafe(t *testing.T) {
 	s := newTestStore()
 	if !s.ApplyMetrics(metricsWith(metricTraceCorrelation, 1, map[string]string{
@@ -293,6 +299,9 @@ func TestApplyMetrics_TraceCorrelationWithoutTraceIDIsSafe(t *testing.T) {
 	}
 	if snap.GameTraceID != "" {
 		t.Fatalf("GameTraceID = %q, want empty (no game_trace_id label)", snap.GameTraceID)
+	}
+	if snap.GameTraceSpanID != "" {
+		t.Fatalf("GameTraceSpanID = %q, want empty (no game_trace_span_id label)", snap.GameTraceSpanID)
 	}
 }
 

--- a/services/agent/gamecontext/model.go
+++ b/services/agent/gamecontext/model.go
@@ -151,9 +151,17 @@ type GameContext struct {
 	// shared game.id attribute (Phase 1). Empty when not yet observed or the game span
 	// was unsampled; an empty value means "no link" (graceful fallback, no error).
 	GameTraceID string
-	Session     SessionSignals
-	Players     map[string]*PlayerSignals
-	UpdatedAt   time.Time
+	// GameTraceSpanID is the hex span_id of the coordinator's root game span for
+	// this session (#1157, follow-up to #1133). Source: the game_trace_span_id
+	// datapoint label on the same game_trace_correlation gauge. Carried alongside
+	// GameTraceID so the decision/retro Link references the actual game-start span
+	// (Jaeger highlights it via uiFind) rather than an all-zero span id under the
+	// trace. Empty when not yet observed or the game span was unsampled; an empty
+	// trace_id OR span_id means "no link" (graceful fallback, no error).
+	GameTraceSpanID string
+	Session         SessionSignals
+	Players         map[string]*PlayerSignals
+	UpdatedAt       time.Time
 
 	// Timeline is a bounded, oldest-first slice of the partition's recent rolling
 	// narrative (#916): periodic state deltas, eliminations, and session phase

--- a/services/agent/gamecontext/store.go
+++ b/services/agent/gamecontext/store.go
@@ -539,6 +539,22 @@ func (s *Store) SetGameTraceID(id string) {
 	s.touchSession()
 }
 
+// SetGameTraceSpanID records the coordinator's root game-span span_id (#1157) from
+// the game_trace_span_id label on the game_trace_correlation signal. Mirrors
+// SetGameTraceID exactly: an empty id is ignored so an unlabeled signal never
+// clobbers a previously observed span id. The decision/retro loop reads this to
+// set the SpanID on its game-trace Link so Jaeger highlights the actual game-start
+// span; an empty value there simply yields no Link (graceful fallback).
+func (s *Store) SetGameTraceSpanID(id string) {
+	if id == "" {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.ctx.GameTraceSpanID = id
+	s.touchSession()
+}
+
 // SetArm records the experiment arm ("experimental"/"control", #975) from the
 // arm datapoint label or the experiment.arm span attribute. An empty arm is
 // ignored so an unlabeled signal never clobbers a previously observed arm.
@@ -780,7 +796,8 @@ func (s *Store) EvictStale() {
 		s.ctx.GameKind = ""
 		s.ctx.ExperimentID = ""
 		s.ctx.Arm = ""
-		s.ctx.GameTraceID = "" // drop the finished game's trace link (#1133)
+		s.ctx.GameTraceID = ""     // drop the finished game's trace link (#1133)
+		s.ctx.GameTraceSpanID = "" // ditto, the linked span_id (#1157)
 		s.elimOrder = make(map[string]int)
 		s.endedAt = time.Time{}
 		s.ctx.UpdatedAt = now

--- a/services/game_coordinator/game_session.py
+++ b/services/game_coordinator/game_session.py
@@ -29,6 +29,7 @@ import time
 from contextlib import suppress
 
 from opentelemetry import trace
+from opentelemetry.context import Context
 
 from lib.feature_flags import (
     GAME_KIND_REAL as EVAL_GAME_KIND_REAL,
@@ -71,7 +72,7 @@ class GameSession:
         game_config,
         event_bus: EventBus,
         game_kind: str,
-        parent_context,
+        stream_span_context=None,
         experiment_id: str = "",
         arm: str = "",
         rng_seed: int = 0,
@@ -82,7 +83,12 @@ class GameSession:
         self.game_config = game_config
         self.event_bus = event_bus
         self.game_kind = game_kind
-        self.game_parent_context = parent_context
+        # SpanContext of the inbound StreamGameEvents/StartGame RPC span (#1157).
+        # The game-lifecycle span is rooted as its OWN trace (a NEW root, not a
+        # child of the long-lived stream), and this is added back as an OTel Link
+        # so the inbound call stays navigable in Jaeger. None when there is no
+        # recordable inbound span (telemetry off / unsampled) — handled gracefully.
+        self.stream_span_context = stream_span_context
         # Experiment attribution within a shadow session (#975, epic #982). Empty
         # for a non-experiment game; set by #976's spawn binding. These are finer-
         # grained labels WITHIN game_kind=shadow, never a replacement for it.
@@ -103,6 +109,12 @@ class GameSession:
         # game_trace_id label so the agent can link agent.decision -> this game trace.
         # Empty until the span opens; used at retire to remove the exact gauge series.
         self.game_trace_id = ""
+        # Hex span_id of this session's root game span (#1157). Carried alongside
+        # game_trace_id on the correlation gauge so the agent's Link references the
+        # actual game-start span (Jaeger highlights it via uiFind) rather than an
+        # all-zero span id under the trace. Captured/cleared in lockstep with
+        # game_trace_id.
+        self.game_trace_span_id = ""
 
         # Per-session loop runs in its own thread with its own GrpcClientManager.
         self.clients = GrpcClientManager()
@@ -140,12 +152,15 @@ class GameSession:
             with suppress(KeyError, ValueError):
                 gauge.remove(*labels)
 
-        # The trace-correlation gauge (#1133) carries a different label tuple
-        # (game_kind, game_id, game_trace_id) and was only set when the span was
-        # sampled (game_trace_id non-empty), so remove it separately and only then.
+        # The trace-correlation gauge (#1133/#1157) carries a different label tuple
+        # (game_kind, game_id, game_trace_id, game_trace_span_id) and was only set
+        # when the span was sampled (game_trace_id non-empty), so remove it
+        # separately and only then.
         if self.game_trace_id:
             with suppress(KeyError, ValueError):
-                metrics.game_trace_correlation.remove(self.game_kind, self.game_id, self.game_trace_id)
+                metrics.game_trace_correlation.remove(
+                    self.game_kind, self.game_id, self.game_trace_id, self.game_trace_span_id
+                )
 
     def on_event_state_sync(self, event_type: str) -> None:
         """EventBus state-sync callback bound to THIS session's state (#775).
@@ -238,11 +253,23 @@ class GameSession:
         # Get the display name for the game span
         game_span_name = get_game_display_name(self.game_name)
 
-        # Parent context captured from the StartGame RPC span keeps the game span
-        # in the same trace as the StartGame call.
-        parent_context = self.game_parent_context
+        # Root the game-lifecycle span as its OWN trace (#1157), NOT as a child of
+        # the long-lived StreamGameEvents stream span. Following the agent's
+        # trace-correlation Link then lands on the game itself, and a single bidi
+        # stream no longer parents (and bloats) every game's trace. We pass an
+        # explicit empty Context so any ambient span in this thread/context is also
+        # ignored as a parent. The inbound stream/start-RPC span stays navigable
+        # via an OTel Link back to it (omitted when there is no recordable inbound
+        # span — telemetry off / unsampled — so we never link to an invalid context).
+        links = []
+        if self.stream_span_context is not None and self.stream_span_context.trace_id != 0:
+            links.append(trace.Link(self.stream_span_context))
 
-        with tracer.start_as_current_span(game_span_name, context=parent_context) as game_span:
+        with tracer.start_as_current_span(
+            game_span_name,
+            context=Context(),
+            links=links,
+        ) as game_span:
             game_span.set_attribute("game.name", self.game_name)
             game_span.set_attribute("game.id", self.game_id)
             game_span.set_attribute("game.kind", self.game_kind)
@@ -263,10 +290,15 @@ class GameSession:
             span_ctx = game_span.get_span_context()
             if span_ctx.trace_id != 0:
                 self.game_trace_id = trace.format_trace_id(span_ctx.trace_id)
+                # Carry the root span's span_id too (#1157) so the agent's Link
+                # references the actual game-start span (Jaeger uiFind highlight)
+                # rather than an all-zero span id under that trace.
+                self.game_trace_span_id = trace.format_span_id(span_ctx.span_id)
                 metrics.game_trace_correlation.labels(
                     game_kind=self.game_kind,
                     game_id=self.game_id,
                     game_trace_id=self.game_trace_id,
+                    game_trace_span_id=self.game_trace_span_id,
                 ).set(1)
 
             try:

--- a/services/game_coordinator/metrics.py
+++ b/services/game_coordinator/metrics.py
@@ -58,14 +58,18 @@ current_game_mode = Gauge(
 # path is not feasible end-to-end in this stack; this dedicated attribute-carrying
 # signal is the documented Approach B.
 #
-# Cardinality: game_trace_id is 1:1 with game_id (one trace per game), so it
-# multiplies NO series beyond the already-unbounded game_id. Like the other
-# per-game gauges it is SET to 1 inside the live game span and REMOVED at retire
-# (clear_metrics, #1018) so the series does not accumulate.
+# It also carries the root span's hex span_id as game_trace_span_id (#1157) so the
+# agent's Link references the actual game-start span (Jaeger highlights it via
+# uiFind) rather than an all-zero span id under that trace.
+#
+# Cardinality: game_trace_id and game_trace_span_id are both 1:1 with game_id (one
+# trace/root span per game), so they multiply NO series beyond the already-unbounded
+# game_id. Like the other per-game gauges it is SET to 1 inside the live game span
+# and REMOVED at retire (clear_metrics, #1018) so the series does not accumulate.
 game_trace_correlation = Gauge(
     "game_trace_correlation",
     "Correlation marker tying a live game_id to its root span trace_id (always 1 while live)",
-    ["game_kind", "game_id", "game_trace_id"],
+    ["game_kind", "game_id", "game_trace_id", "game_trace_span_id"],
 )
 
 game_duration_seconds = Gauge(

--- a/services/game_coordinator/servicer.py
+++ b/services/game_coordinator/servicer.py
@@ -472,7 +472,12 @@ class GameCoordinatorServicer(game_coordinator_pb2_grpc.GameCoordinatorServiceSe
                 return None, True
 
             game_id = f"game_{uuid.uuid4().hex[:12]}"
-            parent_context = trace.set_span_in_context(parent_span)
+            # The game-lifecycle span is rooted as its OWN trace (#1157), not as a
+            # child of the long-lived StreamGameEvents stream span. We capture the
+            # inbound stream/start-RPC span's SpanContext here so the session can
+            # add an OTel Link back to it (keeping the inbound call navigable in
+            # Jaeger) without inheriting the stream's trace_id as the game's root.
+            stream_span_context = parent_span.get_span_context() if parent_span is not None else None
 
             # Experiment/cohort spawn binding (#976, epic #982). The caller
             # provides (experiment_id, arm) on StartGameConfig; the registry
@@ -509,7 +514,7 @@ class GameCoordinatorServicer(game_coordinator_pb2_grpc.GameCoordinatorServiceSe
                 game_config=config,
                 event_bus=event_bus,
                 game_kind=game_kind,
-                parent_context=parent_context,
+                stream_span_context=stream_span_context,
                 experiment_id=experiment_id,
                 arm=arm,
                 rng_seed=rng_seed,

--- a/services/game_coordinator/tests/test_game_session.py
+++ b/services/game_coordinator/tests/test_game_session.py
@@ -27,20 +27,21 @@ from services.game_coordinator.game_session import GAME_KIND_PRIMARY, GAME_KIND_
 
 
 class MockSpanContext:
-    """Mock SpanContext exposing trace_id (#1133 correlation gauge reads it)."""
+    """Mock SpanContext exposing trace_id + span_id (#1133/#1157 gauge reads both)."""
 
-    def __init__(self, trace_id):
+    def __init__(self, trace_id, span_id=0x051581BF3CB55C13):
         self.trace_id = trace_id
+        self.span_id = span_id
 
 
 class MockSpan:
     """Mock OpenTelemetry span supporting set_attribute + context manager."""
 
-    def __init__(self, trace_id=0x4BF92F3577B34DA6A3CE929D0E0E4736):
+    def __init__(self, trace_id=0x4BF92F3577B34DA6A3CE929D0E0E4736, span_id=0x051581BF3CB55C13):
         self.attributes = {}
         # Non-zero trace_id by default so the #1133 correlation gauge fires; a test
         # can pass trace_id=0 to exercise the unsampled-span fallback (no gauge).
-        self._span_context = MockSpanContext(trace_id)
+        self._span_context = MockSpanContext(trace_id, span_id)
 
     def set_attribute(self, key, value):
         self.attributes[key] = value
@@ -73,7 +74,7 @@ def _make_session(game_kind=GAME_KIND_PRIMARY, experiment_id="", arm=""):
         game_config=game_coordinator_pb2.StartGameConfig(sensitivity=2),
         event_bus=event_bus,
         game_kind=game_kind,
-        parent_context=None,
+        stream_span_context=None,
         experiment_id=experiment_id,
         arm=arm,
     )
@@ -89,8 +90,8 @@ def _make_session(game_kind=GAME_KIND_PRIMARY, experiment_id="", arm=""):
     return session
 
 
-def _tracer_mock(trace_id=0x4BF92F3577B34DA6A3CE929D0E0E4736):
-    mock_span = MockSpan(trace_id=trace_id)
+def _tracer_mock(trace_id=0x4BF92F3577B34DA6A3CE929D0E0E4736, span_id=0x051581BF3CB55C13):
+    mock_span = MockSpan(trace_id=trace_id, span_id=span_id)
     mock_tracer = MagicMock()
     mock_tracer.start_as_current_span.return_value.__enter__ = MagicMock(return_value=mock_span)
     mock_tracer.start_as_current_span.return_value.__exit__ = MagicMock(return_value=False)
@@ -360,24 +361,31 @@ class TestGameSessionLoop:
     @patch("services.game_coordinator.game_session.GameFactory")
     @patch("services.game_coordinator.game_session.tracer")
     async def test_loop_emits_trace_correlation_gauge(self, mock_tracer_mod, mock_factory, mock_metrics):
-        """#1133: while the game span is live the loop publishes game_trace_correlation
-        carrying game_id + the span's hex trace_id, so the agent can link
-        agent.decision -> this game trace. The hex id is captured onto the session."""
+        """#1133/#1157: while the game span is live the loop publishes
+        game_trace_correlation carrying game_id + the span's hex trace_id AND its
+        hex span_id, so the agent can link agent.decision -> this exact game span.
+        Both hex ids are captured onto the session."""
         from opentelemetry import trace as ot_trace
 
         session = _make_session(game_kind=GAME_KIND_SHADOW)
         trace_id = 0x4BF92F3577B34DA6A3CE929D0E0E4736
-        mock_tracer_mod.start_as_current_span = _tracer_mock(trace_id=trace_id).start_as_current_span
+        span_id = 0x051581BF3CB55C13
+        mock_tracer_mod.start_as_current_span = _tracer_mock(trace_id=trace_id, span_id=span_id).start_as_current_span
         mock_game = MagicMock()
         mock_game.run = AsyncMock()
         mock_factory.create_game.return_value = mock_game
 
         await session._run_game_loop_async()
 
-        expected_hex = ot_trace.format_trace_id(trace_id)
-        assert session.game_trace_id == expected_hex
+        expected_trace_hex = ot_trace.format_trace_id(trace_id)
+        expected_span_hex = ot_trace.format_span_id(span_id)
+        assert session.game_trace_id == expected_trace_hex
+        assert session.game_trace_span_id == expected_span_hex
         mock_metrics.game_trace_correlation.labels.assert_any_call(
-            game_kind=GAME_KIND_SHADOW, game_id="game_abc123", game_trace_id=expected_hex
+            game_kind=GAME_KIND_SHADOW,
+            game_id="game_abc123",
+            game_trace_id=expected_trace_hex,
+            game_trace_span_id=expected_span_hex,
         )
         mock_metrics.game_trace_correlation.labels.return_value.set.assert_any_call(1)
 
@@ -398,7 +406,64 @@ class TestGameSessionLoop:
         await session._run_game_loop_async()
 
         assert session.game_trace_id == ""
+        assert session.game_trace_span_id == ""
         mock_metrics.game_trace_correlation.labels.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("services.game_coordinator.game_session.metrics")
+    @patch("services.game_coordinator.game_session.GameFactory")
+    @patch("services.game_coordinator.game_session.tracer")
+    async def test_game_span_is_rooted_with_link_to_stream(self, mock_tracer_mod, mock_factory, mock_metrics):
+        """#1157: the game-lifecycle span is started as a NEW ROOT (explicit empty
+        Context, never the inbound stream span's context) with an OTel Link back to
+        the inbound stream/start-RPC SpanContext — keeping the call navigable
+        without parenting the game under the long-lived stream trace."""
+        from opentelemetry.context import Context
+
+        stream_ctx = MockSpanContext(trace_id=0x11112222333344445555666677778888, span_id=0xAABBCCDDEEFF0011)
+        session = _make_session(game_kind=GAME_KIND_SHADOW)
+        session.stream_span_context = stream_ctx
+        mock_tracer_mod.start_as_current_span = _tracer_mock().start_as_current_span
+        mock_game = MagicMock()
+        mock_game.run = AsyncMock()
+        mock_factory.create_game.return_value = mock_game
+
+        await session._run_game_loop_async()
+
+        _, kwargs = mock_tracer_mod.start_as_current_span.call_args
+        # Rooted as its own trace: an explicit empty Context, NOT the stream context.
+        assert isinstance(kwargs["context"], Context)
+        assert len(kwargs["context"]) == 0
+        # Exactly one Link, pointing at the inbound stream SpanContext.
+        links = kwargs["links"]
+        assert len(links) == 1
+        assert links[0].context is stream_ctx
+
+    @pytest.mark.asyncio
+    @patch("services.game_coordinator.game_session.metrics")
+    @patch("services.game_coordinator.game_session.GameFactory")
+    @patch("services.game_coordinator.game_session.tracer")
+    async def test_game_span_rooted_without_link_when_no_stream_context(
+        self, mock_tracer_mod, mock_factory, mock_metrics
+    ):
+        """#1157: with no recordable inbound span (telemetry off / unsampled stream),
+        the game span is still rooted but carries NO Link (never link an invalid
+        context). stream_span_context=None and trace_id==0 are both treated as 'none'."""
+        from opentelemetry.context import Context
+
+        for stream_ctx in (None, MockSpanContext(trace_id=0, span_id=0)):
+            session = _make_session(game_kind=GAME_KIND_SHADOW)
+            session.stream_span_context = stream_ctx
+            mock_tracer_mod.start_as_current_span = _tracer_mock().start_as_current_span
+            mock_game = MagicMock()
+            mock_game.run = AsyncMock()
+            mock_factory.create_game.return_value = mock_game
+
+            await session._run_game_loop_async()
+
+            _, kwargs = mock_tracer_mod.start_as_current_span.call_args
+            assert isinstance(kwargs["context"], Context)
+            assert kwargs["links"] == []
 
     @pytest.mark.asyncio
     @patch("services.game_coordinator.game_session.metrics")
@@ -504,16 +569,17 @@ class TestGameSessionClearMetrics:
 
     @patch("services.game_coordinator.game_session.metrics")
     def test_clear_metrics_removes_trace_correlation_when_set(self, mock_metrics):
-        """#1133: the trace-correlation gauge (labels game_kind, game_id,
-        game_trace_id) is removed at retire ONLY when a trace id was captured —
-        otherwise it was never set."""
+        """#1133/#1157: the trace-correlation gauge (labels game_kind, game_id,
+        game_trace_id, game_trace_span_id) is removed at retire ONLY when a trace
+        id was captured — otherwise it was never set."""
         session = _make_session(game_kind=GAME_KIND_SHADOW)
         session.game_trace_id = "4bf92f3577b34da6a3ce929d0e0e4736"
+        session.game_trace_span_id = "051581bf3cb55c13"
 
         session.clear_metrics()
 
         mock_metrics.game_trace_correlation.remove.assert_called_once_with(
-            GAME_KIND_SHADOW, "game_abc123", "4bf92f3577b34da6a3ce929d0e0e4736"
+            GAME_KIND_SHADOW, "game_abc123", "4bf92f3577b34da6a3ce929d0e0e4736", "051581bf3cb55c13"
         )
 
     @patch("services.game_coordinator.game_session.metrics")

--- a/services/game_coordinator/tests/test_grpc_integration.py
+++ b/services/game_coordinator/tests/test_grpc_integration.py
@@ -83,6 +83,16 @@ def _make_start_config(game_name="FFA", num_players=3, sensitivity=2, origin=Non
     )
 
 
+class _MockSpanContext:
+    """Minimal SpanContext: the servicer reads trace_id off the inbound span's
+    context to decide whether to add a #1157 game-trace Link. trace_id=0 (invalid,
+    as for an unsampled span) means no Link is attempted — the path direct
+    _start_game_from_config callers exercise."""
+
+    trace_id = 0
+    span_id = 0
+
+
 class _MockSpan:
     """Minimal span for direct _start_game_from_config calls (no gRPC span)."""
 
@@ -91,6 +101,9 @@ class _MockSpan:
 
     def add_event(self, name, attributes=None):
         pass
+
+    def get_span_context(self):
+        return _MockSpanContext()
 
     def __enter__(self):
         return self

--- a/services/game_coordinator/tests/test_servicer.py
+++ b/services/game_coordinator/tests/test_servicer.py
@@ -52,6 +52,14 @@ class MockGrpcContext:
         return self._metadata
 
 
+class _MockSpanContext:
+    """trace_id=0 (invalid, like an unsampled span) so the servicer attempts no
+    #1157 game-trace Link for direct _start_game_from_config callers."""
+
+    trace_id = 0
+    span_id = 0
+
+
 class MockSpan:
     """Mock OpenTelemetry span."""
 
@@ -64,6 +72,9 @@ class MockSpan:
 
     def add_event(self, name, attributes=None):
         self.events.append((name, attributes))
+
+    def get_span_context(self):
+        return _MockSpanContext()
 
     def __enter__(self):
         return self

--- a/services/game_coordinator/tests/test_servicer_sessions.py
+++ b/services/game_coordinator/tests/test_servicer_sessions.py
@@ -1173,6 +1173,14 @@ class TestExperimentSpawnBinding:
         assert order.index(kind_calls[0]) < order.index(("create_game", None, None))
 
 
+class _MockSpanContext:
+    """trace_id=0 (invalid, like an unsampled span) so the servicer attempts no
+    #1157 game-trace Link for direct _start_game_from_config callers."""
+
+    trace_id = 0
+    span_id = 0
+
+
 class _MockSpan:
     """Minimal span supporting set_attribute + context-manager protocol."""
 
@@ -1184,6 +1192,9 @@ class _MockSpan:
 
     def add_event(self, name, attributes=None):
         pass
+
+    def get_span_context(self):
+        return _MockSpanContext()
 
     def __enter__(self):
         return self


### PR DESCRIPTION
Part of #1088, #1157. Fixes #1136/#1142 link rooting + span_id.

## Problem
Agent trace-correlation Links (`agent.decision`, `agent.llm.retro`) landed badly:
- **Cause A — wrong root**: the game-lifecycle span was started as a CHILD of the long-lived `StreamGameEvents` bidi stream span. Following a Link landed on the stream RPC (not the game), and one stream parented every game into a giant unwieldy trace.
- **Cause B — span_id=0**: `gameTraceLink` built a SpanContext with only a trace_id, so the Link target span_id was all-zeros and Jaeger's `uiFind` highlighted nothing.

## Fix
**Coordinator (A) — re-root.** `game_session.py` now starts the game-lifecycle span as its OWN ROOT trace: explicit empty `Context()` (so no ambient/stream span is the parent) plus an OTel **Link** back to the inbound `StreamGameEvents`/`StartGame` RPC SpanContext, keeping the inbound call navigable. No link when there's no recordable inbound span (telemetry off / unsampled trace_id==0). `servicer.py` captures the inbound span's SpanContext and passes it to the session as `stream_span_context` (was `parent_context`).

**Coordinator (C) — span_id.** New `game_trace_span_id` label on `game_trace_correlation`; the root span's span_id is captured + cleared in lockstep with trace_id. Cardinality unchanged (both 1:1 with game_id).

**Agent.** Ingest `game_trace_span_id` into `GameContext.GameTraceSpanID` (mirrors `GameTraceID`: empty-ignored set, cleared at session end). `gameTraceLink(traceID, spanID)` now sets `SpanID:` on the target SpanContext for both `runDecision` and `retro_capture.go`. nil-on-invalid: empty/invalid trace_id **OR** span_id yields no Link (graceful fallback). The separate experiment-loop link primitive is out of scope and untouched.

## Tests
- Coordinator: game span asserted as a root + linked to the stream; no-link fallback when no stream context; correlation gauge carries trace_id + span_id; clear-on-retire updated. Added `get_span_context()` to the test mock spans for the new servicer read path.
- Agent: correlation ingest adopts both ids; decision/retro Links carry + target the span_id and are suppressed when either id is missing/invalid.
- All 1182 coordinator tests pass; agent `go build`/`vet`/`test -race` green.

## ⚠️ Careful review
The reparenting (A) changes coordinator trace structure for ALL games (game spans are now roots, no longer nested under the stream). Check span-test + Grafana/Jaeger dashboard impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)