### PR TITLE
feat(observability): game-coordinator realtime (100ms) metric export

### DIFF
--- a/services/flagd/ci/observability.json
+++ b/services/flagd/ci/observability.json
@@ -10,7 +10,24 @@
         "realtime": 100,
         "normal": 1000
       },
-      "defaultVariant": "normal"
+      "defaultVariant": "normal",
+      "targeting": {
+        "if": [
+          {
+            "in": [
+              {
+                "var": "service"
+              },
+              [
+                "controller-manager-service",
+                "game-coordinator-service"
+              ]
+            ]
+          },
+          "realtime",
+          null
+        ]
+      }
     },
     "grpc_rpc_spans": {
       "state": "ENABLED",

--- a/services/flagd/observability.json
+++ b/services/flagd/observability.json
@@ -14,11 +14,14 @@
       "targeting": {
         "if": [
           {
-            "==": [
+            "in": [
               {
                 "var": "service"
               },
-              "controller-manager-service"
+              [
+                "controller-manager-service",
+                "game-coordinator-service"
+              ]
             ]
           },
           "realtime",


### PR DESCRIPTION
Part of #1193.

## Change (config-only)
Add `game-coordinator-service` to the `realtime` (100ms) targeting of the `metrics_export_interval_ms` flag in `services/flagd/observability.json`, alongside `controller-manager-service`. Extends the existing `if/==` rule to an `if/in` over a service list (the #1177 flag pattern).

Also adds the previously-missing targeting block to `services/flagd/ci/observability.json` for parity (it had `defaultVariant: normal` but no targeting rule).

### Targeting rule, before → after (observability.json)
Before:
```json
"if": [ { "==": [ { "var": "service" }, "controller-manager-service" ] }, "realtime", null ]
```
After:
```json
"if": [ { "in": [ { "var": "service" }, ["controller-manager-service", "game-coordinator-service"] ] }, "realtime", null ]
```

### Resolution (verified)
| service | variant | value |
|---|---|---|
| game-coordinator-service | realtime | 100 |
| controller-manager-service | realtime | 100 |
| agent / menu / audio (default) | normal | 1000 |

## Why
The agent live-influence decision loop is push-driven by the coordinator gameplay-metric exports. At 1000ms the reaction granularity is ~1.1s and a short game can see its first datapoint arrive post-game-end. Dropping the producer floor to 100ms gives ~200ms reaction and mid-game datapoints for short games.

## Caveat
This ~10x's coordinator metric datapoints, but only on the **metrics** pipeline (bounded numeric series, healthy). The collector/jaeger OOMs (#1173/#1191) were on logs/traces — untouched here.

Relates #1177, #828, #1173.

🤖 Generated with [Claude Code](https://claude.com/claude-code)