### PR TITLE
feat(agent): re-parent in-game spans as remote children of the game span (#1178)

### DIFF
--- a/services/agent/decision/async_apply.go
+++ b/services/agent/decision/async_apply.go
@@ -52,6 +52,16 @@ func (l *Loop) applyAsyncResult(root context.Context, snapshot flags.Snapshot, t
 	// as a SpanContext value on the outcome) so the apply trace — and the agent.decision/
 	// agent.action spans nested under it — is navigable from the signal that caused it.
 	// No-op when out.fireSC is invalid (the production default), exactly like gameTraceLink.
+	// #1178: also start it as a remote CHILD of the game span — the async-materialized
+	// decision/action are part of the game, so they live INSIDE the game trace. The
+	// fire-cycle Link is KEPT alongside (navigates to the originating signal cycle); the
+	// game span is the new ROOT parent. Graceful fallback: when the game trace ids
+	// (carried on the outcome from fire time) are absent/invalid gameRemoteParent returns
+	// root unchanged, so this stays its own root + fire-cycle Link exactly as before.
+	applyParent := root
+	if parentCtx, ok := gameRemoteParent(root, out.gameTraceID, out.gameTraceSpanID); ok {
+		applyParent = parentCtx
+	}
 	applyOpts := []trace.SpanStartOption{
 		trace.WithTimestamp(trig.T0),
 		trace.WithSpanKind(trace.SpanKindInternal),
@@ -62,7 +72,7 @@ func (l *Loop) applyAsyncResult(root context.Context, snapshot flags.Snapshot, t
 		),
 	}
 	applyOpts = append(applyOpts, fireCycleLink(out.fireSC)...)
-	applyCtx, applyRoot := l.Tracer.Start(root, SpanLLMApply, applyOpts...)
+	applyCtx, applyRoot := l.Tracer.Start(applyParent, SpanLLMApply, applyOpts...)
 	defer applyRoot.End()
 
 	// Emit the agent.llm.infer call span as a child of the apply root, with the REAL

--- a/services/agent/decision/async_game_child_test.go
+++ b/services/agent/decision/async_game_child_test.go
@@ -1,0 +1,94 @@
+package decision
+
+import (
+	"context"
+	"testing"
+
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/joustmania/agent/gamecontext"
+)
+
+// async_game_child_test.go is the #1178 async-path assertion suite: when the game-session
+// trace ids are present, the async-materialized agent.llm.infer.call and agent.llm.apply
+// spans are started as remote CHILDREN of the game span (they live in the game trace, with
+// the game span as their parent) instead of own roots — while KEEPING the #1140 fire-cycle
+// Link alongside. When the ids are absent the spans stay own-root + fire-cycle Link exactly
+// as before (graceful fallback).
+
+// activeGameTraceContext is activeContext enriched with the game-session trace ids, so the
+// async path can re-parent its spans under the game span.
+func activeGameTraceContext(gameID, serial string) gamecontext.GameContext {
+	c := activeContext(gameID, serial)
+	c.GameTraceID = hubGameTrace
+	c.GameTraceSpanID = hubGameSpanID
+	return c
+}
+
+// TestAsync_InferAndApplyChildrenOfGameSpan: with the game trace ids present, both
+// agent.llm.infer.call and agent.llm.apply are remote children of the game span (their
+// Parent is the game span and they live in the game trace), AND they still carry the
+// fire-cycle Link back to the anchor signal_received.
+func TestAsync_InferAndApplyChildrenOfGameSpan(t *testing.T) {
+	be := &injectingBackend{name: "phi4-mini", response: validShieldResponse}
+	provider := newFakeContextProvider()
+	provider.set("g1", activeGameTraceContext("g1", "AAAA"))
+	l, sr, _ := asyncLoop(t, asyncSnapshot(), resolverWith(be), provider, "g1", nil)
+
+	l.OnEvaluate(context.Background(), activeGameTraceContext("g1", "AAAA"), testTrigger())
+	l.AwaitInflight()
+
+	wantTID, _ := trace.TraceIDFromHex(hubGameTrace)
+	wantSID, _ := trace.SpanIDFromHex(hubGameSpanID)
+
+	for _, name := range []string{SpanLLMInferCall, SpanLLMApply} {
+		spans := spansByName(sr.Ended(), name)
+		if len(spans) != 1 {
+			t.Fatalf("%s spans = %d, want 1", name, len(spans))
+		}
+		s := spans[0]
+		if s.Parent().TraceID() != wantTID {
+			t.Errorf("%s parent trace_id = %s, want game trace %s", name, s.Parent().TraceID(), wantTID)
+		}
+		if s.Parent().SpanID() != wantSID {
+			t.Errorf("%s parent span_id = %s, want game span %s", name, s.Parent().SpanID(), wantSID)
+		}
+		if s.SpanContext().TraceID() != wantTID {
+			t.Errorf("%s must live in the game trace; got %s want %s", name, s.SpanContext().TraceID(), wantTID)
+		}
+		if !s.Parent().IsRemote() {
+			t.Errorf("%s parent must be the REMOTE game span", name)
+		}
+		// The fire-cycle Link is KEPT alongside the new game-span parent.
+		if _, ok := linkToFireCycle(s.Links()); !ok {
+			t.Errorf("%s must keep its fire_cycle Link alongside the game-span parent", name)
+		}
+	}
+}
+
+// TestAsync_InferAndApplyOwnRootWhenIdsAbsent: with no game trace ids the async spans stay
+// own-root (their parent is invalid — they share only the fire-cycle Link), exactly the
+// pre-#1178 shape. infer.call and apply are on disjoint roots from each other.
+func TestAsync_InferAndApplyOwnRootWhenIdsAbsent(t *testing.T) {
+	be := &injectingBackend{name: "phi4-mini", response: validShieldResponse}
+	provider := newFakeContextProvider()
+	provider.set("g1", activeContext("g1", "AAAA")) // no game trace ids
+	l, sr, _ := asyncLoop(t, asyncSnapshot(), resolverWith(be), provider, "g1", nil)
+
+	l.OnEvaluate(context.Background(), activeContext("g1", "AAAA"), testTrigger())
+	l.AwaitInflight()
+
+	for _, name := range []string{SpanLLMInferCall, SpanLLMApply} {
+		spans := spansByName(sr.Ended(), name)
+		if len(spans) != 1 {
+			t.Fatalf("%s spans = %d, want 1", name, len(spans))
+		}
+		if spans[0].Parent().IsValid() {
+			t.Errorf("%s must be own-root when no game trace ids; parent=%v", name, spans[0].Parent())
+		}
+		// The fire-cycle Link remains the sole correlation, as before.
+		if _, ok := linkToFireCycle(spans[0].Links()); !ok {
+			t.Errorf("%s must still carry its fire_cycle Link when own-root", name)
+		}
+	}
+}

--- a/services/agent/decision/async_infer.go
+++ b/services/agent/decision/async_infer.go
@@ -267,22 +267,31 @@ func (l *Loop) runInfer(root context.Context, snapshot flags.Snapshot, backend B
 	// carries only the request model — no gen_ai attribution duplication; the apply-time
 	// agent.llm.infer keeps owning that. Default-safe: with a no-op tracer/propagator
 	// this is a no-op and no header is written.
-	// #1140 (Slice A): Link this otherwise parent-less outbound-call root back to the
-	// originating fire-cycle's agent.signal_received trace, so a reader of the infer
-	// trace can navigate to the signal that caused it. No-op when fireSC is invalid.
+	// #1140 (Slice A): Link this outbound-call root back to the originating fire-cycle's
+	// agent.signal_received trace, so a reader of the infer trace can navigate to the
+	// signal that caused it. No-op when fireSC is invalid.
+	// #1178: also start it as a remote CHILD of the game span — the async-materialized
+	// inference is part of the game, so it lives INSIDE the game trace (not merely Linked
+	// to it). The fire-cycle Link is KEPT alongside (it navigates to the originating
+	// signal cycle); the game span is the new ROOT parent. Graceful fallback: when the
+	// game trace ids are absent/invalid gameRemoteParent returns inferCtx unchanged, so
+	// this stays its own root + fire-cycle Link exactly as before.
+	callParent := inferCtx
+	if parentCtx, ok := gameRemoteParent(inferCtx, c.GameTraceID, c.GameTraceSpanID); ok {
+		callParent = parentCtx
+	}
 	callOpts := []trace.SpanStartOption{
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
 			attribute.String("gen_ai.request.model", backend.Name()),
 			// game.id + session.id (#1174): make the outbound-call span findable by game,
-			// so the LLM call for game X is a queryable spoke (it already Links to the
-			// fire cycle, which Links to the hub). c is THIS game's GameContext.
+			// so the LLM call for game X is a queryable spoke. c is THIS game's GameContext.
 			attribute.String(AttrGameID, c.SessionID),
 			attribute.String(AttrSessionID, c.SessionID),
 		),
 	}
 	callOpts = append(callOpts, fireCycleLink(fireSC)...)
-	callCtx, callSpan := l.Tracer.Start(inferCtx, SpanLLMInferCall, callOpts...)
+	callCtx, callSpan := l.Tracer.Start(callParent, SpanLLMInferCall, callOpts...)
 	raw, inferErr := backend.Infer(callCtx, prompt)
 	callSpan.End()
 	end := now()
@@ -298,6 +307,11 @@ func (l *Loop) runInfer(root context.Context, snapshot flags.Snapshot, backend B
 		contextNotePresent: notePresent,
 		contextNoteLen:     noteLen,
 		fireSC:             fireSC,
+		// #1178: carry the game-session trace ids so the apply root can be started as a
+		// remote child of the game span (the apply path runs off the loop, with no game
+		// span in its ctx). Captured from THIS game's fire-time GameContext.
+		gameTraceID:     c.GameTraceID,
+		gameTraceSpanID: c.GameTraceSpanID,
 	})
 }
 
