### PR TITLE
feat(agent): experiment ROOT span + re-parent analysis spans as its children (#1188)

### DIFF
--- a/services/agent/decision/retro_capture.go
+++ b/services/agent/decision/retro_capture.go
@@ -163,6 +163,20 @@ type RetroCoordinator struct {
 	// via SetFitnessLookup; not safe to call concurrently with OnGameEnd.
 	fitnessLookup func(gameID string) (float64, bool)
 
+	// experimentParent resolves the long-lived agent.experiment ROOT span's SpanContext
+	// by experiment_id (#1188), reading the registry's ExperimentSpanContext accessor.
+	// When wired and the finished game is experiment-bound (GameContext.ExperimentID set)
+	// AND the experiment still has a live root span, the agent.llm.retro span is started
+	// as a remote CHILD of the experiment span instead of an own-root span — so the
+	// retro joins the experiment's trace. This is sound even though the retro is ASYNC
+	// (post-#1179, the infer goroutine ends the span seconds later): the experiment span
+	// OUTLIVES its games (the registry ends it only at the terminal transition, well
+	// after the per-game retro), so the parent is alive when the retro starts. A nil
+	// lookup (the default / tests), a non-experiment game, or a torn-down experiment
+	// (ok=false) falls back to the pre-#1188 game-LINKED own-root span — unchanged.
+	// Injected via SetExperimentParent; not safe to call concurrently with OnGameEnd.
+	experimentParent func(experimentID string) (trace.SpanContext, bool)
+
 	// inferWG tracks every in-flight retro inference goroutine (#1179). OnGameEnd is
 	// a lifecycle hook and MUST NOT block on the 2-10s network call, so the
 	// infer+decode+capture runs in its own goroutine; this wait group lets graceful
@@ -231,6 +245,19 @@ func (rc *RetroCoordinator) SetResolver(r *Resolver) { rc.resolver = r }
 // construction.
 func (rc *RetroCoordinator) SetFitnessLookup(f func(gameID string) (float64, bool)) {
 	rc.fitnessLookup = f
+}
+
+// SetExperimentParent injects the experiment ROOT-span SpanContext lookup seam
+// (#1188): a func that returns the agent.experiment span's SpanContext for an
+// experiment_id (reading the registry's ExperimentSpanContext) and whether one is
+// available. When wired and the finished game is experiment-bound with a live root
+// span, the agent.llm.retro span is re-parented as a remote CHILD of the experiment
+// span (joining the experiment's trace) instead of the pre-#1188 game-linked own-root
+// span. A nil lookup (the default), a non-experiment game, or a torn-down experiment
+// falls back to the existing behavior. Not safe to call concurrently with OnGameEnd —
+// set it during construction.
+func (rc *RetroCoordinator) SetExperimentParent(f func(experimentID string) (trace.SpanContext, bool)) {
+	rc.experimentParent = f
 }
 
 // SetRootContext injects the agent's root context (#1179). The async retro inference
@@ -369,7 +396,14 @@ func (rc *RetroCoordinator) OnGameEnd(c gamecontext.GameContext) {
 			trace.WithAttributes(attribute.String(AttrGameTraceID, c.GameTraceID)))
 	}
 
-	spanCtx, span := rc.Tracer.Start(context.Background(), SpanLLMRetro, startOpts...)
+	// #1188: for an experiment-bound game, re-parent the retro under the experiment
+	// ROOT span — the retro is "in between" games and the experiment outlives them, so
+	// it joins the experiment's trace as a child. The game Link above is RETAINED so the
+	// retro stays navigable to its originating game too. A non-experiment game / unwired
+	// lookup / torn-down experiment yields an invalid SpanContext, so retroParentCtx
+	// returns context.Background(): the pre-#1188 game-linked own-root span, unchanged.
+	parent := rc.retroParentCtx(c.ExperimentID)
+	spanCtx, span := rc.Tracer.Start(parent, SpanLLMRetro, startOpts...)
 
 	rc.Log.Info("agent.llm.retro_captured",
 		"session_id", c.SessionID,
@@ -752,6 +786,29 @@ func (rc *RetroCoordinator) experimentAttributes(c gamecontext.GameContext) []at
 		}
 	}
 	return out
+}
+
+// retroParentCtx returns the context the agent.llm.retro span is started from (#1188):
+// a context whose remote parent is the experiment ROOT span for an experiment-bound
+// game with a live root span, else plain context.Background() (the pre-#1188 own-root
+// behavior). It reads the SpanContext via the injected experimentParent seam and installs
+// it with gamecontext.RemoteParentFromSpanContext.
+//
+// GRACEFUL FALLBACK: an empty experiment_id (non-experiment game), a nil seam (the
+// default / tests), or ok=false (the experiment has no live root span — torn down, or
+// tracer disabled) all yield context.Background(), so the retro span is byte-identical
+// to before #1188 and emission is never broken.
+func (rc *RetroCoordinator) retroParentCtx(experimentID string) context.Context {
+	base := context.Background()
+	if experimentID == "" || rc.experimentParent == nil {
+		return base
+	}
+	sc, ok := rc.experimentParent(experimentID)
+	if !ok {
+		return base
+	}
+	ctx, _ := gamecontext.RemoteParentFromSpanContext(base, sc)
+	return ctx
 }
 
 // compile-time guard: RetroCoordinator.OnGameEnd matches the store hook signature.

--- a/services/agent/decision/retro_trace_link_test.go
+++ b/services/agent/decision/retro_trace_link_test.go
@@ -89,6 +89,62 @@ func TestRetroSpan_LinksToGameTrace(t *testing.T) {
 	}
 }
 
+// TestRetroSpan_ReparentedUnderExperiment (#1188): when an experiment-parent seam is
+// wired and the finished game is experiment-bound with a live root span, the
+// agent.llm.retro span is a CHILD of the experiment root span (same trace_id, parent =
+// the root span_id), AND the game Link is retained. A non-experiment game keeps its
+// own-root behavior.
+func TestRetroSpan_ReparentedUnderExperiment(t *testing.T) {
+	const gameTrace = "4bf92f3577b34da6a3ce929d0e0e4736"
+	rootTID, _ := trace.TraceIDFromHex("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	rootSID, _ := trace.SpanIDFromHex("bbbbbbbbbbbbbbbb")
+	rootSC := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID: rootTID, SpanID: rootSID, TraceFlags: trace.FlagsSampled, Remote: true,
+	})
+
+	rc, sr := recordingRetro(t, retroFlagSnapshot())
+	rc.SetExperimentParent(func(id string) (trace.SpanContext, bool) {
+		if id == "exp_42" {
+			return rootSC, true
+		}
+		return trace.SpanContext{}, false
+	})
+
+	c := endedSessionWithTrace(gameTrace)
+	c.ExperimentID = "exp_42"
+	rc.OnGameEnd(c)
+
+	spans := spansByName(sr.Ended(), SpanLLMRetro)
+	if len(spans) != 1 {
+		t.Fatalf("agent.llm.retro spans = %d, want 1", len(spans))
+	}
+	span := spans[0]
+	if got := span.SpanContext().TraceID(); got != rootTID {
+		t.Errorf("retro trace_id = %s, want experiment root %s", got, rootTID)
+	}
+	if got := span.Parent().SpanID(); got != rootSID {
+		t.Errorf("retro parent span_id = %s, want experiment root %s", got, rootSID)
+	}
+	// The game Link is RETAINED (re-parenting is additive).
+	if n := len(span.Links()); n != 1 {
+		t.Errorf("retro links = %d, want 1 (game Link retained under experiment re-parent)", n)
+	}
+
+	// A non-experiment game (seam returns ok=false) stays own-root.
+	rc2, sr2 := recordingRetro(t, retroFlagSnapshot())
+	rc2.SetExperimentParent(func(string) (trace.SpanContext, bool) { return trace.SpanContext{}, false })
+	c2 := endedSession()
+	c2.ExperimentID = "exp_unknown"
+	rc2.OnGameEnd(c2)
+	own := spansByName(sr2.Ended(), SpanLLMRetro)
+	if len(own) != 1 {
+		t.Fatalf("non-experiment retro spans = %d, want 1", len(own))
+	}
+	if own[0].Parent().IsValid() {
+		t.Error("non-experiment retro must remain own-root (no valid parent)")
+	}
+}
+
 // TestRetroSpan_NoLinkWhenTraceAbsent: a finished game with no GameTraceID (a shadow
 // game, or any game before the correlation signal arrives) emits the retro span with
 // NO Link and NO game.trace_id attribute — graceful fallback, byte-identical to

