### PR TITLE
fix(agent): demote per-cycle heartbeat logs from INFO to DEBUG

### DIFF
--- a/services/agent/decision/decision.go
+++ b/services/agent/decision/decision.go
@@ -936,7 +936,7 @@ func (l *Loop) captureLLMPrompt(ctx context.Context, snapshot flags.Snapshot, c 
 	_, span := l.Tracer.Start(ctx, SpanLLMPrompt, trace.WithAttributes(attrs...))
 	span.End()
 
-	l.Log.Info("agent.llm.prompt_captured",
+	l.Log.Debug("agent.llm.prompt_captured",
 		"session_id", c.SessionID,
 		"variant", prompt.Variant,
 		"model", prompt.Model,

--- a/services/agent/experiment_loop.go
+++ b/services/agent/experiment_loop.go
@@ -491,7 +491,7 @@ func (e *experimentLoop) allocateIfEnabled(ctx context.Context) {
 	// freshly-Started experiment can accrue games on the same tick.
 	e.declareDynamicIfEnabled(ctx, cfg)
 	if n := e.registry.AllocateAndSpawn(ctx); n > 0 {
-		e.log.Info("experiment: spawned shadow games this tick", "count", n,
+		e.log.Debug("experiment: spawned shadow games this tick", "count", n,
 			"in_flight", e.registry.TotalInFlight(), "capacity", e.registry.Capacity())
 	}
 }

--- a/services/agent/gamerunner/runner.go
+++ b/services/agent/gamerunner/runner.go
@@ -451,7 +451,7 @@ func (r *Runner) StartExperimentGame(startCtx, driveCtx context.Context, spec Sp
 		terminal, _, outcome := r.awaitTerminal(driveCtx, cl, stream, gameID)
 		finalOutcome = outcome
 		stopDrive()
-		r.log.Info("experiment shadow game finished",
+		r.log.Debug("experiment shadow game finished",
 			"game_id", gameID, "run_id", spec.RunID, "experiment_id", spec.ExperimentID,
 			"arm", spec.Arm, "outcome", outcome, "terminal_event", terminal)
 	}()
@@ -492,7 +492,7 @@ func (r *Runner) run(ctx context.Context, cl *clients, spec Spec, span trace.Spa
 		return result, err
 	}
 	result.GameID = gameID
-	r.log.Info("shadow game started", "run_id", spec.RunID, "game_id", gameID, "mode", spec.GameName)
+	r.log.Debug("shadow game started", "run_id", spec.RunID, "game_id", gameID, "mode", spec.GameName)
 
 	// (d) Drive the game to its win condition in the background while (e) we
 	// await the terminal event on the stream.

--- a/services/agent/shadow_spawner.go
+++ b/services/agent/shadow_spawner.go
@@ -117,7 +117,7 @@ func (s *shadowSpawner) Spawn(ctx context.Context, experimentID, arm string, see
 		}
 		return "", fmt.Errorf("shadow spawn for experiment %s arm %s: %w", experimentID, arm, err)
 	}
-	s.log.Info("experiment: shadow game spawned",
+	s.log.Debug("experiment: shadow game spawned",
 		"experiment_id", experimentID, "arm", arm, "seed", seed, "game_id", gameID, "run_id", runID)
 	return gameID, nil
 }


### PR DESCRIPTION
Part of #1173 (reduce filelog volume at the source).

## What

The agent's logger defaults to `LOG_LEVEL=info` (`main.go:461-463`, `slog.HandlerOptions{Level: level}`), so DEBUG lines are filtered out at the default prod level. Demoting per-shadow-game / per-tick HEARTBEAT logs to DEBUG therefore genuinely stops them reaching stdout/filelog in production, cutting the high-volume source the collector's filelog receiver scrapes.

Logging-level changes ONLY — no logic, message-content, or span-emission changes.

## Lines lowered INFO -> DEBUG (heartbeats / snapshots, not discrete events)

| File:line | msg string | why it is a heartbeat |
|---|---|---|
| `decision/decision.go:939` | `agent.llm.prompt_captured` | per-cycle prompt snapshot; shares the same throttle slot as `agent.evaluate` (decision.go:551) |
| `shadow_spawner.go:120` | `experiment: shadow game spawned` | per-shadow-game spawn |
| `gamerunner/runner.go:495` | `shadow game started` | per-shadow-game (pairs with spawn) |
| `gamerunner/runner.go:454` | `experiment shadow game finished` | per-shadow-game; the discrete record is `experiment.game_concluded` in registry.go |
| `experiment_loop.go:494` | `experiment: spawned shadow games this tick` | explicitly per-tick |

## `agent.evaluate` intentionally KEPT at INFO (review #1176 catch)

The first revision also demoted `agent.evaluate` (decision.go:558). A PR review found this breaks two live consumers, so it has been **reverted to INFO**:

- `tests/integration/test_experiment_cohort_loop.py::test_inference_absent_degrades_to_rules` — a live (non-xfail) CI gate that runs the agent container at `LOG_LEVEL=info` and polls `docker logs` for `mode=rules`. `agent.evaluate` (which renders `mode=<snapshot.Mode>`) is the SOLE INFO emitter of that field on the rules-degradation path; demoting it would time the test out at the default level.
- `tools/demo/validation_harness.py` (`_RE_EVALUATE = agent\.evaluate.*?mode=(\w+)`) parses the same line from `docker logs` for the M5 demo.

`agent.evaluate` is already `shouldLog()`-throttled (at most one line per throttle interval), so it is the most bounded of the candidates and acceptable to keep at INFO. None of the five remaining demoted strings are referenced by any integration test or the demo harness (verified by grep over `tests/` and `tools/`).

## Kept at INFO (discrete, valuable events — confirmed NOT demoted)

- `agent.evaluate` (see above)
- Experiment lifecycle: `experiment.declared` / `.started` / `.game_assigned` / `.game_concluded` / `.game_released` / `.concluded` / `.terminated_inconclusive` / `.torn_down` / `.target_n_reconciled` (registry.go)
- Backend selection (#1048) `Inference backend selected`, pre-warm (#1130) `Inference pre-warm *`
- Promotion / safety-net: `code_improvement.promoted`, autonomous re-watch outcomes, `agent.rollout_expand`
- `agent.llm.system_prompt_ref` — deduped once-per-distinct-fingerprint, not per-cycle
- `synthetic run: shadow validation batch complete` (per-batch), `swept orphaned shadow-game controllers` (only when removals > 0), one-shot CLI shadow path in `main.go` — all low-volume, kept
- All WARN / ERROR untouched

## Verify

`cd services/agent && gofmt -l . && go build ./... && go vet ./... && go test ./... -race -count=1` — all green; gofmt clean. No Go test asserts the demoted strings. The integration gate that polls `mode=rules` is preserved by keeping `agent.evaluate` at INFO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)