### PR TITLE
fix(agent,telemetry): cut infra observe latency + reconcile stale rollout observations

### DIFF
--- a/lib/telemetry.py
+++ b/lib/telemetry.py
@@ -35,6 +35,11 @@ from lib.otel_resource import get_otel_resource
 
 logger = logging.getLogger(__name__)
 
+# Fail-open default for the BSP flush delay (#828). The OpenTelemetry Python SDK
+# default is 5000ms; we keep that as the safe fallback so telemetry init behaves
+# exactly as before whenever the flagd read below is unavailable.
+_DEFAULT_BSP_SCHEDULE_DELAY_MS = 5000
+
 # Lazy initialization state
 _initialized = False
 _init_lock = threading.Lock()
@@ -85,6 +90,53 @@ class SpanAttr:
     VALIDATION_REASON = "validation.reason"
 
 
+def _get_bsp_schedule_delay_ms(service_name: str) -> int:
+    """Read the BSP flush delay from flagd, per-service, fail-open (#828).
+
+    The agent observes ``controller.bluetooth_health`` spans 8-16s late because
+    the BatchSpanProcessor's default flush (~5s) compounds with the collector
+    traces batch. This makes the flush delay a flagd flag with PER-SERVICE
+    TARGETING so controller-manager can flush faster (lower rollout-health
+    observe latency) while other services keep the conservative default.
+
+    READ-ONCE-AT-INIT: the SDK fixes schedule_delay at BatchSpanProcessor
+    construction, so this is read exactly once during telemetry init and never
+    re-tuned live (mirrors lib/otel_metrics._get_export_interval_ms).
+
+    FAIL-OPEN: telemetry init runs very early in service startup, before flagd
+    is guaranteed reachable. This MUST NOT break or block telemetry — on ANY
+    error (provider not ready, missing flag, evaluation error, non-numeric
+    value) it returns the safe SDK-equivalent default. The flagd client itself
+    is fail-open with a bounded internal deadline, so an unreachable flagd
+    resolves to the supplied default rather than hanging.
+
+    The ``feature_flags`` import is done lazily INSIDE this function on purpose:
+    ``lib.feature_flags`` -> ``lib.flag_eval_visibility`` -> ``lib.otel_metrics``,
+    so a module-level import here would risk an import cycle through the
+    telemetry/metrics shared libs. Mirrors otel_metrics._get_export_interval_ms.
+    """
+    try:
+        from openfeature.evaluation_context import EvaluationContext
+
+        from lib.feature_flags import get_flag_client, init_flag_domain
+
+        init_flag_domain("observability")
+        client = get_flag_client("observability")
+        delay = client.get_integer_value(
+            "otel_bsp_schedule_delay_millis",
+            _DEFAULT_BSP_SCHEDULE_DELAY_MS,
+            EvaluationContext(attributes={"service": service_name}),
+        )
+        logger.info(f"otel_bsp_schedule_delay_millis from flagd: {delay}ms (service={service_name})")
+        return delay
+    except Exception as e:
+        logger.warning(
+            f"Failed to read otel_bsp_schedule_delay_millis from flagd, "
+            f"using default {_DEFAULT_BSP_SCHEDULE_DELAY_MS}ms: {e}"
+        )
+        return _DEFAULT_BSP_SCHEDULE_DELAY_MS
+
+
 def _do_init() -> None:
     """Perform actual OpenTelemetry initialization from env vars (internal)."""
     otlp_endpoint = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")
@@ -92,9 +144,11 @@ def _do_init() -> None:
 
     resource = get_otel_resource()
 
+    schedule_delay_ms = _get_bsp_schedule_delay_ms(service_name)
+
     provider = TracerProvider(resource=resource)
     otlp_exporter = OTLPSpanExporter(endpoint=otlp_endpoint, insecure=True)
-    provider.add_span_processor(BatchSpanProcessor(otlp_exporter))
+    provider.add_span_processor(BatchSpanProcessor(otlp_exporter, schedule_delay_millis=schedule_delay_ms))
 
     trace.set_tracer_provider(provider)
 

--- a/lib/tests/test_telemetry.py
+++ b/lib/tests/test_telemetry.py
@@ -3,7 +3,7 @@
 import os
 import sys
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -132,6 +132,45 @@ class TestInitTelemetry:
 
         tracer = init_telemetry()
         assert isinstance(tracer, trace.Tracer)
