### PR TITLE
feat(observability): re-parent agent in-game spans under gameplay_phase (#1195)

### DIFF
--- a/services/agent/decision/async_apply.go
+++ b/services/agent/decision/async_apply.go
@@ -52,14 +52,15 @@ func (l *Loop) applyAsyncResult(root context.Context, snapshot flags.Snapshot, t
 	// as a SpanContext value on the outcome) so the apply trace — and the agent.decision/
 	// agent.action spans nested under it — is navigable from the signal that caused it.
 	// No-op when out.fireSC is invalid (the production default), exactly like gameTraceLink.
-	// #1178: also start it as a remote CHILD of the game span — the async-materialized
-	// decision/action are part of the game, so they live INSIDE the game trace. The
-	// fire-cycle Link is KEPT alongside (navigates to the originating signal cycle); the
-	// game span is the new ROOT parent. Graceful fallback: when the game trace ids
-	// (carried on the outcome from fire time) are absent/invalid gameRemoteParent returns
-	// root unchanged, so this stays its own root + fire-cycle Link exactly as before.
+	// #1195 (refining #1178): also start it as a remote CHILD of the gameplay_phase
+	// span — the async-materialized decision/action are part of the game's active play,
+	// so they live INSIDE the game trace nested under gameplay_phase. The fire-cycle
+	// Link is KEPT alongside (navigates to the originating signal cycle); gameplay_phase
+	// is the new parent. Two-tier fallback (inGameRemoteParent): gameplay_phase span_id
+	// -> game ROOT span_id (#1187) -> own root + fire-cycle Link, all carried on the
+	// outcome from fire time, so this never loses correlation.
 	applyParent := root
-	if parentCtx, ok := gameRemoteParent(root, out.gameTraceID, out.gameTraceSpanID); ok {
+	if parentCtx, ok := inGameRemoteParent(root, out.gameTraceID, out.gameTraceSpanID, out.gameplayPhaseSpanID); ok {
 		applyParent = parentCtx
 	}
 	applyOpts := []trace.SpanStartOption{

--- a/services/agent/decision/async_infer.go
+++ b/services/agent/decision/async_infer.go
@@ -270,14 +270,15 @@ func (l *Loop) runInfer(root context.Context, snapshot flags.Snapshot, backend B
 	// #1140 (Slice A): Link this outbound-call root back to the originating fire-cycle's
 	// agent.signal_received trace, so a reader of the infer trace can navigate to the
 	// signal that caused it. No-op when fireSC is invalid.
-	// #1178: also start it as a remote CHILD of the game span — the async-materialized
-	// inference is part of the game, so it lives INSIDE the game trace (not merely Linked
-	// to it). The fire-cycle Link is KEPT alongside (it navigates to the originating
-	// signal cycle); the game span is the new ROOT parent. Graceful fallback: when the
-	// game trace ids are absent/invalid gameRemoteParent returns inferCtx unchanged, so
-	// this stays its own root + fire-cycle Link exactly as before.
+	// #1195 (refining #1178): also start it as a remote CHILD of the gameplay_phase
+	// span — the async-materialized inference is part of the game's active play, so it
+	// lives INSIDE the game trace nested under gameplay_phase (not merely Linked to it).
+	// The fire-cycle Link is KEPT alongside (it navigates to the originating signal
+	// cycle); gameplay_phase is the new parent. Two-tier fallback (inGameRemoteParent):
+	// gameplay_phase span_id -> game ROOT span_id (#1187) -> own root + fire-cycle Link,
+	// so this never loses correlation.
 	callParent := inferCtx
-	if parentCtx, ok := gameRemoteParent(inferCtx, c.GameTraceID, c.GameTraceSpanID); ok {
+	if parentCtx, ok := inGameRemoteParent(inferCtx, c.GameTraceID, c.GameTraceSpanID, c.GameplayPhaseSpanID); ok {
 		callParent = parentCtx
 	}
 	callOpts := []trace.SpanStartOption{
@@ -307,11 +308,13 @@ func (l *Loop) runInfer(root context.Context, snapshot flags.Snapshot, backend B
 		contextNotePresent: notePresent,
 		contextNoteLen:     noteLen,
 		fireSC:             fireSC,
-		// #1178: carry the game-session trace ids so the apply root can be started as a
-		// remote child of the game span (the apply path runs off the loop, with no game
-		// span in its ctx). Captured from THIS game's fire-time GameContext.
-		gameTraceID:     c.GameTraceID,
-		gameTraceSpanID: c.GameTraceSpanID,
+		// #1178/#1195: carry the game-session trace ids + gameplay_phase span_id so the
+		// apply root can be started as a remote child of the gameplay_phase span (the
+		// apply path runs off the loop, with no game span in its ctx). Captured from THIS
+		// game's fire-time GameContext.
+		gameTraceID:         c.GameTraceID,
+		gameTraceSpanID:     c.GameTraceSpanID,
+		gameplayPhaseSpanID: c.GameplayPhaseSpanID,
 	})
 }
 
@@ -353,10 +356,13 @@ type asyncOutcome struct {
 	// (the production default — no span active at fire time) yields no link (graceful).
 	fireSC trace.SpanContext
 	// gameTraceID/gameTraceSpanID are THIS game's game-session trace ids, captured from the
-	// fire-time GameContext (#1178). The apply root (agent.llm.apply) is started as a remote
-	// CHILD of the game span via these ids, so the async-materialized decision/action live
-	// INSIDE the game trace. Empty/invalid => the apply root stays its own root (graceful
-	// fallback, fire-cycle Link only), exactly as before.
-	gameTraceID     string
-	gameTraceSpanID string
+	// fire-time GameContext (#1178). gameplayPhaseSpanID is the gameplay_phase sub-span id
+	// (#1195). The apply root (agent.llm.apply) is started as a remote CHILD of the
+	// gameplay_phase span via inGameRemoteParent (two-tier fallback: gameplay_phase ->
+	// game ROOT span (#1187) -> own root), so the async-materialized decision/action live
+	// INSIDE the game trace nested under active play. Empty/invalid => the apply root
+	// stays its own root (graceful fallback, fire-cycle Link only), exactly as before.
+	gameTraceID         string
+	gameTraceSpanID     string
+	gameplayPhaseSpanID string
 }

--- a/services/agent/decision/decision.go
+++ b/services/agent/decision/decision.go
@@ -660,18 +660,20 @@ func (l *Loop) startSignalReceivedSpan(ctx context.Context, c gamecontext.GameCo
 			attribute.String(AttrGameID, c.SessionID),
 		),
 	}
-	// In-game re-parenting (#1178, refining #1174): the agent's in-game decisions/actions
-	// ARE part of the game — they happen within the game span's duration and shape it — so
-	// this cycle-root span is started as a remote CHILD of the game span instead of LINKED
-	// to it. Because it is the parent of the whole sync decision->action subtree AND the
-	// #1140 async fire anchor (both call this shared helper), that whole subtree is pulled
-	// INSIDE the game trace in one change. The game span is remote (we hold only its
-	// SpanContext from the #1133 correlation gauge); a remote child can be started under it
-	// regardless of its liveness, and inherits the game trace's sampling fate. Graceful
-	// fallback: when the game trace ids are absent/invalid (correlation gauge not yet
-	// ingested) gameRemoteParent returns ctx unchanged + ok=false, so this stays an own-root
-	// span exactly as before. The game trace ids are still stamped as searchable attributes.
-	if parentCtx, ok := gameRemoteParent(ctx, c.GameTraceID, c.GameTraceSpanID); ok {
+	// In-game re-parenting (#1195, refining #1178/#1174): the agent's in-game
+	// decisions/actions ARE part of the game's ACTIVE PLAY — they happen within the
+	// gameplay_phase span's duration and shape it — so this cycle-root span is started
+	// as a remote CHILD of the coordinator's gameplay_phase span instead of LINKED to
+	// the game. Because it is the parent of the whole sync decision->action subtree AND
+	// the #1140 async fire anchor (both call this shared helper), that whole subtree is
+	// pulled INSIDE the game trace, nested under gameplay_phase, in one change. The
+	// gameplay_phase span is remote (we hold only its span_id from the #1133/#1195
+	// correlation gauge); a remote child can be started under it regardless of its
+	// liveness, and inherits the game trace's sampling fate. Two-tier fallback
+	// (inGameRemoteParent): gameplay_phase span_id -> game ROOT span_id (#1187) -> own
+	// root, so correlation is never lost. The game trace ids are still stamped as
+	// searchable attributes.
+	if parentCtx, ok := inGameRemoteParent(ctx, c.GameTraceID, c.GameTraceSpanID, c.GameplayPhaseSpanID); ok {
 		ctx = parentCtx
 	}
 	if c.GameTraceID != "" {
@@ -1221,6 +1223,32 @@ func gameTraceLink(gameTraceID, gameTraceSpanID string) []trace.SpanStartOption 
 // single primitive in gamecontext so the SpanContext construction is shared with the Link.
 func gameRemoteParent(ctx context.Context, gameTraceID, gameTraceSpanID string) (context.Context, bool) {
 	return gamecontext.RemoteParent(ctx, gameTraceID, gameTraceSpanID)
+}
+
+// inGameRemoteParent re-parents the agent's IN-GAME decision chain (#1195, refining
+// #1187). It is the target-swap entry point: the in-game cycle root, the async
+// infer-call span, and the async apply root all parent under the coordinator's
+// gameplay_phase span — the stable active-play window — instead of the game ROOT
+// span, so a reader sees interventions nested where they actually occurred.
+//
+// Two-tier fallback (the safety property — correlation is never lost):
+//  1. gameplay_phase span_id (gameplayPhaseSpanID), if a valid hex id -> child of
+//     gameplay_phase.
+//  2. else the game ROOT span_id (gameTraceSpanID) -> child of the game root (the
+//     #1187 behavior) — used until gameplay_phase opens / when it is unsampled.
+//  3. else (both empty/invalid) -> ctx unchanged, ok=false: own-root span.
+//
+// gameTraceID (the trace_id) is identical for both spans (same trace), so the same
+// id selects either parent. Delegates to gameRemoteParent for the actual remote
+// SpanContext construction + validation (gameSpanContext rejects empty/invalid ids,
+// which is what drives the fallback to the next tier). The POST-game spans
+// (retro/summary/experiment.*) deliberately do NOT use this — they keep targeting
+// the game root via their existing Links/experiment-parenting.
+func inGameRemoteParent(ctx context.Context, gameTraceID, gameTraceSpanID, gameplayPhaseSpanID string) (context.Context, bool) {
+	if parentCtx, ok := gameRemoteParent(ctx, gameTraceID, gameplayPhaseSpanID); ok {
+		return parentCtx, true
+	}
+	return gameRemoteParent(ctx, gameTraceID, gameTraceSpanID)
 }
 
 // GameTraceLink is the exported entry point to the gameTraceLink primitive so other

--- a/services/agent/decision/gameplay_phase_parent_test.go
+++ b/services/agent/decision/gameplay_phase_parent_test.go
@@ -1,0 +1,223 @@
+package decision
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/joustmania/agent/gamecontext"
+)
+
+// gameplay_phase_parent_test.go is the #1195 assertion suite (refines #1187): the
+// agent's IN-GAME decision chain (signal_received -> decision -> action; the async
+// infer.call + apply spans) re-parents under the coordinator's gameplay_phase span
+// when its span_id is present, with a STRICT two-tier fallback so correlation is
+// never lost:
+//
+//  1. gameplay_phase span_id present  -> child of gameplay_phase (the new target).
+//  2. gameplay_phase absent, game root present -> child of game root (#1187 behavior).
+//  3. both absent -> own-root (pre-#1187 shape).
+//
+// gameplay_phase is in the SAME trace as the game root (GameTraceID is identical),
+// so the only thing that changes between tiers 1 and 2 is the parent span_id.
+
+// A distinct, valid gameplay_phase span id within the same game trace as hubGameSpanID.
+const hubGameplayPhaseSpanID = "00f067aa0ba902b7" // valid 8-byte hex span id
+
+// gameplayPhaseCtx is gameTraceCtx additionally carrying the gameplay_phase span id.
+func gameplayPhaseCtx(gameID string) gamecontext.GameContext {
+	c := gameTraceCtx(gameID)
+	c.GameplayPhaseSpanID = hubGameplayPhaseSpanID
+	return c
+}
+
+// gameplayPhaseAsyncCtx is the async-path analog (activeContext + all three ids).
+func gameplayPhaseAsyncCtx(gameID, serial string) gamecontext.GameContext {
+	c := activeGameTraceContext(gameID, serial) // sets GameTraceID + GameTraceSpanID
+	c.GameplayPhaseSpanID = hubGameplayPhaseSpanID
+	return c
+}
+
+// TestSignalReceived_ChildOfGameplayPhaseSpan: the sync cycle-root agent.signal_received
+// span (and thus the whole sync decision->action subtree) parents under the gameplay_phase
+// span when its id is present — NOT the game root span.
+func TestSignalReceived_ChildOfGameplayPhaseSpan(t *testing.T) {
+	l, sr, _ := meteredTestLoop(t)
+	l.Rules = fakeRules{out: []Decision{{Intervention: "noop", Reason: "x"}}}
+	l.Actions = &fakeSink{}
+
+	l.OnEvaluate(context.Background(), gameplayPhaseCtx("game_gp01"),
+		EvalTrigger{Signal: "metrics", T0: time.Now(), RPCService: "svc"})
+
+	root := spansByName(sr.Ended(), SignalReceived)[0]
+	wantTID, _ := trace.TraceIDFromHex(hubGameTrace)
+	wantSID, _ := trace.SpanIDFromHex(hubGameplayPhaseSpanID)
+	rootSID, _ := trace.SpanIDFromHex(hubGameSpanID)
+
+	if root.Parent().SpanID() != wantSID {
+		t.Errorf("signal_received parent span_id = %s, want gameplay_phase %s", root.Parent().SpanID(), wantSID)
+	}
+	if root.Parent().SpanID() == rootSID {
+		t.Errorf("signal_received parented under the GAME ROOT span %s; want gameplay_phase %s", rootSID, wantSID)
+	}
+	if root.Parent().TraceID() != wantTID {
+		t.Errorf("signal_received parent trace_id = %s, want game trace %s", root.Parent().TraceID(), wantTID)
+	}
+	if !root.Parent().IsRemote() {
+		t.Error("signal_received parent must be the REMOTE gameplay_phase span")
+	}
+	if root.SpanContext().TraceID() != wantTID {
+		t.Errorf("signal_received must live in the game trace; got %s want %s", root.SpanContext().TraceID(), wantTID)
+	}
+}
+
+// TestSignalReceived_FallsBackToGameRootWhenGameplayPhaseAbsent: with the gameplay_phase
+// id empty but the game root id present, the span parents under the game ROOT (tier 2 —
+// the #1187 behavior). This proves the fallback never loses the existing correlation.
+func TestSignalReceived_FallsBackToGameRootWhenGameplayPhaseAbsent(t *testing.T) {
+	l, sr, _ := meteredTestLoop(t)
+	l.Rules = fakeRules{out: []Decision{{Intervention: "noop", Reason: "x"}}}
+	l.Actions = &fakeSink{}
+
+	// gameTraceCtx has GameplayPhaseSpanID == "" (tier-2 input).
+	l.OnEvaluate(context.Background(), gameTraceCtx("game_gp02"),
+		EvalTrigger{Signal: "metrics", T0: time.Now(), RPCService: "svc"})
+
+	root := spansByName(sr.Ended(), SignalReceived)[0]
+	wantSID, _ := trace.SpanIDFromHex(hubGameSpanID)
+	if root.Parent().SpanID() != wantSID {
+		t.Errorf("signal_received parent span_id = %s, want game ROOT %s (fallback)", root.Parent().SpanID(), wantSID)
+	}
+	if !root.Parent().IsRemote() {
+		t.Error("signal_received parent must be the REMOTE game root span on fallback")
+	}
+}
+
+// TestSignalReceived_OwnRootWhenBothAbsent: tier 3 — both ids absent -> own-root span,
+// the pre-#1187 shape.
+func TestSignalReceived_OwnRootWhenBothAbsent(t *testing.T) {
+	l, sr, _ := meteredTestLoop(t)
+	l.Rules = fakeRules{out: []Decision{{Intervention: "noop", Reason: "x"}}}
+	l.Actions = &fakeSink{}
+
+	l.OnEvaluate(context.Background(), gamecontext.GameContext{SessionID: "s"},
+		EvalTrigger{Signal: "metrics", T0: time.Now(), RPCService: "svc"})
+
+	root := spansByName(sr.Ended(), SignalReceived)[0]
+	if root.Parent().IsValid() {
+		t.Errorf("signal_received must be own-root when no ids; parent=%v", root.Parent())
+	}
+}
+
+// TestAsync_InferAndApplyChildrenOfGameplayPhaseSpan: the async infer.call + apply spans
+// parent under the gameplay_phase span when present (not the game root), KEEPING the
+// fire-cycle Link alongside.
+func TestAsync_InferAndApplyChildrenOfGameplayPhaseSpan(t *testing.T) {
+	be := &injectingBackend{name: "phi4-mini", response: validShieldResponse}
+	provider := newFakeContextProvider()
+	provider.set("g1", gameplayPhaseAsyncCtx("g1", "AAAA"))
+	l, sr, _ := asyncLoop(t, asyncSnapshot(), resolverWith(be), provider, "g1", nil)
+
+	l.OnEvaluate(context.Background(), gameplayPhaseAsyncCtx("g1", "AAAA"), testTrigger())
+	l.AwaitInflight()
+
+	wantTID, _ := trace.TraceIDFromHex(hubGameTrace)
+	wantSID, _ := trace.SpanIDFromHex(hubGameplayPhaseSpanID)
+	rootSID, _ := trace.SpanIDFromHex(hubGameSpanID)
+
+	for _, name := range []string{SpanLLMInferCall, SpanLLMApply} {
+		spans := spansByName(sr.Ended(), name)
+		if len(spans) != 1 {
+			t.Fatalf("%s spans = %d, want 1", name, len(spans))
+		}
+		s := spans[0]
+		if s.Parent().SpanID() != wantSID {
+			t.Errorf("%s parent span_id = %s, want gameplay_phase %s", name, s.Parent().SpanID(), wantSID)
+		}
+		if s.Parent().SpanID() == rootSID {
+			t.Errorf("%s parented under the GAME ROOT span; want gameplay_phase", name)
+		}
+		if s.Parent().TraceID() != wantTID {
+			t.Errorf("%s parent trace_id = %s, want game trace %s", name, s.Parent().TraceID(), wantTID)
+		}
+		if !s.Parent().IsRemote() {
+			t.Errorf("%s parent must be the REMOTE gameplay_phase span", name)
+		}
+		if _, ok := linkToFireCycle(s.Links()); !ok {
+			t.Errorf("%s must keep its fire_cycle Link alongside the gameplay_phase parent", name)
+		}
+	}
+}
+
+// TestAsync_FallsBackToGameRootWhenGameplayPhaseAbsent: tier 2 for the async path — with
+// only the game root id, the async spans parent under the game ROOT (#1187 behavior).
+func TestAsync_FallsBackToGameRootWhenGameplayPhaseAbsent(t *testing.T) {
+	be := &injectingBackend{name: "phi4-mini", response: validShieldResponse}
+	provider := newFakeContextProvider()
+	provider.set("g1", activeGameTraceContext("g1", "AAAA")) // no gameplay_phase id
+	l, sr, _ := asyncLoop(t, asyncSnapshot(), resolverWith(be), provider, "g1", nil)
+
+	l.OnEvaluate(context.Background(), activeGameTraceContext("g1", "AAAA"), testTrigger())
+	l.AwaitInflight()
+
+	wantSID, _ := trace.SpanIDFromHex(hubGameSpanID)
+	for _, name := range []string{SpanLLMInferCall, SpanLLMApply} {
+		spans := spansByName(sr.Ended(), name)
+		if len(spans) != 1 {
+			t.Fatalf("%s spans = %d, want 1", name, len(spans))
+		}
+		if spans[0].Parent().SpanID() != wantSID {
+			t.Errorf("%s parent span_id = %s, want game ROOT %s (fallback)", name, spans[0].Parent().SpanID(), wantSID)
+		}
+	}
+}
+
+// TestInGameRemoteParent_TwoTierFallback exercises the resolver directly: gameplay_phase
+// wins when valid; game root is used when gameplay_phase is empty/invalid; own-root when
+// both are empty/invalid.
+func TestInGameRemoteParent_TwoTierFallback(t *testing.T) {
+	parentSpanID := func(ctx context.Context) trace.SpanID {
+		return trace.SpanContextFromContext(ctx).SpanID()
+	}
+
+	t.Run("gameplay_phase wins", func(t *testing.T) {
+		ctx, ok := inGameRemoteParent(context.Background(), hubGameTrace, hubGameSpanID, hubGameplayPhaseSpanID)
+		want, _ := trace.SpanIDFromHex(hubGameplayPhaseSpanID)
+		if !ok || parentSpanID(ctx) != want {
+			t.Errorf("want gameplay_phase parent %s (ok=%v), got %s", want, ok, parentSpanID(ctx))
+		}
+	})
+
+	t.Run("falls back to game root when gameplay_phase empty", func(t *testing.T) {
+		ctx, ok := inGameRemoteParent(context.Background(), hubGameTrace, hubGameSpanID, "")
+		want, _ := trace.SpanIDFromHex(hubGameSpanID)
+		if !ok || parentSpanID(ctx) != want {
+			t.Errorf("want game-root parent %s (ok=%v), got %s", want, ok, parentSpanID(ctx))
+		}
+	})
+
+	t.Run("falls back to game root when gameplay_phase invalid", func(t *testing.T) {
+		ctx, ok := inGameRemoteParent(context.Background(), hubGameTrace, hubGameSpanID, "not-hex")
+		want, _ := trace.SpanIDFromHex(hubGameSpanID)
+		if !ok || parentSpanID(ctx) != want {
+			t.Errorf("want game-root parent %s (ok=%v), got %s", want, ok, parentSpanID(ctx))
+		}
+	})
+
+	t.Run("own-root when both empty", func(t *testing.T) {
+		base := context.Background()
+		ctx, ok := inGameRemoteParent(base, hubGameTrace, "", "")
+		if ok || trace.SpanContextFromContext(ctx).IsValid() {
+			t.Errorf("want own-root (ok=false), got ok=%v parent=%v", ok, trace.SpanContextFromContext(ctx))
+		}
+	})
+
+	t.Run("own-root when trace id empty", func(t *testing.T) {
+		ctx, ok := inGameRemoteParent(context.Background(), "", hubGameSpanID, hubGameplayPhaseSpanID)
+		if ok || trace.SpanContextFromContext(ctx).IsValid() {
+			t.Errorf("want own-root when trace id empty (ok=false), got ok=%v", ok)
+		}
+	})
+}

--- a/services/agent/gamecontext/extract_metrics.go
+++ b/services/agent/gamecontext/extract_metrics.go
@@ -65,6 +65,13 @@ const (
 	// same game_trace_correlation signal (#1157). Hex string; empty when the game
 	// span was unsampled.
 	attrGameTraceSpanID = "game_trace_span_id"
+	// attrGameplayPhaseSpanID is the coordinator gameplay_phase sub-span span_id
+	// carried on the same game_trace_correlation signal (#1195). Hex string; empty
+	// until the gameplay_phase span opens (or unsampled). The agent re-parents its
+	// in-game decision chain under THIS span instead of the game root (#1187) when
+	// present, falling back to attrGameTraceSpanID otherwise. Same trace as
+	// game_trace_id.
+	attrGameplayPhaseSpanID = "gameplay_phase_span_id"
 	// Experiment attribution (#975, epic #982): finer-grained labels WITHIN a
 	// shadow game. Carried on the LOW-RATE lifecycle metrics (game_active,
 	// game_active_players, game_duration_seconds) the same way game_kind is —
@@ -102,6 +109,12 @@ type gameLabels struct {
 	// GameTraceSpanID carries the coordinator's root game-span span_id (#1157),
 	// likewise only on the game_trace_correlation gauge and likewise enrichment.
 	GameTraceSpanID string
+	// GameplayPhaseSpanID carries the coordinator's gameplay_phase sub-span span_id
+	// (#1195), likewise only on the game_trace_correlation gauge and likewise
+	// enrichment. The agent re-parents its in-game decision chain under this span
+	// (a refinement of the #1187 game-root parenting); empty -> fall back to
+	// GameTraceSpanID. Same trace as GameTraceID.
+	GameplayPhaseSpanID string
 }
 
 // gameIDOf reads the game_id datapoint label; empty when absent.
@@ -152,15 +165,24 @@ func gameTraceSpanIDOf(attrs pcommon.Map) string {
 	return ""
 }
 
+// gameplayPhaseSpanIDOf reads the gameplay_phase_span_id datapoint label (#1195); empty when absent.
+func gameplayPhaseSpanIDOf(attrs pcommon.Map) string {
+	if v, ok := attrs.Get(attrGameplayPhaseSpanID); ok {
+		return v.AsString()
+	}
+	return ""
+}
+
 // metricGameLabels resolves the game identity labels on a metric datapoint.
 func metricGameLabels(attrs pcommon.Map) gameLabels {
 	return gameLabels{
-		GameID:          gameIDOf(attrs),
-		GameKind:        gameKindOf(attrs),
-		ExperimentID:    experimentIDOf(attrs),
-		Arm:             armOf(attrs),
-		GameTraceID:     gameTraceIDOf(attrs),
-		GameTraceSpanID: gameTraceSpanIDOf(attrs),
+		GameID:              gameIDOf(attrs),
+		GameKind:            gameKindOf(attrs),
+		ExperimentID:        experimentIDOf(attrs),
+		Arm:                 armOf(attrs),
+		GameTraceID:         gameTraceIDOf(attrs),
+		GameTraceSpanID:     gameTraceSpanIDOf(attrs),
+		GameplayPhaseSpanID: gameplayPhaseSpanIDOf(attrs),
 	}
 }
 
@@ -390,6 +412,7 @@ func (s *Store) adoptGame(labels gameLabels) {
 	s.SetGameKind(labels.GameKind)
 	s.SetExperimentID(labels.ExperimentID)
 	s.SetArm(labels.Arm)
-	s.SetGameTraceID(labels.GameTraceID)         // #1133: empty on all but game_trace_correlation
-	s.SetGameTraceSpanID(labels.GameTraceSpanID) // #1157: ditto
+	s.SetGameTraceID(labels.GameTraceID)                 // #1133: empty on all but game_trace_correlation
+	s.SetGameTraceSpanID(labels.GameTraceSpanID)         // #1157: ditto
+	s.SetGameplayPhaseSpanID(labels.GameplayPhaseSpanID) // #1195: ditto
 }

--- a/services/agent/gamecontext/extract_metrics_test.go
+++ b/services/agent/gamecontext/extract_metrics_test.go
@@ -263,11 +263,13 @@ func TestApplyMetrics_AdoptsGameTraceID(t *testing.T) {
 	s := newTestStore()
 	const tid = "4bf92f3577b34da6a3ce929d0e0e4736"
 	const sid = "051581bf3cb55c13"
+	const gpSid = "00f067aa0ba902b7"
 	if !s.ApplyMetrics(metricsWith(metricTraceCorrelation, 1, map[string]string{
-		attrGameID:          "game-99",
-		attrGameKind:        "real",
-		attrGameTraceID:     tid,
-		attrGameTraceSpanID: sid,
+		attrGameID:              "game-99",
+		attrGameKind:            "real",
+		attrGameTraceID:         tid,
+		attrGameTraceSpanID:     sid,
+		attrGameplayPhaseSpanID: gpSid,
 	})) {
 		t.Fatal("game_trace_correlation carrying game_trace_id must apply")
 	}
@@ -280,6 +282,34 @@ func TestApplyMetrics_AdoptsGameTraceID(t *testing.T) {
 	}
 	if snap.GameTraceSpanID != sid {
 		t.Fatalf("GameTraceSpanID = %q, want %q", snap.GameTraceSpanID, sid)
+	}
+	if snap.GameplayPhaseSpanID != gpSid {
+		t.Fatalf("GameplayPhaseSpanID = %q, want %q (#1195)", snap.GameplayPhaseSpanID, gpSid)
+	}
+}
+
+// TestApplyMetrics_GameplayPhaseSpanIDAbsentLeavesEmpty verifies the #1195 two-tier
+// fallback INPUT: a correlation datapoint with the root span_id but NO
+// gameplay_phase_span_id (e.g. before the gameplay_phase span opens) leaves
+// GameplayPhaseSpanID empty while still adopting the root id — so the agent keeps
+// parenting under the game root until gameplay_phase publishes its id.
+func TestApplyMetrics_GameplayPhaseSpanIDAbsentLeavesEmpty(t *testing.T) {
+	s := newTestStore()
+	const tid = "4bf92f3577b34da6a3ce929d0e0e4736"
+	const sid = "051581bf3cb55c13"
+	if !s.ApplyMetrics(metricsWith(metricTraceCorrelation, 1, map[string]string{
+		attrGameID:          "game-101",
+		attrGameTraceID:     tid,
+		attrGameTraceSpanID: sid,
+	})) {
+		t.Fatal("correlation datapoint must apply")
+	}
+	snap := s.Snapshot()
+	if snap.GameTraceSpanID != sid {
+		t.Fatalf("GameTraceSpanID = %q, want %q (root still adopted)", snap.GameTraceSpanID, sid)
+	}
+	if snap.GameplayPhaseSpanID != "" {
+		t.Fatalf("GameplayPhaseSpanID = %q, want empty (no label -> fall back to root)", snap.GameplayPhaseSpanID)
 	}
 }
 

--- a/services/agent/gamecontext/model.go
+++ b/services/agent/gamecontext/model.go
@@ -159,9 +159,20 @@ type GameContext struct {
 	// trace. Empty when not yet observed or the game span was unsampled; an empty
 	// trace_id OR span_id means "no link" (graceful fallback, no error).
 	GameTraceSpanID string
-	Session         SessionSignals
-	Players         map[string]*PlayerSignals
-	UpdatedAt       time.Time
+	// GameplayPhaseSpanID is the hex span_id of the coordinator's gameplay_phase
+	// sub-span for this session (#1195, refines #1187). Source: the
+	// gameplay_phase_span_id datapoint label on the same game_trace_correlation
+	// gauge. gameplay_phase is the STABLE active-play window WITHIN the game trace;
+	// the agent re-parents its in-game decision chain (signal_received -> decision
+	// -> action) under THIS span instead of the game root, so a reader sees
+	// interventions nested where they actually occurred. Same trace as GameTraceID.
+	// Two-tier fallback: when empty (gameplay_phase not yet open / unsampled) the
+	// re-parent uses GameTraceSpanID (the game root, #1187 behavior); when that is
+	// also empty the span stays own-root. Never breaks span emission.
+	GameplayPhaseSpanID string
+	Session             SessionSignals
+	Players             map[string]*PlayerSignals
+	UpdatedAt           time.Time
 
 	// Timeline is a bounded, oldest-first slice of the partition's recent rolling
 	// narrative (#916): periodic state deltas, eliminations, and session phase

--- a/services/agent/gamecontext/store.go
+++ b/services/agent/gamecontext/store.go
@@ -555,6 +555,24 @@ func (s *Store) SetGameTraceSpanID(id string) {
 	s.touchSession()
 }
 
+// SetGameplayPhaseSpanID records the coordinator's gameplay_phase sub-span span_id
+// (#1195, refines #1187) from the gameplay_phase_span_id label on the
+// game_trace_correlation signal. Mirrors SetGameTraceSpanID exactly: an empty id is
+// ignored so an unlabeled signal (or a not-yet-open gameplay_phase span) never
+// clobbers a previously observed id — the agent then keeps re-parenting under the
+// game root via GameTraceSpanID. The decision/async loops read this to re-parent the
+// in-game decision chain under gameplay_phase, with two-tier fallback to the game
+// root; an empty value there simply keeps the #1187 behavior (graceful fallback).
+func (s *Store) SetGameplayPhaseSpanID(id string) {
+	if id == "" {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.ctx.GameplayPhaseSpanID = id
+	s.touchSession()
+}
+
 // SetArm records the experiment arm ("experimental"/"control", #975) from the
 // arm datapoint label or the experiment.arm span attribute. An empty arm is
 // ignored so an unlabeled signal never clobbers a previously observed arm.
@@ -796,8 +814,9 @@ func (s *Store) EvictStale() {
 		s.ctx.GameKind = ""
 		s.ctx.ExperimentID = ""
 		s.ctx.Arm = ""
-		s.ctx.GameTraceID = ""     // drop the finished game's trace link (#1133)
-		s.ctx.GameTraceSpanID = "" // ditto, the linked span_id (#1157)
+		s.ctx.GameTraceID = ""         // drop the finished game's trace link (#1133)
+		s.ctx.GameTraceSpanID = ""     // ditto, the linked span_id (#1157)
+		s.ctx.GameplayPhaseSpanID = "" // ditto, the gameplay_phase span_id (#1195)
 		s.elimOrder = make(map[string]int)
 		s.endedAt = time.Time{}
 		s.ctx.UpdatedAt = now

--- a/services/game_coordinator/game_session.py
+++ b/services/game_coordinator/game_session.py
@@ -124,6 +124,15 @@ class GameSession:
         # all-zero span id under the trace. Captured/cleared in lockstep with
         # game_trace_id.
         self.game_trace_span_id = ""
+        # Hex span_id of this session's gameplay_phase span (#1195). gameplay_phase
+        # is the stable active-play sub-span within the game trace; the agent
+        # re-parents its in-game decision chain under THIS span instead of the game
+        # root (#1187). Empty until the gameplay_phase span opens (base.py calls
+        # publish_gameplay_phase_span_id); carried as the gameplay_phase_span_id
+        # label on the correlation gauge alongside game_trace_span_id (same trace).
+        # Captured/cleared in lockstep with game_trace_id so retire removes the
+        # exact gauge series.
+        self.gameplay_phase_span_id = ""
 
         # Per-session loop runs in its own thread with its own GrpcClientManager.
         self.clients = GrpcClientManager()
@@ -161,15 +170,62 @@ class GameSession:
             with suppress(KeyError, ValueError):
                 gauge.remove(*labels)
 
-        # The trace-correlation gauge (#1133/#1157) carries a different label tuple
-        # (game_kind, game_id, game_trace_id, game_trace_span_id) and was only set
-        # when the span was sampled (game_trace_id non-empty), so remove it
-        # separately and only then.
+        # The trace-correlation gauge (#1133/#1157/#1195) carries a different label
+        # tuple (game_kind, game_id, game_trace_id, game_trace_span_id,
+        # gameplay_phase_span_id) and was only set when the span was sampled
+        # (game_trace_id non-empty), so remove it separately and only then. Remove
+        # with the CURRENT gameplay_phase_span_id: it is "" until the gameplay_phase
+        # span opens and is then updated in lockstep with the gauge re-emit, so this
+        # always matches the live series tuple.
         if self.game_trace_id:
             with suppress(KeyError, ValueError):
                 metrics.game_trace_correlation.remove(
-                    self.game_kind, self.game_id, self.game_trace_id, self.game_trace_span_id
+                    self.game_kind,
+                    self.game_id,
+                    self.game_trace_id,
+                    self.game_trace_span_id,
+                    self.gameplay_phase_span_id,
                 )
+
+    def publish_gameplay_phase_span_id(self, gameplay_phase_span_id: str) -> None:
+        """Re-emit the correlation gauge carrying the gameplay_phase span_id (#1195).
+
+        Called by the game (base.py) when its gameplay_phase span opens, passing
+        that span's hex span_id. gameplay_phase is the stable active-play sub-span;
+        the agent re-parents its in-game decision chain under it (a strict
+        refinement of the #1187 game-root parenting).
+
+        The gauge was already SET to 1 at game-root-span time with an EMPTY
+        gameplay_phase_span_id label (different label tuple -> different series).
+        To avoid leaving that empty-labeled series behind, REMOVE it first, then SET
+        the series carrying the populated id, and update self.gameplay_phase_span_id
+        so clear_metrics removes the live tuple at retire.
+
+        No-op when the game span was unsampled (game_trace_id empty -> the gauge was
+        never set) or the passed id is empty/invalid: the agent then keeps falling
+        back to the game root span (game_trace_span_id), so correlation is never lost.
+        """
+        if not self.game_trace_id or not gameplay_phase_span_id:
+            return
+        if gameplay_phase_span_id == self.gameplay_phase_span_id:
+            return
+        # Remove the previously-set series (empty gameplay id at first publish).
+        with suppress(KeyError, ValueError):
+            metrics.game_trace_correlation.remove(
+                self.game_kind,
+                self.game_id,
+                self.game_trace_id,
+                self.game_trace_span_id,
+                self.gameplay_phase_span_id,
+            )
+        self.gameplay_phase_span_id = gameplay_phase_span_id
+        metrics.game_trace_correlation.labels(
+            game_kind=self.game_kind,
+            game_id=self.game_id,
+            game_trace_id=self.game_trace_id,
+            game_trace_span_id=self.game_trace_span_id,
+            gameplay_phase_span_id=self.gameplay_phase_span_id,
+        ).set(1)
 
     def on_event_state_sync(self, event_type: str) -> None:
         """EventBus state-sync callback bound to THIS session's state (#775).
@@ -326,11 +382,18 @@ class GameSession:
                 # references the actual game-start span (Jaeger uiFind highlight)
                 # rather than an all-zero span id under that trace.
                 self.game_trace_span_id = trace.format_span_id(span_ctx.span_id)
+                # gameplay_phase_span_id (#1195) is empty here: the gameplay_phase
+                # span has not opened yet (it opens inside game.run()). Early
+                # correlation is preserved via game_trace_span_id; the agent's
+                # two-tier fallback uses the game root span until gameplay_phase
+                # publishes its id, at which point the gauge is re-emitted with the
+                # populated label (publish_gameplay_phase_span_id).
                 metrics.game_trace_correlation.labels(
                     game_kind=self.game_kind,
                     game_id=self.game_id,
                     game_trace_id=self.game_trace_id,
                     game_trace_span_id=self.game_trace_span_id,
+                    gameplay_phase_span_id=self.gameplay_phase_span_id,
                 ).set(1)
 
             try:
@@ -375,6 +438,12 @@ class GameSession:
                 # set_game_transaction_context carries it for flag evaluation (#975).
                 game.experiment_id = self.experiment_id
                 game.arm = self.arm
+                # Let the game publish its gameplay_phase span_id back to the
+                # correlation gauge (#1195) when that span opens, so the agent can
+                # re-parent its in-game decision chain under gameplay_phase. The
+                # game holds only this callback (not the session), mirroring how the
+                # session sets game_kind/experiment_id on the game.
+                game.on_gameplay_phase_open = self.publish_gameplay_phase_span_id
 
                 # Store reference and run game
                 self.current_game = game

--- a/services/game_coordinator/games/base.py
+++ b/services/game_coordinator/games/base.py
@@ -698,6 +698,12 @@ class BaseGameMode(ABC):
         self._reset_global_gauges_on_end = True
         self.experiment_id = ""
         self.arm = ""
+        # Callback the owning GameSession sets so the game can publish its
+        # gameplay_phase span_id to the trace-correlation gauge (#1195) when that
+        # span opens — letting the agent re-parent its in-game decision chain under
+        # gameplay_phase. Defaults to a no-op so a standalone game / every existing
+        # test runs unchanged.
+        self.on_gameplay_phase_open: Callable[[str], None] = lambda _span_id: None
 
         # Game state
         self.state = GameState.IDLE
@@ -2694,6 +2700,16 @@ class BaseGameMode(ABC):
                 # Store span reference and context for background tasks
                 self.gameplay_span = gameplay_span
                 self.gameplay_span_context = otel_context.get_current()
+
+                # Publish the gameplay_phase span_id to the trace-correlation gauge
+                # (#1195) so the agent re-parents its in-game decision chain under
+                # THIS span instead of the game root (#1187). gameplay_phase is the
+                # stable active-play window; a span_ctx with a zero/invalid span_id
+                # (unsampled) yields an empty hex id, which the session treats as a
+                # no-op so the agent keeps falling back to the game root span.
+                gameplay_span_ctx = gameplay_span.get_span_context()
+                if gameplay_span_ctx.span_id != 0:
+                    self.on_gameplay_phase_open(trace.format_span_id(gameplay_span_ctx.span_id))
 
                 # Create "players" parent span (collapsible group in Jaeger)
                 self._players_span = tracer.start_span(

--- a/services/game_coordinator/metrics.py
+++ b/services/game_coordinator/metrics.py
@@ -62,14 +62,26 @@ current_game_mode = Gauge(
 # agent's Link references the actual game-start span (Jaeger highlights it via
 # uiFind) rather than an all-zero span id under that trace.
 #
-# Cardinality: game_trace_id and game_trace_span_id are both 1:1 with game_id (one
-# trace/root span per game), so they multiply NO series beyond the already-unbounded
-# game_id. Like the other per-game gauges it is SET to 1 inside the live game span
-# and REMOVED at retire (clear_metrics, #1018) so the series does not accumulate.
+# It ADDITIONALLY carries the hex span_id of the gameplay_phase sub-span as
+# gameplay_phase_span_id (#1195). gameplay_phase is the STABLE span covering the
+# whole active-play window WITHIN the game trace; the agent re-parents its in-game
+# decision chain (signal_received -> decision -> action) under THIS span instead of
+# the game root (#1187), so a reader sees interventions nested where they actually
+# occurred. Same trace as game_trace_span_id (game_trace_id is identical), so it is
+# a strict refinement: the agent falls back to game_trace_span_id (game root) when
+# this is empty (gameplay_phase not yet open / unsampled). The gamesummary hub-link
+# (#1174) and the retro/experiment Links deliberately KEEP targeting game_trace_span_id
+# (the root) — only the in-game decision chain retargets to gameplay_phase.
+#
+# Cardinality: game_trace_id / game_trace_span_id / gameplay_phase_span_id are each
+# 1:1 with game_id (one trace/root span/gameplay_phase span per game), so they
+# multiply NO series beyond the already-unbounded game_id. Like the other per-game
+# gauges it is SET to 1 inside the live game span and REMOVED at retire (clear_metrics,
+# #1018) so the series does not accumulate.
 game_trace_correlation = Gauge(
     "game_trace_correlation",
     "Correlation marker tying a live game_id to its root span trace_id (always 1 while live)",
-    ["game_kind", "game_id", "game_trace_id", "game_trace_span_id"],
+    ["game_kind", "game_id", "game_trace_id", "game_trace_span_id", "gameplay_phase_span_id"],
 )
 
 game_duration_seconds = Gauge(

--- a/services/game_coordinator/tests/test_game_session.py
+++ b/services/game_coordinator/tests/test_game_session.py
@@ -381,11 +381,15 @@ class TestGameSessionLoop:
         expected_span_hex = ot_trace.format_span_id(span_id)
         assert session.game_trace_id == expected_trace_hex
         assert session.game_trace_span_id == expected_span_hex
+        # The root-span emit carries an EMPTY gameplay_phase_span_id (#1195): the
+        # gameplay_phase span opens later inside game.run(), and the mocked game here
+        # never opens it, so it stays "".
         mock_metrics.game_trace_correlation.labels.assert_any_call(
             game_kind=GAME_KIND_SHADOW,
             game_id="game_abc123",
             game_trace_id=expected_trace_hex,
             game_trace_span_id=expected_span_hex,
+            gameplay_phase_span_id="",
         )
         mock_metrics.game_trace_correlation.labels.return_value.set.assert_any_call(1)
 
@@ -659,17 +663,23 @@ class TestGameSessionClearMetrics:
 
     @patch("services.game_coordinator.game_session.metrics")
     def test_clear_metrics_removes_trace_correlation_when_set(self, mock_metrics):
-        """#1133/#1157: the trace-correlation gauge (labels game_kind, game_id,
-        game_trace_id, game_trace_span_id) is removed at retire ONLY when a trace
-        id was captured — otherwise it was never set."""
+        """#1133/#1157/#1195: the trace-correlation gauge (labels game_kind, game_id,
+        game_trace_id, game_trace_span_id, gameplay_phase_span_id) is removed at retire
+        ONLY when a trace id was captured — otherwise it was never set. Removes with the
+        CURRENT gameplay_phase_span_id."""
         session = _make_session(game_kind=GAME_KIND_SHADOW)
         session.game_trace_id = "4bf92f3577b34da6a3ce929d0e0e4736"
         session.game_trace_span_id = "051581bf3cb55c13"
+        session.gameplay_phase_span_id = "00f067aa0ba902b7"
 
         session.clear_metrics()
 
         mock_metrics.game_trace_correlation.remove.assert_called_once_with(
-            GAME_KIND_SHADOW, "game_abc123", "4bf92f3577b34da6a3ce929d0e0e4736", "051581bf3cb55c13"
+            GAME_KIND_SHADOW,
+            "game_abc123",
+            "4bf92f3577b34da6a3ce929d0e0e4736",
+            "051581bf3cb55c13",
+            "00f067aa0ba902b7",
         )
 
     @patch("services.game_coordinator.game_session.metrics")
@@ -682,6 +692,68 @@ class TestGameSessionClearMetrics:
         session.clear_metrics()
 
         mock_metrics.game_trace_correlation.remove.assert_not_called()
+
+
+class TestPublishGameplayPhaseSpanID:
+    """#1195: when the gameplay_phase span opens, the game calls
+    publish_gameplay_phase_span_id; the session re-emits the correlation gauge
+    swapping the empty gameplay_phase_span_id series for the populated one, so the
+    agent re-parents its in-game decision chain under gameplay_phase."""
+
+    @patch("services.game_coordinator.game_session.metrics")
+    def test_publish_swaps_empty_series_for_populated(self, mock_metrics):
+        session = _make_session(game_kind=GAME_KIND_SHADOW)
+        # Simulate the root-span emit having run (gauge set with empty gameplay id).
+        session.game_trace_id = "4bf92f3577b34da6a3ce929d0e0e4736"
+        session.game_trace_span_id = "051581bf3cb55c13"
+
+        session.publish_gameplay_phase_span_id("00f067aa0ba902b7")
+
+        # Empty-gameplay series removed first ...
+        mock_metrics.game_trace_correlation.remove.assert_called_once_with(
+            GAME_KIND_SHADOW,
+            "game_abc123",
+            "4bf92f3577b34da6a3ce929d0e0e4736",
+            "051581bf3cb55c13",
+            "",
+        )
+        # ... then the populated series set.
+        mock_metrics.game_trace_correlation.labels.assert_called_once_with(
+            game_kind=GAME_KIND_SHADOW,
+            game_id="game_abc123",
+            game_trace_id="4bf92f3577b34da6a3ce929d0e0e4736",
+            game_trace_span_id="051581bf3cb55c13",
+            gameplay_phase_span_id="00f067aa0ba902b7",
+        )
+        mock_metrics.game_trace_correlation.labels.return_value.set.assert_called_once_with(1)
+        assert session.gameplay_phase_span_id == "00f067aa0ba902b7"
+
+    @patch("services.game_coordinator.game_session.metrics")
+    def test_publish_noop_when_game_trace_unsampled(self, mock_metrics):
+        """No gauge was ever set (game_trace_id empty) -> publish is a no-op so the
+        agent keeps falling back to the (absent) root; gameplay id stays empty."""
+        session = _make_session(game_kind=GAME_KIND_SHADOW)
+        # game_trace_id stays "" (unsampled).
+
+        session.publish_gameplay_phase_span_id("00f067aa0ba902b7")
+
+        mock_metrics.game_trace_correlation.remove.assert_not_called()
+        mock_metrics.game_trace_correlation.labels.assert_not_called()
+        assert session.gameplay_phase_span_id == ""
+
+    @patch("services.game_coordinator.game_session.metrics")
+    def test_publish_noop_when_span_id_empty(self, mock_metrics):
+        """An empty/unsampled gameplay_phase span_id is a no-op (two-tier fallback to
+        the root span on the agent side)."""
+        session = _make_session(game_kind=GAME_KIND_SHADOW)
+        session.game_trace_id = "4bf92f3577b34da6a3ce929d0e0e4736"
+        session.game_trace_span_id = "051581bf3cb55c13"
+
+        session.publish_gameplay_phase_span_id("")
+
+        mock_metrics.game_trace_correlation.remove.assert_not_called()
+        mock_metrics.game_trace_correlation.labels.assert_not_called()
+        assert session.gameplay_phase_span_id == ""
 
     def test_clear_metrics_idempotent_on_missing_series(self):
         """A double-retire (or never-started session) must not raise — the gauge


### PR DESCRIPTION
Part of #1181, #1195 (refines #1187).

## What

Re-parents the agent's **in-game decision chain** (`agent.signal_received` -> `agent.decision` -> `agent.action`, plus the async `agent.llm.infer.call` + `agent.llm.apply` spans) under the coordinator's **`gameplay_phase`** span — the stable active-play window — instead of the game ROOT span (#1187). A reader following a game trace now sees interventions nested where they actually occurred.

`game_cycle` was deliberately NOT used (per-frame + ephemeral; the async intervention lands at a different cycle than observed). `gameplay_phase` is the stable semantic parent.

## Coordinator
- `game_trace_correlation` gauge gains a `gameplay_phase_span_id` label (`metrics.py`). It is set **empty** at game-root-span time and **re-emitted with the populated id** once the `gameplay_phase` span opens — via a new `GameSession.publish_gameplay_phase_span_id`, wired through a game callback (`on_gameplay_phase_open`) the session sets on the game and `base.py` invokes when the span opens. `clear_metrics` removes the live 5-tuple.
- The existing `game_trace_span_id` (root) is **KEPT**: the gamesummary hub-link (#1174) and the retro/experiment Links legitimately target the root.

## Agent
- `gamecontext` ingests `gameplay_phase_span_id` (`extract_metrics.go` / `model.go` / `store.go`), mirroring `GameTraceSpanID`.
- New `inGameRemoteParent` does the **target swap** at the three #1187 re-parent sites with a strict **two-tier fallback**: `gameplay_phase` span_id → (empty/invalid) game ROOT span_id (#1187 behavior) → (both absent) own-root. Same trace for both parents (`game_trace_id` is identical).

## Out of scope (untouched)
Post-game spans (retro / summary / experiment.*) keep their existing Links/experiment-parenting. No experiment_loop/proposer/registry, controller_manager, or flagd ci changes. **Observability only — no game/decision behavior change.** Real + shadow games both benefit (gameplay_phase exists for both).

## Tests
- Agent: `gofmt`/`go build`/`go vet` clean; `go test ./... -race -count=1` green. New `gameplay_phase_parent_test.go` asserts the two-tier fallback (gameplay_phase parent, game-root fallback, own-root) for sync + async paths; mutation-checked (reverting the swap to game-root fails the new tests). gamecontext ingest test extended + absent-label case.
- Coordinator: full suite (1192) green; new `publish_gameplay_phase_span_id` tests (swap empty->populated series; no-op when unsampled / empty id); correlation-gauge + clear_metrics tests updated for the new label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)