### PR TITLE
fix(trace): carry game root span_id in experiment.* span Links (#1140)

### DIFF
--- a/services/agent/decision/decision.go
+++ b/services/agent/decision/decision.go
@@ -1203,6 +1203,19 @@ func gameTraceLink(gameTraceID, gameTraceSpanID string) []trace.SpanStartOption 
 	}
 }
 
+// GameTraceLink is the exported entry point to the gameTraceLink primitive so other
+// agent packages (e.g. the experiment loop, #1140 Slice C) can build the SAME
+// game-trace-correlation span Link the agent.decision / agent.llm.retro spans use,
+// instead of maintaining a divergent replica. It carries identical semantics: when
+// BOTH gameTraceID and gameTraceSpanID are valid hex ids it returns one trace.WithLinks
+// option targeting the game's root span (so Jaeger highlights the game-start span,
+// #1157); an empty/unparseable/all-zero trace_id OR span_id yields NO option (graceful
+// fallback, no Link, no error). Sharing this avoids the #1157 span_id=0 bug recurring
+// in a replica.
+func GameTraceLink(gameTraceID, gameTraceSpanID string) []trace.SpanStartOption {
+	return gameTraceLink(gameTraceID, gameTraceSpanID)
+}
+
 // attrLinkKind labels a span Link with what the link points at, so a reader who lands
 // on the link target knows WHY it is there. #1140 (Slice A) stamps it
 // linkKindFireCycle on the agent.llm.infer.call + agent.llm.apply Links so a reader of

