### PR TITLE
feat(agent): explicit experiment THESIS + retro-seeded proposer loop (#1184)

### DIFF
--- a/services/agent/decision/retro_capture.go
+++ b/services/agent/decision/retro_capture.go
@@ -177,6 +177,18 @@ type RetroCoordinator struct {
 	// Injected via SetExperimentParent; not safe to call concurrently with OnGameEnd.
 	experimentParent func(experimentID string) (trace.SpanContext, bool)
 
+	// suggestionSink forwards each DECODED retro suggestion (#1184) to a downstream
+	// consumer — in production the experiment loop's retro-seeded THESIS proposer,
+	// which turns a suggestion into a candidate experiment whose thesis is seeded from
+	// the retro's reasoning, closing the game→retro→thesis→experiment loop. It is
+	// PURELY additive: the suggestion is still stamped as a span event regardless. nil
+	// (the default / tests / proposer-disabled) means the suggestion is recorded-only,
+	// byte-identical to pre-#1184. The sink itself decides whether to act on the
+	// suggestion (the proposer is gated default-OFF), so wiring the sink is safe even
+	// when the proposer opt-in is off. Injected via SetSuggestionSink; not safe to call
+	// concurrently with OnGameEnd.
+	suggestionSink func(llm.RetroSuggestion)
+
 	// inferWG tracks every in-flight retro inference goroutine (#1179). OnGameEnd is
 	// a lifecycle hook and MUST NOT block on the 2-10s network call, so the
 	// infer+decode+capture runs in its own goroutine; this wait group lets graceful
@@ -256,6 +268,14 @@ func (rc *RetroCoordinator) SetFitnessLookup(f func(gameID string) (float64, boo
 // span. A nil lookup (the default), a non-experiment game, or a torn-down experiment
 // falls back to the existing behavior. Not safe to call concurrently with OnGameEnd —
 // set it during construction.
+// SetSuggestionSink injects the downstream consumer of decoded retro suggestions
+// (#1184) — the experiment loop's retro-seeded thesis proposer in production. Each
+// suggestion a post-game retro decodes is forwarded to the sink (in addition to
+// being stamped as a span event). nil leaves the retro recorded-only (pre-#1184
+// behavior). Not safe to call concurrently with OnGameEnd — set it during
+// construction.
+func (rc *RetroCoordinator) SetSuggestionSink(f func(llm.RetroSuggestion)) { rc.suggestionSink = f }
+
 func (rc *RetroCoordinator) SetExperimentParent(f func(experimentID string) (trace.SpanContext, bool)) {
 	rc.experimentParent = f
 }
@@ -562,6 +582,14 @@ func (rc *RetroCoordinator) runRetroInfer(ctx context.Context, span trace.Span, 
 			attribute.String(AttrRetroSuggestionEmphasis, s.Emphasis),
 			attribute.String(AttrRetroSuggestionReason, s.Reason),
 		))
+		// #1184: forward the decoded suggestion to the downstream consumer (the
+		// retro-seeded thesis proposer) so it can seed the next experiment's thesis,
+		// closing the game→retro→thesis→experiment loop. Additive — the suggestion is
+		// already recorded as the span event above; a nil sink (proposer not wired)
+		// leaves the retro recorded-only.
+		if rc.suggestionSink != nil {
+			rc.suggestionSink(s)
+		}
 	}
 }
 

--- a/services/agent/decision/retro_inference_test.go
+++ b/services/agent/decision/retro_inference_test.go
@@ -323,3 +323,54 @@ func TestRetro_CaptureOnlyWhenNoBackend(t *testing.T) {
 		t.Errorf("retro.suggestion events = %d, want 0 on capture-only", n)
 	}
 }
+
+// TestRetro_ForwardsSuggestionToSink (#1184): each decoded retro suggestion is
+// forwarded to the SetSuggestionSink consumer (the retro→thesis-proposer seam),
+// IN ADDITION to the span event — closing the game→retro→thesis loop.
+func TestRetro_ForwardsSuggestionToSink(t *testing.T) {
+	reply := `{
+	  "session_assessment": "close finish",
+	  "suggestions": [
+	    {"intervention_type": "grant_shield", "emphasis": "weight_up", "reason": "fast early dropouts"},
+	    {"intervention_type": "adjust_global_difficulty", "emphasis": "weight_down", "reason": "too chaotic"}
+	  ],
+	  "session_focus": "endurance"
+	}`
+	rc, _ := recordingRetro(t, retroFlagSnapshot())
+	rc.SetResolver(reachableRetroResolver(t, "gemma4:latest",
+		func(context.Context, llm.Prompt) (string, error) { return reply, nil }))
+
+	var got []llm.RetroSuggestion
+	rc.SetSuggestionSink(func(s llm.RetroSuggestion) { got = append(got, s) })
+
+	rc.OnGameEnd(endedSession())
+	rc.AwaitInflight()
+
+	if len(got) != 2 {
+		t.Fatalf("sink received %d suggestions, want 2", len(got))
+	}
+	if got[0].InterventionType != "grant_shield" || got[0].Emphasis != "weight_up" || got[0].Reason != "fast early dropouts" {
+		t.Errorf("first forwarded suggestion = %+v", got[0])
+	}
+	if got[1].InterventionType != "adjust_global_difficulty" || got[1].Emphasis != "weight_down" {
+		t.Errorf("second forwarded suggestion = %+v", got[1])
+	}
+}
+
+// TestRetro_NilSinkIsSafe (#1184): with no sink wired (the default), a decoded retro
+// is recorded-only and does not panic — the suggestion forwarding is purely additive.
+func TestRetro_NilSinkIsSafe(t *testing.T) {
+	reply := `{"session_assessment":"ok","suggestions":[{"intervention_type":"grant_shield","emphasis":"enable","reason":"x"}],"session_focus":"balanced"}`
+	rc, sr := recordingRetro(t, retroFlagSnapshot())
+	rc.SetResolver(reachableRetroResolver(t, "gemma4:latest",
+		func(context.Context, llm.Prompt) (string, error) { return reply, nil }))
+
+	rc.OnGameEnd(endedSession())
+	rc.AwaitInflight()
+
+	// The span still carries the suggestion event (recorded-only path).
+	span := spansByName(sr.Ended(), SpanLLMRetro)[0]
+	if evs := eventsByName(span, SpanLLMRetroSuggestion); len(evs) != 1 {
+		t.Fatalf("retro.suggestion events = %d, want 1", len(evs))
+	}
+}

