### PR TITLE
feat(agent): wire retro to call the LLM + capture its conclusion (#1179)

### DIFF
--- a/services/agent/decision/prompt_fingerprint.go
+++ b/services/agent/decision/prompt_fingerprint.go
@@ -62,6 +62,14 @@ func systemPromptSHA(system string) string {
 	return fmt.Sprintf("%x", sha256.Sum256([]byte(system)))[:systemPromptSHALen]
 }
 
+// responseSHA returns the short hex fingerprint of an LLM raw RESPONSE (#1169/#1179),
+// the same scheme systemPromptSHA uses for prompts: the first systemPromptSHALen hex
+// chars of the SHA-256 digest. It is stamped on the span as llm.retro.response_sha256
+// in place of the full raw text; the once-per-hash reference log resolves it.
+func responseSHA(raw string) string {
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(raw)))[:systemPromptSHALen]
+}
+
 // capUserPrompt bounds the user-prompt text emitted on a span to maxUserPromptBytes,
 // appending userPromptTruncatedMarker when it has to cut. The content is preserved
 // up to the bound — the user prompt is the variable reasoning input we keep (#1168),
@@ -124,3 +132,43 @@ var systemPromptRef = &systemPromptReference{}
 // that assert the once-per-fingerprint emission semantics and must start from a
 // clean slate (the singleton otherwise persists across tests in one binary).
 func resetSystemPromptRef() { systemPromptRef = &systemPromptReference{} }
+
+// retroResponseReference emits the analyst's full RAW reply text exactly ONCE per
+// distinct fingerprint for the process lifetime (#1179), the response counterpart of
+// systemPromptReference. The agent.llm.retro span carries only response_sha256; this
+// carries the full text the hash maps to, on a dedicated LOG line (the OOM is the
+// TRACES pipeline — keep the big recorded-only text off it). On first sight of a hash
+// the full text is logged; subsequent sights are no-ops.
+type retroResponseReference struct {
+	// seen maps a response fingerprint -> struct{} once it has been logged.
+	seen sync.Map
+}
+
+// emit logs the full raw response on the dedicated reference line the FIRST time it
+// sees a given fingerprint, and is a no-op on every subsequent sight. It returns true
+// when it actually emitted (first sight), which tests use to assert the once-per-hash
+// semantics. The log carries the hash, the session id (so a reply is attributable),
+// and the full raw text. A nil log uses slog.Default so the reference is never dropped.
+func (r *retroResponseReference) emit(log *slog.Logger, hash, sessionID, raw string) bool {
+	if _, loaded := r.seen.LoadOrStore(hash, struct{}{}); loaded {
+		return false // already emitted this fingerprint
+	}
+	if log == nil {
+		log = slog.Default()
+	}
+	log.Info(SpanLLMRetroResponseRef,
+		"response_sha256", hash,
+		"session_id", sessionID,
+		"response", raw,
+	)
+	return true
+}
+
+// retroResponseRef is the process-lifetime singleton for the retro raw-response
+// reference (#1179), shared across all concurrent game-end retros so a given raw reply
+// is logged once for the whole process. Tests reset it via resetRetroResponseRef.
+var retroResponseRef = &retroResponseReference{}
+
+// resetRetroResponseRef clears the process-lifetime seen-set for tests that assert
+// the once-per-fingerprint emission semantics.
+func resetRetroResponseRef() { retroResponseRef = &retroResponseReference{} }

--- a/services/agent/decision/retro_capture.go
+++ b/services/agent/decision/retro_capture.go
@@ -12,6 +12,7 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.34.0"
 	"go.opentelemetry.io/otel/trace"
 
+	"github.com/joustmania/agent/flags"
 	"github.com/joustmania/agent/gamecontext"
 	"github.com/joustmania/agent/gamesummary"
 	"github.com/joustmania/agent/llm"
@@ -162,6 +163,18 @@ type RetroCoordinator struct {
 	// via SetFitnessLookup; not safe to call concurrently with OnGameEnd.
 	fitnessLookup func(gameID string) (float64, bool)
 
+	// inferWG tracks every in-flight retro inference goroutine (#1179). OnGameEnd is
+	// a lifecycle hook and MUST NOT block on the 2-10s network call, so the
+	// infer+decode+capture runs in its own goroutine; this wait group lets graceful
+	// shutdown and tests join all in-flight retros (AwaitInflight) so no goroutine
+	// outlives the process and tests can deterministically wait for the conclusion to
+	// land before asserting — mirroring the in-game Loop.inferWG.
+	inferWG sync.WaitGroup
+	// rootCtx is the agent's root context (#1179): the retro inference goroutine derives
+	// its latency-budget context from it, so shutdown cancellation unblocks a
+	// well-behaved in-flight Infer. Nil falls back to context.Background.
+	rootCtx context.Context
+
 	// mu guards the captured-session dedupe state.
 	mu sync.Mutex
 	// captured is the set of recently captured SessionIDs (membership = already
@@ -218,6 +231,19 @@ func (rc *RetroCoordinator) SetResolver(r *Resolver) { rc.resolver = r }
 func (rc *RetroCoordinator) SetFitnessLookup(f func(gameID string) (float64, bool)) {
 	rc.fitnessLookup = f
 }
+
+// SetRootContext injects the agent's root context (#1179) so the async retro
+// inference goroutine derives its latency-budget context from it; shutdown
+// cancellation then unblocks a well-behaved in-flight Infer. Nil (the default) means
+// the goroutine uses context.Background — bounded by the latency budget alone. Not
+// safe to call concurrently with OnGameEnd — set it during construction.
+func (rc *RetroCoordinator) SetRootContext(ctx context.Context) { rc.rootCtx = ctx }
+
+// AwaitInflight blocks until every in-flight async retro inference has completed
+// (#1179). main.go calls it during graceful shutdown so no retro goroutine outlives
+// the process; tests call it to make the conclusion land deterministically before
+// asserting (no real sleeps). Safe to call when nothing is in flight.
+func (rc *RetroCoordinator) AwaitInflight() { rc.inferWG.Wait() }
 
 // OnGameEnd is the gamecontext.Store.OnGameEnd callback. It captures the
 // retrospective prompt for a finished session exactly once. It is defensive:
@@ -340,8 +366,7 @@ func (rc *RetroCoordinator) OnGameEnd(c gamecontext.GameContext) {
 			trace.WithAttributes(attribute.String(AttrGameTraceID, c.GameTraceID)))
 	}
 
