### PR TITLE
fix(litellm): stitch agent↔litellm into one trace (#1205)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -856,6 +856,22 @@ services:
       - OTEL_ENDPOINT=http://otel-collector:4317
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
       - OTEL_RESOURCE_ATTRIBUTES=service.namespace=infrastructure,host.name=${JOUSTMANIA_HOST:-joustmania}
+      # Inbound W3C trace-context propagation (#1205, epic #1140 disjoint-roots).
+      # The agent injects a `traceparent` header on EVERY outbound inference call
+      # (services/agent/inference/openai.go; the sync/async/retro paths each wrap the
+      # call in a recording client span first so the header carries a live trace-id).
+      # LiteLLM's otel callback extracts that header and parents its "Received Proxy
+      # Server Request" SERVER span UNDER it by default (user_api_key_auth.py ->
+      # create_litellm_proxy_request_started_span -> get_traceparent_from_header), so
+      # the gateway gen_ai span shares ONE trace with the decision that caused it
+      # (decision -> agent.llm.infer.call -> litellm -> ollama). The ONLY switch that
+      # silently re-orphans it — turning every proxy span into its own ROOT regardless
+      # of the inbound header (the verification #11 symptom: a litellm trace whose
+      # `services` set is {litellm} only, top span references:[]) — is
+      # OTEL_IGNORE_CONTEXT_PROPAGATION. Pin it OFF explicitly so a stray env on a
+      # fleet host can never re-break the stitch. (This is INBOUND only; forwarding
+      # traceparent DOWNSTREAM to Ollama is a separate, unrelated knob, left off.)
+      - OTEL_IGNORE_CONTEXT_PROPAGATION=false
     volumes:
       - ./services/litellm/config.yaml:/etc/litellm/config.yaml:ro
     # Reach the HOST machine's Ollama (same mechanism the agent uses, #1048).

--- a/services/agent/inference/openai_test.go
+++ b/services/agent/inference/openai_test.go
@@ -15,6 +15,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/propagation"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // sampleCompletion is a realistic OpenAI-compatible /chat/completions response body.
@@ -281,6 +282,66 @@ func TestInfer_InjectsTraceparentWithinActiveSpan(t *testing.T) {
 	// span so the gateway span will nest under THIS trace, not an orphan.
 	if !strings.Contains(gotTraceparent, wantTraceID) {
 		t.Errorf("traceparent %q does not carry active trace-id %q", gotTraceparent, wantTraceID)
+	}
+}
+
+// TestInfer_TraceparentExtractsAsRemoteParent is the #1205 (epic #1140) two-sided
+// stitch contract: it is not enough that openai.go WRITES a traceparent — the header
+// the agent puts on the wire must, when EXTRACTED by a W3C TraceContextTextMapPropagator
+// (exactly what the litellm gateway does in get_traceparent_from_header /
+// _get_span_context), yield a VALID, REMOTE span context that carries the agent's active
+// trace-id. That is the precise condition under which litellm parents its "Received Proxy
+// Server Request" SERVER span UNDER the agent's trace instead of starting a new ROOT (the
+// verification #11 disjoint-trace symptom). This test stands in for the gateway extractor
+// so the contract is guarded in agent CI, with no live stack.
+func TestInfer_TraceparentExtractsAsRemoteParent(t *testing.T) {
+	withTraceContextPropagator(t)
+
+	// Capture the exact headers the production HTTP client puts on the wire.
+	var wireHeaders http.Header
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		wireHeaders = r.Header.Clone()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, sampleCompletion)
+	}))
+	defer srv.Close()
+
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSampler(sdktrace.AlwaysSample()))
+	defer func() { _ = tp.Shutdown(context.Background()) }()
+	ctx, span := tp.Tracer("test").Start(context.Background(), "agent.llm.infer.call")
+	defer span.End()
+	wantTraceID := span.SpanContext().TraceID().String()
+
+	b := newMockBackend(srv, "", "phi4-mini")
+	if _, err := b.Infer(ctx, llm.Prompt{System: "s", User: "u"}); err != nil {
+		t.Fatalf("Infer error: %v", err)
+	}
+	if wireHeaders == nil {
+		t.Fatal("server never observed the request headers")
+	}
+
+	// Replay the gateway's extraction over the wire headers. The agent must have sent a
+	// usable header under one of the case-insensitive W3C names (Go canonicalizes to
+	// "Traceparent"; litellm reads case-insensitively via Starlette). HeaderCarrier.Get
+	// is canonicalizing too, so this mirrors a correct extractor.
+	extracted := propagation.TraceContext{}.Extract(
+		context.Background(), propagation.HeaderCarrier(wireHeaders),
+	)
+	remoteSC := trace.SpanContextFromContext(extracted)
+
+	if !remoteSC.IsValid() {
+		t.Fatalf("gateway-side Extract yielded no valid parent from headers %v; "+
+			"litellm would start a ROOT span (the #1205 disjoint-trace break)", wireHeaders)
+	}
+	if !remoteSC.IsRemote() {
+		t.Error("extracted parent is not marked Remote; litellm would not treat it as an inbound remote parent")
+	}
+	if got := remoteSC.TraceID().String(); got != wantTraceID {
+		t.Errorf("extracted remote trace-id = %q, want the agent's active trace-id %q "+
+			"(the gateway span would land in a DIFFERENT trace)", got, wantTraceID)
+	}
+	if !remoteSC.IsSampled() {
+		t.Error("extracted parent is not sampled; the gateway child span may be dropped, orphaning the rich gen_ai error data")
 	}
 }
 