--- a/services/agent/decision/telemetry.go
+++ b/services/agent/decision/telemetry.go
@@ -551,6 +551,12 @@ const (
 	AttrExperimentFlagKey = "experiment.flag_key"
 	AttrExperimentTargetN = "experiment.target_n"
 	AttrExperimentArms    = "experiment.arms"
+	// AttrExperimentThesis is the experiment's explicit human-readable THESIS (#1184):
+	// the immutable Intent.Hypothesis — what idea is being tested + its expected
+	// effect. Stamped on the agent.experiment ROOT span (#1188/#1190) so a human reading
+	// the trace sees the experiment's WHY, not just the flag/value mechanics. It is the
+	// same string the durable journal persists and the dossier surfaces as `thesis`.
+	AttrExperimentThesis = "experiment.thesis"
 	// AttrVerdictOutcome / AttrVerdictDelta / AttrVerdictSignificant carry the rolling
 	// paired-difference verdict the registry computed: the outcome label
 	// ("inconclusive"/"promote"/"discard"), the experimental-minus-control delta, and

--- a/services/agent/experiment/registry.go
+++ b/services/agent/experiment/registry.go
@@ -635,6 +635,13 @@ func (r *Registry) startSpanLocked(e *entry, intent journal.Intent) {
 	attrs := []attribute.KeyValue{
 		attribute.String(decision.AttrExperimentID, e.id),
 	}
+	// #1184: stamp the explicit THESIS (the immutable Intent.Hypothesis — what idea +
+	// expected effect) on the root span so the trace carries the experiment's WHY, not
+	// just the flag/value mechanics. Same string the journal persists + the dossier
+	// surfaces. Guarded so a thesis-less (legacy/test) intent adds no empty attr.
+	if intent.Hypothesis != "" {
+		attrs = append(attrs, attribute.String(decision.AttrExperimentThesis, intent.Hypothesis))
+	}
 	if intent.FlagKey != "" {
 		attrs = append(attrs, attribute.String(decision.AttrExperimentFlagKey, intent.FlagKey))
 	}

--- a/services/agent/experiment/registry_root_span_test.go
+++ b/services/agent/experiment/registry_root_span_test.go
@@ -242,3 +242,63 @@ func assertRootSpanEndedOnce(t *testing.T, r *Registry, sr *tracetest.SpanRecord
 		t.Error("ExperimentSpanContext must be unavailable after teardown (span ended)")
 	}
 }
+
+// TestRootSpan_CarriesThesisAttr (#1184): the agent.experiment root span carries the
+// experiment THESIS (the immutable Intent.Hypothesis) as experiment.thesis, so the
+// trace records the experiment's WHY, not just the flag/value mechanics.
+func TestRootSpan_CarriesThesisAttr(t *testing.T) {
+	r, sr := rootSpanRegistry(t, RegistryConfig{
+		Spawner: &fakeSpawner{}, Verdict: fakeVerdict{concludeAtN: 1000}, Targeting: &fakeTargeting{},
+		MaxShadowGames: 4,
+	})
+	id, err := r.Declare(sampleIntent())
+	if err != nil {
+		t.Fatalf("declare: %v", err)
+	}
+	if err := r.Start(context.Background(), id); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	// Force the root span to end so it is recorded (Ended() only returns ended spans).
+	if err := r.Abort(context.Background(), id, "test"); err != nil {
+		t.Fatalf("abort: %v", err)
+	}
+	spans := rootSpans(sr)
+	if len(spans) != 1 {
+		t.Fatalf("agent.experiment ended spans = %d, want 1", len(spans))
+	}
+	got, ok := rootSpanAttr(spans[0], decision.AttrExperimentThesis)
+	if !ok {
+		t.Fatalf("root span missing %s attribute", decision.AttrExperimentThesis)
+	}
+	if want := sampleIntent().Hypothesis; got != want {
+		t.Errorf("experiment.thesis = %q, want %q", got, want)
+	}
+}
+
+// TestRootSpan_OmitsEmptyThesis (#1184): a thesis-less (legacy) intent adds no empty
+// experiment.thesis attr — the guard keeps a partial intent clean.
+func TestRootSpan_OmitsEmptyThesis(t *testing.T) {
+	r, sr := rootSpanRegistry(t, RegistryConfig{
+		Spawner: &fakeSpawner{}, Verdict: fakeVerdict{concludeAtN: 1000}, Targeting: &fakeTargeting{},
+		MaxShadowGames: 4,
+	})
+	in := sampleIntent()
+	in.Hypothesis = ""
+	id, err := r.Declare(in)
+	if err != nil {
+		t.Fatalf("declare: %v", err)
+	}
+	if err := r.Start(context.Background(), id); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	if err := r.Abort(context.Background(), id, "test"); err != nil {
+		t.Fatalf("abort: %v", err)
+	}
+	spans := rootSpans(sr)
+	if len(spans) != 1 {
+		t.Fatalf("agent.experiment ended spans = %d, want 1", len(spans))
+	}
+	if _, ok := rootSpanAttr(spans[0], decision.AttrExperimentThesis); ok {
+		t.Errorf("experiment.thesis attr must be omitted for an empty thesis")
+	}
+}

--- a/services/agent/experiment/thesis_proposer.go
+++ b/services/agent/experiment/thesis_proposer.go
@@ -1,0 +1,236 @@
+package experiment
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+)
+
+// thesis_proposer.go closes the agent's research LOOP (#1184, epic #1181 incr. 4):
+//
+//	game → retro (#1179) → THESIS → experiment → verdict → (promote/refine → new thesis)
+//
+// The post-game retro (decision/retro_capture.go) already produces structured
+// RetroSuggestions — {intervention_type, emphasis, reason} — describing what the
+// analyst thinks should change for the next session. Today those land ONLY on the
+// agent.llm.retro span (fire-and-forget); nothing turns them back into an
+// experiment. The ThesisProposer is that missing seam: it CONSUMES recent retro
+// suggestions and EMITS a candidate experiment Intent whose Hypothesis (the
+// experiment's explicit THESIS — what idea + expected effect, #1184) is seeded
+// from the retro's own reasoning. The next experiment therefore TESTS what the
+// last game's retro proposed.
+//
+// This is the #960 Proposer→Intents path made CONCRETE without an inference
+// backend: #960's LLM Proposer is wired but inert (it degrades to no-proposal
+// until #738/#742 land a real Ollama/cloud transport). The ThesisProposer is the
+// deterministic counterpart — it needs no backend, so the loop closes NOW, the
+// same way the #995 dynamic declarer delivered autonomous declaration ahead of the
+// LLM proposer.
+//
+// SAFETY / SCOPE — adds NO new write surface. It does NOT choose a flag/value
+// itself; it DELEGATES that to an injected FlagSelector (the #995 dynamic
+// declarer's Declare in production), so every Intent it emits flows through the
+// SAME #977 Gate + #978 Registry caps as the env seed and the dynamic declarer.
+// Its ONLY distinct contribution is the THESIS provenance: it stamps the retro's
+// intervention_type / emphasis / reason onto the Intent.Hypothesis so the
+// experiment records WHY it was run (the retro that motivated it), and biases the
+// objective from the retro's emphasis where the analyst signalled a direction.
+//
+// GATING — default OFF. The caller only invokes Propose when the opt-in is on
+// (the loop gates it on AGENT_EXPERIMENT_PROPOSER_ENABLED, subordinate to
+// AGENT_EXPERIMENTS_ENABLED + the kill-switch), so it changes the autonomous
+// experiment cadence for NOBODY who has not opted in.
+//
+// DETERMINISM — pure given (recorded suggestions, selector output): no clock, no
+// randomness, no map-iteration-order dependence. Safe for concurrent use (the
+// suggestion ring is mutex-guarded — the retro coordinator records from its own
+// goroutines while the loop reads from the tick goroutines, like the shared
+// Proposer/Resolver).
+
+// RetroSuggestion is the structured post-game recommendation the ThesisProposer
+// consumes (#1184). It MIRRORS llm.RetroSuggestion field-for-field rather than
+// importing it, to keep the experiment package free of an llm dependency on the
+// record path (the LLM Proposer's #960 Backend seam already imports llm; the
+// thesis seam stays dependency-light so the retro side — which decodes the
+// llm.RetroSuggestion — can hand it across with a trivial copy). Captured as-is;
+// no field is validated against an allow-list (the retro is recorded-only).
+type RetroSuggestion struct {
+	// InterventionType is the allow-list intervention the analyst recommends tuning
+	// (e.g. "adjust_global_difficulty"). Carried into the thesis text as provenance.
+	InterventionType string
+	// Emphasis is the direction the analyst recommends (enable / weight_up /
+	// weight_down / disable). Used to bias the experiment objective and recorded in
+	// the thesis as the EXPECTED effect.
+	Emphasis string
+	// Reason is the analyst's one-sentence justification tying the change to session
+	// evidence. It becomes the human-readable core of the experiment's thesis.
+	Reason string
+}
+
+// FlagSelector is the flag/value/objective CHOICE the ThesisProposer delegates to.
+// It returns a partially-filled Intent (FlagKey + ExperimentalValue + a default
+// Objective + TargetNPerArm) for a flag that has no active experiment, or ok=false
+// when nothing is declarable. The ThesisProposer keeps the FlagKey/value/targetN
+// and OVERWRITES the Hypothesis (with the retro-seeded thesis) and, when the retro
+// signalled a direction, the Objective — so the candidate flag selection stays the
+// proven, bounded #995 logic and the proposer adds only the thesis provenance.
+//
+// It is a FUNC type (not an interface) so the production selector — the #995
+// dynamic declarer, whose Declare takes the main package's DEFINED activeFlags type
+// — can be adapted with a one-line closure (a defined-type method cannot satisfy an
+// interface whose method takes the underlying map type). The active-flag set is the
+// flags that already have a live experiment (the per-flag dedup), opaque to the
+// proposer; only the selector interprets it.
+type FlagSelector func(active map[string]struct{}) (Intent, bool)
+
+// DefaultMaxRetroBacklog bounds the recent-suggestion ring so an LLM that emits a
+// suggestion every game cannot grow the proposer's memory without limit. The ring
+// keeps the MOST RECENT suggestions (a freshly-observed problem matters more than a
+// stale one); older entries are dropped as new ones arrive. Bounded-memory
+// discipline, mirroring the journal's recent-tail (#983 §9.2).
+const DefaultMaxRetroBacklog = 16
+
+// ThesisProposer turns recent retro suggestions into candidate experiment theses
+// (#1184). It owns a bounded ring of un-consumed suggestions; the retro side feeds
+// it via Record and the experiment loop drains it via Propose. Safe for concurrent
+// use.
+type ThesisProposer struct {
+	maxBacklog int
+
+	mu sync.Mutex
+	// backlog is the FIFO of un-consumed retro suggestions, oldest first. Propose
+	// consumes from the front (oldest actionable suggestion); Record appends to the
+	// back and evicts the front when over maxBacklog.
+	backlog []RetroSuggestion
+}
+
+// NewThesisProposer builds a ThesisProposer with the given backlog bound (a
+// non-positive value falls back to DefaultMaxRetroBacklog).
+func NewThesisProposer(maxBacklog int) *ThesisProposer {
+	if maxBacklog <= 0 {
+		maxBacklog = DefaultMaxRetroBacklog
+	}
+	return &ThesisProposer{maxBacklog: maxBacklog}
+}
+
+// Record adds a retro suggestion to the backlog (the seam the retro coordinator
+// calls when a post-game retro decodes a suggestion). A suggestion with no Reason
+// AND no InterventionType is dropped (nothing to seed a thesis from). The ring is
+// bounded: appending past maxBacklog evicts the oldest. Concurrency-safe.
+func (tp *ThesisProposer) Record(s RetroSuggestion) {
+	if strings.TrimSpace(s.Reason) == "" && strings.TrimSpace(s.InterventionType) == "" {
+		return
+	}
+	tp.mu.Lock()
+	defer tp.mu.Unlock()
+	tp.backlog = append(tp.backlog, s)
+	if over := len(tp.backlog) - tp.maxBacklog; over > 0 {
+		// Drop the oldest `over` entries (keep the most recent maxBacklog).
+		tp.backlog = append(tp.backlog[:0], tp.backlog[over:]...)
+	}
+}
+
+// Backlog reports the number of un-consumed suggestions (for telemetry/tests).
+func (tp *ThesisProposer) Backlog() int {
+	tp.mu.Lock()
+	defer tp.mu.Unlock()
+	return len(tp.backlog)
+}
+
+// Propose drains the OLDEST recorded retro suggestion and turns it into a candidate
+// experiment Intent whose Hypothesis is the retro-seeded THESIS (#1184). It
+// delegates the flag/value choice to the injected FlagSelector (so the bounded
+// #995 selection logic is reused) and then OVERWRITES the Intent's Hypothesis with
+// the thesis built from the suggestion, biasing the Objective from the suggestion's
+// emphasis when a direction was signalled.
+//
+// It returns ok=false (consuming NOTHING) when:
+//   - there is no recorded suggestion to act on, OR
+//   - the FlagSelector finds nothing declarable (no free candidate flag) — the
+//     suggestion stays in the backlog for a later tick when capacity frees up.
+//
+// A consumed suggestion is removed from the backlog ONLY when an Intent is emitted,
+// so a suggestion is never silently dropped because the flag surface was momentarily
+// full. Pure given (backlog, selector output); no clock, no randomness.
+func (tp *ThesisProposer) Propose(selector FlagSelector, active map[string]struct{}) (Intent, bool) {
+	if selector == nil {
+		return Intent{}, false
+	}
+	tp.mu.Lock()
+	defer tp.mu.Unlock()
+	if len(tp.backlog) == 0 {
+		return Intent{}, false
+	}
+	// Delegate flag/value selection to the proven bounded selector. If it finds
+	// nothing declarable, keep the suggestion for a later tick (do NOT consume it).
+	intent, ok := selector(active)
+	if !ok {
+		return Intent{}, false
+	}
+	suggestion := tp.backlog[0]
+	tp.backlog = append(tp.backlog[:0], tp.backlog[1:]...)
+
+	// The proposer's distinct contribution: stamp the retro-seeded THESIS and bias the
+	// objective from the suggestion's direction. The flag/value/targetN stay as the
+	// selector chose them (bounded, Gate-safe by construction).
+	intent.Hypothesis = thesisFromSuggestion(suggestion, intent)
+	if obj, ok := objectiveFromEmphasis(suggestion.Emphasis); ok {
+		intent.Objective = obj
+	}
+	return intent, true
+}
+
+// thesisFromSuggestion renders the explicit, human-readable THESIS (#1184) for an
+// experiment seeded by a retro suggestion: the IDEA (the flag/value under test) +
+// the EXPECTED EFFECT (the retro's intervention emphasis and reason). It records
+// the provenance ("seeded by the post-game retro") so a human reading the dossier
+// or the trace sees WHY this experiment exists — closing the game→retro→thesis
+// loop visibly. Deterministic given its inputs.
+func thesisFromSuggestion(s RetroSuggestion, intent Intent) string {
+	var b strings.Builder
+	b.WriteString("retro-seeded thesis (#1184): the post-game retro suggested ")
+	if t := strings.TrimSpace(s.InterventionType); t != "" {
+		b.WriteString(t)
+		if e := strings.TrimSpace(s.Emphasis); e != "" {
+			fmt.Fprintf(&b, " (%s)", e)
+		}
+	} else if e := strings.TrimSpace(s.Emphasis); e != "" {
+		b.WriteString(e)
+	} else {
+		b.WriteString("a calibration change")
+	}
+	if r := strings.TrimSpace(s.Reason); r != "" {
+		fmt.Fprintf(&b, " — \"%s\"", r)
+	}
+	fmt.Fprintf(&b, "; testing %s=%v as the closest tunable proxy", intent.FlagKey, intent.ExperimentalValue)
+	if intent.Objective != "" {
+		fmt.Fprintf(&b, " for objective %s", intent.Objective)
+	}
+	b.WriteString(".")
+	return b.String()
+}
+
+// objectiveFromEmphasis maps a retro suggestion's EMPHASIS to the experimentable
+// objective the seeded experiment should optimize, when the direction implies one.
+// The retro's emphasis vocabulary (enable / weight_up / weight_down / disable)
+// signals whether the analyst wants MORE or LESS intervention pressure:
+//
+//   - weight_up / enable  → the analyst wants the agent to act MORE: the room was
+//     fading, so optimize for ENGAGEMENT pace (accelerate).
+//   - weight_down / disable → the analyst wants the agent to act LESS: play was too
+//     chaotic/over-managed, so optimize for ENDURANCE (let games breathe).
+//
+// An unrecognized / empty emphasis returns ok=false, leaving the selector's default
+// objective untouched (the proposer never invents a non-experimentable objective —
+// chaos is never returned, and Registry.Declare rejects it regardless). The mapping
+// is advisory: it only BIASES which objective the bounded experiment scores against.
+func objectiveFromEmphasis(emphasis string) (string, bool) {
+	switch strings.ToLower(strings.TrimSpace(emphasis)) {
+	case "weight_up", "enable":
+		return "accelerate", true
+	case "weight_down", "disable":
+		return "endurance", true
+	default:
+		return "", false
+	}
+}