+
+
+class TestGetBspScheduleDelay:
+    """Tests for _get_bsp_schedule_delay_ms (#828): per-service flagd read, fail-open."""
+
+    def test_fail_open_default_when_flagd_unavailable(self):
+        """flagd unreachable / any error → safe SDK-equivalent default, never raises."""
+        with patch("lib.feature_flags.init_flag_domain", side_effect=RuntimeError("flagd down")):
+            delay = telemetry_module._get_bsp_schedule_delay_ms("controller-manager-service")
+        assert delay == telemetry_module._DEFAULT_BSP_SCHEDULE_DELAY_MS
+
+    def test_reads_per_service_value_from_flagd(self):
+        """Success path: the resolved per-service flag value is returned."""
+        fake_client = MagicMock()
+        fake_client.get_integer_value.return_value = 500
+        with (
+            patch("lib.feature_flags.init_flag_domain"),
+            patch("lib.feature_flags.get_flag_client", return_value=fake_client),
+        ):
+            delay = telemetry_module._get_bsp_schedule_delay_ms("controller-manager-service")
+        assert delay == 500
+        # The service identity must reach the eval context as the "service" attribute
+        # so flagd targeting resolves per service.
+        ctx = fake_client.get_integer_value.call_args.args[2]
+        assert ctx.attributes.get("service") == "controller-manager-service"
+
+    def test_do_init_passes_schedule_delay_to_bsp(self):
+        """_do_init must wire the resolved delay into the BatchSpanProcessor."""
+        with (
+            patch.object(telemetry_module, "_get_bsp_schedule_delay_ms", return_value=500) as mock_get,
+            patch.object(telemetry_module, "BatchSpanProcessor") as mock_bsp,
+            patch.object(telemetry_module, "OTLPSpanExporter"),
+            patch.object(telemetry_module, "TracerProvider"),
+            patch.object(telemetry_module, "get_otel_resource"),
+            patch.object(telemetry_module.trace, "set_tracer_provider"),
+        ):
+            telemetry_module._do_init()
+        mock_get.assert_called_once()
+        assert mock_bsp.call_args.kwargs["schedule_delay_millis"] == 500
 
 
 class TestEnsureInitialized:

--- a/services/agent/decision/infra_loop.go
+++ b/services/agent/decision/infra_loop.go
@@ -176,8 +176,25 @@ type InfraLoop struct {
 	// the locked decide path). Kept as a settable seam for tests.
 	holdExpansion func(now time.Time) bool
 
+	// observeStaleness, when > 0, makes the loop skip acting on an InfraContext
+	// snapshot whose UpdatedAt is older than this bound (the observation predates
+	// the freshness window). GRACEFUL on a zero/absent UpdatedAt: an unset
+	// timestamp (test helpers, an older producer) must NOT block action, so the
+	// guard only fires when UpdatedAt is non-zero AND too old. Zero disables it.
+	observeStaleness time.Duration
+
 	mu            sync.Mutex
 	lastExpansion time.Time
+	// lastWritten is the controller-count VALUE the loop last advanced the rollout
+	// TO (the stage of the last successful expand, or 0 after a rollback). It makes
+	// expansion correctness independent of the dwell-vs-observe-latency race (#828):
+	// after an expand the observed RolloutCount lags for the full observe latency, so
+	// re-reading NextStage(stale_stage) would re-write the SAME stage (a double-write)
+	// if the dwell happens to be shorter than that latency. The loop only expands once
+	// the observation has CAUGHT UP (observed stage >= lastWritten); until then the
+	// just-written stage is in flight and re-writing it is suppressed. Zero means
+	// "nothing written yet", so the first expansion is never blocked.
+	lastWritten int
 	// cooldownUntil is the wall-clock time until which re-expansion is suppressed
 	// after a rollback. Zero = no cooldown. In-memory only (process restart clears
 	// it, which is the demo reset path).
@@ -269,6 +286,16 @@ func (l *InfraLoop) SetGate(g func(snap infracontext.InfraContext, now time.Time
 	}
 }
 
+// SetObserveStaleness sets the freshness bound (#828): an InfraContext snapshot
+// whose UpdatedAt is older than d is skipped (the observation predates the
+// freshness window). d <= 0 disables the guard (the default). The guard is always
+// graceful on a zero/absent UpdatedAt — an unset timestamp never blocks action.
+func (l *InfraLoop) SetObserveStaleness(d time.Duration) {
+	l.mu.Lock()
+	l.observeStaleness = d
+	l.mu.Unlock()
+}
+
 // OnInfraEvaluate runs one rollout-expansion decision cycle. See InfraLoop's doc
 // for the decision matrix. Safe for concurrent use.
 func (l *InfraLoop) OnInfraEvaluate(ctx context.Context, snap infracontext.InfraContext) {
@@ -277,6 +304,14 @@ func (l *InfraLoop) OnInfraEvaluate(ctx context.Context, snap infracontext.Infra
 	// (1) Gate: no fresh controllers → nothing to observe, no span (PR G may
 	// revisit emitting an "idle" span).
 	if l.gate != nil && !l.gate(snap, now) {
+		return
+	}
+
+	// (1b) Freshness guard (#828): skip acting on an observation older than the
+	// configured bound. GRACEFUL on an absent timestamp — a zero UpdatedAt (test
+	// helpers default it to zero; an older producer may omit it) must NOT block
+	// action, so the guard only fires when UpdatedAt is non-zero AND too old.
+	if l.observeStaleness > 0 && !snap.UpdatedAt.IsZero() && now.Sub(snap.UpdatedAt) > l.observeStaleness {
 		return
 	}
 
@@ -326,13 +361,14 @@ func (l *InfraLoop) OnInfraEvaluate(ctx context.Context, snap infracontext.Infra
 	case fit.Evaluated && fit.Passing:
 		// Fitness passes → climb the ladder if eligible (PR E expansion).
 		if l.rollout != nil {
-			if variant, value, ok := l.rollout.NextStage(stage); ok && l.shouldExpandLocked(now) {
+			if variant, value, ok := l.rollout.NextStage(stage); ok && l.shouldExpandLocked(now, stage) {
 				action = RemediationExpand
 				expandedTo = value
 				wroteVariant = variant
 				writeErr = l.rollout.SetControllerCount(variant)
 				if writeErr == nil {
 					l.lastExpansion = now
+					l.lastWritten = value
 				}
 			}
 		}
@@ -360,6 +396,9 @@ func (l *InfraLoop) OnInfraEvaluate(ctx context.Context, snap infracontext.Infra
 			if writeErr == nil {
 				l.rollbackInFlight = true
 				l.cooldownUntil = now.Add(l.cooldown)
+				// Reset the reconcile anchor: the rollout was reset to none(0), so the
+				// next expansion is gated on the observation returning to 0 (#828).
+				l.lastWritten = rolloutStageNoneValue
 			}
 		default:
 			// Active stage but rollback NOT allowed → recommend only (span, no write).
@@ -372,15 +411,29 @@ func (l *InfraLoop) OnInfraEvaluate(ctx context.Context, snap infracontext.Infra
 	l.emitDecisionSpan(ctx, now, snap, fit, target, stage, action, expandedTo, wroteVariant, writeErr)
 }
 
-// shouldExpandLocked is the expansion guard: the dwell since the last expansion
-// must have elapsed AND no hold may be in force. Caller holds mu.
+// shouldExpandLocked is the expansion guard: the observation must have caught up
+// to the last write, the dwell since the last expansion must have elapsed, AND no
+// hold may be in force. Caller holds mu; observedStage is the rollout count read
+// off this cycle's health span.
 //
+//   - reconcile (#828): the observed stage must be >= the value we last wrote
+//     (lastWritten). After an expand the observed RolloutCount lags for the full
+//     observe latency, so re-reading NextStage(stale_stage) would re-write the
+//     SAME stage if the dwell is shorter than that latency. Suppressing expansion
+//     until the observation catches up makes correctness independent of the
+//     dwell-vs-latency race — it no longer relies on the dwell exceeding latency.
+//     lastWritten zero (never written) never blocks the first expansion.
 //   - dwell: fitness needs time to observe each new stage before we add more
 //     controllers. lastExpansion zero (never expanded) passes the dwell check so
 //     the first expansion is not delayed.
 //   - holdExpansion: PR F's post-rollback cooldown — true while now is before
 //     cooldownUntil, blocking re-expansion for a window after a rollback.
-func (l *InfraLoop) shouldExpandLocked(now time.Time) bool {
+func (l *InfraLoop) shouldExpandLocked(now time.Time, observedStage int) bool {
+	if observedStage < l.lastWritten {
+		// The observation has not yet caught up to the stage we already wrote — the
+		// last expansion is still in flight. Acting now would re-write the same stage.
+		return false
+	}
 	if !l.lastExpansion.IsZero() && now.Sub(l.lastExpansion) < l.dwell {
 		return false
 	}

--- a/services/agent/decision/infra_loop_test.go
+++ b/services/agent/decision/infra_loop_test.go
@@ -389,6 +389,126 @@ func TestInfraLoop_HoldExpansionSuppresses(t *testing.T) {
 	}
 }
 
+// TestInfraLoop_ReconcileSuppressesDoubleWrite is the #828 guarantee: after an
+// expansion the observed RolloutCount lags for the full observe latency. With a
+// dwell SHORTER than that latency, a naive loop would re-read NextStage(stale=0)
+// and re-write the SAME stage ("one") a second time. The reconcile guard
+// suppresses the expansion until the observation catches up to what we wrote.
+func TestInfraLoop_ReconcileSuppressesDoubleWrite(t *testing.T) {
+	clock := time.Unix(1000, 0)
+	rollout := &fakeRollout{}
+	l, sr := newInfraLoop(t, rollout, &clock)
+	// Short dwell so the dwell timer is NOT the thing blocking the re-expand — the
+	// reconcile guard must carry correctness on its own.
+	l.dwell = time.Second
+
+	// First expansion: none(0) → one. lastWritten is now 1.
+	l.OnInfraEvaluate(context.Background(), infraSnap("rust", 0, clock, 30))
+	if got := rollout.calls(); len(got) != 1 || got[0] != "one" {
+		t.Fatalf("writes = %v, want [one]", got)
+	}
+
+	// Dwell elapses, but the observed stage is STILL the stale 0 (observation
+	// lagging). Without the reconcile guard NextStage(0)=one would be re-written.
+	clock = clock.Add(2 * time.Second)
+	l.OnInfraEvaluate(context.Background(), infraSnap("rust", 0, clock, 30))
+	if got := rollout.calls(); len(got) != 1 {
+		t.Fatalf("writes = %v, want only the first expansion (reconcile suppresses double-write)", got)
+	}
+
+	// Observation catches up to stage one(1): the loop may now expand one → three.
+	clock = clock.Add(2 * time.Second)
+	l.OnInfraEvaluate(context.Background(), infraSnap("rust", 1, clock, 30))
+	if got := rollout.calls(); len(got) != 2 || got[1] != "three" {
+		t.Fatalf("writes = %v, want [one three] once observation caught up", got)
+	}
+	if n := len(infraSpans(sr)); n != 3 {
+		t.Errorf("got %d spans, want 3 (one per active cycle)", n)
+	}
+}
+
+// TestInfraLoop_ProgressiveClimbsOnFreshObservation confirms the reconcile guard
+// does NOT block the normal climb: each cycle the observation reflects the prior
+// write, so the ladder advances none→one→three→six as observed stages catch up.
+func TestInfraLoop_ProgressiveClimbsOnFreshObservation(t *testing.T) {
+	clock := time.Unix(1000, 0)
+	rollout := &fakeRollout{}
+	l, _ := newInfraLoop(t, rollout, &clock)
+	l.dwell = time.Second
+
+	stages := []int{0, 1, 3, 6}
+	wantWrites := []string{"one", "three", "six", "all"}
+	for i, stage := range stages {
+		clock = clock.Add(2 * time.Second) // exceed dwell each cycle
+		l.OnInfraEvaluate(context.Background(), infraSnap("rust", stage, clock, 30))
+		if got := rollout.calls(); len(got) != i+1 {
+			t.Fatalf("after observing stage %d, writes = %v, want %d total", stage, got, i+1)
+		}
+	}
+	if got := rollout.calls(); len(got) != len(wantWrites) {
+		t.Fatalf("writes = %v, want %v", got, wantWrites)
+	}
+	for i, w := range wantWrites {
+		if rollout.calls()[i] != w {
+			t.Fatalf("write[%d] = %q, want %q", i, rollout.calls()[i], w)
+		}
+	}
+}
+
+// TestInfraLoop_StaleObservationSkipped checks the optional freshness guard:
+// an observation older than the configured bound is skipped (no write, no span).
+func TestInfraLoop_StaleObservationSkipped(t *testing.T) {
+	clock := time.Unix(1000, 0)
+	rollout := &fakeRollout{}
+	l, sr := newInfraLoop(t, rollout, &clock)
+	l.SetObserveStaleness(3 * time.Second)
+
+	snap := infraSnap("rust", 0, clock, 30)
+	snap.UpdatedAt = clock.Add(-10 * time.Second) // observed 10s ago, beyond the 3s bound
+	l.OnInfraEvaluate(context.Background(), snap)
+
+	if got := rollout.calls(); len(got) != 0 {
+		t.Fatalf("writes = %v, want none (stale observation skipped)", got)
+	}
+	if n := len(infraSpans(sr)); n != 0 {
+		t.Fatalf("got %d spans, want 0 (stale observation skipped before span)", n)
+	}
+}
+
+// TestInfraLoop_AbsentTimestampNotBlocked is the graceful-default guarantee: a
+// zero/absent UpdatedAt (test helpers, an older producer) must NOT block action
+// even when the freshness guard is enabled.
+func TestInfraLoop_AbsentTimestampNotBlocked(t *testing.T) {
+	clock := time.Unix(1000, 0)
+	rollout := &fakeRollout{}
+	l, _ := newInfraLoop(t, rollout, &clock)
+	l.SetObserveStaleness(3 * time.Second)
+
+	// infraSnap leaves UpdatedAt zero; the guard must treat it as "behave as before".
+	l.OnInfraEvaluate(context.Background(), infraSnap("rust", 0, clock, 30))
+
+	if got := rollout.calls(); len(got) != 1 || got[0] != "one" {
+		t.Fatalf("writes = %v, want [one] (absent timestamp must not block action)", got)
+	}
+}
+
+// TestInfraLoop_FreshObservationActedOn confirms a within-bound observation is
+// acted on when the freshness guard is enabled.
+func TestInfraLoop_FreshObservationActedOn(t *testing.T) {
+	clock := time.Unix(1000, 0)
+	rollout := &fakeRollout{}
+	l, _ := newInfraLoop(t, rollout, &clock)
+	l.SetObserveStaleness(3 * time.Second)
+
+	snap := infraSnap("rust", 0, clock, 30)
+	snap.UpdatedAt = clock.Add(-1 * time.Second) // within the 3s bound
+	l.OnInfraEvaluate(context.Background(), snap)
+
+	if got := rollout.calls(); len(got) != 1 || got[0] != "one" {
+		t.Fatalf("writes = %v, want [one] (fresh observation acted on)", got)
+	}
+}
+
 func TestInfraLoop_NilActuatorNeverExpands(t *testing.T) {
 	clock := time.Unix(1000, 0)
 	l, sr := newInfraLoop(t, nil, &clock)

--- a/services/flagd/ci/observability.json
+++ b/services/flagd/ci/observability.json
@@ -19,6 +19,28 @@
         "disabled": false
       },
       "defaultVariant": "enabled"
+    },
+    "otel_bsp_schedule_delay_millis": {
+      "state": "ENABLED",
+      "variants": {
+        "fast": 500,
+        "default": 5000
+      },
+      "defaultVariant": "default",
+      "targeting": {
+        "if": [
+          {
+            "==": [
+              {
+                "var": "service"
+              },
+              "controller-manager-service"
+            ]
+          },
+          "fast",
+          null
+        ]
+      }
     }
   }
 }

--- a/services/flagd/observability.json
+++ b/services/flagd/observability.json
@@ -33,6 +33,28 @@
         "disabled": false
       },
       "defaultVariant": "enabled"
+    },
+    "otel_bsp_schedule_delay_millis": {
+      "state": "ENABLED",
+      "variants": {
+        "fast": 500,
+        "default": 5000
+      },
+      "defaultVariant": "default",
+      "targeting": {
+        "if": [
+          {
+            "==": [
+              {
+                "var": "service"
+              },
+              "controller-manager-service"
+            ]
+          },
+          "fast",
+          null
+        ]
+      }
     }
   }
 }