@@ -338,4 +352,11 @@ type asyncOutcome struct {
 	// the agent.llm.apply root back to the originating agent.signal_received trace. Invalid
 	// (the production default — no span active at fire time) yields no link (graceful).
 	fireSC trace.SpanContext
+	// gameTraceID/gameTraceSpanID are THIS game's game-session trace ids, captured from the
+	// fire-time GameContext (#1178). The apply root (agent.llm.apply) is started as a remote
+	// CHILD of the game span via these ids, so the async-materialized decision/action live
+	// INSIDE the game trace. Empty/invalid => the apply root stays its own root (graceful
+	// fallback, fire-cycle Link only), exactly as before.
+	gameTraceID     string
+	gameTraceSpanID string
 }

--- a/services/agent/decision/decision.go
+++ b/services/agent/decision/decision.go
@@ -660,11 +660,20 @@ func (l *Loop) startSignalReceivedSpan(ctx context.Context, c gamecontext.GameCo
 			attribute.String(AttrGameID, c.SessionID),
 		),
 	}
-	// Hub-and-spoke correlation (#1174): this cycle-root span is the parent of the whole
-	// sync decision->action subtree AND the #1140 async fire anchor (both call this shared
-	// helper). Linking it to the game-session trace pulls that ENTIRE subtree onto the hub
-	// in one change. Stamp the game trace_id as a searchable attribute too. nil-safe.
-	startOpts = append(startOpts, gameTraceLink(c.GameTraceID, c.GameTraceSpanID)...)
+	// In-game re-parenting (#1178, refining #1174): the agent's in-game decisions/actions
+	// ARE part of the game — they happen within the game span's duration and shape it — so
+	// this cycle-root span is started as a remote CHILD of the game span instead of LINKED
+	// to it. Because it is the parent of the whole sync decision->action subtree AND the
+	// #1140 async fire anchor (both call this shared helper), that whole subtree is pulled
+	// INSIDE the game trace in one change. The game span is remote (we hold only its
+	// SpanContext from the #1133 correlation gauge); a remote child can be started under it
+	// regardless of its liveness, and inherits the game trace's sampling fate. Graceful
+	// fallback: when the game trace ids are absent/invalid (correlation gauge not yet
+	// ingested) gameRemoteParent returns ctx unchanged + ok=false, so this stays an own-root
+	// span exactly as before. The game trace ids are still stamped as searchable attributes.
+	if parentCtx, ok := gameRemoteParent(ctx, c.GameTraceID, c.GameTraceSpanID); ok {
+		ctx = parentCtx
+	}
 	if c.GameTraceID != "" {
 		startOpts = append(startOpts, trace.WithAttributes(attribute.String(AttrGameTraceID, c.GameTraceID)))
 	}