--- a/services/agent/experiment/thesis_proposer_test.go
+++ b/services/agent/experiment/thesis_proposer_test.go
@@ -1,0 +1,200 @@
+package experiment
+
+import (
+	"strings"
+	"testing"
+)
+
+// fakeSelector is a FlagSelector that returns a fixed Intent (or ok=false), and
+// records whether it was called — so a test can prove the proposer delegates flag
+// selection and consumes a suggestion only on a successful select.
+type fakeSelector struct {
+	intent Intent
+	ok     bool
+	calls  int
+}
+
+func (f *fakeSelector) sel(active map[string]struct{}) (Intent, bool) {
+	f.calls++
+	return f.intent, f.ok
+}
+
+// baseSelected is the partially-filled Intent a selector hands back (flag + value +
+// a default objective + targetN) — the proposer keeps these and overwrites the
+// thesis/objective.
+func baseSelected() Intent {
+	return Intent{
+		Hypothesis:        "selector default (should be overwritten)",
+		FlagKey:           "death_grace_period_seconds",
+		ExperimentalValue: 0.5,
+		Objective:         "balanced",
+		TargetNPerArm:     20,
+	}
+}
+
+// TestRecord_DropsEmptySuggestion: a suggestion with no reason and no intervention
+// type carries nothing to seed a thesis from, so it is dropped.
+func TestRecord_DropsEmptySuggestion(t *testing.T) {
+	tp := NewThesisProposer(0)
+	tp.Record(RetroSuggestion{})
+	tp.Record(RetroSuggestion{Emphasis: "weight_up"}) // emphasis-only is dropped (no reason/type)
+	if got := tp.Backlog(); got != 0 {
+		t.Fatalf("backlog = %d, want 0 (empty suggestions dropped)", got)
+	}
+}
+
+// TestRecord_BoundedRing: the backlog never grows past maxBacklog; the most-recent
+// suggestions are kept (oldest evicted).
+func TestRecord_BoundedRing(t *testing.T) {
+	tp := NewThesisProposer(2)
+	tp.Record(RetroSuggestion{Reason: "first"})
+	tp.Record(RetroSuggestion{Reason: "second"})
+	tp.Record(RetroSuggestion{Reason: "third"})
+	if got := tp.Backlog(); got != 2 {
+		t.Fatalf("backlog = %d, want 2 (bounded ring)", got)
+	}
+	// The oldest ("first") must have been evicted: the next Propose drains "second".
+	sel := &fakeSelector{intent: baseSelected(), ok: true}
+	intent, ok := tp.Propose(sel.sel, nil)
+	if !ok {
+		t.Fatal("propose: want ok")
+	}
+	if !strings.Contains(intent.Hypothesis, "second") {
+		t.Errorf("thesis = %q, want it seeded from the oldest RETAINED suggestion (second)", intent.Hypothesis)
+	}
+}
+
+// TestPropose_NoBacklog_NoOp: with nothing recorded, Propose returns ok=false and
+// never calls the selector (no wasted flag selection).
+func TestPropose_NoBacklog_NoOp(t *testing.T) {
+	tp := NewThesisProposer(0)
+	sel := &fakeSelector{intent: baseSelected(), ok: true}
+	if _, ok := tp.Propose(sel.sel, nil); ok {
+		t.Fatal("propose with empty backlog must return ok=false")
+	}
+	if sel.calls != 0 {
+		t.Errorf("selector called %d times, want 0 (no backlog ⇒ no selection)", sel.calls)
+	}
+}
+
+// TestPropose_SeedsThesisFromSuggestion: a recorded suggestion is turned into an
+// Intent whose thesis embeds the retro's intervention type, emphasis, and reason —
+// the provenance that closes the game→retro→thesis loop. The selector's flag/value
+// are kept; the objective is biased from the emphasis.
+func TestPropose_SeedsThesisFromSuggestion(t *testing.T) {
+	tp := NewThesisProposer(0)
+	tp.Record(RetroSuggestion{
+		InterventionType: "adjust_global_difficulty",
+		Emphasis:         "weight_up",
+		Reason:           "the room faded after the first elimination",
+	})
+	sel := &fakeSelector{intent: baseSelected(), ok: true}
+
+	intent, ok := tp.Propose(sel.sel, nil)
+	if !ok {
+		t.Fatal("propose: want ok")
+	}
+	// Flag/value preserved from the selector.
+	if intent.FlagKey != "death_grace_period_seconds" || intent.ExperimentalValue != 0.5 {
+		t.Errorf("flag/value = %s/%v, want the selector's choice preserved", intent.FlagKey, intent.ExperimentalValue)
+	}
+	// Thesis carries the retro provenance.
+	for _, want := range []string{"adjust_global_difficulty", "weight_up", "the room faded", "retro-seeded"} {
+		if !strings.Contains(intent.Hypothesis, want) {
+			t.Errorf("thesis %q missing %q", intent.Hypothesis, want)
+		}
+	}
+	// weight_up biases the objective to accelerate (act more).
+	if intent.Objective != "accelerate" {
+		t.Errorf("objective = %q, want accelerate (weight_up bias)", intent.Objective)
+	}
+	// The suggestion was consumed.
+	if got := tp.Backlog(); got != 0 {
+		t.Errorf("backlog = %d, want 0 (consumed on success)", got)
+	}
+}
+
+// TestPropose_KeepsSuggestionWhenNothingDeclarable: when the selector finds no
+// declarable flag (full surface), the suggestion is NOT consumed — it waits for a
+// later tick.
+func TestPropose_KeepsSuggestionWhenNothingDeclarable(t *testing.T) {
+	tp := NewThesisProposer(0)
+	tp.Record(RetroSuggestion{Reason: "keep me"})
+	sel := &fakeSelector{ok: false}
+
+	if _, ok := tp.Propose(sel.sel, nil); ok {
+		t.Fatal("propose must return ok=false when the selector finds nothing declarable")
+	}
+	if got := tp.Backlog(); got != 1 {
+		t.Errorf("backlog = %d, want 1 (suggestion retained, not silently dropped)", got)
+	}
+}
+
+// TestPropose_NilSelector_NoOp: a nil selector is a safe no-op (defends the wiring
+// seam — the loop only invokes Propose with the dynamic selector wired).
+func TestPropose_NilSelector_NoOp(t *testing.T) {
+	tp := NewThesisProposer(0)
+	tp.Record(RetroSuggestion{Reason: "x"})
+	if _, ok := tp.Propose(nil, nil); ok {
+		t.Fatal("propose with nil selector must return ok=false")
+	}
+	if got := tp.Backlog(); got != 1 {
+		t.Errorf("backlog = %d, want 1 (nothing consumed on nil selector)", got)
+	}
+}
+
+// TestObjectiveFromEmphasis covers the emphasis→objective bias table, including the
+// unrecognized case that leaves the selector's objective untouched.
+func TestObjectiveFromEmphasis(t *testing.T) {
+	cases := []struct {
+		emphasis string
+		want     string
+		ok       bool
+	}{
+		{"weight_up", "accelerate", true},
+		{"enable", "accelerate", true},
+		{"weight_down", "endurance", true},
+		{"disable", "endurance", true},
+		{"WEIGHT_UP", "accelerate", true}, // case-insensitive
+		{"", "", false},
+		{"sideways", "", false},
+	}
+	for _, c := range cases {
+		got, ok := objectiveFromEmphasis(c.emphasis)
+		if got != c.want || ok != c.ok {
+			t.Errorf("objectiveFromEmphasis(%q) = (%q,%v), want (%q,%v)", c.emphasis, got, ok, c.want, c.ok)
+		}
+	}
+}
+
+// TestPropose_UnknownEmphasis_KeepsSelectorObjective: an emphasis with no direction
+// bias leaves the selector's default objective intact.
+func TestPropose_UnknownEmphasis_KeepsSelectorObjective(t *testing.T) {
+	tp := NewThesisProposer(0)
+	tp.Record(RetroSuggestion{InterventionType: "send_controller_effect", Reason: "flavor"})
+	sel := &fakeSelector{intent: baseSelected(), ok: true}
+	intent, ok := tp.Propose(sel.sel, nil)
+	if !ok {
+		t.Fatal("propose: want ok")
+	}
+	if intent.Objective != "balanced" {
+		t.Errorf("objective = %q, want balanced (selector default kept when emphasis gives no bias)", intent.Objective)
+	}
+}
+
+// TestPropose_FIFOOrder: suggestions are drained oldest-first across calls.
+func TestPropose_FIFOOrder(t *testing.T) {
+	tp := NewThesisProposer(0)
+	tp.Record(RetroSuggestion{Reason: "alpha"})
+	tp.Record(RetroSuggestion{Reason: "beta"})
+	sel := &fakeSelector{intent: baseSelected(), ok: true}
+
+	first, _ := tp.Propose(sel.sel, nil)
+	second, _ := tp.Propose(sel.sel, nil)
+	if !strings.Contains(first.Hypothesis, "alpha") {
+		t.Errorf("first thesis = %q, want oldest (alpha) first", first.Hypothesis)
+	}
+	if !strings.Contains(second.Hypothesis, "beta") {
+		t.Errorf("second thesis = %q, want beta next", second.Hypothesis)
+	}
+}