--- a/services/otel-collector/config.yaml
+++ b/services/otel-collector/config.yaml
@@ -151,6 +151,19 @@ processors:
     timeout: 100ms
     send_batch_size: 1000
 
+  # Traces batch processor (#828): a shorter timeout than the shared `batch`
+  # so the SECOND hop of the agent observe path (collector → otlp/agent) flushes
+  # sooner. Combined with the lower controller-manager BSP flush (per-service
+  # observability flag), this cuts the controller.bluetooth_health observe
+  # latency the rollout loop reacts to. Smaller, sooner trace batches also lower
+  # the collector's peak heap held by the traces pipeline (synergy with the
+  # #1167/#1173 memory work — the memory_limiter envelope is untouched). The
+  # logs/filelog pipelines keep the shared `batch` (5s) unchanged.
+  batch/traces:
+    timeout: 2s
+    send_batch_size: 512
+    send_batch_max_size: 1024
+
   # Memory limiter to prevent OOM (#1155).
   #
   # ROOT CAUSE of the exit-137 OOM-kills: limit_mib (512) was set ABOVE the
@@ -321,7 +334,7 @@ service:
     # Traces pipeline
     traces:
       receivers: [otlp]
-      processors: [memory_limiter, batch, resource]
+      processors: [memory_limiter, batch/traces, resource]
       exporters: [otlp/jaeger, otlp/agent, debug]
 
     # Metrics pipeline - uses fast batch processor for sub-second updates


