### PR TITLE
fix(otel): trim collector envelope + bound filelog receiver (#1173)

### DIFF
--- a/docker-compose.dry-run.yml
+++ b/docker-compose.dry-run.yml
@@ -86,16 +86,26 @@ services:
   # (768 MiB container / limiter 600/150) the collector OOM-killed (exit 137)
   # within ~2 min and refused/dropped agent spans. We keep ALL spans (no sampling)
   # and instead raise the ceiling ONLY for this experiment-heavy stack so the
-  # Pi/prod base stays lean (experiments default off there). Raise the container
-  # to 1536 MiB AND set the env-substituted limiter (config.yaml memory_limiter)
-  # to 1200/300 so the limiter sheds NEAR the 1.5 GiB ceiling (~80% / ~25%) rather
-  # than backpressuring at 600 — without this matching limiter bump the bigger
-  # container would be wasted. Merges onto the base collector by service name.
+  # Pi/prod base stays lean (experiments default off there).
+  #
+  # #1173: verification #8 found the OOM was driven by the filelog/logs pipeline
+  # (all container stdout), not traces; it peaked at ~1.3 GiB, so 1536 MiB /
+  # 1200/300 was provisioned for that. #1176 (heartbeat log demotion) + #1177
+  # (2s traces batch) cut the log volume so far the collector now steady-states
+  # at ~85 MiB / ~6% of 1.5 GiB (verification #9) — heavily over-provisioned.
+  # Reduced to a 1024 MiB ceiling with the limiter at 800/200 (sheds ~78% / ~20%
+  # near the ceiling). Still well above the lean 768 MiB base for sustained-load
+  # headroom (verification #9 couldn't hold a continuous 5-min window, so keep a
+  # buffer); combined with the filelog max_concurrent_files cap (config.yaml) the
+  # receiver stays bounded even if log volume regrows.
+  #
+  # PRIOR (#1167): raised to 1536 MiB / 1200/300 to shed near the 1.5 GiB ceiling.
+  # Merges onto the base collector by service name.
   otel-collector:
     environment:
-      - OTEL_MEMLIMIT_MIB=1200
-      - OTEL_MEMSPIKE_MIB=300
+      - OTEL_MEMLIMIT_MIB=800
+      - OTEL_MEMSPIKE_MIB=200
     deploy:
       resources:
         limits:
-          memory: 1536m
+          memory: 1024m

--- a/docker-compose.gateway.yml
+++ b/docker-compose.gateway.yml
@@ -48,16 +48,24 @@ services:
   # loop / shadow-game span volume as dry-run, so the lean #1161 base envelope
   # (768 MiB / limiter 600/150) OOM-kills (exit 137) the collector under sustained
   # load. We keep ALL spans (no sampling) and raise the ceiling ONLY for this
-  # experiment-heavy stack so the Pi/prod base stays lean. Raise the container to
-  # 1536 MiB AND set the env-substituted limiter (config.yaml memory_limiter) to
-  # 1200/300 so it sheds NEAR the 1.5 GiB ceiling (~80% / ~25%) rather than at 600
-  # — without this matching limiter bump the bigger container would be wasted.
+  # experiment-heavy stack so the Pi/prod base stays lean.
+  #
+  # #1173: verification #8 found the OOM was driven by the filelog/logs pipeline
+  # (all container stdout), not traces; it peaked at ~1.3 GiB, so 1536 MiB /
+  # 1200/300 was provisioned for that. #1176 (heartbeat log demotion) + #1177
+  # (2s traces batch) cut the log volume so far the collector now steady-states
+  # at ~85 MiB / ~6% of 1.5 GiB (verification #9) — heavily over-provisioned.
+  # Reduced to a 1024 MiB ceiling with the limiter at 800/200 (sheds ~78% / ~20%
+  # near the ceiling). Still well above the lean 768 MiB base for sustained-load
+  # headroom; combined with the filelog max_concurrent_files cap (config.yaml)
+  # the receiver stays bounded even if log volume regrows.
+  # PRIOR (#1167): raised to 1536 MiB / 1200/300 to shed near the 1.5 GiB ceiling.
   # Merges onto the base collector by service name. Mirrors docker-compose.dry-run.yml.
   otel-collector:
     environment:
-      - OTEL_MEMLIMIT_MIB=1200
-      - OTEL_MEMSPIKE_MIB=300
+      - OTEL_MEMLIMIT_MIB=800
+      - OTEL_MEMSPIKE_MIB=200
     deploy:
       resources:
         limits:
-          memory: 1536m
+          memory: 1024m

--- a/services/otel-collector/config.yaml
+++ b/services/otel-collector/config.yaml
@@ -53,11 +53,27 @@ receivers:
             - targets: ['envoy:9901']
 
   # Filelog receiver — tail Docker container JSON logs for non-OTLP services
-  # (connect-proxy, rust-hid, envoy, flagd, etc.)
+  # (connect-proxy, rust-hid, envoy, flagd, etc.) AND the agent container (its
+  # experiment.* slog lines feed the dashboard's experiments view via Loki —
+  # LOKI LABEL CONTRACT, see transform/docker_logs + experiments.ts). The agent
+  # is deliberately NOT in filter/exclude_otlp_services, so this pipeline is
+  # load-bearing — it must keep exporting, it cannot be dropped or have the
+  # agent excluded.
+  #
+  # #1173: verification #8 traced the collector OOM (exit-137 under the shadow
+  # experiment loop) to THIS filelog/logs pipeline scraping all container stdout,
+  # not traces. #1176 (heartbeat log demotion) + #1177 (2s traces batch) cut the
+  # volume so hard the collector now steady-states at ~85 MiB / ~6% of 1.5 GiB
+  # (verification #9). To keep memory BOUNDED even if log volume regrows, cap the
+  # number of files tailed concurrently. The collector default is 1024 — absurd
+  # for this stack (~15-25 containers). 32 covers every container with headroom
+  # while bounding the receiver's per-file read-buffer footprint; the receiver
+  # round-robins across files, so NO container's logs are dropped.
   filelog/docker:
     include:
       - /var/lib/docker/containers/*/*-json.log
     start_at: end
+    max_concurrent_files: 32
     include_file_path: true
     include_file_name: false
     operators:
@@ -187,12 +203,21 @@ processors:
   # `${env:VAR:-default}` (supported since collector v0.108.0; this image is
   # built with OCB 0.153.0, well past that — see images/otel-collector/Dockerfile).
   # If the env vars are unset (base/Pi/prod + ci) the limiter stays at 600/150
-  # under the lean 768 MiB ceiling. The experiment-heavy stacks
-  # (docker-compose.dry-run.yml + docker-compose.gateway.yml) raise the container
-  # ceiling to 1536 MiB AND set OTEL_MEMLIMIT_MIB=1200 / OTEL_MEMSPIKE_MIB=300 so
-  # the limiter sheds NEAR the 1.5 GiB ceiling (~80% / ~25%) instead of pointlessly
-  # backpressuring at 600 — without the matching limiter bump the bigger container
-  # would be wasted. No span sampling: ALL spans are kept.
+  # under the lean 768 MiB ceiling.
+  #
+  # #1173: the experiment-heavy stacks (docker-compose.dry-run.yml +
+  # docker-compose.gateway.yml) used to raise the ceiling to 1536 MiB with
+  # 1200/300 — provisioned for the verification-#8 OOM, when the filelog/logs
+  # pipeline peaked at ~1.3 GiB. #1176 (heartbeat log demotion) + #1177 (2s
+  # traces batch) cut the volume so far the collector now steady-states at
+  # ~85 MiB / ~6% (verification #9), making 1.5 GiB heavily over-provisioned.
+  # Those stacks are now reduced to a 1024 MiB ceiling with 800/200 — still
+  # well above the lean 768 MiB base for sustained-load headroom (verification
+  # #9 couldn't hold a continuous 5-min window, so we keep a buffer over the
+  # base rather than collapsing fully to it), and combined with the
+  # max_concurrent_files cap on filelog/docker the receiver stays bounded even
+  # if log volume regrows. The limiter still sheds NEAR the ceiling (~78% / ~20%)
+  # before the cgroup OOM-kills. No span sampling: ALL spans are kept.
   memory_limiter:
     check_interval: 1s
     limit_mib: ${env:OTEL_MEMLIMIT_MIB:-600}


### PR DESCRIPTION
Part of #1173.

## What
Verification #8 traced the collector OOM (exit-137) to the **filelog/logs pipeline** scraping all container stdout, not traces. #1176 (heartbeat log demotion) + #1177 (2s traces batch) cut the log volume so far the collector now steady-states at **~85 MiB / ~6% of 1.5 GiB** (verification #9) — making the #1170 1.5 GiB dry-run/gateway envelope heavily over-provisioned.

### Changes (scope: collector config + experiment-stack envelopes only)
- **Reduce dry-run + gateway collector envelope**: ceiling `1536 -> 1024 MiB`, env-substituted limiter `1200/300 -> 800/200`. Base stays lean at `768 MiB / 600/150` (unchanged). The new soft-shed point (800 MiB) is ~9x above today's steady-state, retaining sustained-load headroom (verification #9 couldn't hold a continuous 5-min window, so a buffer over the 768 base is kept rather than collapsing to it).
- **Bound the filelog receiver**: add `max_concurrent_files: 32` to `filelog/docker` (collector default is 1024 — absurd for ~15-25 containers). This caps the receiver's per-file read-buffer footprint even if log volume regrows. The receiver round-robins across files, so **no container's logs are dropped** — the filelog pipeline stays load-bearing for the dashboard experiments view (LOKI LABEL CONTRACT; the agent's `experiment.*` slog lines reach Loki via filelog, not OTLP).

Did **not** touch traces/metrics pipelines (#1177/#1161) or the agent. Did not drop or scope the filelog pipeline (it feeds the dashboard).

## Verification
- Collector binary `validate --config` exits **0** with the new config (incl. `max_concurrent_files`).
- `docker compose config` merge per stack: base = **768 MiB / 600/150**, dry-run & gateway = **1024 MiB / 800/200**.
- Validated by **reasoning, not live restart**: the running collector is owned by the main checkout (config mounted `:ro`, must not edit) and tied to an active experiment loop. Live `docker stats` under load shows it holding at **~85-153 MiB** — 5-9x below the new 800 MiB soft limit, confirming the reduced envelope holds with comfortable margin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)