-	_, span := rc.Tracer.Start(context.Background(), SpanLLMRetro, startOpts...)
-	span.End()
+	spanCtx, span := rc.Tracer.Start(context.Background(), SpanLLMRetro, startOpts...)
 
 	rc.Log.Info("agent.llm.retro_captured",
 		"session_id", c.SessionID,
@@ -349,6 +374,143 @@ func (rc *RetroCoordinator) OnGameEnd(c gamecontext.GameContext) {
 		"bytes", len(prompt.System)+len(prompt.User),
 		"fallback_reason", attr.fallback,
 	)
+
+	// #1179: actually CALL the model. When a real backend resolved, ask it for the
+	// post-game conclusion and stamp the decoded assessment/suggestions/focus on the
+	// SAME span — which now ends AFTER the response (real latency), not at 10µs. When
+	// no backend resolved (chain unreachable / no resolver wired), keep the pre-#1179
+	// capture-only behavior: end the span now with fallback=no_backend_available.
+	if attr.backend == nil {
+		span.End()
+		return
+	}
+
+	// ASYNC: OnGameEnd is a lifecycle hook on the game-end transition — it must NOT
+	// block on the 2-10s inference call. Fire the infer+decode+capture in its own
+	// goroutine (mirroring the in-game runInfer/applyAsyncResult split) and return
+	// immediately; the span ends inside the goroutine once the response lands. Tracked
+	// on inferWG so shutdown/tests can join it (AwaitInflight).
+	budget := retroLatencyBudget(snapshot)
+	rc.inferWG.Add(1)
+	go rc.runRetroInfer(spanCtx, span, attr.backend, prompt, c.SessionID, budget)
+}
+
+// retroLatencyBudget is the wall-clock cap for one retro inference call (#1179),
+// reusing the SAME llm.latency_budget_seconds flag the in-game async path uses so a
+// retro can never outlive the configured budget. A non-positive value (a hand-built
+// test snapshot) floors at the default — a retro must never run without a deadline, or
+// a hung Infer would leak its goroutine and pin the span open forever.
+func retroLatencyBudget(snapshot flags.Snapshot) time.Duration {
+	budget := snapshot.LLMGate.LatencyBudget
+	if budget <= 0 {
+		budget = time.Duration(flags.DefaultLLMLatencyBudgetSeconds * float64(time.Second))
+	}
+	return budget
+}
+
+// runRetroInfer is the body of the fired retro goroutine (#1179): it calls Infer under
+// the latency-budget context, decodes the reply, stamps the conclusion (or the failure)
+// on the agent.llm.retro span, and ends the span. It runs OFF the game-end hook, so it
+// may take seconds without blocking the lifecycle transition.
+//
+// FAIL-OPEN: it is total and never panics out — a flagd/backend/timeout/decode failure
+// stamps the error on the span (parse_ok=false + llm.infer.error) and emits a WARN log,
+// but the span always ends cleanly. OnGameEnd has already returned by the time this
+// runs, so nothing here can break the game-end transition.
+func (rc *RetroCoordinator) runRetroInfer(ctx context.Context, span trace.Span, backend Backend, prompt llm.RetroPrompt, sessionID string, budget time.Duration) {
+	defer rc.inferWG.Done()
+	defer span.End()
+
+	now := rc.now
+	if now == nil {
+		now = time.Now
+	}
+
+	root := rc.rootCtx
+	if root == nil {
+		root = context.Background()
+	}
+	// Bound the call by the latency budget; a backend that honors ctx unblocks at the
+	// deadline. inferCtx is derived from ctx (the live span context) so #1112's
+	// traceparent injection parents any gateway gen_ai span under this retro trace, and
+	// from rootCtx's cancellation indirectly via the budget timeout.
+	inferCtx, cancel := context.WithTimeout(ctx, budget)
+	defer cancel()
+
+	// Wrap the outbound call in a short-lived client span (mirroring async_infer.go's
+	// SpanLLMInferCall) so callCtx carries an active, sampled span for the #1112
+	// traceparent injector to read — restoring "one trace" through the litellm gateway.
+	callCtx, callSpan := rc.Tracer.Start(inferCtx, SpanLLMInferCall,
+		trace.WithSpanKind(trace.SpanKindClient),
+		trace.WithAttributes(
+			attribute.String("gen_ai.request.model", backend.Name()),
+			attribute.String(AttrGameID, sessionID),
+			attribute.String(AttrSessionID, sessionID),
+		),
+	)
+	start := now()
+	// The retro prompt's System/User map onto the inference Prompt's System/User;
+	// Model rides for attribution (already stamped on the span). The retro has no
+	// in-game Variant.
+	raw, inferErr := backend.Infer(callCtx, llm.Prompt{
+		System: prompt.System,
+		User:   prompt.User,
+		Model:  prompt.Model,
+	})
+	callSpan.End()
+	latencyMs := now().Sub(start).Milliseconds()
+
+	span.SetAttributes(attribute.Int64(AttrLLMRetroLatencyMs, latencyMs))
+
+	// Transport / timeout failure: stamp the error, log loudly, end (fail-open).
+	if inferErr != nil {
+		span.SetAttributes(
+			attribute.Bool(AttrLLMRetroParseOK, false),
+			attribute.String(AttrLLMInferError, inferErr.Error()),
+		)
+		rc.Log.Warn(SpanLLMRetroFailed,
+			"session_id", sessionID,
+			"latency_ms", latencyMs,
+			"error", inferErr.Error(),
+		)
+		return
+	}
+
+	// Keep the big raw text off the traces pipeline (#1169): stamp only the
+	// fingerprint, emit the full text once-per-hash on the reference log.
+	sha := responseSHA(raw)
+	span.SetAttributes(attribute.String(AttrLLMRetroResponseSHA, sha))
+	retroResponseRef.emit(rc.Log, sha, sessionID, raw)
+
+	resp, decodeErr := llm.DecodeRetro(raw)
+	if decodeErr != nil {
+		span.SetAttributes(
+			attribute.Bool(AttrLLMRetroParseOK, false),
+			attribute.String(AttrLLMInferError, decodeErr.Error()),
+		)
+		rc.Log.Warn(SpanLLMRetroFailed,
+			"session_id", sessionID,
+			"latency_ms", latencyMs,
+			"error", decodeErr.Error(),
+		)
+		return
+	}
+
+	// Success: stamp the decoded conclusion on the span and emit one queryable event
+	// per suggestion.
+	span.SetAttributes(
+		attribute.Bool(AttrLLMRetroParseOK, true),
+		attribute.String(AttrLLMRetroSessionAssessment, resp.SessionAssessment),
+		attribute.String(AttrLLMRetroSessionFocus, resp.SessionFocus),
+		attribute.Int(AttrLLMRetroSuggestionCount, len(resp.Suggestions)),
+	)
+	for _, s := range resp.Suggestions {
+		span.AddEvent(SpanLLMRetroSuggestion, trace.WithAttributes(
+			attribute.String(AttrRetroSuggestionType, s.InterventionType),
+			attribute.String(AttrRetroSuggestionEmphasis, s.Emphasis),
+			attribute.String(AttrRetroSuggestionReason, s.Reason),
+		))
+	}
 }
 
 // retroAttribution is the inference attribution for one retro capture: the
@@ -358,6 +520,11 @@ type retroAttribution struct {
 	configured string
 	used       string
 	fallback   string
+	// backend is the LIVE resolved Backend the retro should actually call Infer on
+	// (#1179) — the same instance the resolver handed back, surfaced here instead of
+	// discarded. Nil when the whole chain was unreachable (or no resolver is wired):
+	// the retro then stays capture-only with fallback=no_backend_available.
+	backend Backend
 }
 
 // retroInference computes the retro span/log inference attribution (#1080), routing
