### PR TITLE
feat(agent): surface LLM infer/retro failures as span ERROR (#1206)

### DIFF
--- a/services/agent/decision/async_apply.go
+++ b/services/agent/decision/async_apply.go
@@ -5,6 +5,8 @@ import (
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	semconv "go.opentelemetry.io/otel/semconv/v1.34.0"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/joustmania/agent/flags"
@@ -172,17 +174,36 @@ func (l *Loop) emitAsyncInferSpan(ctx context.Context, out asyncOutcome) ([]Deci
 	defer span.End(trace.WithTimestamp(out.end))
 
 	if out.timedOut {
-		span.SetAttributes(attribute.String(AttrLLMInferError, "latency budget exceeded"))
+		// #1206: surface the timeout as span STATUS=Error (not just an attribute) so the
+		// fail-open degrade-to-rules path is visible in Jaeger's error view. inferErr
+		// carries the deadline error when present; otherwise record the budget cause.
+		const timeoutMsg = "latency budget exceeded"
+		span.SetAttributes(attribute.String(AttrLLMInferError, timeoutMsg))
+		if out.inferErr != nil {
+			span.RecordError(out.inferErr)
+			span.SetAttributes(semconv.ErrorType(out.inferErr))
+		}
+		span.SetStatus(codes.Error, timeoutMsg)
 		return nil, FallbackUnparseable
 	}
 	if out.inferErr != nil {
+		// #1206: transport/infer failure is an ERROR on the span, mirroring litellm's
+		// otel.status_code=ERROR. Control flow unchanged — still degrades to rules.
 		span.SetAttributes(attribute.String(AttrLLMInferError, out.inferErr.Error()))
+		span.RecordError(out.inferErr)
+		span.SetAttributes(semconv.ErrorType(out.inferErr))
+		span.SetStatus(codes.Error, out.inferErr.Error())
 		l.Log.Warn("agent.llm.infer_failed", "session_id", l.gameID, "tier", out.backend.Name(), "error", out.inferErr)
 		return nil, FallbackUnparseable
 	}
 	resp, err := llm.Decode(out.raw)
 	if err != nil {
+		// #1206: an unparseable response is an ERROR on the span, not just parse_ok=false.
+		// Control flow unchanged — still degrades to rules (FallbackUnparseable).
 		span.SetAttributes(attribute.String(AttrLLMInferError, err.Error()))
+		span.RecordError(err)
+		span.SetAttributes(semconv.ErrorType(err))
+		span.SetStatus(codes.Error, err.Error())
 		l.Log.Warn("agent.llm.unparseable", "session_id", l.gameID, "tier", out.backend.Name(), "error", err)
 		return nil, FallbackUnparseable
 	}

--- a/services/agent/decision/async_infer.go
+++ b/services/agent/decision/async_infer.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	semconv "go.opentelemetry.io/otel/semconv/v1.34.0"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/joustmania/agent/flags"
@@ -294,6 +296,15 @@ func (l *Loop) runInfer(root context.Context, snapshot flags.Snapshot, backend B
 	callOpts = append(callOpts, fireCycleLink(fireSC)...)
 	callCtx, callSpan := l.Tracer.Start(callParent, SpanLLMInferCall, callOpts...)
 	raw, inferErr := backend.Infer(callCtx, prompt)
+	// #1206: stamp the outbound-call span (the span active when the transport error /
+	// "context deadline exceeded" actually occurs) with STATUS=Error, mirroring
+	// litellm's otel.status_code=ERROR. Fail-open is unchanged — applyAsyncResult still
+	// degrades to rules; this only makes the failed call observable in Jaeger.
+	if inferErr != nil {
+		callSpan.RecordError(inferErr)
+		callSpan.SetAttributes(semconv.ErrorType(inferErr))
+		callSpan.SetStatus(codes.Error, inferErr.Error())
+	}
 	callSpan.End()
 	end := now()
 

--- a/services/agent/decision/async_span_error_test.go
+++ b/services/agent/decision/async_span_error_test.go
@@ -1,0 +1,176 @@
+package decision
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel/codes"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+)
+
+// async_span_error_test.go is the #1206 assertion: the async inference failure paths
+// (timeout / infer-error / unparseable) must set span STATUS=Error and RecordError on
+// the agent.llm.infer attribution span — so the fail-open degrade-to-rules outcome is
+// VISIBLE in Jaeger's error view, not buried in parse_ok=false attributes. The
+// outbound agent.llm.infer.call span is also error-stamped on a transport failure (the
+// span active when "context deadline exceeded" actually occurs). A SUCCESS leaves the
+// infer span status Unset. Control flow is unchanged — these tests also confirm rules
+// still decided / the result still applied.
+
+// hasExceptionEvent reports whether the span carries an OTel "exception" event (what
+// span.RecordError emits), proving RecordError ran on the failure branch.
+func hasExceptionEvent(span sdktrace.ReadOnlySpan) bool {
+	for _, ev := range span.Events() {
+		if ev.Name == "exception" {
+			return true
+		}
+	}
+	return false
+}
+
+// TestAsync_TimeoutSetsSpanError: on a latency-budget timeout the agent.llm.infer span
+// status is Error and carries an exception event, while fail-open is preserved (rules
+// still decided and dispatched).
+func TestAsync_TimeoutSetsSpanError(t *testing.T) {
+	be := newBlockingBackend("phi4-mini", validShieldResponse)
+	provider := newFakeContextProvider()
+	provider.set("g1", activeContext("g1", "AAAA"))
+	snap := asyncSnapshot()
+	snap.LLMGate.LatencyBudget = 20 * time.Millisecond
+	l, sr, sink := asyncLoop(t, snap, resolverWith(be), provider, "g1",
+		[]Decision{{Intervention: "grant_shield", Reason: "rules on timeout"}})
+
+	l.OnEvaluate(context.Background(), activeContext("g1", "AAAA"), testTrigger())
+	l.AwaitInflight()
+	close(be.release)
+
+	inf := spansByName(sr.Ended(), SpanLLMInfer)
+	if len(inf) != 1 {
+		t.Fatalf("agent.llm.infer spans = %d, want 1", len(inf))
+	}
+	if got := inf[0].Status().Code; got != codes.Error {
+		t.Errorf("infer span status = %v, want Error (#1206 timeout visible in error view)", got)
+	}
+	// The outbound-call span (where the deadline actually fires) is also error-stamped.
+	call := spansByName(sr.Ended(), SpanLLMInferCall)
+	if len(call) != 1 {
+		t.Fatalf("agent.llm.infer.call spans = %d, want 1", len(call))
+	}
+	if got := call[0].Status().Code; got != codes.Error {
+		t.Errorf("infer.call span status = %v, want Error on a timed-out outbound call", got)
+	}
+	if !hasExceptionEvent(call[0]) {
+		t.Error("infer.call span missing RecordError exception event on timeout")
+	}
+	// Fail-open unchanged: rules still decided and dispatched.
+	if sink.calls.Load() != 1 {
+		t.Errorf("action sink calls = %d, want 1 (rules fallback still dispatched)", sink.calls.Load())
+	}
+}
+
+// TestAsync_InferErrorSetsSpanError: a transport error sets Error status + exception on
+// both the infer attribution span and the outbound-call span; rules still decided.
+func TestAsync_InferErrorSetsSpanError(t *testing.T) {
+	be := newBlockingBackend("phi4-mini", "")
+	be.err = errors.New("backend exploded")
+	provider := newFakeContextProvider()
+	provider.set("g1", activeContext("g1", "AAAA"))
+	l, sr, sink := asyncLoop(t, asyncSnapshot(), resolverWith(be), provider, "g1",
+		[]Decision{{Intervention: "grant_shield", Reason: "rules on error"}})
+
+	l.OnEvaluate(context.Background(), activeContext("g1", "AAAA"), testTrigger())
+	close(be.release)
+	l.AwaitInflight()
+
+	inf := spansByName(sr.Ended(), SpanLLMInfer)
+	if len(inf) != 1 {
+		t.Fatalf("agent.llm.infer spans = %d, want 1", len(inf))
+	}
+	if got := inf[0].Status().Code; got != codes.Error {
+		t.Errorf("infer span status = %v, want Error on a transport failure", got)
+	}
+	if inf[0].Status().Description != "backend exploded" {
+		t.Errorf("infer span status description = %q, want the transport error message", inf[0].Status().Description)
+	}
+	if !hasExceptionEvent(inf[0]) {
+		t.Error("infer span missing RecordError exception event on infer error")
+	}
+	call := spansByName(sr.Ended(), SpanLLMInferCall)
+	if len(call) != 1 || call[0].Status().Code != codes.Error {
+		t.Errorf("infer.call span must be Error-stamped on a transport failure")
+	}
+	if sink.calls.Load() != 1 {
+		t.Errorf("action sink calls = %d, want 1 (rules fallback still dispatched)", sink.calls.Load())
+	}
+}
+
+// TestAsync_UnparseableSetsSpanError: a reachable backend returning garbage (clean
+// transport, undecodable body) sets Error status + exception on the infer attribution
+// span; the outbound-call span stays Unset (the transport itself succeeded); rules
+// still decided.
+func TestAsync_UnparseableSetsSpanError(t *testing.T) {
+	be := newBlockingBackend("phi4-mini", "not json at all")
+	provider := newFakeContextProvider()
+	provider.set("g1", activeContext("g1", "AAAA"))
+	l, sr, sink := asyncLoop(t, asyncSnapshot(), resolverWith(be), provider, "g1",
+		[]Decision{{Intervention: "grant_shield", Reason: "rules on unparseable"}})
+
+	l.OnEvaluate(context.Background(), activeContext("g1", "AAAA"), testTrigger())
+	close(be.release)
+	l.AwaitInflight()
+
+	inf := spansByName(sr.Ended(), SpanLLMInfer)
+	if len(inf) != 1 {
+		t.Fatalf("agent.llm.infer spans = %d, want 1", len(inf))
+	}
+	if got := inf[0].Status().Code; got != codes.Error {
+		t.Errorf("infer span status = %v, want Error on an unparseable reply", got)
+	}
+	if !hasExceptionEvent(inf[0]) {
+		t.Error("infer span missing RecordError exception event on unparseable reply")
+	}
+	// The transport succeeded — only the body was bad — so the call span stays Unset.
+	call := spansByName(sr.Ended(), SpanLLMInferCall)
+	if len(call) != 1 {
+		t.Fatalf("agent.llm.infer.call spans = %d, want 1", len(call))
+	}
+	if got := call[0].Status().Code; got != codes.Unset {
+		t.Errorf("infer.call span status = %v, want Unset (transport succeeded)", got)
+	}
+	if sink.calls.Load() != 1 {
+		t.Errorf("action sink calls = %d, want 1 (rules fallback still dispatched)", sink.calls.Load())
+	}
+}
+
+// TestAsync_SuccessLeavesSpanStatusUnset: a fresh, applied result leaves the infer span
+// status Unset (no error) — the #1206 change must NOT error-tag healthy inferences.
+func TestAsync_SuccessLeavesSpanStatusUnset(t *testing.T) {
+	be := newBlockingBackend("phi4-mini", validShieldResponse)
+	provider := newFakeContextProvider()
+	provider.set("g1", activeContext("g1", "AAAA"))
+	l, sr, sink := asyncLoop(t, asyncSnapshot(), resolverWith(be), provider, "g1", nil)
+
+	l.OnEvaluate(context.Background(), activeContext("g1", "AAAA"), testTrigger())
+	close(be.release)
+	l.AwaitInflight()
+
+	inf := spansByName(sr.Ended(), SpanLLMInfer)
+	if len(inf) != 1 {
+		t.Fatalf("agent.llm.infer spans = %d, want 1", len(inf))
+	}
+	if got := inf[0].Status().Code; got != codes.Unset {
+		t.Errorf("infer span status = %v, want Unset on success (no false error tagging)", got)
+	}
+	if hasExceptionEvent(inf[0]) {
+		t.Error("infer span must carry NO exception event on success")
+	}
+	call := spansByName(sr.Ended(), SpanLLMInferCall)
+	if len(call) != 1 || call[0].Status().Code != codes.Unset {
+		t.Errorf("infer.call span status must be Unset on success")
+	}
+	if sink.calls.Load() != 1 {
+		t.Errorf("action sink calls = %d, want 1 (llm decision dispatched)", sink.calls.Load())
+	}
+}

--- a/services/agent/decision/retro_capture.go
+++ b/services/agent/decision/retro_capture.go
@@ -8,6 +8,7 @@ import (
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 	otelmetric "go.opentelemetry.io/otel/metric"
 	semconv "go.opentelemetry.io/otel/semconv/v1.34.0"
 	"go.opentelemetry.io/otel/trace"
@@ -540,6 +541,13 @@ func (rc *RetroCoordinator) runRetroInfer(ctx context.Context, span trace.Span, 
 			attribute.Bool(AttrLLMRetroParseOK, false),
 			attribute.String(AttrLLMInferError, inferErr.Error()),
 		)
+		// #1206: surface the failure as span STATUS=Error (mirroring litellm's
+		// otel.status_code=ERROR) so a timed-out/failed retro is visible in Jaeger's
+		// error view, not just as parse_ok=false. Fail-open is unchanged — the span
+		// still ends cleanly and the game-end transition is unaffected.
+		span.RecordError(inferErr)
+		span.SetAttributes(semconv.ErrorType(inferErr))
+		span.SetStatus(codes.Error, inferErr.Error())
 		rc.Log.Warn(SpanLLMRetroFailed,
 			"session_id", sessionID,
 			"latency_ms", latencyMs,
@@ -560,6 +568,11 @@ func (rc *RetroCoordinator) runRetroInfer(ctx context.Context, span trace.Span, 
 			attribute.Bool(AttrLLMRetroParseOK, false),
 			attribute.String(AttrLLMInferError, decodeErr.Error()),
 		)
+		// #1206: an unparseable retro reply is an ERROR on the span, not just
+		// parse_ok=false. Fail-open is unchanged — the span still ends cleanly.
+		span.RecordError(decodeErr)
+		span.SetAttributes(semconv.ErrorType(decodeErr))
+		span.SetStatus(codes.Error, decodeErr.Error())
 		rc.Log.Warn(SpanLLMRetroFailed,
 			"session_id", sessionID,
 			"latency_ms", latencyMs,

--- a/services/agent/decision/retro_span_error_test.go
+++ b/services/agent/decision/retro_span_error_test.go
@@ -1,0 +1,81 @@
+package decision
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"go.opentelemetry.io/otel/codes"
+
+	"github.com/joustmania/agent/llm"
+)
+
+// retro_span_error_test.go is the #1206 retro-side assertion: a retro inference that
+// fails (transport error / timeout) or returns an unparseable reply must set the
+// agent.llm.retro span STATUS=Error and RecordError — so the failed retro shows up in
+// Jaeger's error view, not only as parse_ok=false. A successful retro leaves the span
+// status Unset. Fail-open is unchanged — the span still ends cleanly either way.
+
+// TestRetro_TransportErrorSetsSpanError: a backend whose Infer errors sets Error status
+// + an exception event on the retro span (in addition to the existing parse_ok=false).
+func TestRetro_TransportErrorSetsSpanError(t *testing.T) {
+	resetRetroResponseRef()
+	rc, sr := recordingRetro(t, retroFlagSnapshot())
+	rc.SetResolver(reachableRetroResolver(t, "gemma4:latest",
+		func(context.Context, llm.Prompt) (string, error) { return "", errors.New("boom") }))
+
+	rc.OnGameEnd(endedSession())
+	rc.AwaitInflight()
+
+	span := spansByName(sr.Ended(), SpanLLMRetro)[0]
+	if got := span.Status().Code; got != codes.Error {
+		t.Errorf("retro span status = %v, want Error on a transport failure (#1206)", got)
+	}
+	if span.Status().Description != "boom" {
+		t.Errorf("retro span status description = %q, want the transport error message", span.Status().Description)
+	}
+	if !hasExceptionEvent(span) {
+		t.Error("retro span missing RecordError exception event on transport error")
+	}
+}
+
+// TestRetro_ParseFailureSetsSpanError: an unparseable reply sets Error status + an
+// exception event on the retro span.
+func TestRetro_ParseFailureSetsSpanError(t *testing.T) {
+	resetRetroResponseRef()
+	rc, sr := recordingRetro(t, retroFlagSnapshot())
+	rc.SetResolver(reachableRetroResolver(t, "gemma4:latest",
+		func(context.Context, llm.Prompt) (string, error) { return "not json at all", nil }))
+
+	rc.OnGameEnd(endedSession())
+	rc.AwaitInflight()
+
+	span := spansByName(sr.Ended(), SpanLLMRetro)[0]
+	if got := span.Status().Code; got != codes.Error {
+		t.Errorf("retro span status = %v, want Error on an unparseable reply (#1206)", got)
+	}
+	if !hasExceptionEvent(span) {
+		t.Error("retro span missing RecordError exception event on parse failure")
+	}
+}
+
+// TestRetro_SuccessLeavesSpanStatusUnset: a parsed, healthy retro leaves the span status
+// Unset — the #1206 change must NOT error-tag a successful retrospective.
+func TestRetro_SuccessLeavesSpanStatusUnset(t *testing.T) {
+	resetRetroResponseRef()
+	reply := `{"session_assessment":"close finish","suggestions":[],"session_focus":"endurance"}`
+	rc, sr := recordingRetro(t, retroFlagSnapshot())
+	rc.SetResolver(reachableRetroResolver(t, "gemma4:latest",
+		func(context.Context, llm.Prompt) (string, error) { return reply, nil }))
+
+	rc.OnGameEnd(endedSession())
+	rc.AwaitInflight()
+
+	span := spansByName(sr.Ended(), SpanLLMRetro)[0]
+	if got := span.Status().Code; got != codes.Unset {
+		t.Errorf("retro span status = %v, want Unset on success (no false error tagging)", got)
+	}
+	if hasExceptionEvent(span) {
+		t.Error("retro span must carry NO exception event on success")
+	}
+}


### PR DESCRIPTION
Part of #1206

The agent recorded LLM infer/retro failures only as span ATTRIBUTES (`parse_ok=false`, `latency_ms`, `llm.infer.error`) but never set span STATUS = Error — so 0 agent spans were error-tagged in Jaeger and failures were invisible in error views, even though litellm sets `otel.status_code=ERROR`.

This adds `span.SetStatus(codes.Error, msg)` + `span.RecordError(err)` (+ `semconv.ErrorType`) at the **existing** failure branches, mirroring the sync apply-path pattern already in `decision.go`:

- `async_apply.go` `emitAsyncInferSpan` — timeout / infer-error / unparseable on the `agent.llm.infer` attribution span
- `async_infer.go` `runInfer` — the outbound `agent.llm.infer.call` client span on a transport failure (the span active when "context deadline exceeded" actually occurs)
- `retro_capture.go` `runRetroInfer` — transport-error / unparseable on the `agent.llm.retro` span

**Fail-open is unchanged** — the agent still degrades to rules / capture-only and every span still ends cleanly. This is observability-only: no control-flow change, no change to what the agent decides. The existing attribute behavior is retained alongside the new status.

### Tests
Focused unit tests assert the span status is `Error` (and a `RecordError` exception event is present) on timeout / infer-error / unparseable, and `Unset` on success — for both the async in-game path (`async_span_error_test.go`) and the retro path (`retro_span_error_test.go`). Each failure test also confirms the fail-open outcome (rules still dispatched / span still ends).

`gofmt -l .`, `go vet ./decision/... ./llm/...`, and `go test ./decision/... ./llm/... -race -count=1` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)