### PR TITLE
fix(agent): fingerprint llm/retro system prompt instead of shipping full text

### DIFF
--- a/services/agent/README.md
+++ b/services/agent/README.md
@@ -740,18 +740,27 @@ The span carries the full prompt plus its attribution (single builder
 | `agent.prompt_variant` | resolved prompt variant |
 | `agent.objectives` | sorted `k=v` weights |
 | `interventions.allowed` | the allow-list summary |
-| `llm.prompt.system` / `llm.prompt.user` | the **full** prompt text (uncapped) |
+| `llm.prompt.system_sha256` | 16-hex **fingerprint** of the system prompt (#1168) — NOT the text; the full text is on the `agent.llm.system_prompt` log line |
+| `llm.prompt.user` | the user prompt text, capped at 32 KiB (a `...[truncated]` marker is appended if it exceeds the cap) |
 | `llm.prompt.bytes` | `len(system)+len(user)` |
 | `inference.configured` | the `model` flag |
 | `inference.used` | `"rules"` (the rules engine decided) |
 | `inference.fallback_reason` | `"no_backend_available"` |
 
 The companion log line `agent.llm.prompt_captured` carries only metadata
-(`session_id`, `variant`, `model`, `bytes`, `fallback_reason`) — the prompt text
-lives on the span alone. **View in Jaeger:** open `http://localhost:8080/jaeger/`,
-service `agent`, operation `agent.llm.prompt`. To replay a captured prompt against
-a real model, copy `llm.prompt.system` / `llm.prompt.user` into two files and run
-`scripts/replay-prompt.sh`. See
+(`session_id`, `variant`, `model`, `bytes`, `fallback_reason`). The **user** prompt
+text lives on the span; the **system** prompt text does **not** — to keep the traces
+pipeline bounded (#1168) the span carries only its 16-hex `llm.prompt.system_sha256`
+fingerprint, and the full system text is emitted **once per distinct fingerprint** on
+the dedicated `agent.llm.system_prompt` log line (fields `{system_sha256,
+prompt_variant, mode, interventions_allowed, system}`). The system prompt is also
+deterministically reconstructable from `(prompt_variant, mode, interventions_allowed)`.
+
+**View in Jaeger:** open `http://localhost:8080/jaeger/`, service `agent`, operation
+`agent.llm.prompt`. To replay a captured prompt against a real model: take the span's
+`llm.prompt.system_sha256`, find the matching `agent.llm.system_prompt` log line by
+that hash (grep the agent logs), copy its `system` field into one file and the span's
+`llm.prompt.user` value into another, then run `scripts/replay-prompt.sh`. See
 [docs/research/739-prompt-capture.md](../../docs/research/739-prompt-capture.md)
 for the response contract and the forward path (#741 backend, #742 auth).
 
@@ -786,7 +795,8 @@ The span carries the full retro prompt plus attribution (single builder
 | `agent.objectives` | sorted `k=v` weights |
 | `interventions.allowed` | the allow-list summary |
 | `session.id` | the finished session's id |
-| `llm.retro.system` / `llm.retro.user` | the **full** retro prompt text (uncapped) |
+| `llm.retro.system_sha256` | 16-hex **fingerprint** of the retro system prompt (#1168) — NOT the text; the full text is on the `agent.llm.system_prompt` log line |
+| `llm.retro.user` | the retro user prompt text, capped at 32 KiB (a `...[truncated]` marker is appended if it exceeds the cap) |
 | `llm.retro.bytes` | `len(system)+len(user)` |
 | `inference.configured` | the `model` flag |
 | `inference.used` | **`"none"`** (divergence — see below) |
@@ -800,8 +810,9 @@ value. The companion log line `agent.llm.retro_captured` carries only metadata
 (`session_id`, `model`, `bytes`, `fallback_reason`). The suggestion contract maps
 to the **calibration surface** (#766: `global_difficulty_factor`,
 `pacing_profile`, `threshold_table`, `objective_variant`), and `replay-prompt.sh`
-replays an `agent.llm.retro` span identically (copy `llm.retro.system` /
-`llm.retro.user`). See
+replays an `agent.llm.retro` span identically — the system text comes from the
+`agent.llm.system_prompt` log line keyed by the span's `llm.retro.system_sha256`,
+the user text from the span's `llm.retro.user`. See
 [docs/research/844-post-game-retro.md](../../docs/research/844-post-game-retro.md).
 
 #### `fitness.evaluated` (#731)

--- a/services/agent/decision/context_note_test.go
+++ b/services/agent/decision/context_note_test.go
@@ -147,8 +147,13 @@ func TestContextNote_CaptureSpanCarriesPresence(t *testing.T) {
 	if v, ok := attrValue(caps[0], AttrLLMContextNoteLen); !ok || v.AsInt64() != int64(len([]rune(note))) {
 		t.Errorf("capture span %s = %d, want %d", AttrLLMContextNoteLen, v.AsInt64(), len([]rune(note)))
 	}
-	if v, ok := attrValue(caps[0], AttrLLMPromptSystem); !ok || !strings.Contains(v.AsString(), note) {
-		t.Errorf("capture span System prompt missing the operator note")
+	// #1168: the System text no longer rides the span (only its fingerprint), so the
+	// note's PRESENCE in the prompt is asserted via the present/len attrs above; the
+	// note's TEXT reaching the System prompt is covered by the production-path tests
+	// (the backend.lastPromptSystem assertions). Here we just confirm the span carries
+	// the System-prompt fingerprint instead of the full text.
+	if v, ok := attrValue(caps[0], AttrLLMPromptSystemSHA); !ok || v.AsString() == "" {
+		t.Errorf("capture span missing the System-prompt fingerprint (llm.prompt.system_sha256)")
 	}
 }
 

--- a/services/agent/decision/context_window_test.go
+++ b/services/agent/decision/context_window_test.go
@@ -199,8 +199,13 @@ func TestContextWindow_CaptureSpanAlsoCarriesCount(t *testing.T) {
 	if v, ok := attrValue(caps[0], AttrLLMContextGames); !ok || v.AsInt64() != 2 {
 		t.Errorf("capture span %s = %d (present=%v), want 2", AttrLLMContextGames, v.AsInt64(), ok)
 	}
-	if v, ok := attrValue(caps[0], AttrLLMPromptSystem); !ok || !strings.Contains(v.AsString(), "PRIOR GAMES") {
-		t.Errorf("capture span System prompt missing the cross-game block")
+	// #1168: the System text no longer rides the span (only its fingerprint), so the
+	// cross-game block's injection is asserted via the context_games attr above; the
+	// block's TEXT reaching the System prompt is covered by the production-path test
+	// (TestContextWindow_AsyncPathInjectsBlock's backend assertion). Here we just
+	// confirm the span carries the System-prompt fingerprint instead of the full text.
+	if v, ok := attrValue(caps[0], AttrLLMPromptSystemSHA); !ok || v.AsString() == "" {
+		t.Errorf("capture span missing the System-prompt fingerprint (llm.prompt.system_sha256)")
 	}
 }
 

--- a/services/agent/decision/decision.go
+++ b/services/agent/decision/decision.go
@@ -916,6 +916,11 @@ func (l *Loop) captureLLMPrompt(ctx context.Context, snapshot flags.Snapshot, c 
 		attribute.Bool(AttrLLMContextNotePresent, notePresent),
 		attribute.Int(AttrLLMContextNoteLen, noteLen),
 	)
+	// #1168: the span carries only the System-prompt fingerprint; emit the full text
+	// once per distinct fingerprint on the agent.llm.system_prompt reference log so
+	// the hash stays resolvable to its text without paying per span (the #1167 OOM).
+	systemPromptRef.emit(l.Log, systemPromptSHA(prompt.System),
+		prompt.Variant, llmModeValue, allowedSummary(snapshot.InterventionsAllowed), prompt.System)
 	_, span := l.Tracer.Start(ctx, SpanLLMPrompt, trace.WithAttributes(attrs...))
 	span.End()
 

--- a/services/agent/decision/llm_capture.go
+++ b/services/agent/decision/llm_capture.go
@@ -52,8 +52,9 @@ type llmPromptAttrs struct {
 //   - agent.prompt_variant  = <resolved variant from llm.Prompt.Variant>
 //   - agent.objectives      = sorted "k=v" weights (summarizeObjectives)
 //   - interventions.allowed = the allow-list summary (allowedSummary)
-//   - llm.prompt.system / llm.prompt.user = the FULL prompt text (uncapped)
-//   - llm.prompt.bytes      = len(system)+len(user)
+//   - llm.prompt.system_sha256 = the System-prompt FINGERPRINT (#1168), NOT the text
+//   - llm.prompt.user       = the User prompt text (capped at maxUserPromptBytes)
+//   - llm.prompt.bytes      = len(system)+len(user) (full size; system TEXT not emitted)
 //   - inference.configured  = <model flag>
 //   - inference.used        = "rules"   (the rules engine actually decided)
 //   - inference.fallback_reason = "no_backend_available"  (#741 supplies the real
@@ -75,9 +76,13 @@ func llmPromptAttributes(in llmPromptAttrs) []attribute.KeyValue {
 		attribute.String(AttrPromptVariant, in.prompt.Variant),
 		attribute.String(AttrObjectives, summarizeObjectives(in.objectives)),
 		attribute.String(AttrInterventionsAllowed, allowedSummary(in.allowed)),
-		// The captured prompt: full text (uncapped) plus its size.
-		attribute.String(AttrLLMPromptSystem, system),
-		attribute.String(AttrLLMPromptUser, user),
+		// #1168: the System prompt rides as a FINGERPRINT (resolvable via the
+		// once-per-hash agent.llm.system_prompt reference log), NOT the full text —
+		// that constant bulk drove the #1167 collector OOM. The User prompt (variable,
+		// valuable) is KEPT, capped at maxUserPromptBytes. bytes still counts the full
+		// system+user size so the at-a-glance number is unchanged.
+		attribute.String(AttrLLMPromptSystemSHA, systemPromptSHA(system)),
+		attribute.String(AttrLLMPromptUser, capUserPrompt(user)),
 		attribute.Int(AttrLLMPromptBytes, len(system)+len(user)),
 		// Inference attribution: the prompt was captured, but no backend ran, so
 		// the rules engine decided. #741's resolve_backend() supplies the honest

--- a/services/agent/decision/llm_capture_test.go
+++ b/services/agent/decision/llm_capture_test.go
@@ -51,8 +51,13 @@ func TestLLMCapture_OnIdle(t *testing.T) {
 		t.Fatalf("agent.llm.prompt spans = %d, want 1", len(caps))
 	}
 	capt := caps[0]
-	if v, ok := attrValue(capt, AttrLLMPromptSystem); !ok || v.AsString() == "" {
-		t.Error("llm.prompt.system must be present and non-empty")
+	// #1168: the span carries the System-prompt FINGERPRINT, not the full text.
+	if v, ok := attrValue(capt, AttrLLMPromptSystemSHA); !ok || v.AsString() == "" {
+		t.Error("llm.prompt.system_sha256 must be present and non-empty")
+	}
+	// The full system text must NOT ride on the span anymore (the #1167 OOM bulk).
+	if v, ok := attrValue(capt, "llm.prompt.system"); ok {
+		t.Errorf("llm.prompt.system must be ABSENT (got %q) — only the fingerprint rides the span", v.AsString())
 	}
 	if v, ok := attrValue(capt, AttrLLMPromptUser); !ok || v.AsString() == "" {
 		t.Error("llm.prompt.user must be present and non-empty")
@@ -90,12 +95,16 @@ func TestLLMCapture_SchemaComplete(t *testing.T) {
 			t.Errorf("attr %s = %q (present=%v), want %q", key, v.AsString(), ok, expected)
 		}
 	}
-	// llm.prompt.bytes equals the combined length of the two prompt texts.
-	sys, _ := attrValue(capt, AttrLLMPromptSystem)
+	// #1168: the System TEXT is no longer on the span — only its fingerprint.
+	if v, ok := attrValue(capt, AttrLLMPromptSystemSHA); !ok || len(v.AsString()) != systemPromptSHALen {
+		t.Errorf("llm.prompt.system_sha256 = %q (present=%v), want %d hex chars", v.AsString(), ok, systemPromptSHALen)
+	}
+	// llm.prompt.bytes still counts the FULL system+user size, so it strictly exceeds
+	// the (user-only) text that now rides the span — the system bulk is accounted for
+	// in the number but no longer shipped as text.
 	usr, _ := attrValue(capt, AttrLLMPromptUser)
-	wantBytes := int64(len(sys.AsString()) + len(usr.AsString()))
-	if v, ok := attrValue(capt, AttrLLMPromptBytes); !ok || v.AsInt64() != wantBytes {
-		t.Errorf("llm.prompt.bytes = %d, want %d", v.AsInt64(), wantBytes)
+	if v, ok := attrValue(capt, AttrLLMPromptBytes); !ok || v.AsInt64() <= int64(len(usr.AsString())) {
+		t.Errorf("llm.prompt.bytes = %d, want > user-text len %d (system size still counted)", v.AsInt64(), len(usr.AsString()))
 	}
 }
 

--- a/services/agent/decision/prompt_fingerprint.go
+++ b/services/agent/decision/prompt_fingerprint.go
@@ -1,0 +1,126 @@
+package decision
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"log/slog"
+	"sync"
+)
+
+// prompt_fingerprint.go is the #1168 root-cause fix for the #1167 traces-pipeline
+// collector OOM. The agent.llm.prompt (#739) and agent.llm.retro (#844) spans used
+// to carry the FULL, UNCAPPED System prompt text on EVERY emission. That text is
+// LARGE (physics model #1091, mode fragment, impact magnitudes #1102, allow-list;
+// retro got physics in #1160) and effectively CONSTANT for a given prompt_variant +
+// mode + interventions_allowed (the cross-game PRIOR-GAMES block #929 and operator
+// note #930 do vary it — see below), so shipping it per span (4 shadow games/tick)
+// is redundant bulk that drove span size, not span count, into the collector OOM.
+//
+// The fix replaces the full System TEXT on the span with a short FINGERPRINT
+// (llm.prompt.system_sha256 / llm.retro.system_sha256) and emits the full System
+// text exactly ONCE per distinct fingerprint on a dedicated LOG line, so any span's
+// hash is resolvable back to the exact text without paying per span.
+//
+// LOG, not span: the OOM is the TRACES pipeline. A reference SPAN would add back to
+// that very pipeline; a log line rides the logs pipeline (or stdout), keeping the
+// traces pipeline lean — the stated goal. The reference is low-rate (once per
+// distinct hash for the process lifetime), so even on a busy logs backend it is
+// negligible.
+
+// systemPromptSHALen is how many hex characters of the SHA-256 digest the span
+// fingerprint carries. 16 hex chars = 64 bits of the digest — enough to make a
+// collision between the handful of distinct system prompts a process ever renders
+// astronomically unlikely, while staying tiny on the span.
+const systemPromptSHALen = 16
+
+// maxUserPromptBytes caps the user-prompt text emitted on a span (#1168). The user
+// prompt is the VARIABLE, valuable reasoning input (per-player arcs, timeline), so
+// it is KEPT — but bounded at a generous 32 KiB so a pathological game can never
+// reintroduce the per-span bloat the system prompt used to cause. A capped value
+// carries the userPromptTruncatedMarker so it is never silently mistaken for the
+// whole prompt. 32 KiB comfortably exceeds any real per-cycle user prompt.
+const maxUserPromptBytes = 32 * 1024
+
+// userPromptTruncatedMarker is appended to a user prompt that exceeded
+// maxUserPromptBytes so the truncation is explicit on the span.
+const userPromptTruncatedMarker = "\n...[truncated]"
+
+// SpanLLMSystemPromptRef is the message of the once-per-fingerprint reference LOG
+// line (#1168). It is deliberately a LOG, not a span (the OOM is the traces
+// pipeline — see file header). It carries {system_sha256, prompt_variant, mode,
+// interventions_allowed, system} so any span's llm.prompt.system_sha256 /
+// llm.retro.system_sha256 is resolvable to the exact full text. The name mirrors
+// the issue's suggested agent.llm.system_prompt reference.
+const SpanLLMSystemPromptRef = "agent.llm.system_prompt"
+
+// systemPromptSHA returns the short hex fingerprint of a system prompt: the first
+// systemPromptSHALen hex chars of its SHA-256 digest. It is the value stamped on
+// the span in place of the full text. A given system prompt always hashes to the
+// same fingerprint, so the reference log line (emitted once per distinct hash) is
+// resolvable for any span carrying it.
+func systemPromptSHA(system string) string {
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(system)))[:systemPromptSHALen]
+}
+
+// capUserPrompt bounds the user-prompt text emitted on a span to maxUserPromptBytes,
+// appending userPromptTruncatedMarker when it has to cut. The content is preserved
+// up to the bound — the user prompt is the variable reasoning input we keep (#1168),
+// only its worst case is capped. It cuts on a byte boundary (the user prompt is
+// rendered ASCII/JSON-ish snapshot text; a stray split rune is harmless on a log/
+// span string and far cheaper than rune-walking 32 KiB every cycle).
+func capUserPrompt(user string) string {
+	if len(user) <= maxUserPromptBytes {
+		return user
+	}
+	return user[:maxUserPromptBytes] + userPromptTruncatedMarker
+}
+
+// systemPromptReference emits the full System-prompt text exactly ONCE per distinct
+// fingerprint for the process lifetime (#1168). It is the recoverability half of the
+// fingerprint scheme: the span carries only the hash, this carries the text the hash
+// maps to. seen is a process-lifetime set of hashes already emitted; on first sight
+// of a hash the full text is logged, subsequent sights are no-ops. When the system
+// prompt changes (new variant / mode / allow-list / context block / note) its hash
+// changes and the new text is re-emitted.
+type systemPromptReference struct {
+	// seen maps a system-prompt fingerprint -> struct{} once it has been logged.
+	// sync.Map suits the write-once-then-read-mostly access pattern across the
+	// concurrent per-game Loops (#845) and the retro coordinator that share it.
+	seen sync.Map
+}
+
+// emit logs the full system prompt on the dedicated reference line the FIRST time it
+// sees a given fingerprint, and is a no-op on every subsequent sight of the same
+// fingerprint. It returns true when it actually emitted (first sight), which the
+// tests use to assert the once-per-fingerprint semantics. The log carries the hash,
+// the low-cardinality determinants (variant / mode / allow-list summary) and the
+// full text, so a hash on any span is resolvable to its text. A nil log uses
+// slog.Default so the reference is never silently dropped.
+func (r *systemPromptReference) emit(log *slog.Logger, hash, variant, mode, allowed, system string) bool {
+	if _, loaded := r.seen.LoadOrStore(hash, struct{}{}); loaded {
+		return false // already emitted this fingerprint
+	}
+	if log == nil {
+		log = slog.Default()
+	}
+	log.Info(SpanLLMSystemPromptRef,
+		"system_sha256", hash,
+		"prompt_variant", variant,
+		"mode", mode,
+		"interventions_allowed", allowed,
+		"system", system,
+	)
+	return true
+}
+
+// systemPromptRef is the process-lifetime singleton shared by the decision-capture
+// (llm_capture.go) and retro-capture (retro_capture.go) paths, so a system prompt
+// rendered by either path is logged once for the whole process — not once per Loop
+// (there is one Loop per concurrent game, #845) and not once per path. Tests reset
+// it via resetSystemPromptRef.
+var systemPromptRef = &systemPromptReference{}
+
+// resetSystemPromptRef clears the process-lifetime seen-set. It exists for tests
+// that assert the once-per-fingerprint emission semantics and must start from a
+// clean slate (the singleton otherwise persists across tests in one binary).
+func resetSystemPromptRef() { systemPromptRef = &systemPromptReference{} }

--- a/services/agent/decision/prompt_fingerprint_test.go
+++ b/services/agent/decision/prompt_fingerprint_test.go
@@ -1,0 +1,202 @@
+package decision
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"github.com/joustmania/agent/flags"
+	"github.com/joustmania/agent/gamecontext"
+)
+
+// TestSystemPromptSHA_Stable: the fingerprint is the first systemPromptSHALen hex
+// chars of the full SHA-256 digest, and identical input always yields identical
+// output (so the reference log is resolvable for any span carrying the hash).
+func TestSystemPromptSHA_Stable(t *testing.T) {
+	const s = "the large constant system prompt"
+	got := systemPromptSHA(s)
+	if len(got) != systemPromptSHALen {
+		t.Fatalf("hash len = %d, want %d", len(got), systemPromptSHALen)
+	}
+	want := fmt.Sprintf("%x", sha256.Sum256([]byte(s)))[:systemPromptSHALen]
+	if got != want {
+		t.Errorf("hash = %q, want %q (prefix of full sha256)", got, want)
+	}
+	if systemPromptSHA(s) != got {
+		t.Error("hash is not stable for identical input")
+	}
+	if systemPromptSHA(s+"x") == got {
+		t.Error("a different system prompt must hash differently")
+	}
+}
+
+// TestCapUserPrompt: a user prompt under the bound is untouched; one over the bound
+// is cut to the bound and carries the truncation marker, preserving the content.
+func TestCapUserPrompt(t *testing.T) {
+	small := strings.Repeat("u", 100)
+	if got := capUserPrompt(small); got != small {
+		t.Error("a small user prompt must be returned unchanged")
+	}
+	big := strings.Repeat("u", maxUserPromptBytes+500)
+	got := capUserPrompt(big)
+	if !strings.HasSuffix(got, userPromptTruncatedMarker) {
+		t.Error("an oversized user prompt must carry the truncation marker")
+	}
+	if !strings.HasPrefix(got, big[:maxUserPromptBytes]) {
+		t.Error("the capped user prompt must preserve content up to the bound")
+	}
+	if len(got) != maxUserPromptBytes+len(userPromptTruncatedMarker) {
+		t.Errorf("capped len = %d, want %d", len(got), maxUserPromptBytes+len(userPromptTruncatedMarker))
+	}
+}
+
+// TestSystemPromptReference_EmitsOncePerFingerprint: the full text is logged on the
+// first sight of a hash and NOT re-logged on a second identical sight; a new hash
+// (changed system prompt) re-emits.
+func TestSystemPromptReference_EmitsOncePerFingerprint(t *testing.T) {
+	ref := &systemPromptReference{}
+	log := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
+
+	const sysA = "system prompt A"
+	hashA := systemPromptSHA(sysA)
+	if !ref.emit(log, hashA, "balanced", "llm", "noop", sysA) {
+		t.Fatal("first sight of a hash must emit")
+	}
+	if ref.emit(log, hashA, "balanced", "llm", "noop", sysA) {
+		t.Error("second sight of the SAME hash must NOT re-emit")
+	}
+	const sysB = "system prompt B (different variant rendered)"
+	if !ref.emit(log, systemPromptSHA(sysB), "aggressive", "llm", "noop", sysB) {
+		t.Error("a NEW hash must emit (system prompt changed)")
+	}
+}
+
+// recordingLoopWithLog mirrors recordingLoop but threads a capturing JSON logger so
+// the test can read the agent.llm.system_prompt reference line back.
+func recordingLoopWithLog(t *testing.T, snap flags.Snapshot, buf *bytes.Buffer) (*Loop, *tracetest.SpanRecorder) {
+	t.Helper()
+	sr := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+	l := NewLoop(&settableFlags{snap: snap}, slog.New(slog.NewJSONHandler(buf, nil)))
+	l.Tracer = tp.Tracer("test")
+	l.Rules = fakeRules{out: nil}
+	l.Actions = &fakeSink{}
+	l.SetLLMBudget(NewLLMBudget())
+	return l, sr
+}
+
+// systemRefLines returns every agent.llm.system_prompt reference log line captured
+// in buf, decoded as a map.
+func systemRefLines(t *testing.T, buf *bytes.Buffer) []map[string]any {
+	t.Helper()
+	var out []map[string]any
+	for _, line := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
+		if line == "" {
+			continue
+		}
+		var m map[string]any
+		if err := json.Unmarshal([]byte(line), &m); err != nil {
+			t.Fatalf("log line not JSON: %q: %v", line, err)
+		}
+		if m["msg"] == SpanLLMSystemPromptRef {
+			out = append(out, m)
+		}
+	}
+	return out
+}
+
+// TestLLMCapture_ReferenceLogCarriesFullSystemOncePerFingerprint: the in-game
+// capture path emits the full System text on the reference LOG exactly once per
+// fingerprint, and the span carries the matching hash (not the text).
+func TestLLMCapture_ReferenceLogCarriesFullSystemOncePerFingerprint(t *testing.T) {
+	resetSystemPromptRef()
+	t.Cleanup(resetSystemPromptRef)
+
+	var buf bytes.Buffer
+	l, sr := recordingLoopWithLog(t, llmSnapshot(), &buf)
+	clock := time.Unix(1000, 0)
+	l.now = func() time.Time { return clock }
+
+	// Two cycles, same snapshot -> same system prompt -> one reference line. Advance
+	// past the 1s throttle so BOTH cycles actually build+emit a capture span.
+	l.OnEvaluate(context.Background(), gamecontext.GameContext{SessionID: "s1", GameKind: "real"}, testTrigger())
+	clock = clock.Add(2 * time.Second)
+	l.OnEvaluate(context.Background(), gamecontext.GameContext{SessionID: "s1", GameKind: "real"}, testTrigger())
+
+	caps := spansByName(sr.Ended(), SpanLLMPrompt)
+	if len(caps) != 2 {
+		t.Fatalf("agent.llm.prompt spans = %d, want 2 (throttle elapsed between cycles)", len(caps))
+	}
+
+	refs := systemRefLines(t, &buf)
+	if len(refs) != 1 {
+		t.Fatalf("agent.llm.system_prompt reference lines = %d, want 1 (once per fingerprint)", len(refs))
+	}
+	ref := refs[0]
+	// The reference carries the FULL system text + the determinants + the hash.
+	full, _ := ref["system"].(string)
+	if full == "" || !strings.Contains(full, "RESPONSE CONTRACT") {
+		t.Errorf("reference line must carry the full system text, got %q", full)
+	}
+	refHash, _ := ref["system_sha256"].(string)
+	if refHash == "" || systemPromptSHA(full) != refHash {
+		t.Errorf("reference hash %q must match sha of its own system text", refHash)
+	}
+	// The span's fingerprint matches the reference's hash, and the span does NOT carry
+	// the large physics/allow-list system text.
+	spanHash, ok := attrValue(caps[0], AttrLLMPromptSystemSHA)
+	if !ok || spanHash.AsString() != refHash {
+		t.Errorf("span hash %q must match reference hash %q", spanHash.AsString(), refHash)
+	}
+	if _, ok := attrValue(caps[0], "llm.prompt.system"); ok {
+		t.Error("span must NOT carry the full system text (only the fingerprint)")
+	}
+}
+
+// TestRetroCapture_ReferenceLogCarriesFullSystemOnce: the retro path also emits the
+// full System text once per fingerprint, and the retro span carries the hash.
+func TestRetroCapture_ReferenceLogCarriesFullSystemOnce(t *testing.T) {
+	resetSystemPromptRef()
+	t.Cleanup(resetSystemPromptRef)
+
+	var buf bytes.Buffer
+	sr := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+	rc := NewRetroCoordinator(&settableFlags{snap: retroFlagSnapshot()}, slog.New(slog.NewJSONHandler(&buf, nil)))
+	rc.Tracer = tp.Tracer("test")
+
+	// Two distinct sessions, same flags -> same retro system prompt -> one reference.
+	s1 := endedSession()
+	s1.SessionID = "session-A"
+	s2 := endedSession()
+	s2.SessionID = "session-B"
+	rc.OnGameEnd(s1)
+	rc.OnGameEnd(s2)
+
+	if n := len(spansByName(sr.Ended(), SpanLLMRetro)); n != 2 {
+		t.Fatalf("agent.llm.retro spans = %d, want 2", n)
+	}
+	refs := systemRefLines(t, &buf)
+	if len(refs) != 1 {
+		t.Fatalf("agent.llm.system_prompt reference lines = %d, want 1 (once per fingerprint)", len(refs))
+	}
+	if mode, _ := refs[0]["mode"].(string); mode != retroModeValue {
+		t.Errorf("reference mode = %q, want %q", mode, retroModeValue)
+	}
+	span := spansByName(sr.Ended(), SpanLLMRetro)[0]
+	refHash, _ := refs[0]["system_sha256"].(string)
+	if h, ok := attrValue(span, AttrLLMRetroSystemSHA); !ok || h.AsString() != refHash {
+		t.Errorf("retro span hash %q must match reference hash %q", h.AsString(), refHash)
+	}
+}

--- a/services/agent/decision/retro_capture.go
+++ b/services/agent/decision/retro_capture.go
@@ -49,13 +49,22 @@ const SpanLLMRetro = "agent.llm.retro"
 // agent.llm.prompt keys (telemetry.go) but in the retro namespace so the two
 // capture kinds never collide in a single trace view.
 const (
-	// AttrLLMRetroSystem / AttrLLMRetroUser carry the full, uncapped System and
-	// User retrospective prompt text. As with the in-game capture, the Go SDK
-	// applies no attribute length limit and the collector does not truncate, so the
-	// entire prompt is preserved for offline replay (scripts/replay-prompt.sh).
-	AttrLLMRetroSystem = "llm.retro.system"
-	AttrLLMRetroUser   = "llm.retro.user"
-	// AttrLLMRetroBytes is len(system)+len(user), the prompt size in bytes (int).
+	// AttrLLMRetroSystemSHA is the FINGERPRINT of the retrospective System prompt
+	// (#1168), the retro-namespace counterpart of AttrLLMPromptSystemSHA: the short
+	// hex SHA-256 of the full system text, stamped INSTEAD of the text. The retro
+	// system prompt is large and effectively constant (it got the physics model in
+	// #1160), so shipping its full text per retro span was part of the #1167
+	// traces-pipeline collector OOM. The full text is emitted ONCE per distinct
+	// fingerprint on the shared agent.llm.system_prompt reference LOG line
+	// (prompt_fingerprint.go), so this hash is always resolvable to the exact text.
+	AttrLLMRetroSystemSHA = "llm.retro.system_sha256"
+	// AttrLLMRetroUser carries the User retrospective prompt text — the VARIABLE,
+	// valuable analysis input — KEPT on the span, capped at maxUserPromptBytes with a
+	// truncation marker. The Go SDK applies no attribute length limit and the
+	// collector does not truncate.
+	AttrLLMRetroUser = "llm.retro.user"
+	// AttrLLMRetroBytes is len(system)+len(user): the FULL prompt size in bytes (int),
+	// unchanged by #1168 (system TEXT no longer emitted, but still counted).
 	AttrLLMRetroBytes = "llm.retro.bytes"
 )
 
@@ -287,6 +296,15 @@ func (rc *RetroCoordinator) OnGameEnd(c gamecontext.GameContext) {
 	// gen_ai.request.model and the log line both name the configured model.
 	prompt.Model = attr.configured
 
+	// #1168: the retro span carries only the System-prompt fingerprint; emit the full
+	// text once per distinct fingerprint on the shared agent.llm.system_prompt
+	// reference log (the same singleton the in-game capture uses) so the hash stays
+	// resolvable to its text without paying per span (the #1167 OOM). The retro system
+	// prompt is its own variant of the constant text, so it hashes distinctly from the
+	// in-game one and is emitted once on its own first sight.
+	systemPromptRef.emit(rc.Log, systemPromptSHA(prompt.System),
+		snapshot.Capability.PromptVariant, retroModeValue, allowedSummary(snapshot.InterventionsAllowed), prompt.System)
+
 	attrs := retroPromptAttributes(retroPromptAttrs{
 		prompt:     prompt,
 		sessionID:  c.SessionID,
@@ -438,8 +456,9 @@ type retroPromptAttrs struct {
 //   - agent.objectives      = sorted "k=v" weights (summarizeObjectives)
 //   - interventions.allowed = the allow-list summary (allowedSummary)
 //   - session.id / game.id  = the finished session's id (= the real game_id, #1088)
-//   - llm.retro.system / llm.retro.user = the FULL prompt text (uncapped)
-//   - llm.retro.bytes       = len(system)+len(user)
+//   - llm.retro.system_sha256 = the System-prompt FINGERPRINT (#1168), NOT the text
+//   - llm.retro.user        = the User prompt text (capped at maxUserPromptBytes)
+//   - llm.retro.bytes       = len(system)+len(user) (full size; system TEXT not emitted)
 //   - inference.configured  = the configured backend model (#1080), or the model flag
 //   - inference.used        = the tier that WOULD serve, or "none" (see DIVERGENCE)
 //   - inference.fallback_reason = "" when the configured backend is reachable, else
@@ -476,9 +495,12 @@ func retroPromptAttributes(in retroPromptAttrs) []attribute.KeyValue {
 		// game.id IS the SessionID (= the real game_id since #845 PR A).
 		attribute.String(AttrSessionID, in.sessionID),
 		attribute.String(AttrGameID, in.sessionID),
-		// The captured prompt: full text (uncapped) plus its size.
-		attribute.String(AttrLLMRetroSystem, system),
-		attribute.String(AttrLLMRetroUser, user),
+		// #1168: the System prompt rides as a FINGERPRINT (resolvable via the
+		// once-per-hash agent.llm.system_prompt reference log), NOT the full text. The
+		// User prompt (variable, valuable) is KEPT, capped at maxUserPromptBytes. bytes
+		// still counts the full system+user size.
+		attribute.String(AttrLLMRetroSystemSHA, systemPromptSHA(system)),
+		attribute.String(AttrLLMRetroUser, capUserPrompt(user)),
 		attribute.Int(AttrLLMRetroBytes, len(system)+len(user)),
 		// Inference attribution (#1080): resolved through the shared resolver so the
 		// configured backend (gemma4) is named when one is wired; used is the tier that

--- a/services/agent/decision/retro_capture_test.go
+++ b/services/agent/decision/retro_capture_test.go
@@ -68,8 +68,13 @@ func TestRetroCapture_EmitsSpan(t *testing.T) {
 	if len(spans) != 1 {
 		t.Fatalf("agent.llm.retro spans = %d, want 1", len(spans))
 	}
-	if v, ok := attrValue(spans[0], AttrLLMRetroSystem); !ok || v.AsString() == "" {
-		t.Error("llm.retro.system must be present and non-empty")
+	// #1168: the span carries the System-prompt FINGERPRINT, not the full text.
+	if v, ok := attrValue(spans[0], AttrLLMRetroSystemSHA); !ok || v.AsString() == "" {
+		t.Error("llm.retro.system_sha256 must be present and non-empty")
+	}
+	// The full retro system text must NOT ride on the span anymore (the #1167 OOM bulk).
+	if v, ok := attrValue(spans[0], "llm.retro.system"); ok {
+		t.Errorf("llm.retro.system must be ABSENT (got %q) — only the fingerprint rides the span", v.AsString())
 	}
 	if v, ok := attrValue(spans[0], AttrLLMRetroUser); !ok || v.AsString() == "" {
 		t.Error("llm.retro.user must be present and non-empty")
@@ -158,12 +163,15 @@ func TestRetroCapture_SchemaComplete(t *testing.T) {
 	if v, _ := attrValue(span, AttrInferenceUsed); v.AsString() == InferenceRules {
 		t.Errorf("inference.used = %q, must NOT be %q for a retrospective", v.AsString(), InferenceRules)
 	}
-	// llm.retro.bytes equals the combined length of the two prompt texts.
-	sys, _ := attrValue(span, AttrLLMRetroSystem)
+	// #1168: the System TEXT is no longer on the span — only its fingerprint.
+	if v, ok := attrValue(span, AttrLLMRetroSystemSHA); !ok || len(v.AsString()) != systemPromptSHALen {
+		t.Errorf("llm.retro.system_sha256 = %q (present=%v), want %d hex chars", v.AsString(), ok, systemPromptSHALen)
+	}
+	// llm.retro.bytes still counts the FULL system+user size, so it strictly exceeds
+	// the (user-only) text that now rides the span.
 	usr, _ := attrValue(span, AttrLLMRetroUser)
-	wantBytes := int64(len(sys.AsString()) + len(usr.AsString()))
-	if v, ok := attrValue(span, AttrLLMRetroBytes); !ok || v.AsInt64() != wantBytes {
-		t.Errorf("llm.retro.bytes = %d, want %d", v.AsInt64(), wantBytes)
+	if v, ok := attrValue(span, AttrLLMRetroBytes); !ok || v.AsInt64() <= int64(len(usr.AsString())) {
+		t.Errorf("llm.retro.bytes = %d, want > user-text len %d (system size still counted)", v.AsInt64(), len(usr.AsString()))
 	}
 }
 

--- a/services/agent/decision/telemetry.go
+++ b/services/agent/decision/telemetry.go
@@ -183,14 +183,26 @@ const AttrLLMInferError = "llm.infer.error"
 // attributes use semconv constants where they exist; these three carry the
 // captured prompt text and size, which have no semantic convention.
 const (
-	// AttrLLMPromptSystem / AttrLLMPromptUser carry the full, uncapped System and
-	// User prompt text the agent would have sent this cycle. The Go SDK applies no
-	// attribute length limit and the collector does not truncate, so the entire
-	// prompt is preserved for offline replay (scripts/replay-prompt.sh).
-	AttrLLMPromptSystem = "llm.prompt.system"
-	AttrLLMPromptUser   = "llm.prompt.user"
-	// AttrLLMPromptBytes is len(system)+len(user), the prompt size in bytes (int),
-	// for at-a-glance sizing without copying the full text out of the span.
+	// AttrLLMPromptSystemSHA is the FINGERPRINT of the System prompt (#1168): the
+	// short hex SHA-256 (systemPromptSHA) of the full system text, stamped INSTEAD of
+	// the text itself. The system prompt is large and effectively constant (a pure
+	// function of the low-cardinality prompt_variant + mode + interventions_allowed,
+	// all already on this span — plus the #929 PRIOR-GAMES block / #930 note when
+	// present), so shipping its full text on every span (4 shadow games/tick) was the
+	// redundant bulk that drove the #1167 traces-pipeline collector OOM. The full text
+	// is emitted ONCE per distinct fingerprint on the agent.llm.system_prompt
+	// reference LOG line (prompt_fingerprint.go), so this hash is always resolvable to
+	// the exact text without paying per span.
+	AttrLLMPromptSystemSHA = "llm.prompt.system_sha256"
+	// AttrLLMPromptUser carries the User prompt text the agent would have sent this
+	// cycle — the VARIABLE, valuable reasoning input (per-player arcs, timeline), so
+	// it is KEPT on the span (capped at maxUserPromptBytes with a truncation marker so
+	// a pathological game cannot reintroduce per-span bloat). The Go SDK applies no
+	// attribute length limit and the collector does not truncate.
+	AttrLLMPromptUser = "llm.prompt.user"
+	// AttrLLMPromptBytes is len(system)+len(user): the FULL prompt size in bytes (int),
+	// unchanged by #1168 (it still counts the system prompt even though the system TEXT
+	// is no longer emitted), so the at-a-glance sizing is the same number as before.
 	AttrLLMPromptBytes = "llm.prompt.bytes"
 )
 

--- a/services/agent/gamewindow/render.go
+++ b/services/agent/gamewindow/render.go
@@ -11,8 +11,8 @@ import (
 // blockHeader labels the cross-game context section in the prompt. It is a fixed,
 // greppable marker (#929 acceptance: "each LLM call includes the last N game
 // summaries as a narrative context block") so the block is findable in a captured
-// prompt and in a Jaeger llm.prompt.system attribute by name, independent of how
-// many games it holds.
+// prompt and in the `agent.llm.system_prompt` reference log's `system` field by
+// name, independent of how many games it holds.
 const blockHeader = "PRIOR GAMES (most recent last; cross-game memory):"
 
 // emptyMarker is rendered when the window is empty (no games have ended yet, or N

--- a/services/agent/scripts/replay-prompt.sh
+++ b/services/agent/scripts/replay-prompt.sh
@@ -12,10 +12,18 @@
 # Usage:
 #   scripts/replay-prompt.sh <system-prompt-file> <user-prompt-file>
 #
-# How to get the two files, from a captured span in Jaeger:
+# How to get the two files, from a captured span in Jaeger (#1168: the span carries
+# only a fingerprint of the system prompt, not its text — the full text is on a log):
 #   1. Open http://localhost:8080/jaeger/ and find a span named `agent.llm.prompt`.
-#   2. Copy the `llm.prompt.system` attribute value into a file, e.g. system.txt.
-#   3. Copy the `llm.prompt.user`   attribute value into a file, e.g. user.txt.
+#   2. Copy the `llm.prompt.user` attribute value into a file, e.g. user.txt.
+#   3. Read the span's `llm.prompt.system_sha256` attribute (a 16-hex fingerprint).
+#      The FULL system text is NOT on the span — it is emitted once per distinct
+#      fingerprint on the `agent.llm.system_prompt` log line. Pull it out by hash:
+#        docker logs joustmania-agent 2>&1 \
+#          | grep agent.llm.system_prompt | grep <system_sha256> | tail -1
+#      and copy that line's `system` field value into a file, e.g. system.txt.
+#      (The system prompt is also deterministically reconstructable from the
+#      span's prompt_variant + mode + interventions.allowed.)
 #   4. Run:  scripts/replay-prompt.sh system.txt user.txt
 #   5. Eyeball the printed response: does it parse as a single JSON object with
 #      the contract fields (intervention, target_serial, value, reason,
@@ -27,9 +35,10 @@
 # `claude` CLI headless path is the current candidate).
 #
 # It ALSO replays post-game `agent.llm.retro` spans (#844) identically: copy the
-# `llm.retro.system` / `llm.retro.user` attribute values out of an
-# `agent.llm.retro` span (instead of llm.prompt.system/user) into the two files
-# and run the same way.
+# `llm.retro.user` attribute value out of an `agent.llm.retro` span (instead of
+# llm.prompt.user) into user.txt, and pull the system text from the
+# `agent.llm.system_prompt` log line keyed by the span's `llm.retro.system_sha256`
+# (instead of llm.prompt.system_sha256) into system.txt; then run the same way.
 
 set -euo pipefail
 
@@ -37,10 +46,14 @@ usage() {
 	cat >&2 <<'EOF'
 usage: replay-prompt.sh <system-prompt-file> <user-prompt-file>
 
-  <system-prompt-file>  file holding the captured llm.prompt.system attribute
+  <system-prompt-file>  file holding the `system` field from the
+                        `agent.llm.system_prompt` log line keyed by the span's
+                        llm.prompt.system_sha256 (the span has only the hash)
   <user-prompt-file>    file holding the captured llm.prompt.user attribute
 
-Copy both attribute values out of an `agent.llm.prompt` span in Jaeger.
+Copy llm.prompt.user out of an `agent.llm.prompt` span in Jaeger; resolve the
+system text from the `agent.llm.system_prompt` log line by the span's
+llm.prompt.system_sha256 hash.
 EOF
 	exit 2
 }


### PR DESCRIPTION
Part of #1168 (root-cause fix for #1167 collector OOM).

## What
The `agent.llm.prompt` (#739) and `agent.llm.retro` (#844) spans carried the FULL, uncapped system prompt text on every emission. That text is large and effectively constant for a given `prompt_variant` + `mode` + `interventions_allowed` (all already span attributes), so shipping it per span (4 shadow games/tick) was the dominant payload driving the #1167 traces-pipeline collector OOM — span SIZE, not count.

## Change
- **Fingerprint, not text**: `llm.prompt.system_sha256` / `llm.retro.system_sha256` (16 hex chars of SHA-256, via `systemPromptSHA`) now ride the span instead of the full system text.
- **Keep the user prompt** (the variable, valuable reasoning input — per-player arcs/timeline), capped at a generous 32 KiB (`capUserPrompt`) with a truncation marker so a pathological game cannot reintroduce per-span bloat.
- **`*.bytes` unchanged**: still `len(system)+len(user)` (full size), so the at-a-glance sizing number is the same; only the system TEXT stops being emitted.
- **Recoverability — once per fingerprint**: the full system text is emitted exactly once per distinct hash on a dedicated `agent.llm.system_prompt` reference **LOG** line (process-lifetime `sync.Map` of seen hashes, shared by both decision and retro paths) carrying `{system_sha256, prompt_variant, mode, interventions_allowed, system}`. **Log, not span**: the OOM is the traces pipeline — a reference span would add back to it; a log line keeps traces lean while any span's hash stays resolvable to its exact text.

## Scope
`services/agent/decision/{telemetry.go,llm_capture.go,retro_capture.go,decision.go}` + new `prompt_fingerprint.go` (hash helper, user-cap, once-per-fingerprint emitter) + tests. No collector config / experiment_loop / async / infracontext touched.

## Per-span reduction
~2.6 KiB+ system text → 16-byte hash per llm span (a minimal-snapshot floor; production prompts are larger with #1091/#1102/#1160).

## Verify
`gofmt -l . && go build ./... && go vet ./... && go test ./... -race -count=1` all green. Tests now assert: span carries the `system_sha256` hash and NOT the full system text (the large physics/allow-list strings are ABSENT); user prompt text still present; full system text emitted once per fingerprint (second identical cycle does NOT re-emit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)