--- a/services/agent/decision/telemetry.go
+++ b/services/agent/decision/telemetry.go
@@ -501,6 +501,16 @@ const AttrDecisionInterventionID = "decision.intervention_id"
 // without changing verdict math, fitness computation, promotion gating, or the loop's
 // control flow.
 const (
+	// SpanExperiment is the long-lived experiment ROOT span (#1188, epic #1181 PR2):
+	// one span per experiment, started when the experiment becomes RUNNING and ended on
+	// its terminal transition (concluded/discarded/promoted/aborted/done). It is the
+	// trace root the per-experiment ANALYSIS spans (experiment.fitness/evaluate/verdict,
+	// agent.llm.retro, agent.game.summary, code_improvement.promote) re-parent under for
+	// an experiment-bound game, so the whole hypothesis-test narrative is ONE trace.
+	// Carries experiment.id / flag_key / objective / target_n / arms. It outlives the
+	// game spans it analyzes (the analysis runs "in between" games), which is why the
+	// analysis spans can be its CHILDREN. Observability only.
+	SpanExperiment = "agent.experiment"
 	// SpanExperimentFitness wraps the per-shadow-game fitness scalar computation in
 	// onGameEnd: the gameFitnessFunc that scores one finished experiment game into the
 	// [0,1] sample the cohort aggregator folds. Carries experiment.id / arm / game.id /
@@ -530,8 +540,17 @@ const (
 	AttrExperimentStatus = "experiment.status"
 	// AttrExperimentObjective is the experiment's fitness objective
 	// (endurance/balanced/accelerate) the per-game fitness was scored against,
-	// recorded on experiment.fitness.
+	// recorded on experiment.fitness. It is also stamped on the agent.experiment ROOT
+	// span (#1188).
 	AttrExperimentObjective = "experiment.objective"
+	// AttrExperimentFlagKey / AttrExperimentTargetN / AttrExperimentArms are the
+	// agent.experiment ROOT span's identifying attributes (#1188): the flag/candidate
+	// under test, the per-arm target sample size, and the comma-joined arm names. They
+	// describe the experiment as a whole (not a single game), so they live only on the
+	// root span.
+	AttrExperimentFlagKey = "experiment.flag_key"
+	AttrExperimentTargetN = "experiment.target_n"
+	AttrExperimentArms    = "experiment.arms"
 	// AttrVerdictOutcome / AttrVerdictDelta / AttrVerdictSignificant carry the rolling
 	// paired-difference verdict the registry computed: the outcome label
 	// ("inconclusive"/"promote"/"discard"), the experimental-minus-control delta, and

--- a/services/agent/experiment/registry.go
+++ b/services/agent/experiment/registry.go
@@ -14,6 +14,9 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/joustmania/agent/decision"
 	"github.com/joustmania/agent/experiment/journal"
@@ -240,6 +243,28 @@ type entry struct {
 	// recover which two games share a seed. The seed is a pure function of
 	// (experimentID, pairIndex) — NEVER a clock — so it is reproducible.
 	armCursor int
+
+	// span is the long-lived experiment ROOT span (#1188, epic #1181 PR2): the
+	// agent.experiment span started when the experiment becomes RUNNING (Start /
+	// Rehydrate) and ended on the terminal transition (teardown). spanCtx is its
+	// SpanContext, exposed via ExperimentSpanContext so the per-experiment analysis
+	// spans (retro / summary, emitted from other components) can re-parent under it.
+	//
+	// LIFECYCLE INVARIANT (no leak): the span is started exactly once per entry (the
+	// startSpanLocked guard is idempotent) and End()ed exactly once, in teardown — the
+	// SINGLE terminal chokepoint every terminal transition (concluded → discarded/done,
+	// aborted) routes through. A nil span (tracer unwired in tests, or never started) is
+	// always safe to End/read.
+	//
+	// RESTART DISCONTINUITY (#1188): the SpanContext is NOT persisted. A rehydrated
+	// experiment (Rehydrate, after a restart) gets a BRAND-NEW root span with a fresh
+	// trace_id, so its post-restart analysis spans hang under the new root — the
+	// pre-restart trace is a separate, already-closed trace. This is deliberate for this
+	// cut: restoring a SpanContext across a process boundary would require persisting +
+	// re-injecting trace ids the journal does not record, for a span that can no longer
+	// be appended to anyway.
+	span    trace.Span
+	spanCtx trace.SpanContext
 }
 
 // inFlight returns the experiment's current count of live (unconcluded) shadow
@@ -268,6 +293,11 @@ type Registry struct {
 	target       TargetingWriter
 	clock        func() time.Time
 	log          *slog.Logger
+	// tracer emits the long-lived agent.experiment ROOT span (#1188). nil-safe like
+	// the #1142 experiment_loop tracer: a nil tracer disables the root span entirely
+	// (every start/end/read is guarded), so the registry stays fully functional in
+	// unit tests that do not wire telemetry. Production injects otel.Tracer(...).
+	tracer trace.Tracer
 
 	// maxGames is the per-experiment termination budget (#1001): the registry gives
 	// up and concludes an experiment INCONCLUSIVE once it has accrued this many
@@ -373,6 +403,12 @@ type RegistryConfig struct {
 	Clock func() time.Time
 	// Log nil ⇒ slog.Default().
 	Log *slog.Logger
+	// Tracer emits the agent.experiment ROOT span (#1188). nil ⇒ otel.Tracer(...) with
+	// the agent instrumentation scope (the production default; the global provider is a
+	// no-op until configured, so this is safe). A test may inject a recording tracer to
+	// assert the root span, or leave it nil to disable the span. The root span and its
+	// re-parenting are OBSERVABILITY ONLY — a nil tracer changes no lifecycle behavior.
+	Tracer trace.Tracer
 }
 
 // NewRegistry builds a Registry over the injected seams. It does NOT touch the
@@ -425,6 +461,13 @@ func NewRegistry(cfg RegistryConfig) *Registry {
 	if log == nil {
 		log = slog.Default()
 	}
+	tracer := cfg.Tracer
+	if tracer == nil {
+		// Default to the agent instrumentation scope (#1188). The global provider is a
+		// no-op until the agent configures OTEL, so this never emits spurious spans in a
+		// test that does not set up a provider.
+		tracer = otel.Tracer(experimentInstrumentationName)
+	}
 	return &Registry{
 		root:              cfg.Root,
 		maxCap:            maxCap,
@@ -437,10 +480,16 @@ func NewRegistry(cfg RegistryConfig) *Registry {
 		target:            cfg.Targeting,
 		clock:             clock,
 		log:               log,
+		tracer:            tracer,
 		entries:           make(map[string]*entry),
 		releaseTombstones: make(map[string]string),
 	}
 }
+
+// experimentInstrumentationName scopes the registry's root-span tracer. It matches
+// the decision package's instrumentationName so every agent span shares one
+// instrumentation scope in Jaeger.
+const experimentInstrumentationName = "github.com/joustmania/agent"
 
 // Declare defines a new experiment: it mints an experiment_id, persists the
 // immutable intent to the journal (journal.Create), records it as PROPOSED in the
@@ -562,9 +611,61 @@ func (r *Registry) Start(ctx context.Context, id string) error {
 		return nil
 	}
 	e.status = StatusRunning
+	// #1188: start the long-lived agent.experiment ROOT span now that the experiment is
+	// RUNNING (idempotent — a no-op if it is somehow already started). The analysis
+	// spans re-parent under it; teardown ends it.
+	r.startSpanLocked(e, intent)
 	r.recordDecision(e.journal, StatusRunning, "experiment started")
 	r.log.Info("experiment.started", "experiment_id", id)
 	return nil
+}
+
+// startSpanLocked starts the experiment's long-lived agent.experiment ROOT span
+// (#1188) and records its SpanContext on the entry. It is idempotent (a no-op when
+// the span already exists), nil-tracer-safe (no-op), and assumes r.mu is held.
+//
+// The span is started from context.Background() — it is the trace ROOT, with no
+// inbound parent (the experiment is an autonomous, long-lived activity, not a
+// request). intent supplies the identifying attributes; on a partial/zero intent the
+// per-field guards simply skip the empty attrs.
+func (r *Registry) startSpanLocked(e *entry, intent journal.Intent) {
+	if r.tracer == nil || e == nil || e.span != nil {
+		return
+	}
+	attrs := []attribute.KeyValue{
+		attribute.String(decision.AttrExperimentID, e.id),
+	}
+	if intent.FlagKey != "" {
+		attrs = append(attrs, attribute.String(decision.AttrExperimentFlagKey, intent.FlagKey))
+	}
+	if intent.Objective != "" {
+		attrs = append(attrs, attribute.String(decision.AttrExperimentObjective, intent.Objective))
+	}
+	if intent.TargetNPerArm > 0 {
+		attrs = append(attrs, attribute.Int(decision.AttrExperimentTargetN, intent.TargetNPerArm))
+	}
+	if len(intent.Arms) > 0 {
+		attrs = append(attrs, attribute.String(decision.AttrExperimentArms, strings.Join(intent.Arms, ",")))
+	}
+	_, span := r.tracer.Start(context.Background(), decision.SpanExperiment, trace.WithAttributes(attrs...))
+	e.span = span
+	e.spanCtx = span.SpanContext()
+}
+
+// endSpanLocked ends the experiment's root span exactly once (#1188). It is the
+// inverse of startSpanLocked, called from teardown — the single terminal chokepoint —
+// so the span never leaks regardless of which terminal transition fired. Idempotent
+// (clears e.span) and nil-safe. Assumes r.mu is held.
+func (r *Registry) endSpanLocked(e *entry) {
+	if e == nil || e.span == nil {
+		return
+	}
+	e.span.End()
+	e.span = nil
+	// Clear the recorded SpanContext too so ExperimentSpanContext reports unavailable
+	// after teardown: a torn-down experiment is no longer a re-parent target (its span
+	// has ended, so a late analysis span must fall back to its own-root behavior).
+	e.spanCtx = trace.SpanContext{}
 }
 
 // AllocateAndSpawn fills FREE shadow capacity across the live experiments by
@@ -1249,7 +1350,19 @@ func (r *Registry) promote(ctx context.Context, id string, jrnl *journal.Journal
 	}
 	e.status = StatusPromoting
 	r.recordDecision(e.journal, StatusPromoting, "routing to promoter")
+	// #1188: re-parent the code_improvement.promote span as the experiment's TERMINAL
+	// child. The promote span is started from the ctx passed to Promoter.Promote, so
+	// installing the still-live experiment ROOT span on the ctx (an in-process
+	// parent-child, the span lives in THIS process) makes the promotion the experiment's
+	// terminal child with no change to the promote package. The span is captured under
+	// the lock (it is ended later, in teardown, after this returns). A nil span (tracer
+	// unwired) leaves ctx unchanged — graceful.
+	span := e.span
 	r.mu.Unlock()
+
+	if span != nil {
+		ctx = trace.ContextWithSpan(ctx, span)
+	}
 
 	if r.promo != nil {
 		if err := r.promo.Promote(ctx, jrnl.CompactView()); err != nil {
@@ -1326,6 +1439,13 @@ func (r *Registry) teardown(ctx context.Context, id, flagKey string, terminal St
 	if e == nil {
 		return
 	}
+	// #1188: end the long-lived agent.experiment ROOT span here — teardown is the
+	// SINGLE terminal chokepoint every terminal transition routes through (conclude →
+	// discarded/done, abort), so ending it here guarantees no leak on ANY terminal path.
+	// It is placed BEFORE the idempotency guard (and is itself idempotent) so the
+	// promote→DONE path — where promote() already set the terminal status, making the
+	// guard below early-return — still ends the span exactly once.
+	r.endSpanLocked(e)
 	if e.status.IsTerminal() && e.status == terminal {
 		return
 	}
@@ -1376,7 +1496,7 @@ func (r *Registry) Rehydrate(ids []string) error {
 		if st.IsTerminal() {
 			continue // done experiment — nothing to manage.
 		}
-		r.entries[id] = &entry{
+		e := &entry{
 			id:        id,
 			journal:   jrnl,
 			status:    st,
@@ -1385,6 +1505,16 @@ func (r *Registry) Rehydrate(ids []string) error {
 			games:     make(map[string]string),
 			gamePairs: make(map[string]int),
 		}
+		// #1188 RESTART DISCONTINUITY: a rehydrated experiment gets a BRAND-NEW root
+		// span with a fresh trace_id — the SpanContext is NOT persisted across the
+		// restart (the pre-restart trace is already closed and un-appendable). The new
+		// span outlives this rehydrated entry exactly like a freshly-Started one and is
+		// ended in teardown. Rehydrate is the only place a RUNNING entry is created
+		// WITHOUT going through Start, so the span must be started here too. A rehydrated
+		// PROPOSED entry also gets one; if Start later runs, startSpanLocked is a no-op
+		// (idempotent), so no double span.
+		r.startSpanLocked(e, jrnl.Intent())
+		r.entries[id] = e
 	}
 	return nil
 }
@@ -1532,6 +1662,31 @@ func (r *Registry) LiveCount() int {
 		}
 	}
 	return n
+}
+
+// ExperimentSpanContext returns the SpanContext of an experiment's long-lived
+// agent.experiment ROOT span (#1188), for re-parenting that experiment's analysis
+// spans (retro / summary) under it from components OUTSIDE the registry. It is a
+// clean READ accessor: it touches no lifecycle/mutation state, takes the lock only to
+// read the entry's recorded SpanContext, and never mutates.
+//
+// ok=false (and the zero SpanContext) when the experiment is unknown, has no root span
+// (tracer unwired, or already torn down + span ended), or the SpanContext is invalid —
+// every "no usable parent" case. Callers fall back to their CURRENT behavior on
+// ok=false, so a NON-experiment game (empty/unknown experiment_id) never re-parents:
+// graceful, never breaking span emission.
+func (r *Registry) ExperimentSpanContext(id string) (trace.SpanContext, bool) {
+	r.mu.Lock()
+	e := r.entries[id]
+	var sc trace.SpanContext
+	if e != nil {
+		sc = e.spanCtx
+	}
+	r.mu.Unlock()
+	if e == nil || !sc.IsValid() {
+		return trace.SpanContext{}, false
+	}
+	return sc, true
 }
 
 // CompactView returns the bounded journal view for an experiment (intent +

--- a/services/agent/experiment/registry_root_span_test.go
+++ b/services/agent/experiment/registry_root_span_test.go
@@ -1,0 +1,244 @@
+package experiment
+
+import (
+	"context"
+	"testing"
+
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"github.com/joustmania/agent/decision"
+)
+
+// #1188 (epic #1181 PR2): the registry owns a long-lived agent.experiment ROOT span
+// per experiment — started when the experiment becomes RUNNING, ended on EVERY terminal
+// transition (no leak on any path), and exposed via ExperimentSpanContext for the
+// per-experiment analysis spans to re-parent under. These tests pin that lifecycle.
+
+// rootSpanRegistry builds a registry whose root-span tracer is a recording tracer, so a
+// test can assert the agent.experiment span is started + ended. It returns the registry
+// and the span recorder.
+func rootSpanRegistry(t *testing.T, cfg RegistryConfig) (*Registry, *tracetest.SpanRecorder) {
+	t.Helper()
+	sr := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+	cfg.Tracer = tp.Tracer("test")
+	return newTestRegistry(t, cfg), sr
+}
+
+// rootSpans returns the recorded ENDED spans named agent.experiment.
+func rootSpans(sr *tracetest.SpanRecorder) []sdktrace.ReadOnlySpan {
+	var out []sdktrace.ReadOnlySpan
+	for _, s := range sr.Ended() {
+		if s.Name() == decision.SpanExperiment {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func rootSpanAttr(s sdktrace.ReadOnlySpan, key string) (string, bool) {
+	for _, kv := range s.Attributes() {
+		if string(kv.Key) == key {
+			return kv.Value.Emit(), true
+		}
+	}
+	return "", false
+}
+
+// TestRootSpan_StartedOnRunning_NotBeforeAndExposed: the root span is NOT started at
+// Declare (PROPOSED) and IS started + exposed at Start (RUNNING); it is not yet ended.
+func TestRootSpan_StartedOnRunning_NotBeforeAndExposed(t *testing.T) {
+	r, sr := rootSpanRegistry(t, RegistryConfig{
+		Spawner: &fakeSpawner{}, Verdict: fakeVerdict{concludeAtN: 1000}, Targeting: &fakeTargeting{},
+		MaxShadowGames: 4,
+	})
+	id, err := r.Declare(sampleIntent())
+	if err != nil {
+		t.Fatalf("declare: %v", err)
+	}
+	// PROPOSED: no root span exposed yet, none recorded.
+	if _, ok := r.ExperimentSpanContext(id); ok {
+		t.Error("ExperimentSpanContext must be unavailable before Start (PROPOSED)")
+	}
+
+	if err := r.Start(context.Background(), id); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	sc, ok := r.ExperimentSpanContext(id)
+	if !ok || !sc.IsValid() {
+		t.Fatal("ExperimentSpanContext must be a valid SpanContext once RUNNING")
+	}
+	// Started but NOT yet ended (still live for analysis re-parenting).
+	if n := len(rootSpans(sr)); n != 0 {
+		t.Fatalf("agent.experiment ended spans = %d, want 0 (still live)", n)
+	}
+}
+
+// TestRootSpan_EndedOnDiscard / _OnPromote / _OnAbort: the root span is ended exactly
+// once on EVERY terminal transition, and the SpanContext stops being exposed.
+func TestRootSpan_EndedOnDiscard(t *testing.T) {
+	spawner := &fakeSpawner{}
+	r, sr := rootSpanRegistry(t, RegistryConfig{
+		Spawner:   spawner,
+		Verdict:   fakeVerdict{outcome: CohortOutcomeDiscard, concludeAtN: 1, alwaysReport: true},
+		Targeting: &fakeTargeting{}, MaxShadowGames: 2, EffectiveConcurrency: 1,
+	})
+	id := startedExperiment(t, r)
+	r.AllocateAndSpawn(context.Background())
+	g := spawner.calls[0].gameID
+	if _, err := r.ConcludeGame(context.Background(), g, 0.3, 60); err != nil {
+		t.Fatalf("conclude: %v", err)
+	}
+	assertRootSpanEndedOnce(t, r, sr, id)
+}
+
+func TestRootSpan_EndedOnPromote(t *testing.T) {
+	spawner := &fakeSpawner{}
+	r, sr := rootSpanRegistry(t, RegistryConfig{
+		Spawner:   spawner,
+		Verdict:   fakeVerdict{outcome: CohortOutcomePromote, concludeAtN: 1, alwaysReport: true},
+		Promoter:  &fakePromoter{},
+		Targeting: &fakeTargeting{}, MaxShadowGames: 2, EffectiveConcurrency: 1,
+	})
+	id := startedExperiment(t, r)
+	r.AllocateAndSpawn(context.Background())
+	g := spawner.calls[0].gameID
+	if _, err := r.ConcludeGame(context.Background(), g, 0.9, 60); err != nil {
+		t.Fatalf("conclude: %v", err)
+	}
+	// The promote→DONE path routes through teardown with an already-terminal status —
+	// the span MUST still be ended exactly once (the no-leak invariant on the path the
+	// idempotency guard would otherwise early-return on).
+	assertRootSpanEndedOnce(t, r, sr, id)
+}
+
+func TestRootSpan_EndedOnAbort(t *testing.T) {
+	r, sr := rootSpanRegistry(t, RegistryConfig{
+		Spawner: &fakeSpawner{}, Verdict: fakeVerdict{concludeAtN: 1000}, Targeting: &fakeTargeting{},
+		MaxShadowGames: 2,
+	})
+	id := startedExperiment(t, r)
+	if err := r.Abort(context.Background(), id, "kill-switch"); err != nil {
+		t.Fatalf("abort: %v", err)
+	}
+	assertRootSpanEndedOnce(t, r, sr, id)
+}
+
+// TestRootSpan_DoubleTeardownNoDoubleEnd: a repeated terminal call (Abort then Abort,
+// or AbortAll over an already-aborted experiment) must NOT end the span twice.
+func TestRootSpan_DoubleTeardownNoDoubleEnd(t *testing.T) {
+	r, sr := rootSpanRegistry(t, RegistryConfig{
+		Spawner: &fakeSpawner{}, Verdict: fakeVerdict{concludeAtN: 1000}, Targeting: &fakeTargeting{},
+		MaxShadowGames: 2,
+	})
+	id := startedExperiment(t, r)
+	_ = r.Abort(context.Background(), id, "first")
+	_ = r.Abort(context.Background(), id, "second (no-op)")
+	if n := len(rootSpans(sr)); n != 1 {
+		t.Fatalf("agent.experiment ended spans = %d, want exactly 1 (idempotent end)", n)
+	}
+}
+
+// TestRootSpan_CarriesIdentifyingAttrs: the root span carries experiment.id / flag_key /
+// objective / target_n / arms from the intent.
+func TestRootSpan_CarriesIdentifyingAttrs(t *testing.T) {
+	r, sr := rootSpanRegistry(t, RegistryConfig{
+		Spawner: &fakeSpawner{}, Verdict: fakeVerdict{concludeAtN: 1000}, Targeting: &fakeTargeting{},
+		MaxShadowGames: 2,
+	})
+	id := startedExperiment(t, r)
+	_ = r.Abort(context.Background(), id, "done")
+
+	spans := rootSpans(sr)
+	if len(spans) != 1 {
+		t.Fatalf("agent.experiment spans = %d, want 1", len(spans))
+	}
+	s := spans[0]
+	if v, ok := rootSpanAttr(s, decision.AttrExperimentID); !ok || v != id {
+		t.Errorf("%s = %q, want %q", decision.AttrExperimentID, v, id)
+	}
+	for _, key := range []string{
+		decision.AttrExperimentFlagKey, decision.AttrExperimentObjective,
+		decision.AttrExperimentTargetN, decision.AttrExperimentArms,
+	} {
+		if _, ok := rootSpanAttr(s, key); !ok {
+			t.Errorf("agent.experiment must carry %s", key)
+		}
+	}
+}
+
+// TestRootSpan_NilTracerSafe: a registry without a recording tracer (the global no-op
+// provider) drives the full lifecycle with no panic and exposes no SpanContext.
+func TestRootSpan_NilTracerSafe(t *testing.T) {
+	// No Tracer injected => NewRegistry defaults to the global no-op tracer.
+	r := newTestRegistry(t, RegistryConfig{
+		Spawner: &fakeSpawner{}, Verdict: fakeVerdict{concludeAtN: 1000}, Targeting: &fakeTargeting{},
+		MaxShadowGames: 2,
+	})
+	id := startedExperiment(t, r)
+	// The no-op tracer yields an invalid (non-recording) SpanContext, so the accessor
+	// reports unavailable — graceful for the no-telemetry path.
+	if _, ok := r.ExperimentSpanContext(id); ok {
+		t.Error("no-op tracer: ExperimentSpanContext should report unavailable")
+	}
+	if err := r.Abort(context.Background(), id, "done"); err != nil {
+		t.Fatalf("abort with no-op tracer must not error: %v", err)
+	}
+}
+
+// TestRootSpan_RehydrateGetsFreshSpan: a rehydrated (post-restart) experiment gets a
+// BRAND-NEW root span (the #1188 restart discontinuity) — its SpanContext is valid and
+// it ends on the next teardown.
+func TestRootSpan_RehydrateGetsFreshSpan(t *testing.T) {
+	root := t.TempDir()
+	// Declare + start an experiment in one registry, then rehydrate it in a fresh one
+	// (simulating a restart) and assert it gets a new live root span.
+	r1, _ := rootSpanRegistry(t, RegistryConfig{
+		Root: root, Spawner: &fakeSpawner{}, Verdict: fakeVerdict{concludeAtN: 1000},
+		Targeting: &fakeTargeting{}, MaxShadowGames: 2,
+	})
+	id := startedExperiment(t, r1)
+
+	r2, sr2 := rootSpanRegistry(t, RegistryConfig{
+		Root: root, Spawner: &fakeSpawner{}, Verdict: fakeVerdict{concludeAtN: 1000},
+		Targeting: &fakeTargeting{}, MaxShadowGames: 2,
+	})
+	if err := r2.Rehydrate([]string{id}); err != nil {
+		t.Fatalf("rehydrate: %v", err)
+	}
+	sc, ok := r2.ExperimentSpanContext(id)
+	if !ok || !sc.IsValid() {
+		t.Fatal("rehydrated experiment must get a fresh, valid root span")
+	}
+	_ = r2.Abort(context.Background(), id, "done")
+	if n := len(rootSpans(sr2)); n != 1 {
+		t.Fatalf("rehydrated agent.experiment ended spans = %d, want 1", n)
+	}
+}
+
+// startedExperiment declares + starts one experiment and returns its id.
+func startedExperiment(t *testing.T, r *Registry) string {
+	t.Helper()
+	id, err := r.Declare(sampleIntent())
+	if err != nil {
+		t.Fatalf("declare: %v", err)
+	}
+	if err := r.Start(context.Background(), id); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	return id
+}
+
+// assertRootSpanEndedOnce asserts exactly one agent.experiment span ended and the
+// SpanContext is no longer exposed after teardown.
+func assertRootSpanEndedOnce(t *testing.T, r *Registry, sr *tracetest.SpanRecorder, id string) {
+	t.Helper()
+	if n := len(rootSpans(sr)); n != 1 {
+		t.Fatalf("agent.experiment ended spans = %d, want exactly 1 (no leak, no double-end)", n)
+	}
+	if _, ok := r.ExperimentSpanContext(id); ok {
+		t.Error("ExperimentSpanContext must be unavailable after teardown (span ended)")
+	}
+}

--- a/services/agent/experiment_loop.go
+++ b/services/agent/experiment_loop.go
@@ -744,12 +744,42 @@ func (e *experimentLoop) scoreGameFitness(gc gamecontext.GameContext, objective 
 		attrs = append(attrs, attribute.String(decision.AttrGameTraceID, gc.GameTraceID))
 	}
 	opts := append([]trace.SpanStartOption{trace.WithAttributes(attrs...)}, gameLink...)
-	_, span := e.tracer.Start(context.Background(), decision.SpanExperimentFitness, opts...)
+	// #1188: re-parent under the experiment ROOT span for an experiment-bound game so
+	// the per-game fitness is a CHILD of the experiment (the experiment outlives its
+	// games, so this is timeline-correct). The gameLink is RETAINED — the span is still
+	// navigable to the originating game trace as before. A non-experiment game / unwired
+	// tracer / no root span yields an invalid SpanContext, so experimentParentCtx falls
+	// back to context.Background(): the current own-root behavior, unchanged.
+	ctx := e.experimentParentCtx(gc.ExperimentID)
+	_, span := e.tracer.Start(ctx, decision.SpanExperimentFitness, opts...)
 	defer span.End()
 
 	fitness := e.fitness(gc, objective)
 	span.SetAttributes(attribute.Float64(decision.AttrExperimentFitness, fitness))
 	return fitness
+}
+
+// experimentParentCtx returns a context whose remote parent is the experiment's
+// long-lived agent.experiment ROOT span (#1188), for re-parenting an experiment-bound
+// game's analysis spans (experiment.fitness / evaluate) under it. It reads the root
+// span's SpanContext from the registry by experiment_id and installs it as the remote
+// parent via gamecontext.RemoteParentFromSpanContext.
+//
+// GRACEFUL FALLBACK: an empty/unknown experiment_id, an unwired registry, or a missing
+// root span (the experiment torn down, or the tracer disabled) returns plain
+// context.Background() — the pre-#1188 own-root behavior — so a NON-experiment game and
+// the no-telemetry test path are unchanged and span emission is never broken.
+func (e *experimentLoop) experimentParentCtx(experimentID string) context.Context {
+	base := context.Background()
+	if experimentID == "" || e.registry == nil {
+		return base
+	}
+	sc, ok := e.registry.ExperimentSpanContext(experimentID)
+	if !ok {
+		return base
+	}
+	ctx, _ := gamecontext.RemoteParentFromSpanContext(base, sc)
+	return ctx
 }
 
 // concludeWithSpan folds the concluded game into its arm (the existing
@@ -775,7 +805,11 @@ func (e *experimentLoop) concludeWithSpan(gc gamecontext.GameContext, fitness, d
 		attrs = append(attrs, attribute.String(decision.AttrGameTraceID, gc.GameTraceID))
 	}
 	opts := append([]trace.SpanStartOption{trace.WithAttributes(attrs...)}, gameLink...)
-	ctx, span := e.tracer.Start(context.Background(), decision.SpanExperimentEvaluate, opts...)
+	// #1188: re-parent experiment.evaluate under the experiment ROOT span (same
+	// graceful-fallback as scoreGameFitness — own-root for a non-experiment game). The
+	// experiment.verdict child below inherits this ctx, so it stays a child of evaluate.
+	parent := e.experimentParentCtx(gc.ExperimentID)
+	ctx, span := e.tracer.Start(parent, decision.SpanExperimentEvaluate, opts...)
 	defer span.End()
 
 	status, err := e.registry.ConcludeGame(ctx, gc.SessionID, fitness, duration)

--- a/services/agent/experiment_loop_test.go
+++ b/services/agent/experiment_loop_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/goleak"
 
 	"github.com/joustmania/agent/experiment"
@@ -166,6 +167,23 @@ func buildLoopForTest(
 	fitness gameFitnessFunc,
 ) *experimentLoop {
 	t.Helper()
+	return buildLoopForTestWithTracer(t, spawner, resolveConfig, realDef, github, fitness, nil)
+}
+
+// buildLoopForTestWithTracer is buildLoopForTest with an injectable root-span tracer for
+// the registry (#1188): passing the SAME recording tracer the loop uses lets a test
+// assert the analysis spans re-parent under the registry's agent.experiment ROOT span. A
+// nil tracer leaves the registry on its default (no-op) tracer — the pre-#1188 shape.
+func buildLoopForTestWithTracer(
+	t *testing.T,
+	spawner experiment.ShadowSpawner,
+	resolveConfig promote.ConfigResolver,
+	realDef promote.RealDefaultWriter,
+	github promote.GitHubClient,
+	fitness gameFitnessFunc,
+	tracer trace.Tracer,
+) *experimentLoop {
+	t.Helper()
 	log := testLogger()
 	gamePath := newGameFileForLoop(t)
 	journalRoot := t.TempDir()
@@ -192,6 +210,7 @@ func buildLoopForTest(
 		Promoter:       promo,
 		Targeting:      targeting,
 		Log:            log,
+		Tracer:         tracer,
 	})
 
 	return &experimentLoop{

--- a/services/agent/experiment_root_span_test.go
+++ b/services/agent/experiment_root_span_test.go
@@ -1,0 +1,166 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/joustmania/agent/decision"
+	"github.com/joustmania/agent/experiment"
+	"github.com/joustmania/agent/gamecontext"
+	"github.com/joustmania/agent/promote"
+)
+
+// #1188 (epic #1181 PR2): the per-experiment ANALYSIS spans (experiment.fitness /
+// experiment.evaluate) re-parent as CHILDREN of the long-lived agent.experiment ROOT
+// span for an EXPERIMENT-bound game; a non-experiment game keeps its own-root behavior.
+// These tests assert the re-parenting end-to-end (same trace_id, parent = the root
+// span's span_id) by sharing ONE recording tracer between the registry and the loop.
+
+// rootSpanLoop builds a loop + registry sharing ONE recording tracer provider, so the
+// experiment ROOT span (registry-emitted) and the analysis spans (loop-emitted) land in
+// the same recorder and their parent/child relationship is assertable. It declares +
+// starts one experiment and returns the loop, recorder, spawner, and experiment id.
+func rootSpanLoop(t *testing.T) (*experimentLoop, *tracetest.SpanRecorder, *recordingSpawner, string) {
+	t.Helper()
+	spawner := &recordingSpawner{}
+	realDef := &recordingRealDefault{}
+	github := &recordingGitHub{}
+	resolve := func(context.Context) promote.Config {
+		return promote.Config{Mode: promote.ModeIssue, Target: promote.TargetLocal, Enabled: false}
+	}
+
+	sr := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+	tr := tp.Tracer("test")
+
+	// Build the registry with the SHARED recording tracer so its agent.experiment ROOT
+	// span is recorded by sr, then build the loop over that registry with the same tracer.
+	loop := buildLoopForTestWithTracer(t, spawner, resolve, realDef, github, armFitness(), tr)
+	loop.tracer = tr
+
+	id, err := loop.registry.Declare(experiment.Intent{
+		FlagKey: "invincibility_seconds", ExperimentalValue: 6.0, Objective: "balanced", TargetNPerArm: 3,
+	})
+	if err != nil {
+		t.Fatalf("declare: %v", err)
+	}
+	if err := loop.registry.Start(context.Background(), id); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	return loop, sr, spawner, id
+}
+
+// TestRootSpan_FitnessAndEvaluateReparentedUnderExperiment: for an experiment-bound
+// game, experiment.fitness + experiment.evaluate are CHILDREN of the experiment ROOT
+// span (same trace_id, parent = the root span's span_id).
+func TestRootSpan_FitnessAndEvaluateReparentedUnderExperiment(t *testing.T) {
+	loop, sr, spawner, id := rootSpanLoop(t)
+	rootSC, _ := loop.registry.ExperimentSpanContext(id)
+	rootTrace := rootSC.TraceID()
+	rootSpan := rootSC.SpanID()
+
+	loop.registry.AllocateAndSpawn(context.Background())
+	rec := spawner.drain()
+	if len(rec) == 0 {
+		t.Fatal("expected one allocated shadow game")
+	}
+	c := rec[0]
+	// A game trace is in scope too (the Link is retained); re-parenting is independent.
+	loop.onGameEnd(gcWithTrace(c.gameID, c.experimentID, c.arm,
+		"4bf92f3577b34da6a3ce929d0e0e4736", "00f067aa0ba902b7"))
+
+	for _, name := range []string{decision.SpanExperimentFitness, decision.SpanExperimentEvaluate} {
+		spans := expSpan_findByName(sr.Ended(), name)
+		if len(spans) != 1 {
+			t.Fatalf("%s spans = %d, want 1", name, len(spans))
+		}
+		s := spans[0]
+		if got := s.SpanContext().TraceID(); got != rootTrace {
+			t.Errorf("%s trace_id = %s, want experiment root trace %s", name, got, rootTrace)
+		}
+		if got := s.Parent().SpanID(); got != rootSpan {
+			t.Errorf("%s parent span_id = %s, want experiment root span %s", name, got, rootSpan)
+		}
+		// The game Link is RETAINED (re-parenting is additive to the cross-trace Link).
+		if n := len(s.Links()); n != 1 {
+			t.Errorf("%s links = %d, want 1 (game Link retained)", name, n)
+		}
+	}
+}
+
+// TestRootSpan_NonExperimentGameKeepsOwnRoot: a NON-experiment (real) game has no
+// experiment root span, so its analysis spans keep CURRENT behavior — own-root (no
+// parent), graceful.
+func TestRootSpan_NonExperimentGameKeepsOwnRoot(t *testing.T) {
+	loop, sr, _, _ := rootSpanLoop(t)
+
+	// A real game (empty ExperimentID) flows through onGameEnd's non-experiment branch,
+	// which records baseline fitness but emits NO experiment.* spans. To prove the
+	// graceful fallback of the re-parent itself, drive scoreGameFitness directly with an
+	// empty experiment id: it must produce an OWN-ROOT span (no parent).
+	gc := gcFor("game_real_1", "", "")
+	_ = loop.scoreGameFitness(gc, "balanced", nil)
+
+	spans := expSpan_findByName(sr.Ended(), decision.SpanExperimentFitness)
+	if len(spans) != 1 {
+		t.Fatalf("experiment.fitness spans = %d, want 1", len(spans))
+	}
+	// An empty experiment id yields no remote parent (graceful), so the span is own-root.
+	if sc := trace.SpanContextFromContext(loop.experimentParentCtx("")); sc.IsValid() {
+		t.Error("experimentParentCtx(\"\") must carry no parent SpanContext")
+	}
+	if spans[0].Parent().IsValid() {
+		t.Error("a non-experiment fitness span must be own-root (no valid parent)")
+	}
+}
+
+// TestRootSpan_ReparentDoesNotChangeFitness: re-parenting is observability only — the
+// fitness scalar recorded under the experiment root span equals the bare fitness func.
+func TestRootSpan_ReparentDoesNotChangeFitness(t *testing.T) {
+	loop, sr, spawner, _ := rootSpanLoop(t)
+	loop.registry.AllocateAndSpawn(context.Background())
+	rec := spawner.drain()
+	if len(rec) == 0 {
+		t.Fatal("expected one allocated shadow game")
+	}
+	c := rec[0]
+	gc := gcFor(c.gameID, c.experimentID, c.arm)
+	want := armFitness()(gc, "balanced")
+	loop.onGameEnd(gc)
+
+	fit := expSpan_findByName(sr.Ended(), decision.SpanExperimentFitness)
+	if len(fit) != 1 {
+		t.Fatalf("experiment.fitness spans = %d, want 1", len(fit))
+	}
+	got, ok := fitnessAttrFloat(fit[0])
+	if !ok || got != want {
+		t.Errorf("recorded fitness = %v (ok=%v), want %v (re-parent must not change it)", got, ok, want)
+	}
+}
+
+// TestRootSpan_RetroReparentedUnderExperiment proves the retro re-parent SEAM at the
+// helper level: the gamecontext remote-parent helper, fed the experiment SpanContext,
+// installs the root span as the parent; a non-experiment / torn-down lookup falls back.
+func TestRootSpan_RetroReparentedUnderExperiment(t *testing.T) {
+	loop, _, _, id := rootSpanLoop(t)
+	sc, ok := loop.registry.ExperimentSpanContext(id)
+	if !ok {
+		t.Fatal("experiment span context must be live")
+	}
+	ctx, reparented := gamecontext.RemoteParentFromSpanContext(context.Background(), sc)
+	if !reparented {
+		t.Fatal("RemoteParentFromSpanContext must re-parent under a valid experiment SpanContext")
+	}
+	if got := trace.SpanContextFromContext(ctx).SpanID(); got != sc.SpanID() {
+		t.Errorf("remote parent span_id = %s, want %s", got, sc.SpanID())
+	}
+	// Invalid (torn-down / non-experiment) SpanContext => no re-parent, ctx unchanged.
+	if _, ok := gamecontext.RemoteParentFromSpanContext(context.Background(), trace.SpanContext{}); ok {
+		t.Error("RemoteParentFromSpanContext on an invalid SpanContext must report no re-parent")
+	}
+}

--- a/services/agent/gamecontext/tracelink.go
+++ b/services/agent/gamecontext/tracelink.go
@@ -64,6 +64,25 @@ func RemoteParent(ctx context.Context, gameTraceID, gameTraceSpanID string) (con
 	return trace.ContextWithRemoteSpanContext(ctx, sc), true
 }
 
+// RemoteParentFromSpanContext is the SpanContext-typed sibling of RemoteParent
+// (#1188): it installs an ALREADY-CONSTRUCTED SpanContext as the remote parent of the
+// passed ctx, so a span started from the returned ctx joins that SpanContext's trace as
+// its child. It exists because the experiment ROOT span (registry.go, #1188) is exposed
+// as a trace.SpanContext — not as a pair of hex ids — and its per-experiment analysis
+// spans (experiment.fitness / evaluate, agent.llm.retro, agent.game.summary) re-parent
+// under it from components that hold only the SpanContext, not the live span.
+//
+// An INVALID SpanContext (the zero value, or any !IsValid) returns the UNCHANGED ctx and
+// ok=false, so the caller starts the span exactly as before — the same graceful-fallback
+// contract as RemoteParent, ensuring a non-experiment game (no experiment SpanContext)
+// never re-parents and span emission is never broken.
+func RemoteParentFromSpanContext(ctx context.Context, sc trace.SpanContext) (context.Context, bool) {
+	if !sc.IsValid() {
+		return ctx, false
+	}
+	return trace.ContextWithRemoteSpanContext(ctx, sc), true
+}
+
 // gameSpanContext reconstructs the remote SpanContext of the coordinator's game span from
 // its hex trace_id + span_id. It is the single source of the #1133/#1157 SpanContext
 // construction, shared by TraceLink (Link target) and RemoteParent (remote parent). The

--- a/services/agent/gamecontext/tracelink_test.go
+++ b/services/agent/gamecontext/tracelink_test.go
@@ -89,3 +89,32 @@ func TestRemoteParent(t *testing.T) {
 		})
 	}
 }
+
+// TestRemoteParentFromSpanContext covers the #1188 SpanContext-typed sibling: a VALID
+// SpanContext is installed as the remote parent (ok=true); an invalid (zero)
+// SpanContext returns the unchanged ctx + ok=false (graceful own-root fallback).
+func TestRemoteParentFromSpanContext(t *testing.T) {
+	base := context.Background()
+
+	// Invalid (zero) SpanContext => no re-parent, unchanged ctx.
+	if ctx, ok := RemoteParentFromSpanContext(base, trace.SpanContext{}); ok || ctx != base {
+		t.Errorf("zero SpanContext: ok=%v ctx-changed=%v, want ok=false, unchanged", ok, ctx != base)
+	}
+
+	tid, _ := trace.TraceIDFromHex(validTrace)
+	sid, _ := trace.SpanIDFromHex(validSpanID)
+	sc := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID: tid, SpanID: sid, TraceFlags: trace.FlagsSampled,
+	})
+	ctx, ok := RemoteParentFromSpanContext(base, sc)
+	if !ok {
+		t.Fatal("valid SpanContext must re-parent (ok=true)")
+	}
+	got := trace.SpanContextFromContext(ctx)
+	if got.TraceID() != tid || got.SpanID() != sid {
+		t.Errorf("remote parent = %s/%s, want %s/%s", got.TraceID(), got.SpanID(), tid, sid)
+	}
+	if !got.IsRemote() {
+		t.Error("installed parent SpanContext must be marked Remote")
+	}
+}

--- a/services/agent/gamesummary/coordinator.go
+++ b/services/agent/gamesummary/coordinator.go
@@ -90,6 +90,16 @@ type Coordinator struct {
 	// game end. Set once at construction via SetObserver, before the coordinator
 	// serves, so no lock is needed around the read.
 	observer Observer
+	// experimentParent resolves the agent.experiment ROOT span's SpanContext by
+	// experiment_id (#1188), reading the registry's ExperimentSpanContext. When wired
+	// and the finished game is experiment-bound with a live root span, the
+	// agent.game.summary span is re-parented as a remote CHILD of the experiment span
+	// (joining the experiment's trace) instead of the pre-#1188 game-LINKED own-root
+	// span. The game Link is retained so the summary stays navigable to its game too. A
+	// nil seam (the default / tests), a non-experiment game, or a torn-down experiment
+	// (ok=false) falls back to the existing behavior. Set once at construction via
+	// SetExperimentParent, before the coordinator serves, so no lock is needed.
+	experimentParent func(experimentID string) (trace.SpanContext, bool)
 	// now is injectable for tests; nil uses time.Now. It stamps Summary.GeneratedAt
 	// only — the aggregation itself is clock-free.
 	now func() time.Time
@@ -123,6 +133,18 @@ func NewCoordinator(w *Writer, log *slog.Logger) *Coordinator {
 // observer is exactly the M7-1 behavior. Set during construction, before the
 // store fires OnGameEnd, so the field read in OnGameEnd needs no lock.
 func (c *Coordinator) SetObserver(o Observer) { c.observer = o }
+
+// SetExperimentParent wires the experiment ROOT-span SpanContext lookup seam (#1188):
+// a func returning the agent.experiment span's SpanContext for an experiment_id
+// (reading the registry's ExperimentSpanContext) and whether one is available. When
+// wired and the finished game is experiment-bound with a live root span, the
+// agent.game.summary span is re-parented as a remote CHILD of the experiment span. A
+// nil seam (the default), a non-experiment game, or a torn-down experiment falls back
+// to the pre-#1188 game-linked own-root span. Set during construction, before the
+// store fires OnGameEnd, so the field read needs no lock.
+func (c *Coordinator) SetExperimentParent(f func(experimentID string) (trace.SpanContext, bool)) {
+	c.experimentParent = f
+}
 
 // instrumentationName scopes the coordinator's tracer, matching the agent module
 // convention used by the decision package.
@@ -164,7 +186,13 @@ func (c *Coordinator) OnGameEnd(gc gamecontext.GameContext) {
 	// spokes. The ids come from the OnGameEnd GameContext (#1133 correlation gauge).
 	// nil-safe: empty/invalid ids => no Link, no error.
 	startOpts := gamecontext.TraceLink(gc.GameTraceID, gc.GameTraceSpanID, attrGameTraceID, attrGameTraceSpanID)
-	_, span := c.tracer.Start(context.Background(), SpanGameSummary, startOpts...)
+	// #1188: re-parent the summary under the experiment ROOT span for an
+	// experiment-bound game (the experiment outlives its games, so its per-game summary
+	// is a timeline-correct child). The game Link above is retained. A non-experiment
+	// game / unwired seam / torn-down experiment yields context.Background() — the
+	// pre-#1188 own-root behavior, unchanged.
+	parent := c.summaryParentCtx(gc.ExperimentID)
+	_, span := c.tracer.Start(parent, SpanGameSummary, startOpts...)
 	defer span.End()
 
 	summary := BuildSummary(gc, BuildOptions{Now: now()})
@@ -226,6 +254,28 @@ func (c *Coordinator) claimGame(gameID string) bool {
 		delete(c.claimed, oldest)
 	}
 	return true
+}
+
+// summaryParentCtx returns the context the agent.game.summary span is started from
+// (#1188): a context whose remote parent is the experiment ROOT span for an
+// experiment-bound game with a live root span, else plain context.Background() (the
+// pre-#1188 own-root behavior). Reads the SpanContext via the injected experimentParent
+// seam and installs it with gamecontext.RemoteParentFromSpanContext.
+//
+// GRACEFUL FALLBACK: an empty experiment_id, a nil seam, or ok=false all yield
+// context.Background(), so the summary span is unchanged from before #1188 and emission
+// is never broken.
+func (c *Coordinator) summaryParentCtx(experimentID string) context.Context {
+	base := context.Background()
+	if experimentID == "" || c.experimentParent == nil {
+		return base
+	}
+	sc, ok := c.experimentParent(experimentID)
+	if !ok {
+		return base
+	}
+	ctx, _ := gamecontext.RemoteParentFromSpanContext(base, sc)
+	return ctx
 }
 
 // compile-time guard: Coordinator.OnGameEnd matches the store hook signature.

--- a/services/agent/gamesummary/coordinator_test.go
+++ b/services/agent/gamesummary/coordinator_test.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/joustmania/agent/gamecontext"
 )
@@ -222,5 +223,62 @@ func TestCoordinator_EndToEndFromStore(t *testing.T) {
 
 	if _, err := os.Stat(c.writer.Path("game_e2e")); err != nil {
 		t.Errorf("end-to-end store summary not written: %v", err)
+	}
+}
+
+// TestCoordinator_ReparentsUnderExperiment (#1188): when an experiment-parent seam is
+// wired and the finished game is experiment-bound with a live root span, the
+// agent.game.summary span is a CHILD of the experiment root span (same trace_id, parent
+// = the root span_id). A non-experiment game keeps its own-root behavior.
+func TestCoordinator_ReparentsUnderExperiment(t *testing.T) {
+	c, sr, _ := recordingCoordinator(t)
+
+	// A stand-in experiment ROOT span context the seam returns for "exp_1".
+	rootTID, _ := trace.TraceIDFromHex("4bf92f3577b34da6a3ce929d0e0e4736")
+	rootSID, _ := trace.SpanIDFromHex("00f067aa0ba902b7")
+	rootSC := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID: rootTID, SpanID: rootSID, TraceFlags: trace.FlagsSampled, Remote: true,
+	})
+	c.SetExperimentParent(func(id string) (trace.SpanContext, bool) {
+		if id == "exp_1" {
+			return rootSC, true
+		}
+		return trace.SpanContext{}, false
+	})
+
+	// Experiment-bound game => re-parented under the experiment root span.
+	c.OnGameEnd(gamecontext.GameContext{
+		SessionID: "game_exp", ExperimentID: "exp_1", GameKind: "shadow",
+		Session: gamecontext.SessionSignals{GameActive: bptr(false)},
+	})
+	// Non-experiment game => own-root (the seam returns ok=false).
+	c.OnGameEnd(gamecontext.GameContext{
+		SessionID: "game_real", GameKind: "real",
+		Session: gamecontext.SessionSignals{GameActive: bptr(false)},
+	})
+
+	spans := spansByName(sr.Ended(), SpanGameSummary)
+	if len(spans) != 2 {
+		t.Fatalf("agent.game.summary spans = %d, want 2", len(spans))
+	}
+	var exp, real sdktrace.ReadOnlySpan
+	for _, s := range spans {
+		if v, _ := spanAttr(s, attrGameID); v.AsString() == "game_exp" {
+			exp = s
+		} else {
+			real = s
+		}
+	}
+	if exp == nil || real == nil {
+		t.Fatal("expected one experiment-bound and one real summary span")
+	}
+	if got := exp.SpanContext().TraceID(); got != rootTID {
+		t.Errorf("experiment summary trace_id = %s, want root %s", got, rootTID)
+	}
+	if got := exp.Parent().SpanID(); got != rootSID {
+		t.Errorf("experiment summary parent = %s, want root span %s", got, rootSID)
+	}
+	if real.Parent().IsValid() {
+		t.Error("non-experiment summary must be own-root (no valid parent)")
 	}
 }

--- a/services/agent/main.go
+++ b/services/agent/main.go
@@ -921,6 +921,15 @@ func main() {
 			objResolver.Set(func(flagKey string) string {
 				return objectiveForFlag(reg, flagKey)
 			})
+			// #1188: give the per-game retro + summary spans access to the experiment's
+			// long-lived agent.experiment ROOT span by experiment_id, so an
+			// EXPERIMENT-bound game's agent.llm.retro / agent.game.summary re-parent under
+			// the experiment (joining its trace) instead of standing as own-root spans. The
+			// registry's ExperimentSpanContext is a clean read accessor; a non-experiment
+			// game (empty experiment_id) or a torn-down experiment yields ok=false, so those
+			// spans keep their pre-#1188 game-linked own-root behavior — graceful.
+			retro.SetExperimentParent(reg.ExperimentSpanContext)
+			summaries.SetExperimentParent(reg.ExperimentSpanContext)
 		}
 	}
 


