### PR TITLE
feat(agent): hub-and-spoke span correlation for every per-game artifact (#1174)

### DIFF
--- a/services/agent/decision/async_infer.go
+++ b/services/agent/decision/async_infer.go
@@ -272,7 +272,14 @@ func (l *Loop) runInfer(root context.Context, snapshot flags.Snapshot, backend B
 	// trace can navigate to the signal that caused it. No-op when fireSC is invalid.
 	callOpts := []trace.SpanStartOption{
 		trace.WithSpanKind(trace.SpanKindClient),
-		trace.WithAttributes(attribute.String("gen_ai.request.model", backend.Name())),
+		trace.WithAttributes(
+			attribute.String("gen_ai.request.model", backend.Name()),
+			// game.id + session.id (#1174): make the outbound-call span findable by game,
+			// so the LLM call for game X is a queryable spoke (it already Links to the
+			// fire cycle, which Links to the hub). c is THIS game's GameContext.
+			attribute.String(AttrGameID, c.SessionID),
+			attribute.String(AttrSessionID, c.SessionID),
+		),
 	}
 	callOpts = append(callOpts, fireCycleLink(fireSC)...)
 	callCtx, callSpan := l.Tracer.Start(inferCtx, SpanLLMInferCall, callOpts...)

--- a/services/agent/decision/async_trace_continuity_test.go
+++ b/services/agent/decision/async_trace_continuity_test.go
@@ -79,6 +79,13 @@ func TestAsyncContinuity_ProductionPathAnchored(t *testing.T) {
 		t.Errorf("anchor span %s = %v (ok=%v), want g1", AttrGameID, v.AsString(), ok)
 	}
 
+	// #1174: the outbound-call span carries game.id so it is findable by game.
+	if calls := spansByName(sr.Ended(), SpanLLMInferCall); len(calls) == 1 {
+		if v, ok := attrValue(calls[0], AttrGameID); !ok || v.AsString() != "g1" {
+			t.Errorf("%s %s = %v (ok=%v), want g1", SpanLLMInferCall, AttrGameID, v.AsString(), ok)
+		}
+	}
+
 	for _, name := range []string{SpanLLMInferCall, SpanLLMApply} {
 		spans := spansByName(sr.Ended(), name)
 		if len(spans) != 1 {

--- a/services/agent/decision/decision.go
+++ b/services/agent/decision/decision.go
@@ -645,7 +645,7 @@ func (l *Loop) setLastLayer(state LayerState) {
 // demote this to SpanKindInternal and drop the rpc.* attributes to avoid a duplicate
 // server span for the same RPC.
 func (l *Loop) startSignalReceivedSpan(ctx context.Context, c gamecontext.GameContext, trig EvalTrigger) (context.Context, trace.Span) {
-	return l.Tracer.Start(ctx, SignalReceived,
+	startOpts := []trace.SpanStartOption{
 		trace.WithTimestamp(trig.T0),
 		trace.WithSpanKind(trace.SpanKindServer),
 		trace.WithAttributes(
@@ -659,7 +659,19 @@ func (l *Loop) startSignalReceivedSpan(ctx context.Context, c gamecontext.GameCo
 			// and makes two concurrent games' traces independently attributable.
 			attribute.String(AttrGameID, c.SessionID),
 		),
-	)
+	}
+	// Hub-and-spoke correlation (#1174): this cycle-root span is the parent of the whole
+	// sync decision->action subtree AND the #1140 async fire anchor (both call this shared
+	// helper). Linking it to the game-session trace pulls that ENTIRE subtree onto the hub
+	// in one change. Stamp the game trace_id as a searchable attribute too. nil-safe.
+	startOpts = append(startOpts, gameTraceLink(c.GameTraceID, c.GameTraceSpanID)...)
+	if c.GameTraceID != "" {
+		startOpts = append(startOpts, trace.WithAttributes(attribute.String(AttrGameTraceID, c.GameTraceID)))
+	}
+	if c.GameTraceSpanID != "" {
+		startOpts = append(startOpts, trace.WithAttributes(attribute.String(AttrGameTraceSpanID, c.GameTraceSpanID)))
+	}
+	return l.Tracer.Start(ctx, SignalReceived, startOpts...)
 }
 
 // decide selects the decision path from snapshot.Mode and runs it. The "rules"
@@ -1030,7 +1042,7 @@ func (l *Loop) runDecision(ctx context.Context, snapshot flags.Snapshot, c gamec
 	// thresholds from this cycle's snapshot, so baseline and follow-up sample the SAME
 	// fitness functions against the SAME thresholds. Off the hot path: a cheap map copy
 	// plus a goroutine + timer (bounded, leak-safe via effectWG + rootCtx).
-	if id := l.scheduleEffectSample(d, state.FitnessEvaluated, fitnessThresholds(snapshot.Fitness)); id != "" {
+	if id := l.scheduleEffectSample(dCtx, c, d, state.FitnessEvaluated, fitnessThresholds(snapshot.Fitness)); id != "" {
 		dSpan.SetAttributes(attribute.String(AttrDecisionInterventionID, id))
 	}
 	// Feed the DISPATCHED outcome into this game's #916 rolling narrative timeline
@@ -1180,32 +1192,12 @@ func (l *Loop) shouldLog() bool {
 // the Link; the caller additionally stamps them as span attributes (see runDecision)
 // so they stay queryable as span tags on backends that don't surface Link attributes.
 func gameTraceLink(gameTraceID, gameTraceSpanID string) []trace.SpanStartOption {
-	if gameTraceID == "" || gameTraceSpanID == "" {
-		return nil
-	}
-	tid, err := trace.TraceIDFromHex(gameTraceID)
-	if err != nil || !tid.IsValid() {
-		return nil
-	}
-	sid, err := trace.SpanIDFromHex(gameTraceSpanID)
-	if err != nil || !sid.IsValid() {
-		return nil
-	}
-	sc := trace.NewSpanContext(trace.SpanContextConfig{
-		TraceID:    tid,
-		SpanID:     sid,
-		TraceFlags: trace.FlagsSampled,
-		Remote:     true,
-	})
-	return []trace.SpanStartOption{
-		trace.WithLinks(trace.Link{
-			SpanContext: sc,
-			Attributes: []attribute.KeyValue{
-				attribute.String(AttrGameTraceID, gameTraceID),
-				attribute.String(AttrGameTraceSpanID, gameTraceSpanID),
-			},
-		}),
-	}
+	// Delegates to the single primitive in gamecontext (#1174): the implementation moved
+	// there so the cycle-independent game-end emitters (gamesummary, which decision
+	// imports and so cannot import back) share the EXACT same Link logic instead of a
+	// replica. The canonical Link attribute keys (AttrGameTraceID / AttrGameTraceSpanID)
+	// are passed through, so the on-wire attributes are unchanged.
+	return gamecontext.TraceLink(gameTraceID, gameTraceSpanID, AttrGameTraceID, AttrGameTraceSpanID)
 }
 
 // GameTraceLink is the exported entry point to the gameTraceLink primitive so other
@@ -1231,6 +1223,10 @@ const (
 	attrLinkKind      = "link.kind"
 	attrLinkTraceID   = "link.trace_id"
 	linkKindFireCycle = "fire_cycle"
+	// linkKindDecision labels the #1174 Link from an agent.intervention.effect span back
+	// to the agent.decision span that caused it, so a reader on the effect span can
+	// navigate to the originating decision (the named "no clue what it relates to" gap).
+	linkKindDecision = "decision"
 )
 
 // fireCycleLink builds the #1140 (Slice A) trace-continuity span option: when the
@@ -1251,6 +1247,29 @@ func fireCycleLink(sc trace.SpanContext) []trace.SpanStartOption {
 			SpanContext: sc,
 			Attributes: []attribute.KeyValue{
 				attribute.String(attrLinkKind, linkKindFireCycle),
+				attribute.String(attrLinkTraceID, sc.TraceID().String()),
+			},
+		}),
+	}
+}
+
+// decisionLink builds the #1174 Link from an agent.intervention.effect span back to its
+// CAUSING agent.decision span. The effect span is emitted on its own backdated root
+// seconds after the decision (the follow-up window), so a Link — not parent-child — is
+// the correct relationship, mirroring fireCycleLink. When the captured decision
+// SpanContext is valid it returns one trace.WithLinks option carrying
+// link.kind=decision plus the decision trace_id as a queryable attribute; an
+// invalid/zero SpanContext (no-op tracer / no active decision span) yields NO option —
+// graceful fallback, no Link, no error.
+func decisionLink(sc trace.SpanContext) []trace.SpanStartOption {
+	if !sc.IsValid() {
+		return nil
+	}
+	return []trace.SpanStartOption{
+		trace.WithLinks(trace.Link{
+			SpanContext: sc,
+			Attributes: []attribute.KeyValue{
+				attribute.String(attrLinkKind, linkKindDecision),
 				attribute.String(attrLinkTraceID, sc.TraceID().String()),
 			},
 		}),

--- a/services/agent/decision/effect.go
+++ b/services/agent/decision/effect.go
@@ -10,6 +10,8 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	otelmetric "go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
+
+	"github.com/joustmania/agent/gamecontext"
 )
 
 // newInterventionID returns a fresh dispatch-unique id used to tie an intervention's
@@ -131,7 +133,7 @@ func (l *Loop) AwaitEffects() { l.effectWG.Wait() }
 // follow-up runs in its own goroutine. Without a context provider (the re-validation
 // source, same as the #917 async path) there is no way to read the game's future
 // signals, so it no-ops — an un-wired Loop is behavior-unchanged.
-func (l *Loop) scheduleEffectSample(d Decision, baselineVals map[string]float64, thresholds FitnessThresholds) string {
+func (l *Loop) scheduleEffectSample(decisionCtx context.Context, c gamecontext.GameContext, d Decision, baselineVals map[string]float64, thresholds FitnessThresholds) string {
 	// No re-validation source => cannot read the future context => nothing to measure.
 	if l.ctxProvider == nil {
 		return ""
@@ -186,6 +188,18 @@ func (l *Loop) scheduleEffectSample(d Decision, baselineVals map[string]float64,
 		thresholds:   thresholds,
 		dispatchedAt: dispatchedAt,
 		window:       window,
+		// Hub-and-spoke correlation (#1174): capture the game-session trace ids from the
+		// GameContext in scope at schedule time, so the deferred effect span can Link back
+		// to the game hub via the SHARED gameTraceLink primitive (same as decision/retro).
+		// nil-safe: empty ids => no Link.
+		gameTraceID:     c.GameTraceID,
+		gameTraceSpanID: c.GameTraceSpanID,
+		// Capture the CAUSING agent.decision span's SpanContext while it is still live
+		// (decisionCtx is the decision span's context — it calls schedule). The effect
+		// span (emitted seconds later on its own root) Links to it with link.kind=decision
+		// so decision->effect is navigable, mirroring fireCycleLink. Invalid SpanContext
+		// (no-op tracer / no active span) => no Link.
+		decisionSC: trace.SpanContextFromContext(decisionCtx),
 	}
 
 	l.effectWG.Add(1)
@@ -234,6 +248,14 @@ type pendingEffect struct {
 	thresholds   FitnessThresholds
 	dispatchedAt time.Time
 	window       time.Duration
+	// gameTraceID/gameTraceSpanID are the game-session trace ids captured at schedule
+	// time (#1174), used to Link the effect span back to the game hub. Empty => no Link.
+	gameTraceID     string
+	gameTraceSpanID string
+	// decisionSC is the SpanContext of the agent.decision span that caused this effect,
+	// captured live at schedule time (#1174). The effect root Links to it with
+	// link.kind=decision. Invalid => no Link.
+	decisionSC trace.SpanContext
 }
 
 // emitEffectSample is the follow-up half (#918): it re-reads the game's CURRENT signals
@@ -249,18 +271,38 @@ func (l *Loop) emitEffectSample(ctx context.Context, s pendingEffect) {
 
 	// One backdated root span (to dispatch time) parents the per-objective effect spans,
 	// so a Jaeger trace shows the dispatch->follow-up arc, mirroring the #917 apply root.
-	rootCtx, root := l.Tracer.Start(ctx, SpanInterventionEffect,
+	//
+	// Hub-and-spoke correlation (#1174): the effect span carries the game.id query axis
+	// AND TWO navigation Links — (a) gameTraceLink to the game-session trace (the hub),
+	// so "what did the agent learn for game X" lists this span among the spokes; (b)
+	// decisionLink to the CAUSING agent.decision span, so the named "no clue what it
+	// relates to" gap is closed. The decision trace_id is ALSO stamped as a plain
+	// attribute (AttrDecisionInterventionID joins decision<->effect by tag; the link
+	// trace_id makes the decision trace itself greppable). Both Links are nil-safe.
+	startOpts := []trace.SpanStartOption{
 		trace.WithTimestamp(s.dispatchedAt),
 		trace.WithSpanKind(trace.SpanKindInternal),
 		trace.WithAttributes(
 			attribute.String(AttrSessionID, l.gameID),
 			attribute.String(AttrGameID, l.gameID),
 			attribute.String(AttrEffectInterventionID, s.id),
+			// Stamp the SAME key the decision span uses (#1174 consistency) so one tag
+			// joins decision<->effect even on backends that don't surface Link attrs.
+			attribute.String(AttrDecisionInterventionID, s.id),
 			attribute.String(AttrEffectIntervention, s.intervention),
 			attribute.String(AttrEffectObjective, s.objective),
 			attribute.Float64(AttrEffectWindowSeconds, windowSeconds),
 		),
-	)
+	}
+	startOpts = append(startOpts, gameTraceLink(s.gameTraceID, s.gameTraceSpanID)...)
+	if s.gameTraceID != "" {
+		startOpts = append(startOpts, trace.WithAttributes(attribute.String(AttrGameTraceID, s.gameTraceID)))
+	}
+	if s.gameTraceSpanID != "" {
+		startOpts = append(startOpts, trace.WithAttributes(attribute.String(AttrGameTraceSpanID, s.gameTraceSpanID)))
+	}
+	startOpts = append(startOpts, decisionLink(s.decisionSC)...)
+	rootCtx, root := l.Tracer.Start(ctx, SpanInterventionEffect, startOpts...)
 	defer root.End()
 
 	if !ok {
@@ -282,7 +324,11 @@ func (l *Loop) emitEffectSample(ctx context.Context, s pendingEffect) {
 		_, span := l.Tracer.Start(rootCtx, SpanInterventionEffect,
 			trace.WithSpanKind(trace.SpanKindInternal),
 			trace.WithAttributes(
+				// game.id + the intervention id on the per-signal child too (#1174), so a
+				// child span found in isolation is still attributable to its game + cause.
+				attribute.String(AttrGameID, l.gameID),
 				attribute.String(AttrEffectInterventionID, s.id),
+				attribute.String(AttrDecisionInterventionID, s.id),
 				attribute.String(AttrEffectIntervention, s.intervention),
 				attribute.String(AttrEffectObjective, s.objective),
 				attribute.String(AttrEffectSignal, key),

--- a/services/agent/decision/effect_test.go
+++ b/services/agent/decision/effect_test.go
@@ -114,6 +114,15 @@ func shieldDecision() Decision {
 	return Decision{Intervention: "grant_shield", ObjectiveServed: ObjectiveEndurance, Reason: "test"}
 }
 
+// schedule is the test wrapper for scheduleEffectSample (#1174 added a leading
+// context + GameContext for hub/decision correlation). It passes a background context
+// (no live decision span) and an EMPTY GameContext (no game-trace ids), so existing
+// behavior assertions are unchanged. Correlation-specific tests call
+// scheduleEffectSample directly with a populated context/GameContext.
+func (l *Loop) schedule(d Decision, baseline map[string]float64, th FitnessThresholds) string {
+	return l.scheduleEffectSample(context.Background(), gamecontext.GameContext{}, d, baseline, th)
+}
+
 // ---- baseline stamp + delta emission ----
 
 func TestEffect_DeltaEmittedAfterWindow(t *testing.T) {
@@ -125,7 +134,7 @@ func TestEffect_DeltaEmittedAfterWindow(t *testing.T) {
 
 	l, sr, reader, sched := effectLoop(t, provider, gameID)
 
-	id := l.scheduleEffectSample(shieldDecision(), enduranceBaseline(), defaultFit())
+	id := l.schedule(shieldDecision(), enduranceBaseline(), defaultFit())
 	if id == "" {
 		t.Fatal("scheduleEffectSample returned empty id; expected a scheduled sample")
 	}
@@ -208,7 +217,7 @@ func TestEffect_AbortedWhenGameEvicted(t *testing.T) {
 
 	l, sr, reader, sched := effectLoop(t, provider, gameID)
 
-	id := l.scheduleEffectSample(shieldDecision(), enduranceBaseline(), defaultFit())
+	id := l.schedule(shieldDecision(), enduranceBaseline(), defaultFit())
 	if id == "" {
 		t.Fatal("expected a scheduled sample")
 	}
@@ -259,7 +268,7 @@ func TestEffect_ShutdownCancelsSamplerNoLeak(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	l.SetRootContext(ctx)
 
-	id := l.scheduleEffectSample(shieldDecision(), enduranceBaseline(), defaultFit())
+	id := l.schedule(shieldDecision(), enduranceBaseline(), defaultFit())
 	if id == "" {
 		t.Fatal("expected a scheduled sample")
 	}
@@ -295,7 +304,7 @@ func TestEffect_PendingSetBounded(t *testing.T) {
 
 	scheduled := 0
 	for i := 0; i < maxPendingEffects+10; i++ {
-		if l.scheduleEffectSample(shieldDecision(), enduranceBaseline(), defaultFit()) != "" {
+		if l.schedule(shieldDecision(), enduranceBaseline(), defaultFit()) != "" {
 			scheduled++
 		}
 	}
@@ -308,7 +317,7 @@ func TestEffect_PendingSetBounded(t *testing.T) {
 
 func TestEffect_NoProviderNoSchedule(t *testing.T) {
 	l := NewLoop(&settableFlags{snap: permissiveEffectSnapshot()}, slog.New(slog.NewTextHandler(io.Discard, nil)))
-	if id := l.scheduleEffectSample(shieldDecision(), enduranceBaseline(), defaultFit()); id != "" {
+	if id := l.schedule(shieldDecision(), enduranceBaseline(), defaultFit()); id != "" {
 		t.Errorf("expected no schedule without a context provider, got id %q", id)
 	}
 }
@@ -316,7 +325,7 @@ func TestEffect_NoProviderNoSchedule(t *testing.T) {
 func TestEffect_NoBaselineNoSchedule(t *testing.T) {
 	provider := newFakeContextProvider()
 	l, _, _, _ := effectLoop(t, provider, "g")
-	if id := l.scheduleEffectSample(shieldDecision(), nil, defaultFit()); id != "" {
+	if id := l.schedule(shieldDecision(), nil, defaultFit()); id != "" {
 		t.Errorf("expected no schedule with an empty baseline, got id %q", id)
 	}
 }

--- a/services/agent/decision/hub_spoke_link_test.go
+++ b/services/agent/decision/hub_spoke_link_test.go
@@ -1,0 +1,234 @@
+package decision
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/joustmania/agent/gamecontext"
+)
+
+// hub_spoke_link_test.go covers the #1174 hub-and-spoke correlation additions: every
+// agent per-game span carries the game.id query axis AND a Link back to the
+// game-session trace (the hub). The intervention.effect span additionally Links to its
+// CAUSING agent.decision span (link.kind=decision). All Links are nil-safe.
+
+const (
+	hubGameTrace  = "4bf92f3577b34da6a3ce929d0e0e4736" // valid 16-byte hex trace id
+	hubGameSpanID = "051581bf3cb55c13"                 // valid 8-byte hex span id
+)
+
+// gameTraceCtx is a GameContext carrying the populated game-session trace ids (#1133).
+func gameTraceCtx(gameID string) gamecontext.GameContext {
+	return gamecontext.GameContext{
+		SessionID:       gameID,
+		GameKind:        "real",
+		GameTraceID:     hubGameTrace,
+		GameTraceSpanID: hubGameSpanID,
+	}
+}
+
+// linkByKind returns the Link on the span whose link.kind attribute equals kind, and
+// whether one was found.
+func linkByKind(links []sdktrace.Link, kind string) (sdktrace.Link, bool) {
+	for _, lk := range links {
+		for _, kv := range lk.Attributes {
+			if string(kv.Key) == attrLinkKind && kv.Value.AsString() == kind {
+				return lk, true
+			}
+		}
+	}
+	return sdktrace.Link{}, false
+}
+
+// rootEffectSpan returns the root agent.intervention.effect span (the one carrying the
+// effect id but NO per-signal key), or nil.
+func rootEffectSpan(spans []sdktrace.ReadOnlySpan) sdktrace.ReadOnlySpan {
+	for _, s := range spans {
+		if s.Name() != SpanInterventionEffect {
+			continue
+		}
+		if _, ok := attrValue(s, AttrEffectSignal); ok {
+			continue // per-signal child
+		}
+		return s
+	}
+	return nil
+}
+
+// TestEffectSpan_LinksToGameTraceAndDecision: when both the game-trace ids AND a live
+// decision span are in scope at schedule time, the emitted intervention.effect root
+// carries (a) the game.id attribute, (b) a game-trace Link (to the hub), and (c) a
+// decision Link (link.kind=decision) to the causing decision span. The per-signal
+// child carries game.id + the intervention id.
+func TestEffectSpan_LinksToGameTraceAndDecision(t *testing.T) {
+	provider := newFakeContextProvider()
+	const gameID = "game_hub01"
+	provider.set(gameID, durationContext(gameID, 90))
+
+	l, sr, _, sched := effectLoop(t, provider, gameID)
+
+	// Open a real decision span so its SpanContext is captured at schedule time.
+	decisionCtx, decisionSpan := l.Tracer.Start(context.Background(), SpanDecision)
+
+	id := l.scheduleEffectSample(decisionCtx, gameTraceCtx(gameID), shieldDecision(), enduranceBaseline(), defaultFit())
+	if id == "" {
+		t.Fatal("expected a scheduled sample")
+	}
+	decisionSpan.End()
+	sched.fire()
+	l.AwaitEffects()
+
+	root := rootEffectSpan(sr.Ended())
+	if root == nil {
+		t.Fatal("no root agent.intervention.effect span")
+	}
+
+	// (a) game.id present.
+	if v, ok := attrValue(root, AttrGameID); !ok || v.AsString() != gameID {
+		t.Errorf("effect root game.id = %q (present=%v), want %q", v.AsString(), ok, gameID)
+	}
+
+	// (b) game-trace Link to the hub.
+	wantTID, _ := trace.TraceIDFromHex(hubGameTrace)
+	wantSID, _ := trace.SpanIDFromHex(hubGameSpanID)
+	var sawGameLink bool
+	for _, lk := range root.Links() {
+		if lk.SpanContext.TraceID() == wantTID && lk.SpanContext.SpanID() == wantSID {
+			sawGameLink = true
+		}
+	}
+	if !sawGameLink {
+		t.Errorf("effect root missing game-trace Link to %s/%s; links=%v", wantTID, wantSID, root.Links())
+	}
+	// Searchable game.trace_id attribute too.
+	if v, ok := attrValue(root, AttrGameTraceID); !ok || v.AsString() != hubGameTrace {
+		t.Errorf("effect root game.trace_id = %q (present=%v), want %q", v.AsString(), ok, hubGameTrace)
+	}
+
+	// (c) decision Link (link.kind=decision) targeting the causing decision span.
+	decLink, ok := linkByKind(root.Links(), linkKindDecision)
+	if !ok {
+		t.Fatal("effect root missing link.kind=decision Link to the causing decision span")
+	}
+	if decLink.SpanContext.TraceID() != decisionSpan.SpanContext().TraceID() {
+		t.Errorf("decision Link trace_id = %s, want %s",
+			decLink.SpanContext.TraceID(), decisionSpan.SpanContext().TraceID())
+	}
+	if decLink.SpanContext.SpanID() != decisionSpan.SpanContext().SpanID() {
+		t.Errorf("decision Link span_id = %s, want %s",
+			decLink.SpanContext.SpanID(), decisionSpan.SpanContext().SpanID())
+	}
+
+	// per-signal child carries game.id + the intervention id (both keys).
+	var sawChild bool
+	for _, s := range sr.Ended() {
+		if s.Name() != SpanInterventionEffect {
+			continue
+		}
+		if _, ok := attrValue(s, AttrEffectSignal); !ok {
+			continue
+		}
+		sawChild = true
+		if v, ok := attrValue(s, AttrGameID); !ok || v.AsString() != gameID {
+			t.Errorf("effect child game.id = %q (present=%v), want %q", v.AsString(), ok, gameID)
+		}
+		if v, ok := attrValue(s, AttrDecisionInterventionID); !ok || v.AsString() != id {
+			t.Errorf("effect child %s = %q (present=%v), want %q", AttrDecisionInterventionID, v.AsString(), ok, id)
+		}
+	}
+	if !sawChild {
+		t.Fatal("no per-signal effect child span")
+	}
+}
+
+// TestEffectSpan_NoLinksWhenIdsAbsent: with an empty GameContext and no live decision
+// span, the effect span carries NO game-trace Link and NO decision Link (graceful
+// nil-safe fallback) — exactly the pre-#1174 shape.
+func TestEffectSpan_NoLinksWhenIdsAbsent(t *testing.T) {
+	provider := newFakeContextProvider()
+	const gameID = "game_nolink"
+	provider.set(gameID, durationContext(gameID, 90))
+
+	l, sr, _, sched := effectLoop(t, provider, gameID)
+
+	// background ctx => invalid SpanContext => no decision Link; empty GameContext => no
+	// game-trace Link.
+	id := l.scheduleEffectSample(context.Background(), gamecontext.GameContext{}, shieldDecision(), enduranceBaseline(), defaultFit())
+	if id == "" {
+		t.Fatal("expected a scheduled sample")
+	}
+	sched.fire()
+	l.AwaitEffects()
+
+	root := rootEffectSpan(sr.Ended())
+	if root == nil {
+		t.Fatal("no root agent.intervention.effect span")
+	}
+	if n := len(root.Links()); n != 0 {
+		t.Errorf("effect root links = %d, want 0 (no ids => no Links); links=%v", n, root.Links())
+	}
+	if _, ok := attrValue(root, AttrGameTraceID); ok {
+		t.Error("effect root carries game.trace_id attr despite empty ids")
+	}
+}
+
+// TestSignalReceived_LinksToGameTrace: the cycle-root agent.signal_received span carries
+// a game-trace Link + the searchable game.trace_id attr when the ids are present, and
+// none when absent (nil-safe).
+func TestSignalReceived_LinksToGameTrace(t *testing.T) {
+	t.Run("present", func(t *testing.T) {
+		l, sr, _ := meteredTestLoop(t)
+		l.Rules = fakeRules{out: []Decision{{Intervention: "noop", Reason: "x"}}}
+		l.Actions = &fakeSink{}
+
+		l.OnEvaluate(context.Background(), gameTraceCtx("game_sig01"),
+			EvalTrigger{Signal: "metrics", T0: time.Now(), RPCService: "svc"})
+
+		root := spansByName(sr.Ended(), SignalReceived)[0]
+		wantTID, _ := trace.TraceIDFromHex(hubGameTrace)
+		var sawLink bool
+		for _, lk := range root.Links() {
+			if lk.SpanContext.TraceID() == wantTID {
+				sawLink = true
+			}
+		}
+		if !sawLink {
+			t.Errorf("signal_received missing game-trace Link; links=%v", root.Links())
+		}
+		if v, ok := attrValue(root, AttrGameTraceID); !ok || v.AsString() != hubGameTrace {
+			t.Errorf("signal_received game.trace_id = %q (present=%v), want %q", v.AsString(), ok, hubGameTrace)
+		}
+	})
+
+	t.Run("absent", func(t *testing.T) {
+		l, sr, _ := meteredTestLoop(t)
+		l.Rules = fakeRules{out: []Decision{{Intervention: "noop", Reason: "x"}}}
+		l.Actions = &fakeSink{}
+
+		l.OnEvaluate(context.Background(), gamecontext.GameContext{SessionID: "s"},
+			EvalTrigger{Signal: "metrics", T0: time.Now(), RPCService: "svc"})
+
+		root := spansByName(sr.Ended(), SignalReceived)[0]
+		if n := len(root.Links()); n != 0 {
+			t.Errorf("signal_received links = %d, want 0 (no ids); links=%v", n, root.Links())
+		}
+	})
+}
+
+// TestDecisionLink_Direct unit-tests the helper in isolation: a valid SpanContext yields
+// one Link option carrying link.kind=decision; an invalid/zero SpanContext yields nil.
+func TestDecisionLink_Direct(t *testing.T) {
+	if got := decisionLink(trace.SpanContext{}); got != nil {
+		t.Errorf("decisionLink(zero) = %v, want nil", got)
+	}
+	tid, _ := trace.TraceIDFromHex(hubGameTrace)
+	sid, _ := trace.SpanIDFromHex(hubGameSpanID)
+	sc := trace.NewSpanContext(trace.SpanContextConfig{TraceID: tid, SpanID: sid, TraceFlags: trace.FlagsSampled})
+	if got := decisionLink(sc); len(got) != 1 {
+		t.Errorf("decisionLink(valid) = %d options, want 1", len(got))
+	}
+}

--- a/services/agent/experiment_loop.go
+++ b/services/agent/experiment_loop.go
@@ -738,6 +738,11 @@ func (e *experimentLoop) scoreGameFitness(gc gamecontext.GameContext, objective 
 	if objective != "" {
 		attrs = append(attrs, attribute.String(decision.AttrExperimentObjective, objective))
 	}
+	// #1174 consistency: stamp the game trace_id as a SEARCHABLE attribute too (retro
+	// has both the Link and the attr; this span only had the Link). Empty => skip.
+	if gc.GameTraceID != "" {
+		attrs = append(attrs, attribute.String(decision.AttrGameTraceID, gc.GameTraceID))
+	}
 	opts := append([]trace.SpanStartOption{trace.WithAttributes(attrs...)}, gameLink...)
 	_, span := e.tracer.Start(context.Background(), decision.SpanExperimentFitness, opts...)
 	defer span.End()
@@ -765,6 +770,10 @@ func (e *experimentLoop) concludeWithSpan(gc gamecontext.GameContext, fitness, d
 	if gc.Arm != "" {
 		attrs = append(attrs, attribute.String(decision.AttrExperimentArm, gc.Arm))
 	}
+	// #1174 consistency: stamp the game trace_id as a searchable attribute too. Empty => skip.
+	if gc.GameTraceID != "" {
+		attrs = append(attrs, attribute.String(decision.AttrGameTraceID, gc.GameTraceID))
+	}
 	opts := append([]trace.SpanStartOption{trace.WithAttributes(attrs...)}, gameLink...)
 	ctx, span := e.tracer.Start(context.Background(), decision.SpanExperimentEvaluate, opts...)
 	defer span.End()
@@ -776,7 +785,7 @@ func (e *experimentLoop) concludeWithSpan(gc gamecontext.GameContext, fitness, d
 	// registry computed, when the conclusion produced one. We READ it back via
 	// CompactView — the registry owns the math; this span only surfaces the result.
 	if err == nil {
-		e.recordVerdictSpan(ctx, gc.ExperimentID)
+		e.recordVerdictSpan(ctx, gc)
 	}
 	return status, err
 }
@@ -787,18 +796,26 @@ func (e *experimentLoop) concludeWithSpan(gc gamecontext.GameContext, fitness, d
 // computes nothing. The span is emitted only when a verdict is actually present
 // (a conclusion that has not yet produced one adds no empty span). The ctx is the
 // experiment.evaluate span's context, so the verdict span nests under it.
-func (e *experimentLoop) recordVerdictSpan(ctx context.Context, experimentID string) {
-	cv, ok := e.registry.CompactView(experimentID)
+func (e *experimentLoop) recordVerdictSpan(ctx context.Context, gc gamecontext.GameContext) {
+	cv, ok := e.registry.CompactView(gc.ExperimentID)
 	if !ok || cv.Verdict == nil {
 		return
 	}
 	v := cv.Verdict
-	_, span := e.tracer.Start(ctx, decision.SpanExperimentVerdict, trace.WithAttributes(
-		attribute.String(decision.AttrExperimentID, experimentID),
+	attrs := []attribute.KeyValue{
+		attribute.String(decision.AttrExperimentID, gc.ExperimentID),
+		// #1174 consistency: stamp game.id + experiment.arm directly on the verdict span
+		// (it previously carried neither) so the verdict is queryable by game and arm
+		// like the sibling experiment spans, and findable for "everything for game X".
+		attribute.String(decision.AttrGameID, gc.SessionID),
 		attribute.String(decision.AttrVerdictOutcome, v.Outcome),
 		attribute.Float64(decision.AttrVerdictDelta, v.Delta),
 		attribute.Bool(decision.AttrVerdictSignificant, v.Significant),
-	))
+	}
+	if gc.Arm != "" {
+		attrs = append(attrs, attribute.String(decision.AttrExperimentArm, gc.Arm))
+	}
+	_, span := e.tracer.Start(ctx, decision.SpanExperimentVerdict, trace.WithAttributes(attrs...))
 	span.End()
 }
 

--- a/services/agent/experiment_spans_test.go
+++ b/services/agent/experiment_spans_test.go
@@ -115,6 +115,11 @@ func TestExperimentSpans_FitnessAndEvaluateEmitted(t *testing.T) {
 	if _, ok := expSpan_attr(fit[0], decision.AttrExperimentFitness); !ok {
 		t.Errorf("experiment.fitness must carry %s", decision.AttrExperimentFitness)
 	}
+	// #1174 consistency: the game trace_id is also a SEARCHABLE span attribute, not only
+	// a Link attribute.
+	if v, ok := expSpan_attr(fit[0], decision.AttrGameTraceID); !ok || v != gameTrace {
+		t.Errorf("experiment.fitness %s = %q, want %q", decision.AttrGameTraceID, v, gameTrace)
+	}
 	assertLinksToTrace(t, fit[0], gameTrace, gameSpan, "experiment.fitness")
 
 	eval := expSpan_findByName(ended, decision.SpanExperimentEvaluate)
@@ -123,6 +128,9 @@ func TestExperimentSpans_FitnessAndEvaluateEmitted(t *testing.T) {
 	}
 	if v, ok := expSpan_attr(eval[0], decision.AttrExperimentStatus); !ok || v == "" {
 		t.Errorf("experiment.evaluate must carry a non-empty %s, got %q", decision.AttrExperimentStatus, v)
+	}
+	if v, ok := expSpan_attr(eval[0], decision.AttrGameTraceID); !ok || v != gameTrace {
+		t.Errorf("experiment.evaluate %s = %q, want %q", decision.AttrGameTraceID, v, gameTrace)
 	}
 	assertLinksToTrace(t, eval[0], gameTrace, gameSpan, "experiment.evaluate")
 }
@@ -150,6 +158,14 @@ func TestExperimentSpans_VerdictEmitted(t *testing.T) {
 	}
 	if v, ok := expSpan_attr(last, decision.AttrExperimentID); !ok || v != expID {
 		t.Errorf("experiment.verdict %s = %q, want %q", decision.AttrExperimentID, v, expID)
+	}
+	// #1174 consistency: the verdict span now stamps game.id + experiment.arm directly
+	// (it previously carried neither), so it is queryable by game/arm like its siblings.
+	if v, ok := expSpan_attr(last, decision.AttrGameID); !ok || v == "" {
+		t.Errorf("experiment.verdict must carry a non-empty %s", decision.AttrGameID)
+	}
+	if v, ok := expSpan_attr(last, decision.AttrExperimentArm); !ok || v == "" {
+		t.Errorf("experiment.verdict must carry a non-empty %s", decision.AttrExperimentArm)
 	}
 	// The verdict span nests under an experiment.evaluate span (shares its trace).
 	evals := expSpan_findByName(ended, decision.SpanExperimentEvaluate)

--- a/services/agent/gamecontext/tracelink.go
+++ b/services/agent/gamecontext/tracelink.go
@@ -1,0 +1,54 @@
+package gamecontext
+
+import (
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// TraceLink builds the game-session-trace correlation span Link (#1133/#1157): when
+// BOTH gameTraceID and gameTraceSpanID are valid hex ids it returns a single
+// trace.WithLinks option whose Link targets a remote SpanContext reconstructed from
+// BOTH ids — so the linking span references the game's ROOT span (Jaeger's uiFind
+// highlights the actual game-start span, #1157) rather than an all-zero span id under
+// the trace. The SpanContext is marked Remote + Sampled. Both ids are stamped as Link
+// attributes under traceIDAttrKey / spanIDAttrKey (the caller passes its own canonical
+// keys so the on-wire attribute names are unchanged across packages).
+//
+// An empty/unparseable trace_id OR span_id yields NO option, so the span is created
+// exactly as before: graceful fallback, no Link, no error. Pre-#1157 emitters (or an
+// unsampled game span) carry an empty span_id and therefore produce no Link — the same
+// as a missing trace_id.
+//
+// This is THE single implementation of the game-trace Link primitive (#1174). It lives
+// in gamecontext because both the decision package and the cycle-independent game-end
+// emitters (gamesummary) need it, and gamecontext is the one package both already
+// import with no dependency cycle. decision.GameTraceLink delegates here, preserving
+// the existing exported entry point (#1165).
+func TraceLink(gameTraceID, gameTraceSpanID, traceIDAttrKey, spanIDAttrKey string) []trace.SpanStartOption {
+	if gameTraceID == "" || gameTraceSpanID == "" {
+		return nil
+	}
+	tid, err := trace.TraceIDFromHex(gameTraceID)
+	if err != nil || !tid.IsValid() {
+		return nil
+	}
+	sid, err := trace.SpanIDFromHex(gameTraceSpanID)
+	if err != nil || !sid.IsValid() {
+		return nil
+	}
+	sc := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    tid,
+		SpanID:     sid,
+		TraceFlags: trace.FlagsSampled,
+		Remote:     true,
+	})
+	return []trace.SpanStartOption{
+		trace.WithLinks(trace.Link{
+			SpanContext: sc,
+			Attributes: []attribute.KeyValue{
+				attribute.String(traceIDAttrKey, gameTraceID),
+				attribute.String(spanIDAttrKey, gameTraceSpanID),
+			},
+		}),
+	}
+}

--- a/services/agent/gamecontext/tracelink_test.go
+++ b/services/agent/gamecontext/tracelink_test.go
@@ -1,0 +1,37 @@
+package gamecontext
+
+import "testing"
+
+const (
+	validTrace  = "4bf92f3577b34da6a3ce929d0e0e4736" // valid 16-byte hex trace id
+	validSpanID = "051581bf3cb55c13"                 // valid 8-byte hex span id
+)
+
+// TestTraceLink covers the single game-trace Link primitive (#1174): a valid
+// (trace,span) pair yields exactly one option; any missing/invalid id yields nil
+// (graceful no-Link fallback, no panic).
+func TestTraceLink(t *testing.T) {
+	cases := []struct {
+		name      string
+		trace     string
+		span      string
+		wantLinks int
+	}{
+		{"valid", validTrace, validSpanID, 1},
+		{"empty trace", "", validSpanID, 0},
+		{"empty span", validTrace, "", 0},
+		{"both empty", "", "", 0},
+		{"invalid trace", "zzzz", validSpanID, 0},
+		{"invalid span", validTrace, "zz", 0},
+		{"all-zero trace", "00000000000000000000000000000000", validSpanID, 0},
+		{"all-zero span", validTrace, "0000000000000000", 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := TraceLink(tc.trace, tc.span, "game.trace_id", "game.trace_span_id")
+			if len(got) != tc.wantLinks {
+				t.Errorf("TraceLink(%q,%q) = %d options, want %d", tc.trace, tc.span, len(got), tc.wantLinks)
+			}
+		})
+	}
+}

--- a/services/agent/gamesummary/coordinator.go
+++ b/services/agent/gamesummary/coordinator.go
@@ -48,6 +48,13 @@ const (
 	attrEngagementPoints  = "summary.engagement_points"
 	attrDominated         = "summary.dominated"
 	attrPath              = "summary.path"
+	// attrGameTraceID / attrGameTraceSpanID are the canonical game-session-trace Link
+	// attribute keys (#1133/#1157), matching decision.AttrGameTraceID /
+	// AttrGameTraceSpanID verbatim so the summary's hub Link (#1174) carries the SAME
+	// attribute names every other agent spoke does. Defined locally (not imported from
+	// decision) because decision imports gamesummary — an import cycle the other way.
+	attrGameTraceID     = "game.trace_id"
+	attrGameTraceSpanID = "game.trace_span_id"
 )
 
 // dedupeWindow bounds the per-game claimed-id LRU. It mirrors the retro's bounded
@@ -149,7 +156,15 @@ func (c *Coordinator) OnGameEnd(gc gamecontext.GameContext) {
 
 	// The span IS the audit of the aggregation (#928 acceptance). It is a standalone
 	// root: there is no inbound RPC context at game end (same as the retro span).
-	_, span := c.tracer.Start(context.Background(), SpanGameSummary)
+	//
+	// Hub-and-spoke correlation (#1174): Link this per-game outcome span back to the
+	// game-session trace (the hub) via the SHARED gamecontext.TraceLink primitive — the
+	// same Link logic retro + decision + experiment.* carry (decision.GameTraceLink
+	// delegates to it) — so "show me everything for game X" lists the summary among the
+	// spokes. The ids come from the OnGameEnd GameContext (#1133 correlation gauge).
+	// nil-safe: empty/invalid ids => no Link, no error.
+	startOpts := gamecontext.TraceLink(gc.GameTraceID, gc.GameTraceSpanID, attrGameTraceID, attrGameTraceSpanID)
+	_, span := c.tracer.Start(context.Background(), SpanGameSummary, startOpts...)
 	defer span.End()
 
 	summary := BuildSummary(gc, BuildOptions{Now: now()})

--- a/services/agent/gamesummary/coordinator_test.go
+++ b/services/agent/gamesummary/coordinator_test.go
@@ -75,6 +75,54 @@ func TestCoordinator_WritesFileAndSpan(t *testing.T) {
 	}
 }
 
+// TestCoordinator_LinksToGameTrace: when the game-session trace ids are present on the
+// ending GameContext (#1133), the agent.game.summary span Links back to the game-session
+// trace (the hub, #1174). nil-safe: with no ids, no Link is added.
+func TestCoordinator_LinksToGameTrace(t *testing.T) {
+	const (
+		gameTrace  = "4bf92f3577b34da6a3ce929d0e0e4736"
+		gameSpanID = "051581bf3cb55c13"
+	)
+
+	t.Run("present", func(t *testing.T) {
+		c, sr, _ := recordingCoordinator(t)
+		snap := representativeGame(t)
+		snap.GameTraceID = gameTrace
+		snap.GameTraceSpanID = gameSpanID
+		c.OnGameEnd(snap)
+
+		spans := spansByName(sr.Ended(), SpanGameSummary)
+		if len(spans) != 1 {
+			t.Fatalf("agent.game.summary spans = %d, want 1", len(spans))
+		}
+		links := spans[0].Links()
+		if len(links) != 1 {
+			t.Fatalf("agent.game.summary links = %d, want 1 (the game-trace hub Link)", len(links))
+		}
+		if got := links[0].SpanContext.TraceID().String(); got != gameTrace {
+			t.Errorf("link trace_id = %s, want %s", got, gameTrace)
+		}
+		if got := links[0].SpanContext.SpanID().String(); got != gameSpanID {
+			t.Errorf("link span_id = %s, want %s", got, gameSpanID)
+		}
+		if !links[0].SpanContext.IsValid() {
+			t.Error("game-trace Link must target a valid SpanContext")
+		}
+	})
+
+	t.Run("absent", func(t *testing.T) {
+		c, sr, _ := recordingCoordinator(t)
+		c.OnGameEnd(representativeGame(t)) // no trace ids set
+		spans := spansByName(sr.Ended(), SpanGameSummary)
+		if len(spans) != 1 {
+			t.Fatalf("agent.game.summary spans = %d, want 1", len(spans))
+		}
+		if n := len(spans[0].Links()); n != 0 {
+			t.Errorf("agent.game.summary links = %d, want 0 (no ids => no Link)", n)
+		}
+	})
+}
+
 // TestCoordinator_RunsForShadowGames: the builder runs for synthetic (shadow)
 // games too (#928 — both real AND shadow).
 func TestCoordinator_RunsForShadowGames(t *testing.T) {


### PR DESCRIPTION
## What

Makes every agent per-game span correlate to the game-session trace (hub-and-spoke): each per-game span now carries BOTH the `game.id` query axis AND a Link to the game-session trace via the existing `decision.GameTraceLink` primitive. Brings the lagging spans up to the bar retro + experiment.* already meet, so "show me everything the agent did + learned for game X" = open the game (hub) trace → its Links panel lists every spoke.

**Observability only** — no change to decision/gating/lifecycle/effect-measurement behavior. Reuses the existing Link primitive; no per-game agent root span (preserves the #917/#1141 non-blocking design). All Links are nil-safe (empty/invalid trace_id or span_id → no Link, no error).

## Per-span additions

| Span | game.id | game-trace Link | other |
|------|---------|-----------------|-------|
| `agent.intervention.effect` (root + per-signal child) | added | added (ids captured into `pendingEffect` at schedule) | **+ Link to causing `agent.decision` span (`link.kind=decision`)** + `game.trace_id`/`game.trace_span_id` attrs + `decision.intervention_id` key |
| `agent.game.summary` | already had | added | — |
| `agent.signal_received` | already had | added | `game.trace_id` attr (pulls sync subtree + #1140 async anchor onto the hub) |
| `agent.llm.infer.call` | added | (already Links to fire cycle → hub) | `session.id` |
| `experiment.fitness` / `experiment.evaluate` | already had | already had | `game.trace_id` searchable attr (had Link only) |
| `experiment.verdict` | added | — | `experiment.arm` |

## How the decision SpanContext was captured for the effect link

`runDecision` already opens the `agent.decision` span and calls `scheduleEffectSample` while that span is live. I threaded the decision span's context (`dCtx`) into `scheduleEffectSample`, captured `trace.SpanContextFromContext(decisionCtx)` into the `pendingEffect` struct at schedule time (alongside the game-trace ids from the in-scope `GameContext`), and added it as a `link.kind=decision` Link at emit time — mirroring the existing `fireCycleLink` pattern. Invalid SpanContext (no-op tracer / no active span) → no Link.

## Consistency cleanups
- Effect span stamps `decision.intervention_id` (the SAME key the decision span uses) in addition to `intervention.id`, so one tag joins decision↔effect.
- `experiment.fitness`/`evaluate` now stamp the searchable `game.trace_id` attr (they built the Link but lacked the attr — retro had both).
- `experiment.verdict` now carries `game.id` + `experiment.arm` directly.

## Single primitive, no replica
The cycle-independent game-end emitter (`gamesummary`) cannot import `decision` (decision imports gamesummary). The Link implementation moved to `gamecontext.TraceLink` (the one package both already import, no cycle); `decision.gameTraceLink`/`GameTraceLink` now delegate to it. No new primitive, no divergent replica — the #1157 span_id=0 protection stays in one place.

## Tests
- effect root carries the game-trace Link AND the decision Link (`kind=decision`) when ids present, NONE when absent; per-signal child carries `game.id` + intervention id
- `game.summary` + `signal_received` Link present/absent
- `infer.call` carries `game.id`
- experiment consistency attrs (`game.trace_id` on fitness/evaluate; `game.id`+`arm` on verdict)
- `gamecontext.TraceLink` + `decisionLink` unit tables (valid/empty/invalid/all-zero)
- **Mutation-checked** the effect + summary Link additions (removing them fails the new tests)

`gofmt -l .` clean, `go build ./...`, `go vet ./...`, `go test ./... -race -count=1` all green.

> [!WARNING]
> This changes trace correlation on MANY spans (effect root + child, summary, signal_received, infer.call, experiment fitness/evaluate/verdict). Please review the Link/attribute additions carefully — though all are additive and observability-only.

Part of #1088, #1140 (completes incl. Slice D), #1174.

🤖 Generated with [Claude Code](https://claude.com/claude-code)