--- a/services/agent/experiment_loop.go
+++ b/services/agent/experiment_loop.go
@@ -74,7 +74,25 @@ const (
 	// least one shadow slot to make progress). Unset/non-positive ⇒
 	// defaultDynamicMaxConcurrent.
 	envDynamicMaxConcurrent = "AGENT_EXPERIMENT_DYNAMIC_MAX_CONCURRENT"
+
+	// envProposerEnabled is the opt-in for the retro-seeded THESIS proposer (#1184,
+	// epic #1181 incr. 4): the seam that turns post-game retro suggestions (#1179)
+	// into candidate experiment theses, closing the game→retro→thesis→experiment loop.
+	// Default false ⇒ recorded retro suggestions are NEVER turned into experiments,
+	// byte-identical to pre-#1184 declaration behavior. Subordinate to
+	// AGENT_EXPERIMENTS_ENABLED + the agent.json kill-switch (it is only consulted from
+	// allocateIfEnabled, which self-aborts when either is off) and, like the #995
+	// declarer, it reuses the SAME bounded flag selection + Gate + Registry caps — it
+	// adds ONLY the thesis provenance, never a new write surface.
+	envProposerEnabled = "AGENT_EXPERIMENT_PROPOSER_ENABLED"
 )
+
+// proposerEnabled reports whether the retro-seeded thesis proposer opt-in is on
+// (#1184). Distinct, default-off env gate — independent of (and subordinate to) the
+// experiment-loop opt-in and the kill-switch, mirroring dynamicEnabled().
+func proposerEnabled() bool {
+	return strings.EqualFold(strings.TrimSpace(os.Getenv(envProposerEnabled)), "true")
+}
 
 // defaultDynamicMaxConcurrent is the default ceiling on simultaneously-live
 // dynamically-declared experiments (#995). A small value keeps the autonomous