### PR DESCRIPTION
Part of #1181, #1188 (PR2: experiment root span + analysis children).

## What
Adds a long-lived `agent.experiment` ROOT span per experiment and re-parents the per-experiment analysis spans as its children, so the whole hypothesis-test narrative is ONE trace. Agent-only (no coordinator/cross-service — that is PR3).

## Experiment root span (`experiment/registry.go`)
- New `span`/`spanCtx` on the registry `entry`, plus a nil-safe `tracer` on the `Registry` (`RegistryConfig.Tracer`, defaults to `otel.Tracer(...)`).
- **Started** when the experiment becomes RUNNING: `startSpanLocked` in `Start` (PROPOSED→RUNNING) and in `Rehydrate` (the only place a RUNNING entry is created without `Start`). Carries `experiment.id` / `flag_key` / `objective` / `target_n` / `arms`.
- **Ended** in `teardown` — the SINGLE terminal chokepoint every terminal transition routes through (conclude → discarded/done, abort). End is placed BEFORE the idempotency guard (and is itself idempotent) so the promote→DONE path — where `promote()` already set the terminal status — still ends the span exactly once. No leak on any terminal path; no double-end on a repeated teardown.
- `ExperimentSpanContext(id)` — a clean read accessor (no lifecycle/mutation entanglement); returns ok=false for unknown/torn-down/unwired, so callers fall back gracefully.