### PR DESCRIPTION
**Part of #1205, #1140**

## Root cause (inject vs extract)

**Agent inject side: CORRECT and already tested.** The global propagator is W3C TraceContext (`services/agent/otel.go:96-99`), and `openai.go:230` injects `traceparent` unconditionally from the call ctx on all three live paths — sync (`agent.llm.infer` active), async (`async_infer.go` opens a recording `agent.llm.infer.call` client span around the call), and retro (`retro_capture.go:516` same). Existing `async_traceparent_test.go` / `openai_test.go` already prove the header carries the active span's trace-id. I confirmed Go writes a valid sampled `Traceparent` to the wire.

**litellm extract side: the orphaning surface.** Inspected the pinned image source (`litellm v1.88.2`): the proxy SERVER span "Received Proxy Server Request" is created in `user_api_key_auth.py → create_litellm_proxy_request_started_span → get_traceparent_from_header`, which DOES extract the inbound `traceparent` as remote parent **by default**. The one switch that silently turns it into a per-request ROOT regardless of the inbound header — exactly the verification #11 symptom (`services`={litellm}, top span `references:[]`) — is the `OTEL_IGNORE_CONTEXT_PROPAGATION` env (`OTELConfig.ignore_context_propagation`, defaulted from that env). It is a dataclass field fed by env, **not** a `litellm_settings` YAML key — so the fix belongs in the gateway env, not config.yaml.

## Fix

- **`docker-compose.yml`**: pin `OTEL_IGNORE_CONTEXT_PROPAGATION=false` on the `litellm` service (OTel env block) with a comment documenting the inbound-stitch contract. Regression-proofs the stitch against a stray fleet-host env.
- **`services/agent/inference/openai_test.go`**: `TestInfer_TraceparentExtractsAsRemoteParent` — replays the gateway's W3C `Extract` over the EXACT headers the production `OpenAIBackend` puts on the wire and asserts the recovered parent is valid + remote + sampled + carries the agent's active trace-id (the precise two-sided nest-vs-root condition).

`services/litellm/config.yaml` is **not** touched (keeps the #1208 model_list/fallbacks rebase trivial). `services/flagd/ci/{agent,game}.json` untouched.

## Verification

- `gofmt -l .` clean, `go vet ./...` clean
- `go test ./inference/... ./decision/... -race -count=1` → both `ok`
- `python3 -c "import yaml; yaml.safe_load(...)"` on both edited/inspected YAMLs → OK

**Live one-trace not freshly reproduced**: litellm is currently down (gateway profile inactive; port 4000 unreachable from host, container off the joustmania network), and the single litellm trace in the last 6h is root-only `{litellm}` — consistent with the host smoke-test (which sends no `traceparent`) rather than an agent call. The agent inject contract is proven in CI; the litellm env pin closes the only known disable-switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)