@@ -392,7 +559,8 @@ func (rc *RetroCoordinator) retroInference(flagModel string) retroAttribution {
 	// A nil Backend means the whole chain was unreachable and the decision loop would
 	// fall back to rules; the retro has no rules fallback, so it reports used="none"
 	// (the DIVERGENCE) with the chain's no_backend_available reason — identical to the
-	// pre-#1080 stub attribution.
+	// pre-#1080 stub attribution. The nil backend is surfaced (#1179) so OnGameEnd keeps
+	// the capture-only path with no_backend_available.
 	if res.Backend == nil {
 		return retroAttribution{
 			configured: configured,
@@ -400,10 +568,13 @@ func (rc *RetroCoordinator) retroInference(flagModel string) retroAttribution {
 			fallback:   res.FallbackReason,
 		}
 	}
+	// #1179: surface the LIVE Backend so OnGameEnd can actually call Infer on it,
+	// instead of resolving the attribution and discarding the resolved tier.
 	return retroAttribution{
 		configured: configured,
 		used:       res.Used,
 		fallback:   res.FallbackReason,
+		backend:    res.Backend,
 	}
 }
 

--- a/services/agent/decision/retro_capture.go
+++ b/services/agent/decision/retro_capture.go
@@ -170,9 +170,10 @@ type RetroCoordinator struct {
 	// outlives the process and tests can deterministically wait for the conclusion to
 	// land before asserting — mirroring the in-game Loop.inferWG.
 	inferWG sync.WaitGroup
-	// rootCtx is the agent's root context (#1179): the retro inference goroutine derives
-	// its latency-budget context from it, so shutdown cancellation unblocks a
-	// well-behaved in-flight Infer. Nil falls back to context.Background.
+	// rootCtx is the agent's root context (#1179): the retro inference goroutine bridges
+	// rootCtx.Done() to its (span-derived) budget context's cancel, so shutdown
+	// cancellation promptly unblocks a well-behaved in-flight Infer. Nil means no bridge
+	// — the latency budget alone bounds the call.
 	rootCtx context.Context
 
 	// mu guards the captured-session dedupe state.
@@ -232,11 +233,13 @@ func (rc *RetroCoordinator) SetFitnessLookup(f func(gameID string) (float64, boo
 	rc.fitnessLookup = f
 }
 
-// SetRootContext injects the agent's root context (#1179) so the async retro
-// inference goroutine derives its latency-budget context from it; shutdown
-// cancellation then unblocks a well-behaved in-flight Infer. Nil (the default) means
-// the goroutine uses context.Background — bounded by the latency budget alone. Not
-// safe to call concurrently with OnGameEnd — set it during construction.
+// SetRootContext injects the agent's root context (#1179). The async retro inference
+// goroutine keeps its latency-budget context derived from the retro SPAN context (to
+// preserve #1112 trace parenting), and separately bridges root.Done() -> cancel() so
+// shutdown cancellation promptly unblocks a well-behaved in-flight Infer instead of
+// waiting out the full budget. Nil (the default) means no bridge is installed — the
+// latency budget is the sole deadline. Not safe to call concurrently with OnGameEnd —
+// set it during construction.
 func (rc *RetroCoordinator) SetRootContext(ctx context.Context) { rc.rootCtx = ctx }
 
 // AwaitInflight blocks until every in-flight async retro inference has completed
@@ -426,16 +429,31 @@ func (rc *RetroCoordinator) runRetroInfer(ctx context.Context, span trace.Span, 
 		now = time.Now
 	}
 
-	root := rc.rootCtx
-	if root == nil {
-		root = context.Background()
-	}
-	// Bound the call by the latency budget; a backend that honors ctx unblocks at the
-	// deadline. inferCtx is derived from ctx (the live span context) so #1112's
-	// traceparent injection parents any gateway gen_ai span under this retro trace, and
-	// from rootCtx's cancellation indirectly via the budget timeout.
+	// inferCtx MUST stay derived from ctx (the live retro span context), NOT from
+	// rootCtx: #1112 requires the outbound-call client span below to be parented under
+	// THIS retro span ("one trace" through the litellm gateway), and that parenting flows
+	// through ctx. WithTimeout(ctx, budget) gives us the span parent plus the latency
+	// budget. (The sibling in-game path async_infer.go:232 derives from root directly
+	// because it carries no span-parent-from-ctx constraint — do not copy that here.)
 	inferCtx, cancel := context.WithTimeout(ctx, budget)
 	defer cancel()
+
+	// Linked cancellation: WithTimeout(ctx, budget) does NOT inherit rootCtx's
+	// cancellation (ctx is the standalone retro root, not a child of root), so on
+	// shutdown an in-flight Infer would otherwise wait out the full ~8s budget. Bridge
+	// root.Done() -> cancel() with a small goroutine so shutdown promptly unblocks a
+	// well-behaved Infer; the goroutine also exits when inferCtx finishes normally, so it
+	// never leaks. A nil rootCtx (tests / unwired) skips the bridge — the budget timeout
+	// remains the sole deadline.
+	if root := rc.rootCtx; root != nil {
+		go func() {
+			select {
+			case <-root.Done():
+				cancel()
+			case <-inferCtx.Done():
+			}
+		}()
+	}
 
 	// Wrap the outbound call in a short-lived client span (mirroring async_infer.go's
 	// SpanLLMInferCall) so callCtx carries an active, sampled span for the #1112

--- a/services/agent/decision/retro_capture_test.go
+++ b/services/agent/decision/retro_capture_test.go
@@ -286,6 +286,9 @@ func TestRetroCapture_ConfiguredBackendReachable(t *testing.T) {
 	rc.SetResolver(r)
 
 	rc.OnGameEnd(endedSession())
+	// #1179: the retro now actually calls Infer ASYNC when a backend resolves, so the
+	// span ends inside the fired goroutine — join it before reading the spans.
+	rc.AwaitInflight()
 
 	span := spansByName(sr.Ended(), SpanLLMRetro)[0]
 	want := map[string]string{

--- a/services/agent/decision/retro_inference_test.go
+++ b/services/agent/decision/retro_inference_test.go
@@ -1,0 +1,257 @@
+package decision
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+
+	"github.com/joustmania/agent/llm"
+)
+
+// retro_inference_test.go covers the #1179 wiring: the retro now actually CALLS the
+// resolved backend at game end (async), decodes the conclusion, and stamps it on the
+// agent.llm.retro span. The tests assert the success conclusion + per-suggestion
+// events, the parse-failure path (parse_ok=false + error), the no-block guarantee of
+// the lifecycle hook, and the capture-only fallback when no backend resolves.
+
+// reachableRetroResolver builds a Resolver whose configured inference tier is reachable
+// (a real loopback listener) and whose Infer delegate returns the given canned reply.
+func reachableRetroResolver(t *testing.T, model string, infer func(context.Context, llm.Prompt) (string, error)) *Resolver {
+	t.Helper()
+	addr, closeFn := listenLocal(t)
+	t.Cleanup(closeFn)
+	r := NewInferenceResolver(InferenceTier{Model: model, Addr: addr, Infer: infer}, Endpoints{}, 0)
+	r.Refresh(context.Background())
+	return r
+}
+
+// eventByName returns the first span event with the given name, or false.
+func eventsByName(span sdktrace.ReadOnlySpan, name string) []sdktrace.Event {
+	var out []sdktrace.Event
+	for _, ev := range span.Events() {
+		if ev.Name == name {
+			out = append(out, ev)
+		}
+	}
+	return out
+}
+
+func eventAttr(ev sdktrace.Event, key string) (string, bool) {
+	for _, kv := range ev.Attributes {
+		if string(kv.Key) == key {
+			return kv.Value.AsString(), true
+		}
+	}
+	return "", false
+}
+
+// TestRetro_CapturesConclusionOnSuccess: with a reachable backend that returns a valid
+// analyst reply, the retro span carries the decoded assessment / focus / suggestion
+// count, one retro.suggestion event per suggestion, parse_ok=true, a latency, and the
+// raw-response fingerprint.
+func TestRetro_CapturesConclusionOnSuccess(t *testing.T) {
+	resetRetroResponseRef()
+	reply := `{
+	  "session_assessment": "close finish",
+	  "suggestions": [
+	    {"intervention_type": "grant_shield", "emphasis": "weight_up", "reason": "fast early dropouts"}
+	  ],
+	  "session_focus": "endurance"
+	}`
+	rc, sr := recordingRetro(t, retroFlagSnapshot())
+	rc.SetResolver(reachableRetroResolver(t, "gemma4:latest",
+		func(context.Context, llm.Prompt) (string, error) { return reply, nil }))
+
+	rc.OnGameEnd(endedSession())
+	rc.AwaitInflight()
+
+	span := spansByName(sr.Ended(), SpanLLMRetro)[0]
+	if v, ok := attrValue(span, AttrLLMRetroSessionAssessment); !ok || v.AsString() != "close finish" {
+		t.Errorf("session_assessment = %q (present=%v)", v.AsString(), ok)
+	}
+	if v, ok := attrValue(span, AttrLLMRetroSessionFocus); !ok || v.AsString() != "endurance" {
+		t.Errorf("session_focus = %q (present=%v)", v.AsString(), ok)
+	}
+	if v, ok := attrValue(span, AttrLLMRetroSuggestionCount); !ok || v.AsInt64() != 1 {
+		t.Errorf("suggestion_count = %d (present=%v), want 1", v.AsInt64(), ok)
+	}
+	if v, ok := attrValue(span, AttrLLMRetroParseOK); !ok || !v.AsBool() {
+		t.Errorf("parse_ok = %v (present=%v), want true", v.AsBool(), ok)
+	}
+	if _, ok := attrValue(span, AttrLLMRetroLatencyMs); !ok {
+		t.Error("llm.retro.latency_ms must be present")
+	}
+	if v, ok := attrValue(span, AttrLLMRetroResponseSHA); !ok || v.AsString() == "" {
+		t.Error("llm.retro.response_sha256 must be present and non-empty")
+	}
+	// One queryable event per suggestion, carrying the decoded fields.
+	evs := eventsByName(span, SpanLLMRetroSuggestion)
+	if len(evs) != 1 {
+		t.Fatalf("retro.suggestion events = %d, want 1", len(evs))
+	}
+	if v, _ := eventAttr(evs[0], AttrRetroSuggestionType); v != "grant_shield" {
+		t.Errorf("event intervention_type = %q, want grant_shield", v)
+	}
+	if v, _ := eventAttr(evs[0], AttrRetroSuggestionEmphasis); v != "weight_up" {
+		t.Errorf("event emphasis = %q, want weight_up", v)
+	}
+	if v, _ := eventAttr(evs[0], AttrRetroSuggestionReason); v != "fast early dropouts" {
+		t.Errorf("event reason = %q", v)
+	}
+	// No error on the success path.
+	if _, ok := attrValue(span, AttrLLMInferError); ok {
+		t.Error("llm.infer.error must be ABSENT on a parsed reply")
+	}
+}
+
+// TestRetro_EmitsRawResponseOncePerHash: the full raw reply rides a once-per-fingerprint
+// reference log, not the span. We assert via the reference singleton's emit returning
+// false (already-emitted) for the same raw text after the retro ran.
+func TestRetro_EmitsRawResponseOncePerHash(t *testing.T) {
+	resetRetroResponseRef()
+	reply := `{"session_assessment":"ok","suggestions":[],"session_focus":"balanced"}`
+	rc, _ := recordingRetro(t, retroFlagSnapshot())
+	rc.SetResolver(reachableRetroResolver(t, "gemma4:latest",
+		func(context.Context, llm.Prompt) (string, error) { return reply, nil }))
+
+	rc.OnGameEnd(endedSession())
+	rc.AwaitInflight()
+
+	// The retro already emitted the raw reply once; a second emit of the SAME text is a
+	// no-op (returns false), proving the once-per-hash behavior.
+	if retroResponseRef.emit(slog.New(slog.NewTextHandler(io.Discard, nil)), responseSHA(reply), "session-7", reply) {
+		t.Error("raw response should already be emitted once (once-per-hash), got a fresh emit")
+	}
+	// A DIFFERENT raw text emits fresh.
+	if !retroResponseRef.emit(slog.New(slog.NewTextHandler(io.Discard, nil)), responseSHA("other"), "s", "other") {
+		t.Error("a distinct raw response should emit fresh")
+	}
+}
+
+// TestRetro_ParseFailureStampsError: a reachable backend that returns garbage gets
+// parse_ok=false + llm.infer.error and NO conclusion attributes (fail-open: the span
+// still ends cleanly).
+func TestRetro_ParseFailureStampsError(t *testing.T) {
+	resetRetroResponseRef()
+	rc, sr := recordingRetro(t, retroFlagSnapshot())
+	rc.SetResolver(reachableRetroResolver(t, "gemma4:latest",
+		func(context.Context, llm.Prompt) (string, error) { return "not json at all", nil }))
+
+	rc.OnGameEnd(endedSession())
+	rc.AwaitInflight()
+
+	span := spansByName(sr.Ended(), SpanLLMRetro)[0]
+	if v, ok := attrValue(span, AttrLLMRetroParseOK); !ok || v.AsBool() {
+		t.Errorf("parse_ok = %v (present=%v), want false", v.AsBool(), ok)
+	}
+	if v, ok := attrValue(span, AttrLLMInferError); !ok || v.AsString() == "" {
+		t.Error("llm.infer.error must be present on an unparseable reply")
+	}
+	if _, ok := attrValue(span, AttrLLMRetroSessionAssessment); ok {
+		t.Error("session_assessment must be ABSENT on a parse failure")
+	}
+	// Latency is still recorded even on failure.
+	if _, ok := attrValue(span, AttrLLMRetroLatencyMs); !ok {
+		t.Error("llm.retro.latency_ms must be present even on a parse failure")
+	}
+}
+
+// TestRetro_TransportErrorStampsError: a reachable backend whose Infer ERRORS gets
+// parse_ok=false + llm.infer.error carrying the transport error, no conclusion, span
+// still ends (fail-open).
+func TestRetro_TransportErrorStampsError(t *testing.T) {
+	resetRetroResponseRef()
+	rc, sr := recordingRetro(t, retroFlagSnapshot())
+	rc.SetResolver(reachableRetroResolver(t, "gemma4:latest",
+		func(context.Context, llm.Prompt) (string, error) { return "", errors.New("boom") }))
+
+	rc.OnGameEnd(endedSession())
+	rc.AwaitInflight()
+
+	span := spansByName(sr.Ended(), SpanLLMRetro)[0]
+	if v, ok := attrValue(span, AttrLLMRetroParseOK); !ok || v.AsBool() {
+		t.Errorf("parse_ok = %v (present=%v), want false", v.AsBool(), ok)
+	}
+	if v, ok := attrValue(span, AttrLLMInferError); !ok || v.AsString() != "boom" {
+		t.Errorf("llm.infer.error = %q (present=%v), want \"boom\"", v.AsString(), ok)
+	}
+	// No raw-response fingerprint on a transport error (there is no reply text).
+	if _, ok := attrValue(span, AttrLLMRetroResponseSHA); ok {
+		t.Error("response_sha256 must be ABSENT on a transport error (no reply)")
+	}
+}
+
+// TestRetro_OnGameEndDoesNotBlock: OnGameEnd is a lifecycle hook — it must return
+// promptly even when Infer is slow. We block the delegate on a channel and assert
+// OnGameEnd returns before the call completes, then release it.
+func TestRetro_OnGameEndDoesNotBlock(t *testing.T) {
+	resetRetroResponseRef()
+	release := make(chan struct{})
+	var calledOnce sync.Once
+	started := make(chan struct{})
+	rc, sr := recordingRetro(t, retroFlagSnapshot())
+	rc.SetResolver(reachableRetroResolver(t, "gemma4:latest",
+		func(context.Context, llm.Prompt) (string, error) {
+			calledOnce.Do(func() { close(started) })
+			<-release // block until the test releases us
+			return `{"session_assessment":"ok","suggestions":[],"session_focus":"balanced"}`, nil
+		}))
+
+	done := make(chan struct{})
+	go func() { rc.OnGameEnd(endedSession()); close(done) }()
+
+	select {
+	case <-done:
+		// OnGameEnd returned without waiting on the (still-blocked) Infer — the goal.
+	case <-time.After(2 * time.Second):
+		close(release)
+		t.Fatal("OnGameEnd did not return promptly; it blocked on the inference call")
+	}
+
+	// The inference IS in flight (the delegate started) but the span has not ended yet.
+	<-started
+	if n := len(spansByName(sr.Ended(), SpanLLMRetro)); n != 0 {
+		t.Errorf("retro span ended before inference completed: got %d ended spans", n)
+	}
+
+	close(release) // let the goroutine finish
+	rc.AwaitInflight()
+	if n := len(spansByName(sr.Ended(), SpanLLMRetro)); n != 1 {
+		t.Errorf("after inference, retro spans = %d, want 1", n)
+	}
+}
+
+// TestRetro_CaptureOnlyWhenNoBackend: with no resolver wired (nil backend), the retro
+// stays capture-only — the span ends synchronously, carries no conclusion, no
+// parse_ok, and reports no_backend_available.
+func TestRetro_CaptureOnlyWhenNoBackend(t *testing.T) {
+	resetRetroResponseRef()
+	rc, sr := recordingRetro(t, retroFlagSnapshot()) // no SetResolver -> nil backend
+
+	rc.OnGameEnd(endedSession())
+	// No AwaitInflight needed: with no backend the span ends synchronously in OnGameEnd.
+
+	spans := spansByName(sr.Ended(), SpanLLMRetro)
+	if len(spans) != 1 {
+		t.Fatalf("retro spans = %d, want 1", len(spans))
+	}
+	span := spans[0]
+	if v, ok := attrValue(span, AttrInferenceFallback); !ok || v.AsString() != FallbackNoBackend {
+		t.Errorf("fallback_reason = %q (present=%v), want %q", v.AsString(), ok, FallbackNoBackend)
+	}
+	// No conclusion was captured (no backend was called).
+	for _, key := range []string{AttrLLMRetroParseOK, AttrLLMRetroSessionAssessment, AttrLLMRetroLatencyMs, AttrLLMRetroResponseSHA} {
+		if _, ok := attrValue(span, key); ok {
+			t.Errorf("attr %s must be ABSENT on the capture-only path", key)
+		}
+	}
+	if n := len(eventsByName(span, SpanLLMRetroSuggestion)); n != 0 {
+		t.Errorf("retro.suggestion events = %d, want 0 on capture-only", n)
+	}
+}

--- a/services/agent/decision/retro_inference_test.go
+++ b/services/agent/decision/retro_inference_test.go
@@ -227,6 +227,74 @@ func TestRetro_OnGameEndDoesNotBlock(t *testing.T) {
 	}
 }
 
+// TestRetro_RootContextCancellationUnblocksInfer: the seam the #1185 review flagged as
+// untested. The retro goroutine keeps its budget context derived from the SPAN context
+// (for #1112 parenting), so it does NOT inherit rootCtx cancellation automatically;
+// SetRootContext installs a root.Done() -> cancel() bridge. With a backend that blocks
+// until its ctx is cancelled and a generous latency budget (so the budget timeout can
+// NOT be what unblocks us), cancelling rootCtx must promptly unblock the in-flight
+// Infer: the goroutine returns, the span ends stamped with the cancellation error, and
+// AwaitInflight joins.
+func TestRetro_RootContextCancellationUnblocksInfer(t *testing.T) {
+	resetRetroResponseRef()
+	started := make(chan struct{})
+	var startOnce sync.Once
+	rc, sr := recordingRetro(t, retroFlagSnapshot())
+	// A well-behaved backend: it honors ctx and returns its cancellation error rather
+	// than ignoring the deadline. It blocks indefinitely on the context otherwise.
+	rc.SetResolver(reachableRetroResolver(t, "gemma4:latest",
+		func(ctx context.Context, _ llm.Prompt) (string, error) {
+			startOnce.Do(func() { close(started) })
+			<-ctx.Done()
+			return "", ctx.Err()
+		}))
+
+	// A long latency budget guarantees that anything which unblocks the call within the
+	// test timeout must be the root-cancellation bridge, not the budget timeout.
+	snap := retroFlagSnapshot()
+	snap.LLMGate.LatencyBudget = 30 * time.Second
+	rc.Flags = &settableFlags{snap: snap}
+
+	root, cancelRoot := context.WithCancel(context.Background())
+	rc.SetRootContext(root)
+
+	rc.OnGameEnd(endedSession())
+
+	// Wait for the Infer to be genuinely in flight, then cancel the root context.
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		cancelRoot()
+		t.Fatal("retro inference never started")
+	}
+	cancelRoot()
+
+	// AwaitInflight must join promptly (well under the 30s budget) — the bridge unblocked
+	// the call. A test deadline guards against a regression where it waits the budget out.
+	joined := make(chan struct{})
+	go func() { rc.AwaitInflight(); close(joined) }()
+	select {
+	case <-joined:
+	case <-time.After(3 * time.Second):
+		t.Fatal("root cancellation did not unblock the in-flight retro Infer (bridge missing/broken)")
+	}
+
+	// The span ended (it was NOT left open) and carries the cancellation as a stamped
+	// failure (fail-open: parse_ok=false + llm.infer.error), proving the call returned
+	// via cancellation rather than completing or leaking.
+	spans := spansByName(sr.Ended(), SpanLLMRetro)
+	if len(spans) != 1 {
+		t.Fatalf("retro spans = %d, want 1 (span must end on cancellation)", len(spans))
+	}
+	span := spans[0]
+	if v, ok := attrValue(span, AttrLLMRetroParseOK); !ok || v.AsBool() {
+		t.Errorf("parse_ok = %v (present=%v), want false on cancellation", v.AsBool(), ok)
+	}
+	if v, ok := attrValue(span, AttrLLMInferError); !ok || v.AsString() == "" {
+		t.Error("llm.infer.error must be present and non-empty on a cancelled Infer")
+	}
+}
+
 // TestRetro_CaptureOnlyWhenNoBackend: with no resolver wired (nil backend), the retro
 // stays capture-only — the span ends synchronously, carries no conclusion, no
 // parse_ok, and reports no_backend_available.

--- a/services/agent/decision/telemetry.go
+++ b/services/agent/decision/telemetry.go
@@ -206,6 +206,75 @@ const (
 	AttrLLMPromptBytes = "llm.prompt.bytes"
 )
 
+// Custom attribute keys for the retro INFERENCE CONCLUSION (#1179): the values
+// captured on the agent.llm.retro span once the offline analyst actually answers.
+// Until #1179 the retro span only carried the PROMPT (a 10µs capture-only stub);
+// these keys carry the analyst's decoded reply so the maintainer can read the agent's
+// post-game LEARNING in Jaeger. They live in the llm.retro.* namespace alongside the
+// prompt keys (AttrLLMRetroSystemSHA etc., retro_capture.go) so the two never collide.
+//
+// The per-suggestion detail is NOT crammed into a single high-cardinality attribute:
+// each suggestion is emitted as one span EVENT (retro.suggestion) carrying the
+// intervention_type / emphasis / reason, so a reader can expand the timeline and the
+// suggestions stay queryable without ballooning the attribute set.
+const (
+	// AttrLLMRetroSessionAssessment is the analyst's one-sentence read on the game
+	// (RetroResponse.SessionAssessment). Stamped only on a parsed reply.
+	AttrLLMRetroSessionAssessment = "llm.retro.session_assessment"
+	// AttrLLMRetroSessionFocus is the goal the analyst says the next session should
+	// lean toward (RetroResponse.SessionFocus). Stamped only on a parsed reply.
+	AttrLLMRetroSessionFocus = "llm.retro.session_focus"
+	// AttrLLMRetroSuggestionCount is the number of tuning suggestions the analyst
+	// returned (len(RetroResponse.Suggestions)) — 0 is a valid, healthy-session reply.
+	AttrLLMRetroSuggestionCount = "llm.retro.suggestion_count"
+	// AttrLLMRetroLatencyMs is the wall time the inference call took, in integer
+	// milliseconds. Recorded on EVERY backend-called retro (success, decode failure,
+	// or transport/timeout error) so retro inference latency is always queryable —
+	// the retro-namespace counterpart of AttrLLMLatencyMs.
+	AttrLLMRetroLatencyMs = "llm.retro.latency_ms"
+	// AttrLLMRetroParseOK is true when DecodeRetro turned the reply into a
+	// RetroResponse, false when the reply was unparseable. Always present on a
+	// backend-called retro; absent on the capture-only fallback (no backend).
+	AttrLLMRetroParseOK = "llm.retro.parse_ok"
+	// AttrLLMRetroResponseSHA is the FINGERPRINT (short hex SHA-256) of the analyst's
+	// RAW reply text (#1169 pattern): stamped on the span INSTEAD of the full text,
+	// which is large and would re-load the #1167 traces pipeline. The full raw reply is
+	// emitted ONCE per distinct fingerprint on the agent.llm.retro_response reference
+	// LOG line, so this hash is always resolvable to the exact text.
+	AttrLLMRetroResponseSHA = "llm.retro.response_sha256"
+)
+
+// SpanLLMRetroSuggestion is the span EVENT name carrying one decoded retro suggestion
+// (#1179): one event per RetroResponse.Suggestion on the agent.llm.retro span,
+// attributes intervention_type / emphasis / reason. Emitting them as events (not as
+// one fat attribute) keeps each suggestion queryable in Jaeger while bounding the
+// attribute set.
+const SpanLLMRetroSuggestion = "retro.suggestion"
+
+// Span-event attribute keys for a single retro.suggestion event (#1179): the three
+// fields of a RetroSuggestion. Low-cardinality type/emphasis labels + the free-text
+// reason, scoped to the event so they never collide with span-level llm.retro.* keys.
+const (
+	AttrRetroSuggestionType     = "intervention_type"
+	AttrRetroSuggestionEmphasis = "emphasis"
+	AttrRetroSuggestionReason   = "reason"
+)
+
+// SpanLLMRetroResponseRef is the message of the once-per-fingerprint reference LOG
+// line for the analyst's RAW reply (#1169 pattern, #1179): the full raw text is large
+// and recorded-only, so — exactly like the system-prompt reference (prompt_fingerprint.go)
+// — it rides a LOG line (not the traces pipeline) emitted ONCE per distinct
+// response_sha256, keeping the big text off the span while staying resolvable.
+const SpanLLMRetroResponseRef = "agent.llm.retro_response"
+
+// SpanLLMRetroFailed is the WARN log message emitted when a backend-called retro
+// could not yield a conclusion (#1179): a transport/timeout error or an unparseable
+// reply. It is the silent-failure guard — a retro that asked the model but got nothing
+// usable is logged loudly (with the cause) instead of vanishing, so the maintainer
+// sees that the post-game learning attempt failed rather than mistaking "no
+// conclusion" for "nothing to say".
+const SpanLLMRetroFailed = "agent.llm.retro_failed"
+
 // Custom attribute keys of the decision-span schema (issue #724). Attributes
 // covered by a semantic convention (gen_ai.agent.name, rpc.*, error.type,
 // feature_flag.*) use the semconv constants directly and are not listed here.

--- a/services/agent/llm/retro.go
+++ b/services/agent/llm/retro.go
@@ -136,6 +136,13 @@ var (
 // emphasis, a missing focus are all captured verbatim for a human to read. The single
 // hard requirement is parseability: a non-JSON reply is unparseable and the caller
 // stamps parse_ok=false on the span.
+//
+// CONTRACT CAVEAT: the ONLY thing this guarantees is "a parseable JSON object". A
+// structurally-valid but contentless object (e.g. {"foo":1}) parses fine — it yields
+// parse_ok=true with an empty conclusion (empty assessment/focus, no suggestions),
+// INDISTINGUISHABLE from a genuinely empty healthy reply ({}). Callers cannot infer
+// "the analyst said nothing useful" vs "the analyst saw nothing to flag" from parse_ok
+// alone; both are valid, recorded-only outcomes.
 func DecodeRetro(raw string) (RetroResponse, error) {
 	trimmed := strings.TrimSpace(raw)
 	if trimmed == "" {

--- a/services/agent/llm/retro.go
+++ b/services/agent/llm/retro.go
@@ -22,6 +22,8 @@ package llm
 // follow-up wires a real backend once the fallback chain (#741) exists.
 
 import (
+	"encoding/json"
+	"errors"
 	"fmt"
 	"sort"
 	"strconv"
@@ -72,6 +74,88 @@ func BuildRetro(in RetroInput) RetroPrompt {
 		User:   buildRetroUser(in.Context, in.Summary, in.Now),
 		Model:  in.Snapshot.Capability.Model,
 	}
+}
+
+// RetroResponse is the DECODED post-game analyst reply (#1179): the structured
+// shape of the JSON object buildRetroSystem's RESPONSE CONTRACT asks the offline
+// analyst to return (llm/retro.go:146-158). It is the retro sibling of the in-game
+// Response (decode.go): the offline analyst gives a session assessment, a handful of
+// tuning suggestions, and the session focus the next game should lean toward. Unlike
+// the in-game Response it dispatches NOTHING — the retro is RECORDED ONLY (the agent
+// never auto-applies a suggestion), so DecodeRetro is deliberately FORGIVING about
+// the suggestion vocabulary (it does not reject an unknown intervention_type/emphasis):
+// a recorded-only conclusion is captured as-is for a human to read, not gated like a
+// dispatchable action. The only hard requirement is that the reply be a single JSON
+// object — anything else is unparseable and stamped as a parse failure on the span.
+type RetroResponse struct {
+	// SessionAssessment is the analyst's one-sentence read on how the game went.
+	SessionAssessment string `json:"session_assessment"`
+	// Suggestions are the (possibly empty) tuning recommendations. A healthy session
+	// legitimately yields an empty list — that is a VALID, contract-following reply.
+	Suggestions []RetroSuggestion `json:"suggestions"`
+	// SessionFocus is the goal the next session should lean toward (one of
+	// endurance/balanced/accelerate/chaos per the contract). Captured verbatim — not
+	// validated against a vocabulary, since the retro is recorded-only.
+	SessionFocus string `json:"session_focus"`
+}
+
+// RetroSuggestion is one recorded tuning recommendation from the analyst (#1179):
+// which intervention TYPE to change, how (emphasis), and why. Captured as-is for a
+// human to review; never auto-applied, so no field is validated against an allow-list.
+type RetroSuggestion struct {
+	// InterventionType is the allow-list intervention the analyst recommends tuning.
+	InterventionType string `json:"intervention_type"`
+	// Emphasis is the direction of the change (enable/weight_up/weight_down/disable).
+	Emphasis string `json:"emphasis"`
+	// Reason is the one-sentence justification tying the change to session evidence.
+	Reason string `json:"reason"`
+}
+
+// Retro-decode rejection reasons (#1179). The retro path is recorded-only, so the
+// ONLY failure mode is "the reply was not a single JSON object" — there are no
+// required-field or vocabulary checks (a healthy session yields an empty, but valid,
+// reply). Both reasons are stamped as the parse-failure marker on the agent.llm.retro
+// span (parse_ok=false + llm.infer.error).
+var (
+	// ErrRetroEmptyResponse: the analyst returned nothing usable (empty/whitespace).
+	ErrRetroEmptyResponse = errors.New("llm: empty retro response")
+	// ErrRetroNotJSON: no single JSON object could be extracted/parsed from the reply.
+	ErrRetroNotJSON = errors.New("llm: retro response is not a single JSON object")
+)
+
+// DecodeRetro parses a raw analyst reply into a RetroResponse, or returns a typed
+// error (#1179). It is the retro sibling of the in-game Decode (decode.go) and shares
+// its DEFENSIVE JSON extraction: a real model wraps its object in prose or ```json
+// fences despite the "no prose" instruction, so DecodeRetro locates the first '{' and
+// the matching last '}' and parses the span between them (extractJSONObject).
+//
+// It is intentionally LESS strict than Decode: the in-game Decode validates required
+// fields and a closed objective vocabulary because its output DISPATCHES an action;
+// the retro is RECORDED ONLY (never auto-applied), so DecodeRetro captures whatever
+// well-formed JSON the analyst returns — an empty suggestions list, an unknown
+// emphasis, a missing focus are all captured verbatim for a human to read. The single
+// hard requirement is parseability: a non-JSON reply is unparseable and the caller
+// stamps parse_ok=false on the span.
+func DecodeRetro(raw string) (RetroResponse, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return RetroResponse{}, ErrRetroEmptyResponse
+	}
+
+	obj, err := extractJSONObject(trimmed)
+	if err != nil {
+		// Normalize the in-game ErrNotJSON to the retro-namespaced reason so callers
+		// log a coherent "retro" cause; the underlying defensive extraction is shared.
+		return RetroResponse{}, ErrRetroNotJSON
+	}
+
+	var r RetroResponse
+	// DisallowUnknownFields is intentionally NOT used: a compliant analyst may add
+	// commentary keys, and we only consume the contracted ones (mirrors Decode).
+	if err := json.Unmarshal(obj, &r); err != nil {
+		return RetroResponse{}, fmt.Errorf("%w: %v", ErrRetroNotJSON, err)
+	}
+	return r, nil
 }
 
 // buildRetroSystem renders the System prompt: the post-game analyst role, the

--- a/services/agent/llm/retro_decode_test.go
+++ b/services/agent/llm/retro_decode_test.go
@@ -1,0 +1,99 @@
+package llm
+
+import (
+	"errors"
+	"testing"
+)
+
+// retro_decode_test.go covers DecodeRetro (#1179): the defensive parser for the
+// offline analyst's post-game reply. Unlike the in-game Decode it is recorded-only,
+// so the ONLY hard requirement is that the reply be a single JSON object — there is no
+// required-field or vocabulary validation. The tests assert: a clean object decodes; a
+// fenced / prose-wrapped object decodes (the shared defensive extraction); an empty
+// suggestions list is a VALID reply; and non-JSON / empty input return a typed error.
+
+func TestDecodeRetro_Valid(t *testing.T) {
+	raw := `{
+	  "session_assessment": "tight endgame, two strong survivors",
+	  "suggestions": [
+	    {"intervention_type": "grant_shield", "emphasis": "weight_up", "reason": "early dropouts faded fast"},
+	    {"intervention_type": "play_audio_cue", "emphasis": "enable", "reason": "lull mid-game"}
+	  ],
+	  "session_focus": "endurance"
+	}`
+	got, err := DecodeRetro(raw)
+	if err != nil {
+		t.Fatalf("DecodeRetro returned error: %v", err)
+	}
+	if got.SessionAssessment != "tight endgame, two strong survivors" {
+		t.Errorf("session_assessment = %q", got.SessionAssessment)
+	}
+	if got.SessionFocus != "endurance" {
+		t.Errorf("session_focus = %q, want endurance", got.SessionFocus)
+	}
+	if len(got.Suggestions) != 2 {
+		t.Fatalf("suggestions = %d, want 2", len(got.Suggestions))
+	}
+	if got.Suggestions[0].InterventionType != "grant_shield" ||
+		got.Suggestions[0].Emphasis != "weight_up" ||
+		got.Suggestions[0].Reason != "early dropouts faded fast" {
+		t.Errorf("suggestion[0] = %+v", got.Suggestions[0])
+	}
+}
+
+// A model commonly wraps the JSON in a ```json fence and surrounding prose despite the
+// "no prose" instruction; DecodeRetro must still recover the object (shared defensive
+// extraction with the in-game Decode).
+func TestDecodeRetro_FencedAndProseWrapped(t *testing.T) {
+	raw := "Sure! Here is my analysis:\n```json\n" +
+		`{"session_assessment":"healthy","suggestions":[],"session_focus":"balanced"}` +
+		"\n```\nLet me know if you need more."
+	got, err := DecodeRetro(raw)
+	if err != nil {
+		t.Fatalf("DecodeRetro on fenced/prose-wrapped input returned error: %v", err)
+	}
+	if got.SessionFocus != "balanced" {
+		t.Errorf("session_focus = %q, want balanced", got.SessionFocus)
+	}
+	// An empty suggestions list is a VALID, healthy-session reply.
+	if len(got.Suggestions) != 0 {
+		t.Errorf("suggestions = %d, want 0 (empty list is valid)", len(got.Suggestions))
+	}
+}
+
+// An empty suggestions list with a non-empty object is valid (the contract's
+// healthy-session case), distinct from a parse failure.
+func TestDecodeRetro_EmptySuggestionsValid(t *testing.T) {
+	got, err := DecodeRetro(`{"session_assessment":"all good","suggestions":[],"session_focus":"chaos"}`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got.Suggestions) != 0 {
+		t.Errorf("suggestions = %d, want 0", len(got.Suggestions))
+	}
+}
+
+func TestDecodeRetro_GarbageAndEmpty(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		wantErr error
+	}{
+		{"empty", "", ErrRetroEmptyResponse},
+		{"whitespace only", "   \n\t ", ErrRetroEmptyResponse},
+		{"prose with no object", "the game went well, no suggestions", ErrRetroNotJSON},
+		{"unbalanced braces", "{not valid json at all", ErrRetroNotJSON},
+		{"a JSON array, not object", `["session_assessment"]`, ErrRetroNotJSON},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := DecodeRetro(tc.raw)
+			if err == nil {
+				t.Fatalf("DecodeRetro(%q) = nil error, want %v", tc.raw, tc.wantErr)
+			}
+			if !errors.Is(err, tc.wantErr) {
+				t.Errorf("DecodeRetro(%q) error = %v, want errors.Is %v", tc.raw, err, tc.wantErr)
+			}
+		})
+	}
+}

--- a/services/agent/main.go
+++ b/services/agent/main.go
@@ -780,6 +780,12 @@ func main() {
 	// default the resolver has no configured tier and the chain is unreachable, so the
 	// retro degrades to used="none"/no_backend_available exactly as before.
 	retro.SetResolver(sharedResolver)
+	// #1179: bound every async retro inference goroutine to the agent's root context so
+	// shutdown cancellation unblocks a well-behaved in-flight Infer (no leak), the same
+	// SetRootContext pattern the per-game loops use. The retro now actually CALLS the
+	// resolved backend at game end (async), decodes the conclusion, and stamps it on the
+	// agent.llm.retro span.
+	retro.SetRootContext(ctx)
 
 	// Game narrative builder (#928, M7-1): on the SAME GameActive true->false
 	// transition, aggregate the partition's pre-reset snapshot (live signals + the
@@ -997,6 +1003,7 @@ func main() {
 		pipe:             pipe,
 		mux:              mux,
 		loops:            loops,
+		retro:            retro,
 		resolver:         sharedResolver,
 		evictInterval:    lifecycleHolder.EvictInterval(),
 		evictIntervalSrc: lifecycleHolder.EvictInterval,

--- a/services/agent/server.go
+++ b/services/agent/server.go
@@ -151,9 +151,11 @@ func (c *serverComponents) run(ctx context.Context) error {
 		c.logger.Info("Shutdown requested, stopping servers...")
 		grpcServer.GracefulStop()
 		c.loops.AwaitInflight()
-		// Join in-flight async retro inference goroutines (#1179) too: ctx is already
-		// cancelled, so each retro's budget context is cancelled and a well-behaved Infer
-		// returns promptly. No retro outlives the process.
+		// Join in-flight async retro inference goroutines (#1179) too: ctx (the agent
+		// root) is already cancelled, and each retro goroutine bridges root.Done() to its
+		// budget-context cancel (SetRootContext), so a well-behaved in-flight Infer is
+		// unblocked promptly rather than waiting out the full latency budget; AwaitInflight
+		// then joins them. No retro outlives the process.
 		if c.retro != nil {
 			c.retro.AwaitInflight()
 		}

--- a/services/agent/server.go
+++ b/services/agent/server.go
@@ -43,6 +43,11 @@ type serverComponents struct {
 	mux   *gamecontext.Multiplexer
 	loops *decision.LoopSet
 
+	// retro is the post-game RetroCoordinator. Its async inference goroutines (#1179)
+	// are joined on shutdown via AwaitInflight so no retro outlives the process. May be
+	// nil (tests that do not exercise the retro path).
+	retro *decision.RetroCoordinator
+
 	// resolver is the shared inference resolver whose background probe ticker is
 	// started by run and stopped when ctx is cancelled. It may be nil (tests that
 	// do not exercise the inference path).
@@ -146,6 +151,12 @@ func (c *serverComponents) run(ctx context.Context) error {
 		c.logger.Info("Shutdown requested, stopping servers...")
 		grpcServer.GracefulStop()
 		c.loops.AwaitInflight()
+		// Join in-flight async retro inference goroutines (#1179) too: ctx is already
+		// cancelled, so each retro's budget context is cancelled and a well-behaved Infer
+		// returns promptly. No retro outlives the process.
+		if c.retro != nil {
+			c.retro.AwaitInflight()
+		}
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		_ = healthServer.Shutdown(shutdownCtx)


### PR DESCRIPTION
Part of #1181, #1179.

`agent.llm.retro` was a 10µs no-op capture stub: it built the retrospective PROMPT and resolved which tier WOULD serve, but never called `Backend.Infer`, so the agent's post-game LEARNING produced no conclusion. This is increment 1 of epic #1181.

## What changed
- **Decoder** (`llm/retro.go`): `RetroResponse{SessionAssessment, Suggestions[], SessionFocus}` + `RetroSuggestion{InterventionType, Emphasis, Reason}` + `DecodeRetro(raw)` — a defensive parser (tolerates fenced / prose-wrapped JSON), sibling of the in-game `llm.Decode`. Recorded-only, so no required-field / vocabulary gating; the only hard requirement is "a single JSON object".
- **Async infer wiring** (`decision/retro_capture.go` `OnGameEnd`): surfaces the live `res.Backend` (previously resolved in `retroInference` then discarded) and, when non-nil, fires `infer+decode+capture` in a **goroutine** under a `context.WithTimeout` latency budget, wrapping the outbound call in an `agent.llm.infer.call` client span so #1112 traceparent propagates. The lifecycle hook never blocks; the span ends **after** the response (real latency). When `res.Backend==nil` it stays capture-only with `no_backend_available`.
- **Conclusion captured on the SAME span**: `llm.retro.session_assessment`, `llm.retro.session_focus`, `llm.retro.suggestion_count`, one `retro.suggestion` event per suggestion (intervention_type / emphasis / reason), `llm.retro.latency_ms`, `llm.retro.parse_ok`. On transport/timeout/decode failure it stamps `llm.infer.error` + an `agent.llm.retro_failed` WARN log.
- **Raw response once-log** (#1169 pattern): the reply rides `llm.retro.response_sha256` on the span; the full text is emitted **once per distinct hash** on the `agent.llm.retro_response` reference LOG line (keeps big text off the traces pipeline).
- New `llm.retro.*` attr keys in `telemetry.go`; raw-response reference singleton in `prompt_fingerprint.go` (sibling of `systemPromptRef`).
- `main.go` / `server.go`: `SetRootContext` + `AwaitInflight` so retro inference goroutines are bounded by the agent root context and joined on shutdown (no leak).

## Scope notes for review
- **Observability + a real inference call only** — no other behavior change. The budget gate already debited "one request"; now it matches reality.
- The retro span's **parenting is unchanged** (the experiment-as-root hierarchy is a separate later increment, #1182).
- Beyond the issue's strict trio (`retro.go` / `retro_capture.go` / `telemetry.go` + tests), this also touches `prompt_fingerprint.go` (the shared fingerprint infra, where the #1169 reference singleton belongs) and `main.go`/`server.go` (production wiring of the new SetRootContext/AwaitInflight seams). Did **not** touch `decision.go` / `async_*.go` / `effect.go`.
- **Please scrutinize the async / fail-open paths** (`runRetroInfer`): any flagd/backend/timeout/decode failure logs + stamps the error and ends the span cleanly — it must never break `OnGameEnd` or the game-end transition.

## Tests
- `DecodeRetro`: valid / fenced+prose-wrapped / empty-suggestions-valid / garbage+empty → typed errors.
- Retro span carries assessment/focus/suggestion_count + per-suggestion events on success; parse_ok=false + error on bad/garbage reply and on transport error; latency always recorded; raw-response once-per-hash; the goroutine does NOT block `OnGameEnd`; capture-only fallback when backend nil.
- `cd services/agent && gofmt -l . && go build ./... && go vet ./... && go test ./... -race -count=1` — all clean/green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)