## Re-parented analysis spans (experiment-bound games only; graceful own-root otherwise)
- `experiment.fitness` / `experiment.evaluate` (`experiment_loop.go`): re-parent via the registry SpanContext + new `gamecontext.RemoteParentFromSpanContext`. `experiment.verdict` stays a child of `evaluate`. The game Link is retained.
- `agent.llm.retro` (`decision/retro_capture.go`) and `agent.game.summary` (`gamesummary/coordinator.go`): re-parent via an injected `SetExperimentParent` lookup seam (wired in `main.go` to `reg.ExperimentSpanContext`). The retro is async (post-#1179) but the experiment span outlives its games, so the parent is alive when the retro starts.
- `code_improvement.promote` (`promote/` untouched): the registry installs the still-live experiment span on the `ctx` it hands the Promoter seam, so the promote span nests as the experiment's TERMINAL child.

## Restart discontinuity
A rehydrated experiment gets a BRAND-NEW root span (fresh trace_id); the SpanContext is NOT persisted across a restart. Documented in `registry.go` (`Rehydrate` + the `entry.span` doc).

## Tests
- `experiment/registry_root_span_test.go`: start-on-RUNNING (not before), end exactly once on discard/promote/abort, no double-end, identifying attrs, nil-tracer safe, rehydrate fresh span.
- `experiment_root_span_test.go`: fitness/evaluate are children of the root span (same trace_id, parent = root span_id) with the game Link retained; non-experiment game keeps own-root; re-parent does not change the fitness scalar.
- `gamesummary` + `decision` retro tests: experiment-bound re-parent vs non-experiment own-root.
- `gamecontext`: `RemoteParentFromSpanContext` valid/invalid.

`gofmt`/`go build`/`go vet`/`go test ./... -race` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)