### PR TITLE
fix(otel): scope a larger collector envelope to experiment-heavy stacks (#1167)

### DIFF
--- a/docker-compose.dry-run.yml
+++ b/docker-compose.dry-run.yml
@@ -79,3 +79,23 @@ services:
       # agent autonomously pick which game.json flag to experiment on (alongside the
       # seed). The other AGENT_EXPERIMENT_DYNAMIC_* knobs pass through from the base.
       - AGENT_EXPERIMENT_DYNAMIC_ENABLED=${AGENT_EXPERIMENT_DYNAMIC_ENABLED:-false}
+
+  # #1167: experiment-heavy collector envelope. The dry-run cohort loop runs ~4
+  # paired shadow games/tick (~20 in flight), each emitting decision/action/effect
+  # + experiment.* spans (all #1140 Links). At the lean #1161 base envelope
+  # (768 MiB container / limiter 600/150) the collector OOM-killed (exit 137)
+  # within ~2 min and refused/dropped agent spans. We keep ALL spans (no sampling)
+  # and instead raise the ceiling ONLY for this experiment-heavy stack so the
+  # Pi/prod base stays lean (experiments default off there). Raise the container
+  # to 1536 MiB AND set the env-substituted limiter (config.yaml memory_limiter)
+  # to 1200/300 so the limiter sheds NEAR the 1.5 GiB ceiling (~80% / ~25%) rather
+  # than backpressuring at 600 — without this matching limiter bump the bigger
+  # container would be wasted. Merges onto the base collector by service name.
+  otel-collector:
+    environment:
+      - OTEL_MEMLIMIT_MIB=1200
+      - OTEL_MEMSPIKE_MIB=300
+    deploy:
+      resources:
+        limits:
+          memory: 1536m

--- a/docker-compose.gateway.yml
+++ b/docker-compose.gateway.yml
@@ -42,3 +42,22 @@ services:
     depends_on:
       litellm:
         condition: service_healthy
+
+  # #1167: experiment-heavy collector envelope (live-inference stack). When the
+  # agent routes through the LiteLLM gateway it runs the SAME experiment cohort
+  # loop / shadow-game span volume as dry-run, so the lean #1161 base envelope
+  # (768 MiB / limiter 600/150) OOM-kills (exit 137) the collector under sustained
+  # load. We keep ALL spans (no sampling) and raise the ceiling ONLY for this
+  # experiment-heavy stack so the Pi/prod base stays lean. Raise the container to
+  # 1536 MiB AND set the env-substituted limiter (config.yaml memory_limiter) to
+  # 1200/300 so it sheds NEAR the 1.5 GiB ceiling (~80% / ~25%) rather than at 600
+  # — without this matching limiter bump the bigger container would be wasted.
+  # Merges onto the base collector by service name. Mirrors docker-compose.dry-run.yml.
+  otel-collector:
+    environment:
+      - OTEL_MEMLIMIT_MIB=1200
+      - OTEL_MEMSPIKE_MIB=300
+    deploy:
+      resources:
+        limits:
+          memory: 1536m

--- a/services/otel-collector/config.yaml
+++ b/services/otel-collector/config.yaml
@@ -166,10 +166,24 @@ processors:
   # ~600 MiB (soft ~450 MiB) — well under the 768 MiB cgroup ceiling — so under
   # the agent experiment-loop span burst the collector backpressures instead of
   # being OOM-killed, and keeps exporting the #1140 trace-correlation spans.
+  #
+  # #1167: this config.yaml is mounted READ-ONLY by EVERY stack (base/Pi/prod,
+  # ci, dry-run, gateway), so the limiter can't be hardcoded per-stack. The two
+  # thresholds are env-substituted with LEAN DEFAULTS equal to the #1161 base
+  # values, using the OTel Collector confmap env provider's default-value syntax
+  # `${env:VAR:-default}` (supported since collector v0.108.0; this image is
+  # built with OCB 0.153.0, well past that — see images/otel-collector/Dockerfile).
+  # If the env vars are unset (base/Pi/prod + ci) the limiter stays at 600/150
+  # under the lean 768 MiB ceiling. The experiment-heavy stacks
+  # (docker-compose.dry-run.yml + docker-compose.gateway.yml) raise the container
+  # ceiling to 1536 MiB AND set OTEL_MEMLIMIT_MIB=1200 / OTEL_MEMSPIKE_MIB=300 so
+  # the limiter sheds NEAR the 1.5 GiB ceiling (~80% / ~25%) instead of pointlessly
+  # backpressuring at 600 — without the matching limiter bump the bigger container
+  # would be wasted. No span sampling: ALL spans are kept.
   memory_limiter:
     check_interval: 1s
-    limit_mib: 600
-    spike_limit_mib: 150
+    limit_mib: ${env:OTEL_MEMLIMIT_MIB:-600}
+    spike_limit_mib: ${env:OTEL_MEMSPIKE_MIB:-150}
 
   # Resource processors set service.namespace per pipeline.
   # The prometheusremotewrite exporter prefixes job labels with the namespace


### PR DESCRIPTION
Part of #1167 (+ stack-specific collector envelope).

#1161 fixed the limiter/ceiling **misalignment** (768Mi / limiter 600/150) but 768Mi is still under-provisioned for sustained dry-run shadow-experiment span load — the collector OOM-killed (exit 137) within ~2 min and refused/dropped agent spans. Per the maintainer decision: **keep ALL spans (no sampling)** and raise the ceiling, **scoping the bigger envelope to the experiment-heavy stacks** so the Pi/prod base stays lean (experiments default off there).

## Mechanism
`config.yaml` is mounted read-only by **every** stack, so the limiter can't be hardcoded per-stack. `memory_limiter.limit_mib` / `spike_limit_mib` are now env-substituted via the OTel confmap default syntax `${env:VAR:-default}` with **lean defaults = #1161 base values** (600 / 150). The collector is built with **OCB 0.153.0**, which supports the `:-` default syntax (available since collector v0.108.0). Base / Pi / prod / ci leave the env unset → 600/150 under the unchanged 768Mi ceiling.

The experiment-heavy override stacks raise the container to **1536Mi (1.5Gi)** AND set `OTEL_MEMLIMIT_MIB=1200` / `OTEL_MEMSPIKE_MIB=300` so the limiter sheds **near** the 1.5Gi ceiling (~80% / ~25%) instead of pointlessly backpressuring at 600:
- `docker-compose.dry-run.yml` (dry-run cohort loop)
- `docker-compose.gateway.yml` (live-inference: agent routed through LiteLLM)

Batch settings unchanged (5s/512). No sampling/filter processors.

## Validation (`docker compose config` merge)
| Stack | container memory | limiter |
|---|---|---|
| base alone | 768Mi | 600 / 150 (defaults) |
| + dry-run | 1536Mi | 1200 / 300 |
| + gateway | 1536Mi | 1200 / 300 |

## Live validation (running dry-run stack)
- Collector recreated with the new config booted cleanly: `Memory limiter configured ... limit_mib: 1200, spike_limit_mib: 300` + `Everything is ready` (a bad `${...}` syntax would crash-loop on boot — it didn't).
- Under fresh sustained experiment load it held a **1.0–1.3Gi working set (peak 1.316Gi / 87%)** for ~4 min with **restarts=0, oom=false, healthy** — the same load profile that OOM-killed at the old 768Mi ceiling. The limiter shed (backpressure) near 1.2Gi as designed rather than the container being OOM-killed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)