@@ -1200,6 +1209,20 @@ func gameTraceLink(gameTraceID, gameTraceSpanID string) []trace.SpanStartOption 
 	return gamecontext.TraceLink(gameTraceID, gameTraceSpanID, AttrGameTraceID, AttrGameTraceSpanID)
 }
 
+// gameRemoteParent is the #1178 sibling of gameTraceLink: instead of LINKING a span to
+// the game trace it returns a context that makes the span a remote CHILD of the game
+// span. When BOTH gameTraceID and gameTraceSpanID are valid hex ids it installs the SAME
+// remote game SpanContext gameTraceLink targets as the remote parent of ctx and returns
+// ok=true; a span started from the returned ctx joins the game trace under the game span
+// (regardless of the game span's liveness — the remote-parent rule is liveness-free) and
+// inherits the game trace's sampling fate. When either id is empty/unparseable/all-zero
+// it returns the UNCHANGED ctx and ok=false, so the caller starts the span exactly as
+// before (own root): graceful fallback, never breaking span emission. Delegates to the
+// single primitive in gamecontext so the SpanContext construction is shared with the Link.
+func gameRemoteParent(ctx context.Context, gameTraceID, gameTraceSpanID string) (context.Context, bool) {
+	return gamecontext.RemoteParent(ctx, gameTraceID, gameTraceSpanID)
+}
+
 // GameTraceLink is the exported entry point to the gameTraceLink primitive so other
 // agent packages (e.g. the experiment loop, #1140 Slice C) can build the SAME
 // game-trace-correlation span Link the agent.decision / agent.llm.retro spans use,
@@ -1223,10 +1246,6 @@ const (
 	attrLinkKind      = "link.kind"
 	attrLinkTraceID   = "link.trace_id"
 	linkKindFireCycle = "fire_cycle"
-	// linkKindDecision labels the #1174 Link from an agent.intervention.effect span back
-	// to the agent.decision span that caused it, so a reader on the effect span can
-	// navigate to the originating decision (the named "no clue what it relates to" gap).
-	linkKindDecision = "decision"
 )
 
 // fireCycleLink builds the #1140 (Slice A) trace-continuity span option: when the
