### PR TITLE
fix(jaeger): raise memory to 1Gi, add restart policy, bound badger retention

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -137,6 +137,11 @@ services:
     command: ["--config", "/etc/jaeger/config.yaml"]
     networks:
       - joustmania
+    # #1191: self-heal from an OOM (exit 137) instead of staying DEAD with the
+    # trace UI unreachable. With the prior RestartPolicy=no, a single OOM under
+    # the agent experiment-loop span volume left /jaeger 503 for the rest of the
+    # session. unless-stopped brings the trace store back automatically.
+    restart: unless-stopped
     healthcheck:
       test: [ "CMD", "wget", "--spider", "-q", "http://localhost:16686/jaeger/" ]
       interval: 10s
@@ -146,7 +151,15 @@ services:
     deploy:
       resources:
         limits:
-          memory: 384m
+          # #1191: raised 384m -> 1024m. The trace-BACKEND analogue of the
+          # collector OOM (#1173): the agent experiment loop + the #1178/#1188
+          # span hierarchy produce a lot of spans, and Jaeger's badger storage
+          # (compaction + value-log cache) outgrew 384m, getting OOM-killed
+          # (exit 137). Jaeger is a dev/observability component (not a
+          # Pi-gameplay service), so the budget is raised globally rather than
+          # per-stack. Badger span TTL is bounded in services/jaeger/config.yaml
+          # so the store can't creep unbounded over a long demo.
+          memory: 1024m
           cpus: '0.5'
     logging: *default-logging
 

--- a/services/jaeger/config.yaml
+++ b/services/jaeger/config.yaml
@@ -19,8 +19,17 @@ extensions:
           directories:
             keys: /badger/key
             values: /badger/value
+          # #1191: bound badger retention so memory/disk can't creep unbounded
+          # over a long demo under the agent experiment-loop span volume. We only
+          # ever look at recent traces in a demo/dev stack, and badger v2.19.0
+          # exposes no value-log/cache-size knob — the only retention levers are
+          # the span TTL and how often expired data is reclaimed.
           ttl:
-            spans: 168h  # 7 days
+            spans: 24h  # was 168h (7d); a demo only needs the last day of traces
+          # Run badger's value-log GC / compaction on a tighter cadence than the
+          # default so expired spans are actually reclaimed instead of piling up
+          # in the value log between infrequent maintenance cycles.
+          maintenance_interval: 5m
   jaeger_query:
     base_path: /jaeger
     storage:


### PR DESCRIPTION
Part of #1191.

Jaeger was OOM-killed (exit 137) at the **384Mi** container limit under the agent experiment-loop span volume (the #1178/#1188 span hierarchy), and with `RestartPolicy=no` it stayed DEAD → `/jaeger` 503, trace UI unreachable. This is the trace-BACKEND analogue of the collector OOM (#1173).

## Changes
- **Memory 384m → 1024m (1Gi)** in the `docker-compose.yml` jaeger block (base/global). Jaeger is a dev/observability component (not a Pi-gameplay service), so the budget is raised globally rather than per-stack — same spirit as the collector but no dry-run/gateway split is needed (no override file touches jaeger; the base block fully defines it). The dump from the v2.19.0 image shows badger's default `BlockCacheSize` is 256Mi and `ValueLogFileSize` ~1Gi, which is precisely why 384m OOM'd.
- **`restart: unless-stopped`** so Jaeger self-heals from an OOM instead of staying down (the actual reason the UI went unreachable).
- **Bound badger retention** in `services/jaeger/config.yaml`: span TTL `168h → 24h` + `maintenance_interval: 5m` so expired spans are reclaimed on a tight cadence instead of piling up in the value log between infrequent GC cycles. badger v2.19.0 exposes **no** value-log/cache-size knob (verified against the v2.19.0 badger `Config` schema), so TTL + maintenance_interval are the only retention levers available.

## Verification
- `python3 -c "import yaml; yaml.safe_load(...)"` valid for both files.
- `docker compose config` → jaeger `restart: unless-stopped`, `memory: 1073741824`.
- Config accepted by the pinned `jaegertracing/jaeger:2.19.0` binary ("Everything is ready", no unmarshal error for the new badger fields).
- Recreated jaeger live → `running`, `healthy`, `MemLimit=1073741824`, `RestartPolicy=unless-stopped`; `curl http://localhost/jaeger/api/services` → **200**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)