--- a/services/agent/experiment_loop.go
+++ b/services/agent/experiment_loop.go
@@ -689,10 +689,11 @@ func (e *experimentLoop) onGameEnd(gc gamecontext.GameContext) {
 	// #1140 Slice C: emit the experiment-lifecycle spans around the EXISTING fitness /
 	// conclusion computations — observability only, no change to the values computed,
 	// their order, or the loop's control flow. Each span is Linked to the originating
-	// game trace (the #1133 link-from-hex pattern, replicated here as
-	// experimentGameTraceLink) so the experiment phase is navigable to the game it
-	// aggregates.
-	gameLink := experimentGameTraceLink(gc.GameTraceID)
+	// game trace via the SHARED decision.GameTraceLink primitive (#1133/#1157), passing
+	// BOTH the game trace_id AND its root span_id so Jaeger highlights the game-start
+	// span (#1157) instead of an all-zero span id. Sharing the primitive (rather than a
+	// replica) keeps the experiment.* Links at parity with the decision/retro Links.
+	gameLink := decision.GameTraceLink(gc.GameTraceID, gc.GameTraceSpanID)
 
 	// experiment.fitness: the per-shadow-game fitness scalar the cohort aggregator folds.
 	fitness := e.scoreGameFitness(gc, objective, gameLink)
@@ -805,34 +806,6 @@ func (e *experimentLoop) recordVerdictSpan(ctx context.Context, experimentID str
 // decision package's instrumentationName literal so all agent spans share one
 // instrumentation scope in Jaeger.
 const experimentInstrumentationName = "github.com/joustmania/agent"
-
-// experimentGameTraceLink replicates the #1133 gameTraceLink primitive (which is
-// package-private to the decision package) for the experiment loop: when gameTraceID
-// is a valid hex trace_id, it returns a single trace.WithLinks option whose Link
-// targets a remote, sampled SpanContext reconstructed from that trace_id, so an
-// experiment-lifecycle span LINKS to the originating game trace (navigable in Jaeger).
-// The Link carries the trace_id as an attribute. An empty or unparseable id yields NO
-// option — graceful fallback, no Link, no error — exactly like gameTraceLink.
-func experimentGameTraceLink(gameTraceID string) []trace.SpanStartOption {
-	if gameTraceID == "" {
-		return nil
-	}
-	tid, err := trace.TraceIDFromHex(gameTraceID)
-	if err != nil || !tid.IsValid() {
-		return nil
-	}
-	sc := trace.NewSpanContext(trace.SpanContextConfig{
-		TraceID:    tid,
-		TraceFlags: trace.FlagsSampled,
-		Remote:     true,
-	})
-	return []trace.SpanStartOption{
-		trace.WithLinks(trace.Link{
-			SpanContext: sc,
-			Attributes:  []attribute.KeyValue{attribute.String(decision.AttrGameTraceID, gameTraceID)},
-		}),
-	}
-}
 
 // recordFinalizedFitness writes one finalized SHADOW-game fitness sample into the
 // store keyed by game_id (#965). It is the capture side the StoreMeasurer reads:

--- a/services/agent/experiment_spans_test.go
+++ b/services/agent/experiment_spans_test.go
@@ -40,11 +40,12 @@ func expSpan_attr(s sdktrace.ReadOnlySpan, key string) (string, bool) {
 	return "", false
 }
 
-// gcWithTrace mirrors gcFor but stamps a game trace_id so the experiment spans can be
-// asserted to Link to the originating game trace.
-func gcWithTrace(gameID, experimentID, arm, traceID string) gamecontext.GameContext {
+// gcWithTrace mirrors gcFor but stamps a game trace_id AND its root span_id so the
+// experiment spans can be asserted to Link to the originating game's root span (#1157).
+func gcWithTrace(gameID, experimentID, arm, traceID, spanID string) gamecontext.GameContext {
 	gc := gcFor(gameID, experimentID, arm)
 	gc.GameTraceID = traceID
+	gc.GameTraceSpanID = spanID
 	return gc
 }
 
@@ -87,6 +88,7 @@ func recordingExperimentLoop(t *testing.T) (*experimentLoop, *tracetest.SpanReco
 func TestExperimentSpans_FitnessAndEvaluateEmitted(t *testing.T) {
 	loop, sr, spawner, expID := recordingExperimentLoop(t)
 	const gameTrace = "4bf92f3577b34da6a3ce929d0e0e4736"
+	const gameSpan = "00f067aa0ba902b7"
 
 	// Allocate one game so the registry binds it to the experiment, then conclude the
 	// ACTUAL bound game (using the spawner's recorded gameID) so ConcludeGame folds it.
@@ -96,7 +98,7 @@ func TestExperimentSpans_FitnessAndEvaluateEmitted(t *testing.T) {
 		t.Fatal("expected the registry to allocate one shadow game")
 	}
 	c := rec[0]
-	loop.onGameEnd(gcWithTrace(c.gameID, c.experimentID, c.arm, gameTrace))
+	loop.onGameEnd(gcWithTrace(c.gameID, c.experimentID, c.arm, gameTrace, gameSpan))
 
 	ended := sr.Ended()
 
@@ -113,7 +115,7 @@ func TestExperimentSpans_FitnessAndEvaluateEmitted(t *testing.T) {
 	if _, ok := expSpan_attr(fit[0], decision.AttrExperimentFitness); !ok {
 		t.Errorf("experiment.fitness must carry %s", decision.AttrExperimentFitness)
 	}
-	assertLinksToTrace(t, fit[0], gameTrace, "experiment.fitness")
+	assertLinksToTrace(t, fit[0], gameTrace, gameSpan, "experiment.fitness")
 
 	eval := expSpan_findByName(ended, decision.SpanExperimentEvaluate)
 	if len(eval) != 1 {
@@ -122,7 +124,7 @@ func TestExperimentSpans_FitnessAndEvaluateEmitted(t *testing.T) {
 	if v, ok := expSpan_attr(eval[0], decision.AttrExperimentStatus); !ok || v == "" {
 		t.Errorf("experiment.evaluate must carry a non-empty %s, got %q", decision.AttrExperimentStatus, v)
 	}
-	assertLinksToTrace(t, eval[0], gameTrace, "experiment.evaluate")
+	assertLinksToTrace(t, eval[0], gameTrace, gameSpan, "experiment.evaluate")
 }
 
 // TestExperimentSpans_VerdictEmitted: running enough conclusions to reach a rolling
@@ -232,8 +234,9 @@ func fitnessAttrFloat(s sdktrace.ReadOnlySpan) (float64, bool) {
 }
 
 // assertLinksToTrace asserts the span carries exactly one Link to the given game
-// trace_id with the trace_id attribute.
-func assertLinksToTrace(t *testing.T, s sdktrace.ReadOnlySpan, gameTrace, spanName string) {
+// trace_id AND root span_id (#1157), with both the trace_id and span_id attributes.
+// A non-zero SpanID is what makes Jaeger highlight the game-start span.
+func assertLinksToTrace(t *testing.T, s sdktrace.ReadOnlySpan, gameTrace, gameSpan, spanName string) {
 	t.Helper()
 	links := s.Links()
 	if len(links) != 1 {
@@ -243,30 +246,58 @@ func assertLinksToTrace(t *testing.T, s sdktrace.ReadOnlySpan, gameTrace, spanNa
 	if got := links[0].SpanContext.TraceID(); got != wantTID {
 		t.Errorf("%s link trace_id = %s, want %s", spanName, got, wantTID)
 	}
-	var found bool
+	wantSID, _ := trace.SpanIDFromHex(gameSpan)
+	if got := links[0].SpanContext.SpanID(); got != wantSID {
+		t.Errorf("%s link span_id = %s, want %s", spanName, got, wantSID)
+	}
+	if !links[0].SpanContext.SpanID().IsValid() {
+		t.Errorf("%s link span_id must be non-zero so Jaeger highlights the game-start span", spanName)
+	}
+	var foundTrace, foundSpan bool
 	for _, kv := range links[0].Attributes {
 		if string(kv.Key) == decision.AttrGameTraceID && kv.Value.AsString() == gameTrace {
-			found = true
+			foundTrace = true
+		}
+		if string(kv.Key) == decision.AttrGameTraceSpanID && kv.Value.AsString() == gameSpan {
+			foundSpan = true
 		}
 	}
-	if !found {
+	if !foundTrace {
 		t.Errorf("%s link must carry %s=%s", spanName, decision.AttrGameTraceID, gameTrace)
+	}
+	if !foundSpan {
+		t.Errorf("%s link must carry %s=%s", spanName, decision.AttrGameTraceSpanID, gameSpan)
 	}
 }
 
-// TestExperimentGameTraceLink_Direct unit-tests the replicated #1133 link primitive:
-// valid -> one option, empty/invalid -> nil (graceful fallback).
+// TestExperimentGameTraceLink_Direct unit-tests the SHARED #1133/#1157 link primitive
+// the experiment loop now calls (decision.GameTraceLink) at the (trace_id, span_id)
+// signature: a fully-valid pair -> one option carrying a non-zero SpanID; an empty,
+// unparseable, or all-zero trace_id OR span_id -> nil (graceful fallback). This is the
+// parity that prevents the #1157 span_id=0 "highlights nothing" bug recurring here.
 func TestExperimentGameTraceLink_Direct(t *testing.T) {
-	if got := experimentGameTraceLink(""); got != nil {
-		t.Errorf("experimentGameTraceLink(empty) = %v, want nil", got)
+	const validTrace = "4bf92f3577b34da6a3ce929d0e0e4736"
+	const validSpan = "00f067aa0ba902b7"
+
+	if got := decision.GameTraceLink("", validSpan); got != nil {
+		t.Errorf("GameTraceLink(empty trace) = %v, want nil", got)
 	}
-	if got := experimentGameTraceLink("zzzz"); got != nil {
-		t.Errorf("experimentGameTraceLink(invalid) = %v, want nil", got)
+	if got := decision.GameTraceLink(validTrace, ""); got != nil {
+		t.Errorf("GameTraceLink(empty span) = %v, want nil", got)
 	}
-	if got := experimentGameTraceLink("00000000000000000000000000000000"); got != nil {
-		t.Errorf("experimentGameTraceLink(all-zero) = %v, want nil", got)
+	if got := decision.GameTraceLink("zzzz", validSpan); got != nil {
+		t.Errorf("GameTraceLink(invalid trace) = %v, want nil", got)
 	}
-	if got := experimentGameTraceLink("4bf92f3577b34da6a3ce929d0e0e4736"); len(got) != 1 {
-		t.Errorf("experimentGameTraceLink(valid) = %d options, want 1", len(got))
+	if got := decision.GameTraceLink(validTrace, "zz"); got != nil {
+		t.Errorf("GameTraceLink(invalid span) = %v, want nil", got)
+	}
+	if got := decision.GameTraceLink("00000000000000000000000000000000", validSpan); got != nil {
+		t.Errorf("GameTraceLink(all-zero trace) = %v, want nil", got)
+	}
+	if got := decision.GameTraceLink(validTrace, "0000000000000000"); got != nil {
+		t.Errorf("GameTraceLink(all-zero span) = %v, want nil", got)
+	}
+	if got := decision.GameTraceLink(validTrace, validSpan); len(got) != 1 {
+		t.Errorf("GameTraceLink(valid) = %d options, want 1", len(got))
 	}
 }


### PR DESCRIPTION
Part of #1088, #1140 (experiment.* span Link span_id parity with #1164).

#1164 fixed the decision/retro game-trace Links to carry the game-session root **span_id** (non-zero -> Jaeger highlights the game-start span). The experiment-lifecycle spans (`experiment.fitness`/`experiment.evaluate`/`experiment.verdict`, #1140 Slice C) used a separate replica `experimentGameTraceLink` that still built the SpanContext with **trace_id only (span_id=0)**, reproducing the #1157 "highlights nothing" bug.

## Fix (SHARE the primitive)
- Exported `decision.GameTraceLink(traceID, spanID string)` as a thin delegator over the package-private `gameTraceLink` (no logic change to the fixed helper).
- `experiment_loop.go` now calls `decision.GameTraceLink(gc.GameTraceID, gc.GameTraceSpanID)`, passing the root span_id (populated post-#1164). The replica `experimentGameTraceLink` is removed.
- Result: experiment.* Links target the game's root span (non-zero trace+span), at parity with decision/retro.

## Tests
- Updated for the `(trace_id, span_id)` signature; assert non-zero SpanID + span_id attribute when both ids valid, nil when either is empty/invalid/all-zero.

## Verify
`gofmt -l .`, `go build ./...`, `go vet ./...`, `go test ./... -race -count=1` all clean.