@@ -1247,29 +1266,6 @@ func fireCycleLink(sc trace.SpanContext) []trace.SpanStartOption {
 			SpanContext: sc,
 			Attributes: []attribute.KeyValue{
 				attribute.String(attrLinkKind, linkKindFireCycle),
-				attribute.String(attrLinkTraceID, sc.TraceID().String()),
-			},
-		}),
-	}
-}
-
-// decisionLink builds the #1174 Link from an agent.intervention.effect span back to its
-// CAUSING agent.decision span. The effect span is emitted on its own backdated root
-// seconds after the decision (the follow-up window), so a Link — not parent-child — is
-// the correct relationship, mirroring fireCycleLink. When the captured decision
-// SpanContext is valid it returns one trace.WithLinks option carrying
-// link.kind=decision plus the decision trace_id as a queryable attribute; an
-// invalid/zero SpanContext (no-op tracer / no active decision span) yields NO option —
-// graceful fallback, no Link, no error.
-func decisionLink(sc trace.SpanContext) []trace.SpanStartOption {
-	if !sc.IsValid() {
-		return nil
-	}
-	return []trace.SpanStartOption{
-		trace.WithLinks(trace.Link{
-			SpanContext: sc,
-			Attributes: []attribute.KeyValue{
-				attribute.String(attrLinkKind, linkKindDecision),
 				attribute.String(attrLinkTraceID, sc.TraceID().String()),
 			},
 		}),

--- a/services/agent/decision/effect.go
+++ b/services/agent/decision/effect.go
@@ -188,17 +188,17 @@ func (l *Loop) scheduleEffectSample(decisionCtx context.Context, c gamecontext.G
 		thresholds:   thresholds,
 		dispatchedAt: dispatchedAt,
 		window:       window,
-		// Hub-and-spoke correlation (#1174): capture the game-session trace ids from the
-		// GameContext in scope at schedule time, so the deferred effect span can Link back
-		// to the game hub via the SHARED gameTraceLink primitive (same as decision/retro).
-		// nil-safe: empty ids => no Link.
+		// Capture the game-session trace ids from the GameContext in scope at schedule
+		// time (#1133), stamped as searchable attributes on the deferred effect span.
+		// nil-safe: empty ids => no attribute.
 		gameTraceID:     c.GameTraceID,
 		gameTraceSpanID: c.GameTraceSpanID,
 		// Capture the CAUSING agent.decision span's SpanContext while it is still live
-		// (decisionCtx is the decision span's context — it calls schedule). The effect
-		// span (emitted seconds later on its own root) Links to it with link.kind=decision
-		// so decision->effect is navigable, mirroring fireCycleLink. Invalid SpanContext
-		// (no-op tracer / no active span) => no Link.
+		// (decisionCtx is the decision span's context — it calls schedule). #1178: the effect
+		// span (emitted seconds later) is started as a remote CHILD of this decision span, so
+		// decision->effect is structural (nested) and lands inside the game trace transitively
+		// (the decision is itself under the game span). Invalid SpanContext (no-op tracer /
+		// no active span) => no remote parent => the effect span stays its own root.
 		decisionSC: trace.SpanContextFromContext(decisionCtx),
 	}
 
@@ -249,12 +249,12 @@ type pendingEffect struct {
 	dispatchedAt time.Time
 	window       time.Duration
 	// gameTraceID/gameTraceSpanID are the game-session trace ids captured at schedule
-	// time (#1174), used to Link the effect span back to the game hub. Empty => no Link.
+	// time (#1133), stamped as searchable attributes on the effect span. Empty => no attr.
 	gameTraceID     string
 	gameTraceSpanID string
 	// decisionSC is the SpanContext of the agent.decision span that caused this effect,
-	// captured live at schedule time (#1174). The effect root Links to it with
-	// link.kind=decision. Invalid => no Link.
+	// captured live at schedule time (#1178). The effect root is started as a remote CHILD
+	// of it (nested under the decision in the game trace). Invalid => effect stays own-root.
 	decisionSC trace.SpanContext
 }
 
@@ -272,13 +272,18 @@ func (l *Loop) emitEffectSample(ctx context.Context, s pendingEffect) {
 	// One backdated root span (to dispatch time) parents the per-objective effect spans,
 	// so a Jaeger trace shows the dispatch->follow-up arc, mirroring the #917 apply root.
 	//
-	// Hub-and-spoke correlation (#1174): the effect span carries the game.id query axis
-	// AND TWO navigation Links — (a) gameTraceLink to the game-session trace (the hub),
-	// so "what did the agent learn for game X" lists this span among the spokes; (b)
-	// decisionLink to the CAUSING agent.decision span, so the named "no clue what it
-	// relates to" gap is closed. The decision trace_id is ALSO stamped as a plain
-	// attribute (AttrDecisionInterventionID joins decision<->effect by tag; the link
-	// trace_id makes the decision trace itself greppable). Both Links are nil-safe.
+	// In-game re-parenting (#1178, refining #1174): the effect measurement is part of the
+	// game (it measures what an in-game decision did), so the effect span is started as a
+	// remote CHILD of its CAUSING agent.decision span instead of LINKED to the game trace.
+	// The decision span is itself (transitively) under the game span — its cycle root
+	// agent.signal_received was re-parented under the game span — so the effect lands INSIDE
+	// the game trace, nested under the decision that caused it: the "no clue what it relates
+	// to" gap is closed structurally. The separate game-trace Link is DROPPED (it is now
+	// transitive); the standalone decisionLink is likewise dropped (the decision is now the
+	// PARENT, so a Link to it would be a self-link). game.id stays the query axis, and the
+	// game trace ids stay as searchable span attributes. Graceful fallback: an invalid
+	// decisionSC (no-op tracer / no active decision span) yields no remote parent, so the
+	// effect span stays its own root exactly as the nil-safe decisionLink did before.
 	startOpts := []trace.SpanStartOption{
 		trace.WithTimestamp(s.dispatchedAt),
 		trace.WithSpanKind(trace.SpanKindInternal),
@@ -294,15 +299,17 @@ func (l *Loop) emitEffectSample(ctx context.Context, s pendingEffect) {
 			attribute.Float64(AttrEffectWindowSeconds, windowSeconds),
 		),
 	}
-	startOpts = append(startOpts, gameTraceLink(s.gameTraceID, s.gameTraceSpanID)...)
 	if s.gameTraceID != "" {
 		startOpts = append(startOpts, trace.WithAttributes(attribute.String(AttrGameTraceID, s.gameTraceID)))
 	}
 	if s.gameTraceSpanID != "" {
 		startOpts = append(startOpts, trace.WithAttributes(attribute.String(AttrGameTraceSpanID, s.gameTraceSpanID)))
 	}
-	startOpts = append(startOpts, decisionLink(s.decisionSC)...)
-	rootCtx, root := l.Tracer.Start(ctx, SpanInterventionEffect, startOpts...)
+	effectParent := ctx
+	if s.decisionSC.IsValid() {
+		effectParent = trace.ContextWithRemoteSpanContext(ctx, s.decisionSC)
+	}
+	rootCtx, root := l.Tracer.Start(effectParent, SpanInterventionEffect, startOpts...)
 	defer root.End()
 
 	if !ok {

--- a/services/agent/decision/hub_spoke_link_test.go
+++ b/services/agent/decision/hub_spoke_link_test.go
@@ -11,10 +11,13 @@ import (
 	"github.com/joustmania/agent/gamecontext"
 )
 
-// hub_spoke_link_test.go covers the #1174 hub-and-spoke correlation additions: every
-// agent per-game span carries the game.id query axis AND a Link back to the
-// game-session trace (the hub). The intervention.effect span additionally Links to its
-// CAUSING agent.decision span (link.kind=decision). All Links are nil-safe.
+// hub_spoke_link_test.go covers the #1178 in-game re-parenting (refining #1174): the
+// agent's per-game IN-GAME spans become remote CHILDREN of the game span instead of
+// Links to the game trace. agent.signal_received re-parents under the game span (pulling
+// its whole sync subtree + the async fire anchor into the game trace); the
+// agent.intervention.effect span re-parents under its CAUSING agent.decision span. Every
+// span keeps the game.id query axis. All re-parenting is graceful: absent/invalid ids ->
+// own-root span exactly as before.
 
 const (
 	hubGameTrace  = "4bf92f3577b34da6a3ce929d0e0e4736" // valid 16-byte hex trace id
@@ -29,19 +32,6 @@ func gameTraceCtx(gameID string) gamecontext.GameContext {
 		GameTraceID:     hubGameTrace,
 		GameTraceSpanID: hubGameSpanID,
 	}
-}
-
-// linkByKind returns the Link on the span whose link.kind attribute equals kind, and
-// whether one was found.
-func linkByKind(links []sdktrace.Link, kind string) (sdktrace.Link, bool) {
-	for _, lk := range links {
-		for _, kv := range lk.Attributes {
-			if string(kv.Key) == attrLinkKind && kv.Value.AsString() == kind {
-				return lk, true
-			}
-		}
-	}
-	return sdktrace.Link{}, false
 }
 
 // rootEffectSpan returns the root agent.intervention.effect span (the one carrying the
@@ -59,12 +49,13 @@ func rootEffectSpan(spans []sdktrace.ReadOnlySpan) sdktrace.ReadOnlySpan {
 	return nil
 }
 
-// TestEffectSpan_LinksToGameTraceAndDecision: when both the game-trace ids AND a live
-// decision span are in scope at schedule time, the emitted intervention.effect root
-// carries (a) the game.id attribute, (b) a game-trace Link (to the hub), and (c) a
-// decision Link (link.kind=decision) to the causing decision span. The per-signal
-// child carries game.id + the intervention id.
-func TestEffectSpan_LinksToGameTraceAndDecision(t *testing.T) {
+// TestEffectSpan_ChildOfDecision: when a live decision span is in scope at schedule time,
+// the emitted intervention.effect root is a remote CHILD of that decision span — its
+// Parent is the decision SpanContext and it lives in the decision's trace — and it carries
+// NO standalone Links (the game-trace Link is dropped, the decision is now the parent).
+// game.id stays the query axis; the game trace ids stay as searchable attributes. The
+// per-signal child carries game.id + the intervention id.
+func TestEffectSpan_ChildOfDecision(t *testing.T) {
 	provider := newFakeContextProvider()
 	const gameID = "game_hub01"
 	provider.set(gameID, durationContext(gameID, 90))
@@ -92,35 +83,27 @@ func TestEffectSpan_LinksToGameTraceAndDecision(t *testing.T) {
 		t.Errorf("effect root game.id = %q (present=%v), want %q", v.AsString(), ok, gameID)
 	}
 
-	// (b) game-trace Link to the hub.
-	wantTID, _ := trace.TraceIDFromHex(hubGameTrace)
-	wantSID, _ := trace.SpanIDFromHex(hubGameSpanID)
-	var sawGameLink bool
-	for _, lk := range root.Links() {
-		if lk.SpanContext.TraceID() == wantTID && lk.SpanContext.SpanID() == wantSID {
-			sawGameLink = true
-		}
+	// (b) the effect root is a remote CHILD of the causing decision span.
+	if root.Parent().TraceID() != decisionSpan.SpanContext().TraceID() {
+		t.Errorf("effect root trace_id = %s, want decision trace %s",
+			root.Parent().TraceID(), decisionSpan.SpanContext().TraceID())
 	}
-	if !sawGameLink {
-		t.Errorf("effect root missing game-trace Link to %s/%s; links=%v", wantTID, wantSID, root.Links())
+	if root.Parent().SpanID() != decisionSpan.SpanContext().SpanID() {
+		t.Errorf("effect root parent span_id = %s, want decision span %s",
+			root.Parent().SpanID(), decisionSpan.SpanContext().SpanID())
 	}
-	// Searchable game.trace_id attribute too.
-	if v, ok := attrValue(root, AttrGameTraceID); !ok || v.AsString() != hubGameTrace {
-		t.Errorf("effect root game.trace_id = %q (present=%v), want %q", v.AsString(), ok, hubGameTrace)
+	if root.SpanContext().TraceID() != decisionSpan.SpanContext().TraceID() {
+		t.Errorf("effect root must share the decision trace; got %s want %s",
+			root.SpanContext().TraceID(), decisionSpan.SpanContext().TraceID())
 	}
 
-	// (c) decision Link (link.kind=decision) targeting the causing decision span.
-	decLink, ok := linkByKind(root.Links(), linkKindDecision)
-	if !ok {
-		t.Fatal("effect root missing link.kind=decision Link to the causing decision span")
+	// (c) no standalone Links: the game-trace Link is dropped, the decision is the parent.
+	if n := len(root.Links()); n != 0 {
+		t.Errorf("effect root links = %d, want 0 (re-parented, not Linked); links=%v", n, root.Links())
 	}
-	if decLink.SpanContext.TraceID() != decisionSpan.SpanContext().TraceID() {
-		t.Errorf("decision Link trace_id = %s, want %s",
-			decLink.SpanContext.TraceID(), decisionSpan.SpanContext().TraceID())
-	}
-	if decLink.SpanContext.SpanID() != decisionSpan.SpanContext().SpanID() {
-		t.Errorf("decision Link span_id = %s, want %s",
-			decLink.SpanContext.SpanID(), decisionSpan.SpanContext().SpanID())
+	// Searchable game.trace_id attribute is still stamped.
+	if v, ok := attrValue(root, AttrGameTraceID); !ok || v.AsString() != hubGameTrace {
+		t.Errorf("effect root game.trace_id = %q (present=%v), want %q", v.AsString(), ok, hubGameTrace)
 	}
 
 	// per-signal child carries game.id + the intervention id (both keys).
@@ -145,18 +128,18 @@ func TestEffectSpan_LinksToGameTraceAndDecision(t *testing.T) {
 	}
 }
 
-// TestEffectSpan_NoLinksWhenIdsAbsent: with an empty GameContext and no live decision
-// span, the effect span carries NO game-trace Link and NO decision Link (graceful
-// nil-safe fallback) — exactly the pre-#1174 shape.
-func TestEffectSpan_NoLinksWhenIdsAbsent(t *testing.T) {
+// TestEffectSpan_OwnRootWhenDecisionAbsent: with no live decision span in scope (and an
+// empty GameContext) the effect span is its own root — no parent, no Links — exactly the
+// graceful fallback the nil-safe Link produced before.
+func TestEffectSpan_OwnRootWhenDecisionAbsent(t *testing.T) {
 	provider := newFakeContextProvider()
 	const gameID = "game_nolink"
 	provider.set(gameID, durationContext(gameID, 90))
 
 	l, sr, _, sched := effectLoop(t, provider, gameID)
 
-	// background ctx => invalid SpanContext => no decision Link; empty GameContext => no
-	// game-trace Link.
+	// background ctx => invalid decision SpanContext => no remote parent; empty
+	// GameContext => no game trace ids.
 	id := l.scheduleEffectSample(context.Background(), gamecontext.GameContext{}, shieldDecision(), enduranceBaseline(), defaultFit())
 	if id == "" {
 		t.Fatal("expected a scheduled sample")
@@ -168,6 +151,9 @@ func TestEffectSpan_NoLinksWhenIdsAbsent(t *testing.T) {
 	if root == nil {
 		t.Fatal("no root agent.intervention.effect span")
 	}
+	if root.Parent().IsValid() {
+		t.Errorf("effect root must be own-root when no decision span in scope; parent=%v", root.Parent())
+	}
 	if n := len(root.Links()); n != 0 {
 		t.Errorf("effect root links = %d, want 0 (no ids => no Links); links=%v", n, root.Links())
 	}
@@ -176,10 +162,12 @@ func TestEffectSpan_NoLinksWhenIdsAbsent(t *testing.T) {
 	}
 }
 
-// TestSignalReceived_LinksToGameTrace: the cycle-root agent.signal_received span carries
-// a game-trace Link + the searchable game.trace_id attr when the ids are present, and
-// none when absent (nil-safe).
-func TestSignalReceived_LinksToGameTrace(t *testing.T) {
+// TestSignalReceived_ChildOfGameSpan: the cycle-root agent.signal_received span is a
+// remote CHILD of the game span when the game trace ids are present (its Parent is the
+// game span, it lives in the game trace), and an OWN-ROOT span (no parent) when they are
+// absent. The searchable game.trace_id attr rides along when present. The whole sync
+// decision->action subtree is therefore pulled into the game trace.
+func TestSignalReceived_ChildOfGameSpan(t *testing.T) {
 	t.Run("present", func(t *testing.T) {
 		l, sr, _ := meteredTestLoop(t)
 		l.Rules = fakeRules{out: []Decision{{Intervention: "noop", Reason: "x"}}}
@@ -190,14 +178,23 @@ func TestSignalReceived_LinksToGameTrace(t *testing.T) {
 
 		root := spansByName(sr.Ended(), SignalReceived)[0]
 		wantTID, _ := trace.TraceIDFromHex(hubGameTrace)
-		var sawLink bool
-		for _, lk := range root.Links() {
-			if lk.SpanContext.TraceID() == wantTID {
-				sawLink = true
-			}
+		wantSID, _ := trace.SpanIDFromHex(hubGameSpanID)
+		if root.Parent().TraceID() != wantTID {
+			t.Errorf("signal_received parent trace_id = %s, want game trace %s", root.Parent().TraceID(), wantTID)
 		}
-		if !sawLink {
-			t.Errorf("signal_received missing game-trace Link; links=%v", root.Links())
+		if root.Parent().SpanID() != wantSID {
+			t.Errorf("signal_received parent span_id = %s, want game span %s", root.Parent().SpanID(), wantSID)
+		}
+		if root.SpanContext().TraceID() != wantTID {
+			t.Errorf("signal_received must live in the game trace; got %s want %s", root.SpanContext().TraceID(), wantTID)
+		}
+		if !root.Parent().IsRemote() {
+			t.Error("signal_received parent must be the REMOTE game span")
+		}
+		// The decision span (sync subtree) shares the game trace as a consequence.
+		dec := spansByName(sr.Ended(), SpanDecision)[0]
+		if dec.SpanContext().TraceID() != wantTID {
+			t.Errorf("agent.decision must be pulled into the game trace; got %s want %s", dec.SpanContext().TraceID(), wantTID)
 		}
 		if v, ok := attrValue(root, AttrGameTraceID); !ok || v.AsString() != hubGameTrace {
 			t.Errorf("signal_received game.trace_id = %q (present=%v), want %q", v.AsString(), ok, hubGameTrace)
@@ -213,22 +210,55 @@ func TestSignalReceived_LinksToGameTrace(t *testing.T) {
 			EvalTrigger{Signal: "metrics", T0: time.Now(), RPCService: "svc"})
 
 		root := spansByName(sr.Ended(), SignalReceived)[0]
+		if root.Parent().IsValid() {
+			t.Errorf("signal_received must be own-root when no game ids; parent=%v", root.Parent())
+		}
 		if n := len(root.Links()); n != 0 {
 			t.Errorf("signal_received links = %d, want 0 (no ids); links=%v", n, root.Links())
 		}
 	})
 }
 
-// TestDecisionLink_Direct unit-tests the helper in isolation: a valid SpanContext yields
-// one Link option carrying link.kind=decision; an invalid/zero SpanContext yields nil.
-func TestDecisionLink_Direct(t *testing.T) {
-	if got := decisionLink(trace.SpanContext{}); got != nil {
-		t.Errorf("decisionLink(zero) = %v, want nil", got)
-	}
-	tid, _ := trace.TraceIDFromHex(hubGameTrace)
-	sid, _ := trace.SpanIDFromHex(hubGameSpanID)
-	sc := trace.NewSpanContext(trace.SpanContextConfig{TraceID: tid, SpanID: sid, TraceFlags: trace.FlagsSampled})
-	if got := decisionLink(sc); len(got) != 1 {
-		t.Errorf("decisionLink(valid) = %d options, want 1", len(got))
+// TestGameRemoteParent_Direct unit-tests the helper in isolation: a valid (trace,span)
+// pair installs a remote parent (ok=true, a span started from the ctx becomes a child);
+// any empty/invalid id returns the unchanged ctx + ok=false (graceful fallback, own root).
+func TestGameRemoteParent_Direct(t *testing.T) {
+	base := context.Background()
+
+	for _, tc := range []struct {
+		name            string
+		traceID, spanID string
+		wantOK          bool
+	}{
+		{"valid", hubGameTrace, hubGameSpanID, true},
+		{"empty trace", "", hubGameSpanID, false},
+		{"empty span", hubGameTrace, "", false},
+		{"invalid trace", "zzzz", hubGameSpanID, false},
+		{"invalid span", hubGameTrace, "zz", false},
+		{"all-zero trace", "00000000000000000000000000000000", hubGameSpanID, false},
+		{"all-zero span", hubGameTrace, "0000000000000000", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, ok := gameRemoteParent(base, tc.traceID, tc.spanID)
+			if ok != tc.wantOK {
+				t.Fatalf("gameRemoteParent ok = %v, want %v", ok, tc.wantOK)
+			}
+			if !tc.wantOK {
+				if ctx != base {
+					t.Error("invalid ids must return the unchanged ctx")
+				}
+				return
+			}
+			// ok=true: a span started from ctx is a remote child of the game span.
+			wantTID, _ := trace.TraceIDFromHex(tc.traceID)
+			wantSID, _ := trace.SpanIDFromHex(tc.spanID)
+			sc := trace.SpanContextFromContext(ctx)
+			if sc.TraceID() != wantTID || sc.SpanID() != wantSID {
+				t.Errorf("remote parent = %s/%s, want %s/%s", sc.TraceID(), sc.SpanID(), wantTID, wantSID)
+			}
+			if !sc.IsRemote() {
+				t.Error("remote parent SpanContext must be marked Remote")
+			}
+		})
 	}
 }

--- a/services/agent/gamecontext/tracelink.go
+++ b/services/agent/gamecontext/tracelink.go
@@ -1,6 +1,8 @@
 package gamecontext
 
 import (
+	"context"
+
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -25,23 +27,10 @@ import (
 // import with no dependency cycle. decision.GameTraceLink delegates here, preserving
 // the existing exported entry point (#1165).
 func TraceLink(gameTraceID, gameTraceSpanID, traceIDAttrKey, spanIDAttrKey string) []trace.SpanStartOption {
-	if gameTraceID == "" || gameTraceSpanID == "" {
+	sc, ok := gameSpanContext(gameTraceID, gameTraceSpanID)
+	if !ok {
 		return nil
 	}
-	tid, err := trace.TraceIDFromHex(gameTraceID)
-	if err != nil || !tid.IsValid() {
-		return nil
-	}
-	sid, err := trace.SpanIDFromHex(gameTraceSpanID)
-	if err != nil || !sid.IsValid() {
-		return nil
-	}
-	sc := trace.NewSpanContext(trace.SpanContextConfig{
-		TraceID:    tid,
-		SpanID:     sid,
-		TraceFlags: trace.FlagsSampled,
-		Remote:     true,
-	})
 	return []trace.SpanStartOption{
 		trace.WithLinks(trace.Link{
 			SpanContext: sc,
@@ -51,4 +40,51 @@ func TraceLink(gameTraceID, gameTraceSpanID, traceIDAttrKey, spanIDAttrKey strin
 			},
 		}),
 	}
+}
+
+// RemoteParent is the sibling of TraceLink for the #1178 in-game re-parenting: instead
+// of LINKING a span to the game trace it makes the span a remote CHILD of the game span.
+// When BOTH gameTraceID and gameTraceSpanID are valid hex ids it reconstructs the SAME
+// remote game SpanContext TraceLink builds (gameSpanContext) and returns a context with
+// that SpanContext installed as the remote parent (trace.ContextWithRemoteSpanContext on
+// the passed parent ctx), plus ok=true. A span started from that ctx joins the game
+// trace as a child of the game span — regardless of the game span's liveness, since the
+// "can't child an ended span" rule is local-only — and inherits the game trace's sampling.
+//
+// When either id is empty/unparseable/all-zero it returns the UNCHANGED parent ctx and
+// ok=false, so the caller starts the span exactly as before (own root, no parent):
+// graceful fallback, never breaking span emission. This mirrors TraceLink's nil contract
+// (an empty span_id from a pre-#1157 / unsampled game span yields no parent, same as a
+// missing trace_id).
+func RemoteParent(ctx context.Context, gameTraceID, gameTraceSpanID string) (context.Context, bool) {
+	sc, ok := gameSpanContext(gameTraceID, gameTraceSpanID)
+	if !ok {
+		return ctx, false
+	}
+	return trace.ContextWithRemoteSpanContext(ctx, sc), true
+}
+
+// gameSpanContext reconstructs the remote SpanContext of the coordinator's game span from
+// its hex trace_id + span_id. It is the single source of the #1133/#1157 SpanContext
+// construction, shared by TraceLink (Link target) and RemoteParent (remote parent). The
+// returned SpanContext is marked Remote + Sampled. ok=false when either id is empty,
+// unparseable, or all-zero (invalid) — the graceful-fallback signal for both callers.
+func gameSpanContext(gameTraceID, gameTraceSpanID string) (trace.SpanContext, bool) {
+	if gameTraceID == "" || gameTraceSpanID == "" {
+		return trace.SpanContext{}, false
+	}
+	tid, err := trace.TraceIDFromHex(gameTraceID)
+	if err != nil || !tid.IsValid() {
+		return trace.SpanContext{}, false
+	}
+	sid, err := trace.SpanIDFromHex(gameTraceSpanID)
+	if err != nil || !sid.IsValid() {
+		return trace.SpanContext{}, false
+	}
+	return trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    tid,
+		SpanID:     sid,
+		TraceFlags: trace.FlagsSampled,
+		Remote:     true,
+	}), true
 }

--- a/services/agent/gamecontext/tracelink_test.go
+++ b/services/agent/gamecontext/tracelink_test.go
@@ -1,6 +1,11 @@
 package gamecontext
 
-import "testing"
+import (
+	"context"
+	"testing"
+
+	"go.opentelemetry.io/otel/trace"
+)
 
 const (
 	validTrace  = "4bf92f3577b34da6a3ce929d0e0e4736" // valid 16-byte hex trace id
@@ -31,6 +36,55 @@ func TestTraceLink(t *testing.T) {
 			got := TraceLink(tc.trace, tc.span, "game.trace_id", "game.trace_span_id")
 			if len(got) != tc.wantLinks {
 				t.Errorf("TraceLink(%q,%q) = %d options, want %d", tc.trace, tc.span, len(got), tc.wantLinks)
+			}
+		})
+	}
+}
+
+// TestRemoteParent covers the #1178 sibling primitive: a valid (trace,span) pair returns a
+// context carrying the game span as a remote parent (ok=true), reusing the EXACT
+// SpanContext construction TraceLink uses; any missing/invalid id returns the unchanged
+// ctx + ok=false (graceful own-root fallback, no panic).
+func TestRemoteParent(t *testing.T) {
+	cases := []struct {
+		name   string
+		trace  string
+		span   string
+		wantOK bool
+	}{
+		{"valid", validTrace, validSpanID, true},
+		{"empty trace", "", validSpanID, false},
+		{"empty span", validTrace, "", false},
+		{"both empty", "", "", false},
+		{"invalid trace", "zzzz", validSpanID, false},
+		{"invalid span", validTrace, "zz", false},
+		{"all-zero trace", "00000000000000000000000000000000", validSpanID, false},
+		{"all-zero span", validTrace, "0000000000000000", false},
+	}
+	base := context.Background()
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, ok := RemoteParent(base, tc.trace, tc.span)
+			if ok != tc.wantOK {
+				t.Fatalf("RemoteParent(%q,%q) ok = %v, want %v", tc.trace, tc.span, ok, tc.wantOK)
+			}
+			if !tc.wantOK {
+				if ctx != base {
+					t.Error("invalid ids must return the unchanged ctx")
+				}
+				return
+			}
+			sc := trace.SpanContextFromContext(ctx)
+			wantTID, _ := trace.TraceIDFromHex(tc.trace)
+			wantSID, _ := trace.SpanIDFromHex(tc.span)
+			if sc.TraceID() != wantTID || sc.SpanID() != wantSID {
+				t.Errorf("remote parent = %s/%s, want %s/%s", sc.TraceID(), sc.SpanID(), wantTID, wantSID)
+			}
+			if !sc.IsRemote() {
+				t.Error("remote parent SpanContext must be marked Remote")
+			}
+			if !sc.IsSampled() {
+				t.Error("remote parent SpanContext must be Sampled so the child inherits the game's sampling")
 			}
 		})
 	}


### PR DESCRIPTION
Part of #1181, #1178 (PR1: in-game spans → game-span children).

## What

Converts the agent's IN-GAME spans from Links-to-the-game-trace into remote CHILDREN of the game span, so the agent's in-game influence appears INSIDE the game trace. Refines the #1174 hub-and-spoke model: the agent's in-game decisions/actions ARE part of the game (they happen within the game span's duration and shape it), so they belong as children, not separate linked traces.

The agent already holds the game span's remote SpanContext (`GameTraceID` + `GameTraceSpanID`, from the #1133 correlation gauge). A remote child can be started under a remote parent regardless of the parent's liveness, and inherits the game trace's sampling fate.

## Changes

- **`gamecontext.RemoteParent` + `decision.gameRemoteParent`** — sibling of `TraceLink`, reusing the EXACT remote game SpanContext construction (refactored into a shared `gameSpanContext` helper so Link and remote-parent never diverge). Returns the unchanged ctx + `ok=false` on empty/unparseable/all-zero ids.
- **`agent.signal_received`** — started under the remote game-span parent instead of adding the Link, pulling the whole sync `decision → action` subtree AND the #1140 async fire anchor into the game trace.
- **`agent.llm.infer.call` / `agent.llm.apply`** — started under the remote game-span parent; the #1140 fire-cycle Link is KEPT alongside (the game span is the new root parent). The apply path carries the game trace ids on `asyncOutcome` (captured at fire time).
- **`agent.intervention.effect`** — re-parented under its CAUSING `agent.decision` span (the SpanContext already captured for the #1175 decision Link); the separate game-trace Link AND the now-redundant `decisionLink` helper are dropped. `game.id` + searchable `game.trace_id` attrs stay.

## Graceful fallback

Missing/invalid `GameTraceID`/`GameTraceSpanID` (correlation gauge not yet ingested) → own-root span exactly as today. Proven by direct helper tests (`TestGameRemoteParent_Direct`, `TestRemoteParent`) and the `absent` / `OwnRootWhenIdsAbsent` subtests; mutation-checked (forcing `ok=false` / never-reparent fails the present-case tests).

## Kept as Links (untouched, PR2 / #1182)

`agent.llm.retro`, `agent.game.summary`, `experiment.*` — own root + Link. `retro_capture.go` / `gamesummary` / `experiment_loop.go` not touched.

## Behavior

Observability-only — no decision/gating/lifecycle/effect-measurement change.

**For review: this changes in-game correlation from Links to parent-child.**

## Verify

`gofmt -l .` clean, `go build ./...`, `go vet ./...`, `go test ./... -race -count=1` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)