@@ -157,6 +175,16 @@ type experimentLoop struct {
 	// off→on flip starts dynamic declaration with no restart. nil only in tests that
 	// do not wire it.
 	dynamic *dynamicDeclarer
+
+	// proposer is the retro-seeded THESIS proposer (#1184): it consumes the post-game
+	// retro's structured suggestions (#1179) and turns the oldest into a candidate
+	// experiment whose thesis is seeded from the retro's reasoning, closing the
+	// game→retro→thesis→experiment loop. It DELEGATES flag/value selection to e.dynamic
+	// (the proven #995 selector), adding only the thesis provenance + objective bias.
+	// Whether it actually declares each tick is gated by proposerEnabled() (default
+	// OFF, #1184). nil only in tests that do not wire it. The retro coordinator feeds it
+	// via Record (wired in main.go).
+	proposer *experiment.ThesisProposer
 
 	// configOverride, when non-nil, supplies the live ExperimentConfig instead of
 	// reading e.flags.Experiment — the injectable seam tests use to drive the
@@ -312,6 +340,11 @@ func buildExperimentLoop(
 		fitness:        defaultGameFitness,
 		completedGrace: completedGrace(),
 		dynamic:        newDynamicDeclarerFromEnv(gameFlagPath, nil),
+		// #1184: the retro-seeded thesis proposer is ALWAYS built (like the #995
+		// declarer) so the retro coordinator can Record into it unconditionally; whether
+		// it actually DECLARES is gated by proposerEnabled() (default OFF) in
+		// declareFromRetroIfEnabled. Backlog is bounded (DefaultMaxRetroBacklog).
+		proposer: experiment.NewThesisProposer(0),
 	}
 	// Build the M7-7 Validator (#935) over the LIVE seams (#965): the shadow
 	// SyntheticRunner drives real shadow games via the spawner; the FitnessMeasurer +
@@ -490,6 +523,13 @@ func (e *experimentLoop) allocateIfEnabled(ctx context.Context) {
 	// backstop and the per-flag dedup. This runs BEFORE AllocateAndSpawn so a
 	// freshly-Started experiment can accrue games on the same tick.
 	e.declareDynamicIfEnabled(ctx, cfg)
+	// Retro-seeded thesis proposal (#1184): close the game→retro→thesis→experiment
+	// loop. When the proposer opt-in is on (default OFF), turn the oldest recorded
+	// retro suggestion into a candidate experiment whose thesis is seeded from the
+	// retro's reasoning. It runs AFTER dynamic declaration (so a retro-seeded
+	// experiment is the marginal one when both are enabled) and BEFORE AllocateAndSpawn
+	// (so a freshly-declared experiment accrues games this tick).
+	e.declareFromRetroIfEnabled(ctx, cfg)
 	if n := e.registry.AllocateAndSpawn(ctx); n > 0 {
 		e.log.Debug("experiment: spawned shadow games this tick", "count", n,
 			"in_flight", e.registry.TotalInFlight(), "capacity", e.registry.Capacity())
@@ -584,6 +624,71 @@ func (e *experimentLoop) declareDynamicIfEnabled(ctx context.Context, cfg flags.
 	}
 	e.log.Info("experiment: dynamic declarer declared a new experiment (#995)",
 		"flag_key", intent.FlagKey, "value", intent.ExperimentalValue, "objective", intent.Objective)
+}
+
+// declareFromRetroIfEnabled lets the retro-seeded THESIS proposer (#1184) declare
+// ONE fresh experiment per call when:
+//   - the proposer is wired (proposer != nil) AND opted-in (proposerEnabled(), the
+//     default-OFF #1184 gate), AND
+//   - the dynamic selector is wired (the proposer DELEGATES flag/value choice to it —
+//     it adds only the thesis provenance, no new selection surface), AND
+//   - the live experiment count is below the SAME concurrent-experiment backstop the
+//     dynamic declarer obeys (clamped to shadow capacity), AND
+//   - there is a recorded retro suggestion AND the selector finds a declarable flag.
+//
+// It is a NO-OP when not opted in, so declaration is byte-identical for everyone who
+// has not flipped AGENT_EXPERIMENT_PROPOSER_ENABLED on. Reached only from
+// allocateIfEnabled, which already confirmed experiments_enabled + the kill-switch —
+// so the proposer is subordinate to the SAME gates as every other declaration. At
+// most ONE experiment is declared per call (one retro suggestion drained per tick),
+// keeping the rate bounded.
+//
+// CONCURRENCY: it holds the dynamic declarer's mutex around the whole
+// budget-check → select → declare sequence (the proposer delegates to e.dynamic.Declare,
+// which mutates the shared round-robin cursor), mirroring declareDynamicIfEnabled so a
+// retro declare and a dynamic declare can never race the cursor or over-declare past
+// the budget. The ThesisProposer's own backlog mutex is separate and never held across
+// a registry call.
+func (e *experimentLoop) declareFromRetroIfEnabled(ctx context.Context, cfg flags.ExperimentConfig) {
+	if e.proposer == nil || e.dynamic == nil {
+		return // proposer/selector not wired (test path): declaration unchanged.
+	}
+	if !proposerEnabled() {
+		return // default-OFF #1184 opt-in: no retro-seeded experiments.
+	}
+	// Serialize with the dynamic declarer (shared cursor + the same over-declaration
+	// budget window) — see declareDynamicIfEnabled's CONCURRENCY note.
+	e.dynamic.mu.Lock()
+	defer e.dynamic.mu.Unlock()
+
+	budget := cfg.DynamicMaxConcurrent
+	if budget <= 0 {
+		budget = e.expDefaults.DynamicMaxConcurrent
+	}
+	if capacity := e.registry.Capacity(); capacity > 0 && budget > capacity {
+		budget = capacity
+	}
+	if e.registry.LiveCount() >= budget {
+		return
+	}
+	// Adapt the #995 dynamic declarer to the proposer's FlagSelector: its Declare takes
+	// the main-package activeFlags defined type, so a one-line closure bridges it to the
+	// proposer's map[string]struct{} selector signature.
+	intent, ok := e.proposer.Propose(
+		func(active map[string]struct{}) (experiment.Intent, bool) { return e.dynamic.Declare(active) },
+		e.registry.ActiveFlags(),
+	)
+	if !ok {
+		return // no recorded suggestion, or nothing declarable this tick.
+	}
+	if err := e.declareAndStart(ctx, intent); err != nil {
+		e.log.Warn("experiment: retro-seeded declare/start failed (#1184)",
+			"flag_key", intent.FlagKey, "objective", intent.Objective, "error", err)
+		return
+	}
+	e.log.Info("experiment: retro-seeded thesis proposer declared a new experiment (#1184)",
+		"flag_key", intent.FlagKey, "value", intent.ExperimentalValue, "objective", intent.Objective,
+		"thesis", intent.Hypothesis, "backlog_remaining", e.proposer.Backlog())
 }
 
 // ensureStarted runs the deferred ONE-TIME bootstrap the FIRST time the loop

--- a/services/agent/main.go
+++ b/services/agent/main.go
@@ -931,6 +931,23 @@ func main() {
 			retro.SetExperimentParent(reg.ExperimentSpanContext)
 			summaries.SetExperimentParent(reg.ExperimentSpanContext)
 		}
+		// #1184: close the game→retro→thesis→experiment loop. Forward each decoded
+		// post-game retro suggestion (#1179) into the experiment loop's retro-seeded
+		// THESIS proposer, so the next experiment's thesis is seeded from the retro's
+		// reasoning. This wiring is purely additive — the suggestion is still recorded
+		// on the retro span — and the proposer only ACTS on the backlog when its
+		// opt-in (AGENT_EXPERIMENT_PROPOSER_ENABLED, default OFF) is on, so feeding it
+		// here changes autonomous behavior for nobody who has not opted in.
+		if expLoop.proposer != nil {
+			proposer := expLoop.proposer
+			retro.SetSuggestionSink(func(s llm.RetroSuggestion) {
+				proposer.Record(experiment.RetroSuggestion{
+					InterventionType: s.InterventionType,
+					Emphasis:         s.Emphasis,
+					Reason:           s.Reason,
+				})
+			})
+		}
 	}
 
 	// GameContext multiplexer (#845 PR B): one Store partition per game_id, plus the

--- a/services/agent/thesis_proposer_loop_test.go
+++ b/services/agent/thesis_proposer_loop_test.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/joustmania/agent/decision"
+	"github.com/joustmania/agent/experiment"
+	"github.com/joustmania/agent/flags"
+)
+
+// thesis_proposer_loop_test.go pins the LOOP-LEVEL wiring of the #1184 retro-seeded
+// thesis proposer: it is default-OFF, subordinate to the dynamic selector, and turns
+// a recorded retro suggestion into a started experiment when opted in — reusing the
+// loopWithRealRegistry / gameFileForDeclarer helpers from dynamic_declarer_test.go.
+
+// proposerLoop builds a loop with a real registry, a wired dynamic selector (the
+// proposer delegates flag selection to it), and a ThesisProposer.
+func proposerLoop(t *testing.T) *experimentLoop {
+	t.Helper()
+	loop, path := loopWithRealRegistry(t, 8)
+	loop.dynamic = &dynamicDeclarer{
+		gameFlagPath:     path,
+		candidates:       []string{"sensitivity", "num_teams"},
+		defaultObjective: decision.ObjectiveBalanced,
+	}
+	loop.proposer = experiment.NewThesisProposer(0)
+	return loop
+}
+
+// TestRetroProposer_DisabledByDefault: with AGENT_EXPERIMENT_PROPOSER_ENABLED unset,
+// a recorded suggestion is NEVER turned into an experiment — the loop's autonomous
+// cadence is unchanged for anyone who has not opted in.
+func TestRetroProposer_DisabledByDefault(t *testing.T) {
+	t.Setenv(envProposerEnabled, "") // explicitly unset
+	loop := proposerLoop(t)
+	loop.proposer.Record(experiment.RetroSuggestion{InterventionType: "adjust_global_difficulty", Emphasis: "weight_up", Reason: "room faded"})
+
+	loop.declareFromRetroIfEnabled(context.Background(), dynCfg(5))
+
+	if got := loop.registry.LiveCount(); got != 0 {
+		t.Fatalf("LiveCount = %d, want 0 (proposer default-OFF must not declare)", got)
+	}
+	if got := loop.proposer.Backlog(); got != 1 {
+		t.Errorf("backlog = %d, want 1 (suggestion untouched while disabled)", got)
+	}
+}
+
+// TestRetroProposer_NilProposerOrSelector_NoOp: the hook is a safe no-op when the
+// proposer or the selector is unwired (test paths), even with the opt-in on.
+func TestRetroProposer_NilProposerOrSelector_NoOp(t *testing.T) {
+	t.Setenv(envProposerEnabled, "true")
+	loop, _ := loopWithRealRegistry(t, 8)
+	// No proposer, no dynamic selector wired.
+	loop.declareFromRetroIfEnabled(context.Background(), dynCfg(5))
+	if got := loop.registry.LiveCount(); got != 0 {
+		t.Fatalf("LiveCount = %d, want 0 (no proposer wired ⇒ no-op)", got)
+	}
+}
+
+// TestRetroProposer_EnabledDeclaresFromSuggestion: opted in, a recorded suggestion
+// becomes a STARTED experiment whose thesis is seeded from the retro, on a flag the
+// dynamic selector chose.
+func TestRetroProposer_EnabledDeclaresFromSuggestion(t *testing.T) {
+	t.Setenv(envProposerEnabled, "true")
+	loop := proposerLoop(t)
+	loop.proposer.Record(experiment.RetroSuggestion{
+		InterventionType: "adjust_global_difficulty",
+		Emphasis:         "weight_up",
+		Reason:           "the room faded after the first elimination",
+	})
+
+	loop.declareFromRetroIfEnabled(context.Background(), dynCfg(5))
+
+	if got := loop.registry.LiveCount(); got != 1 {
+		t.Fatalf("LiveCount = %d, want 1 (opted-in proposer declares from the suggestion)", got)
+	}
+	if got := loop.proposer.Backlog(); got != 0 {
+		t.Errorf("backlog = %d, want 0 (suggestion consumed on declare)", got)
+	}
+	// The declared experiment's intent carries the retro-seeded thesis.
+	live := loop.registry.Live()
+	if len(live) != 1 {
+		t.Fatalf("live experiments = %d, want 1", len(live))
+	}
+}
+
+// TestRetroProposer_NoBacklog_NoOp: opted in but with no recorded suggestion, the
+// hook declares nothing (it only acts on the retro backlog).
+func TestRetroProposer_NoBacklog_NoOp(t *testing.T) {
+	t.Setenv(envProposerEnabled, "true")
+	loop := proposerLoop(t)
+	loop.declareFromRetroIfEnabled(context.Background(), dynCfg(5))
+	if got := loop.registry.LiveCount(); got != 0 {
+		t.Fatalf("LiveCount = %d, want 0 (no suggestion ⇒ nothing declared)", got)
+	}
+}
+
+// TestRetroProposer_RespectsBudget: opted in, the concurrent-experiment budget caps
+// retro-seeded declaration just like the dynamic declarer.
+func TestRetroProposer_RespectsBudget(t *testing.T) {
+	t.Setenv(envProposerEnabled, "true")
+	loop := proposerLoop(t)
+	loop.proposer.Record(experiment.RetroSuggestion{Reason: "first"})
+	loop.proposer.Record(experiment.RetroSuggestion{Reason: "second"})
+
+	// Budget 1: the first declare fills it; the second is suppressed (suggestion kept).
+	loop.declareFromRetroIfEnabled(context.Background(), budgetCfg(1))
+	if got := loop.registry.LiveCount(); got != 1 {
+		t.Fatalf("after first declare LiveCount = %d, want 1", got)
+	}
+	loop.declareFromRetroIfEnabled(context.Background(), budgetCfg(1))
+	if got := loop.registry.LiveCount(); got != 1 {
+		t.Fatalf("LiveCount = %d, want 1 (budget 1 caps a second declare)", got)
+	}
+	if got := loop.proposer.Backlog(); got != 1 {
+		t.Errorf("backlog = %d, want 1 (the budget-suppressed suggestion is retained)", got)
+	}
+}
+
+// budgetCfg is a live ExperimentConfig with the gates on and a given concurrent
+// budget, for the budget cap test.
+func budgetCfg(maxConcurrent int) flags.ExperimentConfig {
+	return flags.ExperimentConfig{
+		Enabled:                    true,
+		DynamicEnabled:             true,
+		DynamicMaxConcurrent:       maxConcurrent,
+		ShadowEffectiveConcurrency: 4,
+	}
+}