### PR DESCRIPTION
Part of #828.

## Problem
The agent observed `controller.bluetooth_health` spans 8-16s after the window they describe: the Python BSP default flush (~5s, `lib/telemetry.py`) compounded with the collector traces `batch.timeout` (5s). The rollout loop's correctness leaned on `AGENT_ROLLOUT_DWELL_SECONDS` (15s) exceeding that observe latency — a shorter dwell + lagging observed `rollout_count` would double-write the same stage.

## Changes

### Part 1 — BSP flush as a per-service flagd flag
- New flag `otel_bsp_schedule_delay_millis` in the **observability** domain (`services/flagd/observability.json` + `ci/observability.json`), variants `fast=500` / `default=5000`, targeting on the `service` context attribute: **controller-manager-service → 500ms**, all others → **5000ms**. Mirrors the existing `metrics_export_interval_ms` per-service pattern in the same file.
- `lib/telemetry.py`: at telemetry init `_get_bsp_schedule_delay_ms(service_name)` reads the flag with `{"service": OTEL_SERVICE_NAME}` in the eval context and passes it as `schedule_delay_millis` to the `BatchSpanProcessor`.
  - **Read-once-at-init**: the SDK fixes the schedule delay at construction; no live re-tune.
  - **Fail-open**: any error (flagd unreachable/missing flag/non-numeric) returns the safe SDK-equivalent default (5000ms). Telemetry never breaks or blocks on flagd.
  - **Import-cycle avoidance**: `feature_flags` is imported *lazily inside* the reader (the chain `feature_flags → flag_eval_visibility → otel_metrics` would otherwise risk a cycle), exactly as `otel_metrics._get_export_interval_ms` does.

