### PR TITLE
feat(envoy): route the experiment dossier through the gateway at /experiments

### DIFF
--- a/services/envoy/envoy.yaml
+++ b/services/envoy/envoy.yaml
@@ -93,6 +93,13 @@ static_resources:
                           redirect:
                             path_redirect: "/victoria-metrics/"
 
+                        # Agent experiment dossier (#1183)
+                        # PRESERVE prefix - agent serves /experiments + /experiments/{id} at root
+                        - match:
+                            prefix: "/experiments"
+                          route:
+                            cluster: agent_dossier
+
                         # Chaos fault injection API
                         # PRESERVE prefix - connect-proxy handles /chaos/* paths
                         - match:
@@ -236,6 +243,20 @@ static_resources:
                     socket_address:
                       address: dashboard
                       port_value: 8080
+
+    # Agent experiment-dossier HTTP view (#1183)
+    - name: agent_dossier
+      type: STRICT_DNS
+      lb_policy: ROUND_ROBIN
+      load_assignment:
+        cluster_name: agent_dossier
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: agent
+                      port_value: 13134
 
     # OTEL Collector for trace export (gRPC on port 4317)
     - name: otel_collector


### PR DESCRIPTION
## What
Adds an envoy route `/experiments` → new `agent_dossier` cluster (`agent:13134`, PRESERVE prefix) so the agent's experiment-dossier HTTP view (#1183) is browsable at `http://localhost/experiments` and `http://localhost/experiments/{id}`.

## Why
The dossier listened only on the internal port `agent:13134`, unreachable from the host. Every other UI/API (Jaeger, Grafana, Prometheus, Loki, VictoriaMetrics) is reached through the envoy gateway on `:80` — docker-compose.yml documents the pattern as 'all ports exposed only within Docker network (envoy proxies to it)'. This brings the dossier in line, and supersedes the throwaway local `docker-compose.dossier-expose.yml` host-port stopgap used during verification #11.

## Notes
- PRESERVE prefix (no `prefix_rewrite`): the agent mounts its routes at `/experiments` + `/experiments/{id}` (dossier.go), so the path passes through unchanged.
- Route is ordered before the dashboard SPA catch-all (`/`), so `/experiments` resolves to the agent, not the SPA.
- Verified live: `GET http://localhost/experiments` → 200, serving the journal list.

Part of #1203

🤖 Generated with [Claude Code](https://claude.com/claude-code)