### PR DESCRIPTION
Closes the agent's research loop: **game → retro → THESIS → experiment → verdict → (promote/refine → new thesis)** (epic #1181 increment 4).

## THESIS field (#1190)
The experiment's immutable `Intent.Hypothesis` — *what idea is tested + its expected effect* — is now stamped on the `agent.experiment` ROOT span as `experiment.thesis`. It was already persisted in the durable journal and surfaced in the dossier (`GET /experiments/{id}` → `thesis`); this adds the trace surface so the WHY rides the span, not just the flag/value mechanics. A thesis-less (legacy/test) intent omits the attr.

## Proposer loop (#960 made concrete, no inference backend required)
The #960 LLM Proposer is wired but inert until a real Ollama/cloud transport (#738/#742). This delivers the deterministic counterpart that closes the loop **now** (the same way #995 delivered autonomous declaration ahead of the LLM proposer):

- New `experiment/thesis_proposer.go`: a `ThesisProposer` consumes the post-game retro's structured suggestions (#1179: `intervention_type` / `emphasis` / `reason`) and turns the oldest into a candidate experiment whose **thesis is seeded from the retro's reasoning**, biasing the objective from the suggestion's emphasis (weight_up/enable → accelerate, weight_down/disable → endurance).
- It **delegates** flag/value selection to the proven #995 dynamic declarer (a `FlagSelector` func seam), so it adds **only the thesis provenance** — no new write surface. Every Intent still flows through the same #977 Gate + #978 Registry caps.
- The retro coordinator forwards each decoded suggestion via a new `SetSuggestionSink` seam (purely additive — the suggestion is still recorded as a span event).

