### PR TITLE
[DO NOT MERGE] Verify #1086 gating — deliberate CI failure

### DIFF
--- a/services/agent/decision/zzz_verify_1086_fail_test.go
+++ b/services/agent/decision/zzz_verify_1086_fail_test.go
@@ -1,0 +1,11 @@
+package decision
+
+import "testing"
+
+// TestDeliberate1086GatingFailure is a THROWAWAY deliberate failure to verify the
+// #1086 CI-gating fix (PR #1146) live: a genuine test failure must make the
+// `CI Complete` required status post FAILURE and block the merge. This PR is
+// created only to observe that, and will be CLOSED — never merged.
+func TestDeliberate1086GatingFailure(t *testing.T) {
+	t.Fatal("deliberate failure verifying #1086: CI Complete must post FAILURE and block merge")
+}


### PR DESCRIPTION
Throwaway PR to confirm PR #1146 (#1086) live: a real test failure MUST post `CI Complete: FAILURE` and block merge. Will be closed after observation. Also testing that adding a non-`ci-full` label does not flip the red SHA green.