### Part 1b — collector traces batch (config)
- Dedicated `batch/traces` processor (timeout **2s**) for the traces pipeline only; logs/filelog pipelines keep the shared `batch` (5s) unchanged. `memory_limiter` envelope untouched. Smaller/sooner trace batches also lower collector peak heap (synergy with #1167/#1173).

### Part 2 — reconcile stale rollout observations (`services/agent/decision/infra_loop.go`)
- Track `lastWritten` (the controller-count value the loop last advanced TO). `shouldExpandLocked` now skips expansion while the observed stage hasn't caught up (`observedStage < lastWritten`), so re-expansion no longer depends on the dwell-vs-latency race. Reset to 0 on rollback.
- Optional freshness guard `SetObserveStaleness(d)`: skip observations older than `d` (`snap.UpdatedAt` vs now), **graceful on a zero/absent UpdatedAt** (never blocks action). Disabled by default.
- off/progressive/immediate (#829) semantics intact.

## Tests
- Python: `lib/tests/test_telemetry.py` — fail-open default path, success path (service in eval context), `_do_init` wires `schedule_delay_millis`. game_coordinator (1185) + controller_manager (688) suites pass; telemetry init works with and without flagd reachable.
- Go: new `infra_loop_test.go` cases — reconcile suppresses double-write under a short dwell, ladder still climbs on fresh observations, stale-observation skipped, absent-timestamp not blocked, fresh observation acted on. `gofmt`/`go build`/`go vet`/`go test -race` all green.
- flagd JSON + collector YAML validated.

## Review note
Please pay particular attention to the telemetry-init flagd read ordering — it runs early in startup; the lazy import + fail-open default are the load-bearing safety properties.

🤖 Generated with [Claude Code](https://claude.com/claude-code)