### PR TITLE
feat(trace): shadow game span as experiment child via spawn-traceparent (#1182)

### DIFF
--- a/services/agent/experiment/registry.go
+++ b/services/agent/experiment/registry.go
@@ -743,9 +743,20 @@ type startedArm struct {
 // pair — including a sibling arm that already spawned a live game — so a half-pair
 // never enters the cohort statistics (the atomic-pair invariant).
 func (r *Registry) spawnPair(ctx context.Context, plan pairPlan) (bound int, stop bool) {
+	// Spawn-traceparent propagation (#1182, epic #1181): carry this experiment's
+	// long-lived ROOT span context on the spawn ctx as a REMOTE parent. The
+	// spawner reads it off the ctx and (for an experiment-bound shadow game)
+	// injects it as the outgoing traceparent so the coordinator's game span
+	// becomes a CHILD of the experiment span. When the experiment has no valid
+	// root span (tracer unwired / torn down) the ctx is unchanged, so nothing is
+	// injected and the game stays own-rooted — graceful, exactly as before.
+	spawnCtx := ctx
+	if sc, ok := r.ExperimentSpanContext(plan.id); ok {
+		spawnCtx = trace.ContextWithRemoteSpanContext(ctx, sc)
+	}
 	var live []startedArm
 	for i, arm := range plan.arms {
-		gameID, err := r.spawner.Spawn(ctx, plan.id, arm, plan.seed)
+		gameID, err := r.spawner.Spawn(spawnCtx, plan.id, arm, plan.seed)
 		if err != nil {
 			// Roll the WHOLE pair back atomically (#1003): release the failed arm and
 			// every arm AFTER it (whose Spawn was never attempted, still reserved), and

--- a/services/agent/experiment/registry_spawn_traceparent_test.go
+++ b/services/agent/experiment/registry_spawn_traceparent_test.go
@@ -1,0 +1,102 @@
+package experiment
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"go.opentelemetry.io/otel/trace"
+)
+
+// #1182 (epic #1181 PR3): the registry carries the experiment's long-lived ROOT
+// span context onto the spawn ctx (as a remote parent), so the real shadowSpawner
+// can inject it as the outgoing traceparent and the coordinator's game span
+// becomes a CHILD of the experiment span. These tests pin that the SpanContext the
+// registry exposes is exactly the one handed to Spawn — and that a no-telemetry
+// registry hands a clean (invalid) SpanContext, the graceful own-root path.
+
+// spanCapturingSpawner records the SpanContext present on the ctx of each Spawn
+// call, so a test can assert the registry propagated the experiment root span.
+type spanCapturingSpawner struct {
+	mu       sync.Mutex
+	captured []trace.SpanContext
+	seq      int
+}
+
+func (s *spanCapturingSpawner) Spawn(ctx context.Context, _, _ string, _ uint64) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.captured = append(s.captured, trace.SpanContextFromContext(ctx))
+	s.seq++
+	return spanCapturingGameID(s.seq), nil
+}
+
+func spanCapturingGameID(n int) string {
+	return "game_spancap" + string(rune('0'+n%10))
+}
+
+func (s *spanCapturingSpawner) first() (trace.SpanContext, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.captured) == 0 {
+		return trace.SpanContext{}, false
+	}
+	return s.captured[0], true
+}
+
+// TestSpawnCtxCarriesExperimentSpanContext: with a recording tracer (a valid
+// experiment root span), the SpanContext on the spawn ctx equals the experiment's
+// exposed root SpanContext — the parent the coordinator will nest the game under.
+func TestSpawnCtxCarriesExperimentSpanContext(t *testing.T) {
+	spawner := &spanCapturingSpawner{}
+	r, _ := rootSpanRegistry(t, RegistryConfig{
+		Spawner: spawner, Verdict: fakeVerdict{concludeAtN: 1000}, Targeting: &fakeTargeting{},
+		MaxShadowGames: 2, EffectiveConcurrency: 1,
+	})
+	id := startedExperiment(t, r)
+
+	want, ok := r.ExperimentSpanContext(id)
+	if !ok || !want.IsValid() {
+		t.Fatal("experiment must expose a valid root SpanContext once RUNNING")
+	}
+
+	r.AllocateAndSpawn(context.Background())
+
+	got, ok := spawner.first()
+	if !ok {
+		t.Fatal("no spawn call recorded")
+	}
+	if !got.IsValid() {
+		t.Fatal("spawn ctx carried no valid SpanContext (experiment root not propagated)")
+	}
+	if got.TraceID() != want.TraceID() || got.SpanID() != want.SpanID() {
+		t.Fatalf("spawn ctx SpanContext = trace=%s span=%s, want trace=%s span=%s",
+			got.TraceID(), got.SpanID(), want.TraceID(), want.SpanID())
+	}
+	if !got.IsRemote() {
+		t.Error("propagated experiment SpanContext should be marked remote (a cross-service parent)")
+	}
+}
+
+// TestSpawnCtxNoSpanContextWhenNoTracer: a registry with the no-op tracer exposes
+// no valid root SpanContext, so the spawn ctx carries an invalid SpanContext and
+// the spawner injects nothing — the game stays own-rooted (graceful).
+func TestSpawnCtxNoSpanContextWhenNoTracer(t *testing.T) {
+	spawner := &spanCapturingSpawner{}
+	// No Tracer => global no-op provider => invalid (non-recording) root span.
+	r := newTestRegistry(t, RegistryConfig{
+		Spawner: spawner, Verdict: fakeVerdict{concludeAtN: 1000}, Targeting: &fakeTargeting{},
+		MaxShadowGames: 2, EffectiveConcurrency: 1,
+	})
+	_ = startedExperiment(t, r)
+
+	r.AllocateAndSpawn(context.Background())
+
+	got, ok := spawner.first()
+	if !ok {
+		t.Fatal("no spawn call recorded")
+	}
+	if got.IsValid() {
+		t.Fatalf("spawn ctx carried a valid SpanContext with no tracer: %v", got)
+	}
+}

--- a/services/agent/gamerunner/fakes_test.go
+++ b/services/agent/gamerunner/fakes_test.go
@@ -10,6 +10,7 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/test/bufconn"
 
 	mockpb "github.com/joustmania/agent/gen/controller_manager_mock"
@@ -127,11 +128,15 @@ type fakeCoord struct {
 	listGames      func() (*gcpb.ListGamesResponse, error)
 	forceEndSignal chan *gcpb.GameEvent
 	startConfig    *gcpb.StartGameConfig // captured from the last StreamGameEvents
+	streamMetadata metadata.MD           // incoming metadata from the last StreamGameEvents
 }
 
 func (c *fakeCoord) StreamGameEvents(req *gcpb.StreamEventsRequest, stream grpc.ServerStreamingServer[gcpb.GameEvent]) error {
 	c.mu.Lock()
 	c.startConfig = req.GetStartConfig()
+	if md, ok := metadata.FromIncomingContext(stream.Context()); ok {
+		c.streamMetadata = md.Copy()
+	}
 	c.mu.Unlock()
 	for _, ev := range c.events {
 		ev.GameId = c.gameID
@@ -193,6 +198,14 @@ func (c *fakeCoord) capturedStartConfig() *gcpb.StartGameConfig {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return c.startConfig
+}
+
+// capturedMetadata returns the incoming metadata from the last StreamGameEvents
+// call (nil until one arrives).
+func (c *fakeCoord) capturedMetadata() metadata.MD {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.streamMetadata
 }
 
 // testHarness wires fake servers over bufconn and injects a dialer into a Runner.

--- a/services/agent/gamerunner/operations.go
+++ b/services/agent/gamerunner/operations.go
@@ -8,7 +8,11 @@ import (
 	"strings"
 	"time"
 
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 
 	mockpb "github.com/joustmania/agent/gen/controller_manager_mock"
 	gcpb "github.com/joustmania/agent/gen/game_coordinator"
@@ -218,6 +222,12 @@ func (r *Runner) startAndCapture(
 	ctx context.Context, cl *clients, spec Spec, serials []string,
 ) (grpc.ServerStreamingClient[gcpb.GameEvent], string, error) {
 	cfg := buildStartConfig(spec, serials)
+	// Spawn-traceparent propagation (#1182, epic #1181): for an experiment-bound
+	// shadow spawn carrying a valid experiment SpanContext, inject it as the
+	// OUTGOING traceparent so the coordinator's game-lifecycle span is created as
+	// a CHILD of the experiment span. A real game / unbound shadow game (invalid
+	// SpanContext) injects nothing and stays own-rooted.
+	ctx = injectExperimentTraceparent(ctx, spec.ExperimentSpanContext)
 	stream, err := cl.coord.StreamGameEvents(ctx, &gcpb.StreamEventsRequest{StartConfig: cfg})
 	if err != nil {
 		return nil, "", fmt.Errorf("StreamGameEvents: %w", err)
@@ -245,6 +255,43 @@ func (r *Runner) startAndCapture(
 			return stream, id, nil
 		}
 	}
+}
+
+// injectExperimentTraceparent injects the experiment ROOT span context (#1182,
+// epic #1181) as the W3C traceparent on the outgoing gRPC metadata, so the
+// coordinator's server interceptor extracts it and parents the spawned game's
+// lifecycle span under the experiment span (causal parent-child, not a Link).
+//
+// It is deliberately TARGETED rather than a blanket client stats-handler: only
+// an experiment-bound spawn carrying a VALID SpanContext propagates a parent. A
+// real game or an unbound shadow game has the zero (invalid) SpanContext and
+// injects NOTHING — the coordinator then sees no incoming traceparent and keeps
+// the game own-rooted (#1157/#1164). This is the single cross-service hop that
+// stitches the experiment trace together, so it is explicit and gated here.
+//
+// The SpanContext is wrapped as a REMOTE parent (NonRecordingSpan) and run
+// through the globally-configured TextMapPropagator into a metadata carrier,
+// which is merged onto any existing outgoing metadata on ctx.
+func injectExperimentTraceparent(ctx context.Context, sc trace.SpanContext) context.Context {
+	if !sc.IsValid() {
+		return ctx
+	}
+	carrier := propagation.MapCarrier{}
+	parentCtx := trace.ContextWithRemoteSpanContext(ctx, sc)
+	otel.GetTextMapPropagator().Inject(parentCtx, carrier)
+	if len(carrier) == 0 {
+		// No propagator configured (e.g. telemetry off): nothing to inject, so the
+		// game stays own-rooted exactly as before.
+		return ctx
+	}
+	md := metadata.MD{}
+	if existing, ok := metadata.FromOutgoingContext(ctx); ok {
+		md = existing.Copy()
+	}
+	for k, v := range carrier {
+		md.Set(k, v)
+	}
+	return metadata.NewOutgoingContext(ctx, md)
 }
 
 // startRejectedInProgress reports whether a game_start_error event's data is the

--- a/services/agent/gamerunner/operations_traceparent_test.go
+++ b/services/agent/gamerunner/operations_traceparent_test.go
@@ -1,0 +1,187 @@
+package gamerunner
+
+import (
+	"context"
+	"testing"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
+	"google.golang.org/grpc/metadata"
+
+	gcpb "github.com/joustmania/agent/gen/game_coordinator"
+)
+
+// withTraceContextPropagator installs the same W3C TraceContext propagator the
+// agent configures in otel.go for the duration of a test, then restores the
+// prior global. Without a configured propagator Inject is a no-op (the graceful
+// telemetry-off path), so the positive-propagation tests must set one.
+func withTraceContextPropagator(t *testing.T) {
+	t.Helper()
+	prev := otel.GetTextMapPropagator()
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+	t.Cleanup(func() { otel.SetTextMapPropagator(prev) })
+}
+
+// experimentSpanContext builds a VALID remote SpanContext standing in for the
+// agent's long-lived experiment ROOT span.
+func experimentSpanContext(t *testing.T) trace.SpanContext {
+	t.Helper()
+	tid, err := trace.TraceIDFromHex("0123456789abcdef0123456789abcdef")
+	if err != nil {
+		t.Fatalf("TraceIDFromHex: %v", err)
+	}
+	sid, err := trace.SpanIDFromHex("0123456789abcdef")
+	if err != nil {
+		t.Fatalf("SpanIDFromHex: %v", err)
+	}
+	return trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    tid,
+		SpanID:     sid,
+		TraceFlags: trace.FlagsSampled,
+		Remote:     true,
+	})
+}
+
+// TestInjectExperimentTraceparent_ValidInjects asserts a valid experiment
+// SpanContext is injected as the W3C traceparent on the outgoing metadata,
+// carrying the experiment's trace_id and span_id so the coordinator parents the
+// game span under the experiment span.
+func TestInjectExperimentTraceparent_ValidInjects(t *testing.T) {
+	withTraceContextPropagator(t)
+	sc := experimentSpanContext(t)
+
+	ctx := injectExperimentTraceparent(context.Background(), sc)
+
+	md, ok := metadata.FromOutgoingContext(ctx)
+	if !ok {
+		t.Fatal("no outgoing metadata after inject")
+	}
+	tp := md.Get("traceparent")
+	if len(tp) != 1 {
+		t.Fatalf("traceparent entries = %v, want exactly 1", tp)
+	}
+	// W3C format: 00-<trace_id>-<span_id>-<flags>. The injected parent must carry
+	// the experiment trace + span ids so the coordinator nests the game under it.
+	wantTrace := sc.TraceID().String()
+	wantSpan := sc.SpanID().String()
+	if got := tp[0]; len(got) < 55 ||
+		got[3:3+32] != wantTrace ||
+		got[36:36+16] != wantSpan {
+		t.Fatalf("traceparent = %q, want trace_id=%s span_id=%s", got, wantTrace, wantSpan)
+	}
+}
+
+// TestInjectExperimentTraceparent_InvalidNoOp asserts the zero (invalid)
+// SpanContext — a real game or an unbound shadow game — injects NOTHING, so the
+// coordinator sees no incoming traceparent and keeps the game own-rooted.
+func TestInjectExperimentTraceparent_InvalidNoOp(t *testing.T) {
+	withTraceContextPropagator(t)
+
+	ctx := injectExperimentTraceparent(context.Background(), trace.SpanContext{})
+
+	if md, ok := metadata.FromOutgoingContext(ctx); ok {
+		if tp := md.Get("traceparent"); len(tp) != 0 {
+			t.Fatalf("traceparent injected for invalid SpanContext: %v", tp)
+		}
+	}
+}
+
+// TestInjectExperimentTraceparent_PreservesExistingMetadata asserts the inject
+// merges onto, rather than replaces, any pre-existing outgoing metadata.
+func TestInjectExperimentTraceparent_PreservesExistingMetadata(t *testing.T) {
+	withTraceContextPropagator(t)
+	sc := experimentSpanContext(t)
+
+	base := metadata.NewOutgoingContext(context.Background(),
+		metadata.Pairs("flagd-selector", "flagSetId=game"))
+	ctx := injectExperimentTraceparent(base, sc)
+
+	md, ok := metadata.FromOutgoingContext(ctx)
+	if !ok {
+		t.Fatal("no outgoing metadata after inject")
+	}
+	if got := md.Get("flagd-selector"); len(got) != 1 || got[0] != "flagSetId=game" {
+		t.Errorf("pre-existing metadata lost: flagd-selector=%v", got)
+	}
+	if tp := md.Get("traceparent"); len(tp) != 1 {
+		t.Errorf("traceparent not added alongside existing metadata: %v", tp)
+	}
+}
+
+// TestStartExperimentGame_InjectsTraceparent is the cross-service-flow assertion:
+// an experiment-bound spawn whose Spec carries a valid experiment SpanContext
+// reaches the coordinator with the experiment traceparent on the incoming
+// metadata. The fakeCoord captures it from the stream context.
+func TestStartExperimentGame_InjectsTraceparent(t *testing.T) {
+	withTraceContextPropagator(t)
+	sc := experimentSpanContext(t)
+
+	mock := &fakeMock{}
+	coord := &fakeCoord{
+		gameID: "game_exp123",
+		events: []*gcpb.GameEvent{ev("game_started")},
+	}
+	h := newHarness(t, mock, coord)
+	defer h.stop()
+
+	driveCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	spec := Spec{
+		RunID:                 "run-exp",
+		GameName:              "JoustFFA",
+		Players:               2,
+		Sensitivity:           2,
+		ExperimentID:          "exp-1",
+		Arm:                   "experimental",
+		ExperimentSpanContext: sc,
+	}
+	if _, err := h.runner.StartExperimentGame(context.Background(), driveCtx, spec); err != nil {
+		t.Fatalf("StartExperimentGame error: %v", err)
+	}
+
+	md := coord.capturedMetadata()
+	if md == nil {
+		t.Fatal("coordinator captured no incoming metadata")
+	}
+	tp := md.Get("traceparent")
+	if len(tp) != 1 {
+		t.Fatalf("coordinator traceparent = %v, want exactly 1 carrying the experiment span", tp)
+	}
+	if got := tp[0]; len(got) < 55 || got[3:3+32] != sc.TraceID().String() {
+		t.Fatalf("coordinator traceparent = %q, want trace_id=%s", got, sc.TraceID())
+	}
+}
+
+// TestStartExperimentGame_NoTraceparentWhenNoSpanContext is the real-game / unbound
+// path: a spawn WITHOUT an experiment SpanContext injects no traceparent, so the
+// coordinator keeps the game own-rooted.
+func TestStartExperimentGame_NoTraceparentWhenNoSpanContext(t *testing.T) {
+	withTraceContextPropagator(t)
+
+	mock := &fakeMock{}
+	coord := &fakeCoord{
+		gameID: "game_plain",
+		events: []*gcpb.GameEvent{ev("game_started")},
+	}
+	h := newHarness(t, mock, coord)
+	defer h.stop()
+
+	driveCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// No ExperimentSpanContext set (zero value) — mirrors a real game / unbound
+	// shadow game.
+	spec := Spec{RunID: "run-plain", GameName: "JoustFFA", Players: 2, Sensitivity: 2}
+	if _, err := h.runner.StartExperimentGame(context.Background(), driveCtx, spec); err != nil {
+		t.Fatalf("StartExperimentGame error: %v", err)
+	}
+
+	md := coord.capturedMetadata()
+	if md != nil {
+		if tp := md.Get("traceparent"); len(tp) != 0 {
+			t.Fatalf("traceparent injected for a spawn with no experiment SpanContext: %v", tp)
+		}
+	}
+}

--- a/services/agent/gamerunner/runner.go
+++ b/services/agent/gamerunner/runner.go
@@ -185,6 +185,16 @@ type Spec struct {
 	ExperimentID string
 	Arm          string
 
+	// ExperimentSpanContext is the SpanContext of the agent's long-lived
+	// EXPERIMENT root span (#1182, epic #1181). When set (Valid), an
+	// experiment-bound shadow spawn injects it as the OUTGOING traceparent on the
+	// StreamGameEvents start call, so the coordinator's game-lifecycle span is
+	// created as a CHILD of the experiment span (causal parent-child) rather than
+	// its own root. The zero (invalid) value — a real game, an unbound shadow
+	// game, or an experiment with no recordable root span — injects nothing, so
+	// the game stays own-rooted exactly as before (graceful).
+	ExperimentSpanContext trace.SpanContext
+
 	// Seed is the deterministic RNG seed for paired CRN shadow games (#1003).
 	// When set (non-zero), it is threaded onto StartGameConfig.rng_seed so the
 	// game-coordinator constructs the game's per-instance RNG from it — the two

--- a/services/agent/shadow_spawner.go
+++ b/services/agent/shadow_spawner.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 
 	"github.com/google/uuid"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/joustmania/agent/experiment"
 	"github.com/joustmania/agent/gamerunner"
@@ -96,6 +97,13 @@ func (s *shadowSpawner) Spawn(ctx context.Context, experimentID, arm string, see
 	// spawn spec so the game-coordinator builds the shadow session's per-instance
 	// RNG from it. Both arms of a pair receive the same seed; 0 means entropy.
 	spec.Seed = seed
+	// Spawn-traceparent propagation (#1182, epic #1181): the registry carries the
+	// experiment's long-lived ROOT span context on the spawn ctx as a remote
+	// parent. Thread it onto the spec so StartExperimentGame injects it as the
+	// outgoing traceparent and the coordinator's game span becomes a CHILD of the
+	// experiment span. An invalid SpanContext (no root span) threads nothing, so
+	// the game stays own-rooted — graceful.
+	spec.ExperimentSpanContext = trace.SpanContextFromContext(ctx)
 
 	runner := gamerunner.New(s.cfg, s.log)
 	if s.onTerminal != nil {

--- a/services/game_coordinator/game_session.py
+++ b/services/game_coordinator/game_session.py
@@ -73,6 +73,7 @@ class GameSession:
         event_bus: EventBus,
         game_kind: str,
         stream_span_context=None,
+        experiment_parent_span_context=None,
         experiment_id: str = "",
         arm: str = "",
         rng_seed: int = 0,
@@ -89,6 +90,14 @@ class GameSession:
         # so the inbound call stays navigable in Jaeger. None when there is no
         # recordable inbound span (telemetry off / unsampled) — handled gracefully.
         self.stream_span_context = stream_span_context
+        # SpanContext of the SPAWNING agent EXPERIMENT span, propagated as the
+        # incoming traceparent on the shadow-game spawn RPC (#1182, epic #1181).
+        # For a SHADOW + experiment-bound game this becomes the game-lifecycle
+        # span's PARENT (causal parent-child, not a Link) so the game span is a
+        # CHILD of its long-lived experiment span in the same trace. None for a
+        # real game, an unbound shadow game, or when no traceparent was injected
+        # — those keep the own-root model (#1157/#1164), handled gracefully.
+        self.experiment_parent_span_context = experiment_parent_span_context
         # Experiment attribution within a shadow session (#975, epic #982). Empty
         # for a non-experiment game; set by #976's spawn binding. These are finer-
         # grained labels WITHIN game_kind=shadow, never a replacement for it.
@@ -265,9 +274,32 @@ class GameSession:
         if self.stream_span_context is not None and self.stream_span_context.trace_id != 0:
             links.append(trace.Link(self.stream_span_context))
 
+        # Choose the game-span PARENT context (#1182, epic #1181).
+        #
+        # A real (primary) game — and any shadow game NOT bound to an experiment —
+        # is rooted as its OWN trace (#1157/#1164): we pass an explicit empty
+        # Context so neither the inbound stream span nor any ambient span parents
+        # it. The inbound call stays navigable via the Link above.
+        #
+        # A SHADOW + experiment-bound game whose spawn carried the agent's
+        # experiment traceparent is instead made a CHILD of that experiment span
+        # (causal parent-child), so it nests under the long-lived experiment span
+        # in the same trace. The gate is STRICT (shadow AND experiment_id AND a
+        # valid injected parent) so the real-game own-root structure is never
+        # touched. We still keep the Link (harmless for shadow, navigability for
+        # real).
+        parent_context = Context()
+        if (
+            self.game_kind == GAME_KIND_SHADOW
+            and self.experiment_id
+            and self.experiment_parent_span_context is not None
+            and self.experiment_parent_span_context.trace_id != 0
+        ):
+            parent_context = trace.set_span_in_context(trace.NonRecordingSpan(self.experiment_parent_span_context))
+
         with tracer.start_as_current_span(
             game_span_name,
-            context=Context(),
+            context=parent_context,
             links=links,
         ) as game_span:
             game_span.set_attribute("game.name", self.game_name)

--- a/services/game_coordinator/servicer.py
+++ b/services/game_coordinator/servicer.py
@@ -479,6 +479,19 @@ class GameCoordinatorServicer(game_coordinator_pb2_grpc.GameCoordinatorServiceSe
             # Jaeger) without inheriting the stream's trace_id as the game's root.
             stream_span_context = parent_span.get_span_context() if parent_span is not None else None
 
+            # Spawn-traceparent propagation (#1182, epic #1181). When the agent
+            # spawns a shadow game it injects its long-lived EXPERIMENT span's
+            # traceparent into the StreamGameEvents call; the server interceptor
+            # extracts it (lib/grpc_tracing.py) so the current span's context here
+            # chains back to that experiment span. We capture it as the candidate
+            # PARENT for a shadow + experiment-bound game so its lifecycle span is
+            # a CHILD of the experiment span (causal parent-child, not just a
+            # Link). For a real game (or any game with no incoming traceparent)
+            # this is the same harmless SpanContext used for the Link; the strict
+            # shadow+experiment gate in GameSession keeps a real game own-rooted
+            # (#1157/#1164).
+            experiment_parent_span_context = stream_span_context
+
             # Experiment/cohort spawn binding (#976, epic #982). The caller
             # provides (experiment_id, arm) on StartGameConfig; the registry
             # (#978) will decide+supply them later — #976 is only the plumbing
@@ -515,6 +528,7 @@ class GameCoordinatorServicer(game_coordinator_pb2_grpc.GameCoordinatorServiceSe
                 event_bus=event_bus,
                 game_kind=game_kind,
                 stream_span_context=stream_span_context,
+                experiment_parent_span_context=experiment_parent_span_context,
                 experiment_id=experiment_id,
                 arm=arm,
                 rng_seed=rng_seed,

--- a/services/game_coordinator/tests/test_game_session.py
+++ b/services/game_coordinator/tests/test_game_session.py
@@ -469,6 +469,96 @@ class TestGameSessionLoop:
     @patch("services.game_coordinator.game_session.metrics")
     @patch("services.game_coordinator.game_session.GameFactory")
     @patch("services.game_coordinator.game_session.tracer")
+    async def test_shadow_experiment_game_span_is_child_of_injected_parent(
+        self, mock_tracer_mod, mock_factory, mock_metrics
+    ):
+        """#1182: a SHADOW + experiment-bound game whose spawn carried the agent's
+        experiment traceparent starts its game span as a CHILD of that remote parent
+        (causal parent-child), so it nests under the long-lived experiment span. The
+        parent context is a real, NON-empty Context containing the experiment span."""
+        from opentelemetry import trace as ot_trace
+        from opentelemetry.context import Context
+
+        exp_trace_id = 0x9999AAAABBBBCCCCDDDDEEEEFFFF0000
+        exp_span_id = 0x1122334455667788
+        parent_ctx = MockSpanContext(trace_id=exp_trace_id, span_id=exp_span_id)
+
+        session = _make_session(game_kind=GAME_KIND_SHADOW, experiment_id="exp-1", arm="experimental")
+        session.experiment_parent_span_context = parent_ctx
+        mock_tracer_mod.start_as_current_span = _tracer_mock().start_as_current_span
+        mock_game = MagicMock()
+        mock_game.run = AsyncMock()
+        mock_factory.create_game.return_value = mock_game
+
+        await session._run_game_loop_async()
+
+        _, kwargs = mock_tracer_mod.start_as_current_span.call_args
+        ctx = kwargs["context"]
+        # NOT own-root: a non-empty Context carrying the experiment span as parent.
+        assert isinstance(ctx, Context)
+        assert len(ctx) > 0, "shadow+experiment game must be parented, not own-rooted"
+        parent_span = ot_trace.get_current_span(ctx)
+        sc = parent_span.get_span_context()
+        assert sc.trace_id == exp_trace_id
+        assert sc.span_id == exp_span_id
+
+    @pytest.mark.asyncio
+    @patch("services.game_coordinator.game_session.metrics")
+    @patch("services.game_coordinator.game_session.GameFactory")
+    @patch("services.game_coordinator.game_session.tracer")
+    async def test_real_game_stays_own_root_even_with_parent_context(self, mock_tracer_mod, mock_factory, mock_metrics):
+        """#1182 real-game protection: a PRIMARY (real) game is own-rooted (#1157/#1164)
+        even if an experiment parent context and experiment_id are erroneously present.
+        The strict shadow+experiment gate keeps the real-game trace structure UNCHANGED."""
+        from opentelemetry.context import Context
+
+        parent_ctx = MockSpanContext(trace_id=0x9999AAAABBBBCCCCDDDDEEEEFFFF0000, span_id=0x1122334455667788)
+        # Real (primary) kind. The servicer zeroes experiment_id for a real game; even
+        # if a parent context leaked through, the kind gate alone must keep it own-root.
+        session = _make_session(game_kind=GAME_KIND_PRIMARY, experiment_id="exp-1")
+        session.experiment_parent_span_context = parent_ctx
+        mock_tracer_mod.start_as_current_span = _tracer_mock().start_as_current_span
+        mock_game = MagicMock()
+        mock_game.run = AsyncMock()
+        mock_factory.create_game.return_value = mock_game
+
+        await session._run_game_loop_async()
+
+        _, kwargs = mock_tracer_mod.start_as_current_span.call_args
+        ctx = kwargs["context"]
+        assert isinstance(ctx, Context)
+        assert len(ctx) == 0, "real game must stay own-rooted (#1157/#1164), never parented"
+
+    @pytest.mark.asyncio
+    @patch("services.game_coordinator.game_session.metrics")
+    @patch("services.game_coordinator.game_session.GameFactory")
+    @patch("services.game_coordinator.game_session.tracer")
+    async def test_shadow_experiment_game_own_root_when_no_parent(self, mock_tracer_mod, mock_factory, mock_metrics):
+        """#1182 graceful: a shadow + experiment game with NO injected parent
+        (telemetry off, or no traceparent on the spawn) stays own-rooted — the
+        own-root #1164 path is preserved when there is nothing valid to parent under.
+        Covers both None and an invalid (trace_id==0) parent context."""
+        from opentelemetry.context import Context
+
+        for parent_ctx in (None, MockSpanContext(trace_id=0, span_id=0)):
+            session = _make_session(game_kind=GAME_KIND_SHADOW, experiment_id="exp-1", arm="experimental")
+            session.experiment_parent_span_context = parent_ctx
+            mock_tracer_mod.start_as_current_span = _tracer_mock().start_as_current_span
+            mock_game = MagicMock()
+            mock_game.run = AsyncMock()
+            mock_factory.create_game.return_value = mock_game
+
+            await session._run_game_loop_async()
+
+            _, kwargs = mock_tracer_mod.start_as_current_span.call_args
+            ctx = kwargs["context"]
+            assert isinstance(ctx, Context)
+            assert len(ctx) == 0, "shadow+experiment with no valid parent must stay own-rooted"
+
+    @pytest.mark.asyncio
+    @patch("services.game_coordinator.game_session.metrics")
+    @patch("services.game_coordinator.game_session.GameFactory")
+    @patch("services.game_coordinator.game_session.tracer")
     async def test_shadow_loop_does_not_reset_players_alive(self, mock_tracer_mod, mock_factory, mock_metrics):
         """A shadow session ending must not reset the global players_alive gauge."""
         session = _make_session(game_kind=GAME_KIND_SHADOW)

--- a/services/game_coordinator/tests/test_servicer_sessions.py
+++ b/services/game_coordinator/tests/test_servicer_sessions.py
@@ -1102,6 +1102,23 @@ class TestExperimentSpawnBinding:
         assert session.arm == ""
 
     @pytest.mark.asyncio
+    async def test_shadow_experiment_threads_parent_span_context(self, servicer):
+        """#1182: the inbound (experiment-traceparent) SpanContext is threaded onto
+        the shadow+experiment session as experiment_parent_span_context so the game
+        span can be created as a CHILD of the experiment span. Uses a span with a
+        VALID (non-zero) trace_id, mirroring an injected experiment traceparent."""
+        with _NO_THREAD:
+            ok, gid = await servicer._start_game_from_config(
+                _experiment_config(serials=("a1", "a2"), experiment_id="exp_abc123", arm="experimental"),
+                _ValidParentSpan(),
+            )
+        assert ok is True
+        session = servicer.sessions[gid]
+        # The parent context is captured from the inbound span's SpanContext.
+        assert session.experiment_parent_span_context is not None
+        assert session.experiment_parent_span_context.trace_id == _VALID_PARENT_TRACE_ID
+
+    @pytest.mark.asyncio
     @patch("services.game_coordinator.servicer.metrics")
     async def test_bound_experiment_labels_live_gauges(self, mock_metrics, servicer):
         """The spawn binding feeds the per-live-game GAUGE labels (#975) so an
@@ -1181,6 +1198,17 @@ class _MockSpanContext:
     span_id = 0
 
 
+_VALID_PARENT_TRACE_ID = 0x9999AAAABBBBCCCCDDDDEEEEFFFF0000
+
+
+class _ValidParentSpanContext:
+    """A VALID (non-zero) SpanContext standing in for an injected experiment
+    traceparent (#1182), so the servicer captures it as the game-span parent."""
+
+    trace_id = _VALID_PARENT_TRACE_ID
+    span_id = 0x1122334455667788
+
+
 class _MockSpan:
     """Minimal span supporting set_attribute + context-manager protocol."""
 
@@ -1201,3 +1229,11 @@ class _MockSpan:
 
     def __exit__(self, *args):
         return False
+
+
+class _ValidParentSpan(_MockSpan):
+    """A _MockSpan whose SpanContext is VALID (non-zero trace_id), simulating an
+    inbound experiment traceparent (#1182)."""
+
+    def get_span_context(self):
+        return _ValidParentSpanContext()


### PR DESCRIPTION
Part of #1181, #1182 (PR3: spawn-traceparent → shadow game spans as experiment children).

## What

Make a SHADOW game's lifecycle span a CHILD of its agent `experiment` span by propagating the experiment's traceparent on the cross-service spawn call — the one piece that crosses the agent (Go) → coordinator (Python) boundary. The experiment root span exists from PR2 (#1190).

## Agent (Go) — inject the experiment traceparent on spawn

- `experiment/registry.go` `spawnPair`: wraps the spawn ctx with the experiment's exposed root SpanContext (`ExperimentSpanContext`, PR2) via `trace.ContextWithRemoteSpanContext` — keeps the `ShadowSpawner.Spawn` interface and every test fake unchanged.
- `shadow_spawner.go`: reads the SpanContext off the ctx (`trace.SpanContextFromContext`) and threads it onto the gamerunner `Spec.ExperimentSpanContext`.
- `gamerunner/operations.go`: at the `StreamGameEvents` start call, **manually** `otel.GetTextMapPropagator().Inject`s it into a `metadata.NewOutgoingContext` carrier (`injectExperimentTraceparent`). **Manual Inject, not an otelgrpc client stats-handler**, because injection must be TARGETED: only an experiment-bound spawn with a VALID SpanContext propagates a parent. A real / unbound shadow game has the zero SpanContext and injects nothing — so the coordinator sees no incoming traceparent and keeps the game own-rooted.

## Coordinator (Python) — use the incoming remote parent as the game-span parent

- The server interceptor already extracts an incoming traceparent (`lib/grpc_tracing.py`).
- `servicer.py`: captures that parent context (`experiment_parent_span_context`) alongside `stream_span_context` and threads it onto the `GameSession`.
- `game_session.py`: starts the game span with `context = set_span_in_context(NonRecordingSpan(remote_sc))` **only** when `game_kind == SHADOW and experiment_id and the parent is valid`. Every other path keeps `context=Context()` own-root (#1157/#1164). The existing stream-span Link is retained (harmless for shadow, navigability for real).

## Real-game protection (own-root unchanged)

Two independent guards keep real games own-rooted:
1. The strict `shadow + experiment_id + valid-parent` gate in `game_session.py`.
2. The servicer's existing hard invariant that drops experiment fields for a real (primary) game, so `experiment_id` is always empty there.

Graceful: no incoming traceparent (real game / telemetry off / experiment span absent) → own-root exactly as #1164.

## Tests

- **Agent**: `injectExperimentTraceparent` injects the experiment trace/span ids when the SpanContext is valid, nothing when invalid, and preserves pre-existing metadata; an experiment spawn reaches the (in-process) coordinator with the traceparent on incoming metadata, a plain spawn does not; the registry carries the experiment SpanContext (marked remote) onto the spawn ctx, and nothing under the no-op tracer.
- **Coordinator**: a shadow+experiment game span is a CHILD of the injected remote parent; a real game stays own-rooted even with a parent context present; a shadow+experiment game with no/invalid parent stays own-rooted; the servicer threads a valid inbound parent onto the session.

`go test ./... -race` (agent), `uv run --extra test pytest` (coordinator, 1189 passed), `make lint`, `gofmt`/`go vet` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)