## Gating
Default **OFF** behind `AGENT_EXPERIMENT_PROPOSER_ENABLED` (env, mirroring the #995 `AGENT_EXPERIMENT_DYNAMIC_ENABLED` gate), subordinate to `AGENT_EXPERIMENTS_ENABLED` + the agent.json kill-switch. Declaration is byte-identical for anyone who has not opted in; the live experiment cadence is unchanged by default.

## Tests
- Thesis span attr: present + omitted-when-empty.
- Proposer seam: retro suggestion → seeded thesis, FIFO drain, bounded ring, emphasis→objective table, keep-suggestion-on-no-capacity, nil-selector safety.
- Loop-level gating: default-OFF no-op, declares when enabled, budget-capped, no-backlog no-op.
- Retro→sink forwarding end-to-end (two suggestions forwarded + nil-sink safety).

`gofmt -l`, `go vet`, `go build`, `go test ./... -race -count=1` all green.

## Scope
Strictly `services/agent/experiment/*`, the retro→proposer seam (`decision/retro_capture.go` sink + `decision/telemetry.go` attr), the loop wiring, and `main.go`. No touch to `game_session.py`/`metrics.py`, the coordinator, decision spans, or flagd `ci/{agent,game}.json`.

Part of #1181, #1184, #960.

🤖 Generated with [Claude Code](https://claude.com/claude-code)