### PR TITLE
feat(agent): rules-first in-game decisions, LLM as length-gated async upgrade (#1207)

### DIFF
--- a/services/agent/decision/async_infer_test.go
+++ b/services/agent/decision/async_infer_test.go
@@ -149,9 +149,19 @@ func asyncLoop(t *testing.T, snap flags.Snapshot, resolver *Resolver, provider *
 
 // asyncSnapshot is an llm-mode snapshot whose #847 gate always admits, with a short
 // latency budget for the timeout test and a permissive allow-list + rate budget.
+//
+// #1207: the rules-first default means the async LLM only fires when the upgrade gate
+// passes, so these async-fire tests turn the master switch ON and set the estimate
+// parameters generously (per-player seconds well above the 5s budget) so even a
+// single-player activeContext clears the length gate and the existing fire path is
+// still exercised. The dedicated gate test (upgrade_gate_test.go) covers the
+// switch-off / short-game NEGATIVE paths.
 func asyncSnapshot() flags.Snapshot {
 	s := llmDecideSnapshot()
 	s.LLMGate.LatencyBudget = 5 * time.Second
+	s.LLMGate.InGameAsyncUpgrade = true
+	s.LLMGate.SecondsPerPlayer = 10
+	s.LLMGate.StyleFactor = 1.0
 	return s
 }
 

--- a/services/agent/decision/decision.go
+++ b/services/agent/decision/decision.go
@@ -769,6 +769,28 @@ func (l *Loop) decide(ctx context.Context, snapshot flags.Snapshot, c gamecontex
 				// means this cycle emits no synchronous decision span — the async apply
 				// trace carries it.
 				if l.asyncEnabled() {
+					// #1207: RULES-FIRST in game. mode="llm" no longer fires the async LLM
+					// every admitted cycle — it does so only as an explicit, length-gated
+					// UPGRADE. The upgrade gate (master switch llm.in_game_async_upgrade +
+					// the derived length estimate) is evaluated BEFORE firing: when it fails,
+					// this cycle decides IMMEDIATELY via the deterministic rules engine and no
+					// async LLM is launched. This inverts the #917 default — short real games
+					// (the only place the latency race ever bit, since shadow games are
+					// rules-only via eligibility) now get an instant rules decision instead of
+					// deferring a beat to an async result that may land after the game moved on.
+					//
+					// LATE-LLM = SEPARATE INTERVENTION (reverses reason fork (B) in
+					// async_infer.go:24-49 for the *upgrade* case): on a game long enough to
+					// pass the gate we DO fire async, and when that result lands after rules
+					// already acted it dispatches through the SAME runDecision chain as its OWN
+					// intervention. A double-fire-within-context is INTENDED here and is bounded
+					// by policy.max_interventions_per_minute (the rate limiter), with the
+					// per-game inflight CAS preventing two concurrent Infers. The gate's length
+					// estimate ensures we only opt into that double-fire on games whose duration
+					// can absorb the extra intervention.
+					if !l.shouldUpgradeToAsyncLLM(snapshot, c) {
+						return l.Rules.Evaluate(ctx, c)
+					}
 					// #1140 (Slice A): an async-fire cycle is NOT idle — a decision was
 					// dispatched (just asynchronously). It therefore deserves a trace
 					// presence, and that presence is the ANCHOR the later agent.llm.infer.call
@@ -876,6 +898,44 @@ func (l *Loop) gateLLM(ctx context.Context, snapshot flags.Snapshot, c gameconte
 	// the allow() call above. This is the ONLY path that does not return a reason.
 	l.lastLLMAttempt = t
 	return ""
+}
+
+// shouldUpgradeToAsyncLLM reports whether an admitted mode="llm" cycle should be
+// UPGRADED from the rules-first default to firing the async LLM (#1207). It is the
+// in-game upgrade gate, evaluated AFTER the #847 call gate has already admitted the
+// cycle and a reachable backend has been resolved. Two conditions, both required:
+//
+//  1. master switch — llm.in_game_async_upgrade must be on. When off, mode="llm" is
+//     rules-first in game and never fires the async LLM, regardless of game length.
+//  2. length gate — the derived expected game length must be at least the existing
+//     latency budget: only a game long enough to absorb a 2-10s async result (and the
+//     late-LLM intervention it may dispatch) earns the upgrade. A 2p/6s shadow-sized
+//     game stays rules-only; an 8p endurance game fires the LLM.
+//
+// On either failure the caller decides immediately via the rules engine. The shadow/
+// real distinction is emergent: short games self-gate to rules without a static table.
+func (l *Loop) shouldUpgradeToAsyncLLM(snapshot flags.Snapshot, c gamecontext.GameContext) bool {
+	if !snapshot.LLMGate.InGameAsyncUpgrade {
+		return false
+	}
+	expected := expectedGameSeconds(c, snapshot.LLMGate.SecondsPerPlayer, snapshot.LLMGate.StyleFactor)
+	return expected >= snapshot.LLMGate.LatencyBudget.Seconds()
+}
+
+// expectedGameSeconds derives the expected remaining game length (#1207) from the
+// active player count and the two tunable estimate parameters:
+//
+//	expected_seconds = ActivePlayerCount × secondsPerPlayer × styleFactor
+//
+// ActivePlayerCount comes from Session.ActivePlayerCount (the live game_active_players
+// signal); when it has not been observed yet (nil) it falls back to the number of
+// known players in the context, so a fresh game still produces a usable estimate.
+func expectedGameSeconds(c gamecontext.GameContext, secondsPerPlayer, styleFactor float64) float64 {
+	players := len(c.Players)
+	if c.Session.ActivePlayerCount != nil {
+		players = *c.Session.ActivePlayerCount
+	}
+	return float64(players) * secondsPerPlayer * styleFactor
 }
 
 // resolveBackend walks the inference fallback chain (#741) for an ADMITTED llm

--- a/services/agent/decision/upgrade_gate_test.go
+++ b/services/agent/decision/upgrade_gate_test.go
@@ -1,0 +1,208 @@
+package decision
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/joustmania/agent/flags"
+	"github.com/joustmania/agent/gamecontext"
+)
+
+// upgrade_gate_test.go covers the #1207 rules-first in-game decision gate: by default
+// mode="llm" decides IMMEDIATELY via rules, and the async LLM is fired only as an
+// explicit, length-gated UPGRADE. The gate has two conditions, both required:
+//
+//	1. master switch llm.in_game_async_upgrade ON, and
+//	2. expected_seconds (= ActivePlayerCount × seconds_per_player × style_factor) at
+//	   least the existing latency budget.
+//
+// The first three sub-tests exercise shouldUpgradeToAsyncLLM directly (switch off →
+// rules; short game → rules; long game → fires). The last drives the full decide()
+// path through the async-wired loop to prove a sub-budget game NEVER fires the backend
+// (rules decided synchronously) while a long one DOES.
+
+// upgradeSnapshot is an llm-mode snapshot whose #847 call gate always admits, with the
+// #1207 upgrade switch ON and an 8s latency budget (the production default). The two
+// estimate parameters are caller-tunable per sub-test.
+func upgradeSnapshot(secondsPerPlayer, styleFactor float64) flags.Snapshot {
+	s := llmDecideSnapshot()
+	s.LLMGate.LatencyBudget = 8 * time.Second
+	s.LLMGate.InGameAsyncUpgrade = true
+	s.LLMGate.SecondsPerPlayer = secondsPerPlayer
+	s.LLMGate.StyleFactor = styleFactor
+	return s
+}
+
+// ctxWithActivePlayers builds an active real-game context whose Session.ActivePlayerCount
+// is set to n — the signal the length estimate reads.
+func ctxWithActivePlayers(n int) gamecontext.GameContext {
+	return gamecontext.GameContext{
+		SessionID: "g1",
+		GameKind:  "real",
+		Session:   gamecontext.SessionSignals{GameActive: boolPtr(true), ActivePlayerCount: &n},
+	}
+}
+
+func TestUpgradeGate_SwitchOff_RulesOnly(t *testing.T) {
+	l := NewLoop(nil, nil)
+	s := upgradeSnapshot(10, 1.0) // 8 players would easily clear the budget...
+	s.LLMGate.InGameAsyncUpgrade = false
+	// ...but the master switch is OFF, so the gate must refuse regardless of length.
+	if l.shouldUpgradeToAsyncLLM(s, ctxWithActivePlayers(8)) {
+		t.Fatal("upgrade gate fired with the master switch OFF — mode=llm must be rules-first")
+	}
+}
+
+func TestUpgradeGate_ShortGame_RulesOnly(t *testing.T) {
+	l := NewLoop(nil, nil)
+	// 2 players × 3s × 1.0 = 6s expected < 8s budget → a short (shadow-sized) game.
+	s := upgradeSnapshot(3, 1.0)
+	if l.shouldUpgradeToAsyncLLM(s, ctxWithActivePlayers(2)) {
+		t.Fatal("upgrade gate fired on a sub-budget game — short games must stay rules-only")
+	}
+}
+
+func TestUpgradeGate_LongGame_Fires(t *testing.T) {
+	l := NewLoop(nil, nil)
+	// 8 players × 3s × 1.0 = 24s expected ≥ 8s budget → a long endurance game.
+	s := upgradeSnapshot(3, 1.0)
+	if !l.shouldUpgradeToAsyncLLM(s, ctxWithActivePlayers(8)) {
+		t.Fatal("upgrade gate refused a game whose expected length clears the budget")
+	}
+}
+
+// TestUpgradeGate_BoundaryExactlyBudgetFires pins the inclusive comparison: an estimate
+// EXACTLY equal to the budget fires (expected_seconds ≥ budget).
+func TestUpgradeGate_BoundaryExactlyBudgetFires(t *testing.T) {
+	l := NewLoop(nil, nil)
+	// 4 players × 2s × 1.0 = 8s == 8s budget.
+	s := upgradeSnapshot(2, 1.0)
+	if !l.shouldUpgradeToAsyncLLM(s, ctxWithActivePlayers(4)) {
+		t.Fatal("upgrade gate refused an estimate EXACTLY at the budget (comparison must be ≥)")
+	}
+}
+
+// TestUpgradeGate_StyleFactorShiftsCrossover shows the style knob moving the decision:
+// the same 2-player game is rules-only at the balanced 1.0 factor but fires at the
+// aggressive 1.5 factor (2 × 3 × 1.5 = 9 ≥ 8).
+func TestUpgradeGate_StyleFactorShiftsCrossover(t *testing.T) {
+	l := NewLoop(nil, nil)
+	if l.shouldUpgradeToAsyncLLM(upgradeSnapshot(3, 1.0), ctxWithActivePlayers(2)) {
+		t.Fatal("balanced style_factor should keep the 2-player game rules-only")
+	}
+	if !l.shouldUpgradeToAsyncLLM(upgradeSnapshot(3, 1.5), ctxWithActivePlayers(2)) {
+		t.Fatal("aggressive style_factor should let the 2-player game upgrade to LLM")
+	}
+}
+
+// TestExpectedGameSeconds_FallsBackToPlayerCount proves the nil-ActivePlayerCount
+// fallback uses len(c.Players).
+func TestExpectedGameSeconds_FallsBackToPlayerCount(t *testing.T) {
+	c := gamecontext.GameContext{
+		Players: map[string]*gamecontext.PlayerSignals{
+			"A": {Serial: "A"},
+			"B": {Serial: "B"},
+			"C": {Serial: "C"},
+		},
+	}
+	// ActivePlayerCount is nil → fall back to 3 known players: 3 × 3 × 1 = 9.
+	if got := expectedGameSeconds(c, 3, 1.0); got != 9 {
+		t.Fatalf("expectedGameSeconds with nil ActivePlayerCount = %v, want 9 (len(Players) fallback)", got)
+	}
+	// With ActivePlayerCount set it takes precedence over the map size: 5 × 3 × 1 = 15.
+	n := 5
+	c.Session.ActivePlayerCount = &n
+	if got := expectedGameSeconds(c, 3, 1.0); got != 15 {
+		t.Fatalf("expectedGameSeconds with ActivePlayerCount=5 = %v, want 15", got)
+	}
+}
+
+// TestUpgradeGate_DecidePath_ShortGameRulesOnly drives the FULL decide() path through an
+// async-wired loop: a sub-budget game must NOT fire the backend — the rules engine
+// decides synchronously this very cycle (rules-first).
+func TestUpgradeGate_DecidePath_ShortGameRulesOnly(t *testing.T) {
+	be := newBlockingBackend("phi4-mini", validShieldResponse)
+	provider := newFakeContextProvider()
+	provider.set("g1", ctxWithActivePlayers(2))
+	// 2 players × 3s × 1.0 = 6s < 8s budget.
+	l, _, sink := asyncLoop(t, upgradeSnapshot(3, 1.0), resolverWith(be), provider, "g1",
+		[]Decision{{Intervention: "grant_shield", Reason: "from rules"}})
+
+	l.OnEvaluate(context.Background(), ctxWithActivePlayers(2), testTrigger())
+	l.AwaitInflight()
+
+	if be.callCount() != 0 {
+		t.Fatalf("backend Infer calls = %d, want 0 (short game must be rules-only, no async fire)", be.callCount())
+	}
+	if sink.calls.Load() != 1 {
+		t.Fatalf("action sink calls = %d, want 1 (rules decided synchronously)", sink.calls.Load())
+	}
+}
+
+// TestUpgradeGate_DecidePath_LongGameFires is the positive twin: a game whose estimate
+// clears the budget DOES fire the async backend.
+func TestUpgradeGate_DecidePath_LongGameFires(t *testing.T) {
+	be := newBlockingBackend("phi4-mini", validShieldResponse)
+	provider := newFakeContextProvider()
+	provider.set("g1", ctxWithActivePlayers(8))
+	// 8 players × 3s × 1.0 = 24s ≥ 8s budget.
+	l, _, _ := asyncLoop(t, upgradeSnapshot(3, 1.0), resolverWith(be), provider, "g1", nil)
+
+	l.OnEvaluate(context.Background(), ctxWithActivePlayers(8), testTrigger())
+
+	// The fire happens in a goroutine; let it start, release, and join.
+	select {
+	case <-be.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("backend Infer never started — the long game did not fire the async LLM upgrade")
+	}
+	close(be.release)
+	l.AwaitInflight()
+
+	if be.callCount() != 1 {
+		t.Fatalf("backend Infer calls = %d, want 1 (long game fires the async LLM upgrade)", be.callCount())
+	}
+}
+
+// TestUpgradeGate_LateLLMIsSeparateIntervention_RateLimited is the #1207 double-fire
+// proof and the reversal of reason fork (B) in async_infer.go:24-49. On a long game the
+// async LLM upgrade fires; its late result lands AFTER rules could already have acted in
+// a prior cycle, and it dispatches through the SAME runDecision chain as its OWN
+// intervention — INTENDED, and bounded by policy.max_interventions_per_minute. Here the
+// single rate slot is pre-spent (modeling the prior rules intervention), so the late LLM
+// result is rate-limited at apply time and discarded: the limiter — not a new suppression
+// rule — is what bounds the second fire within one context.
+func TestUpgradeGate_LateLLMIsSeparateIntervention_RateLimited(t *testing.T) {
+	be := newBlockingBackend("phi4-mini", validShieldResponse)
+	provider := newFakeContextProvider()
+	long := ctxWithActivePlayers(8) // 24s ≥ 8s budget → fires
+	long.Players = map[string]*gamecontext.PlayerSignals{"AAAA": {Serial: "AAAA", Active: boolPtr(true)}}
+	provider.set("g1", long)
+
+	snap := upgradeSnapshot(3, 1.0)
+	snap.Policy.MaxInterventionsPerMinute = 1 // one weighted slot shared by rules + late LLM
+	clock := time.Unix(5000, 0)
+	l, sr, sink := asyncLoop(t, snap, resolverWith(be), provider, "g1", nil)
+	l.now = func() time.Time { return clock }
+
+	// Model the EARLIER rules intervention having already consumed the single slot. The
+	// late LLM result is a SECOND fire in the same context; the rate limiter must bound it.
+	if !l.limiter.allow(clock, interventionCost("grant_shield"), 1) {
+		t.Fatal("expected the first (rules) slot to be available")
+	}
+
+	l.OnEvaluate(context.Background(), long, testTrigger())
+	close(be.release)
+	l.AwaitInflight()
+
+	if sink.calls.Load() != 0 {
+		t.Errorf("action sink calls = %d, want 0 (late LLM is a separate intervention, rate-bounded)", sink.calls.Load())
+	}
+	if be.callCount() != 1 {
+		t.Errorf("backend Infer calls = %d, want 1 (the upgrade DID fire; the limiter bounds the apply)", be.callCount())
+	}
+	// The late result went through the runDecision chain and was bounded by the limiter,
+	// not suppressed by a new in-context rule.
+	assertDiscard(t, sr, DiscardRateLimited)
+}

--- a/services/agent/flags/flags.go
+++ b/services/agent/flags/flags.go
@@ -48,6 +48,23 @@ const (
 	// cycle like the other gate flags so the budget can be tuned live on stage.
 	keyLLMLatencyBudget = "llm.latency_budget_seconds"
 
+	// In-game rules-first async upgrade (#1207). Default behavior for mode="llm" is
+	// now RULES-FIRST/immediate; the in-game LLM is demoted to an explicit,
+	// length-gated async UPGRADE layered UNDER mode="llm" (no third mode). Read every
+	// cycle like the other gate flags so the switch and the estimate parameters can be
+	// tuned live on stage. The two numeric flags MUST use the TYPED getters — a numeric
+	// flag read via ObjectValue silently TYPE_MISMATCHes to its default (see the gotcha
+	// at llmGate).
+	//
+	//	keyLLMInGameAsyncUpgrade — master switch (bool, default off). When off, mode="llm"
+	//	    short-circuits to rules every in-game cycle: no async LLM is ever fired in game.
+	//	keyLLMSecondsPerPlayer   — per-player time budget for the length estimate (number).
+	//	keyLLMStyleFactor        — "balanced<->aggressive" knob scaling the expected length
+	//	    (number), shifting how often the LLM upgrade gets to weigh in.
+	keyLLMInGameAsyncUpgrade = "llm.in_game_async_upgrade"
+	keyLLMSecondsPerPlayer   = "llm.seconds_per_player"
+	keyLLMStyleFactor        = "llm.style_factor"
+
 	// M7-2 rolling game context window (#929). How many recent game summaries the
 	// agent injects into EVERY llm prompt as the cross-game narrative context block.
 	// Read EVERY cycle (never cached) on the decision hot path — exactly like the
@@ -184,6 +201,28 @@ const (
 	// healthy backend to answer, short enough that a hung tier degrades to rules
 	// within one decision interval.
 	DefaultLLMLatencyBudgetSeconds = 8.0
+
+	// In-game rules-first async upgrade defaults (#1207), mirroring the
+	// services/flagd/agent.json defaultVariants. Applied when flagd is unreachable or a
+	// flag is undefined.
+
+	// DefaultLLMInGameAsyncUpgrade is the master-switch default: OFF. A fresh
+	// deployment or an unreachable flagd keeps mode="llm" RULES-FIRST in game and never
+	// fires the async LLM upgrade — the operator opts in by setting the flag. This is
+	// fail-closed to the immediate, deterministic rules path.
+	DefaultLLMInGameAsyncUpgrade = false
+	// DefaultLLMSecondsPerPlayer is the per-player time budget for the length estimate
+	// (llm.seconds_per_player). expected_seconds = ActivePlayerCount × seconds_per_player
+	// × style_factor; the async LLM upgrade fires only when expected_seconds is at least
+	// the latency budget (default 8s). At 3s/player the cross-over is ~3 players at
+	// style_factor 1.0, so a 2p/6s shadow stays rules-only while an 8p endurance game
+	// earns the upgrade.
+	DefaultLLMSecondsPerPlayer = 3.0
+	// DefaultLLMStyleFactor scales the expected length (llm.style_factor), the
+	// "balanced<->aggressive" knob: >1 lengthens the estimate so the LLM weighs in on
+	// shorter games, <1 shortens it so only longer games qualify. 1.0 is neutral.
+	DefaultLLMStyleFactor = 1.0
+
 	// DefaultLLMContextGames is the M7-2 cross-game context window size (#929): how
 	// many recent game summaries to inject into every llm prompt when flagd is
 	// unreachable or the flag is undefined. 3 mirrors the agent.json defaultVariant
@@ -384,6 +423,22 @@ type LLMGate struct {
 	// past this. Default 8s. A non-positive value falls back to the default (never
 	// "no budget", which would let a hung call leak the inference goroutine forever).
 	LatencyBudget time.Duration
+
+	// InGameAsyncUpgrade is the #1207 master switch (llm.in_game_async_upgrade). When
+	// false (the default), mode="llm" is RULES-FIRST in game: every in-game cycle
+	// short-circuits to the deterministic rules engine and no async LLM is fired. When
+	// true, the cycle additionally evaluates the length gate below and fires the async
+	// LLM upgrade only on a game long enough to absorb the latency.
+	InGameAsyncUpgrade bool
+	// SecondsPerPlayer is the per-player time budget for the length estimate
+	// (llm.seconds_per_player): expected_seconds = ActivePlayerCount × SecondsPerPlayer
+	// × StyleFactor. The async LLM upgrade fires only when expected_seconds ≥
+	// LatencyBudget, so short games stay rules-only and the latency race never bites.
+	SecondsPerPlayer float64
+	// StyleFactor scales the expected length (llm.style_factor) — the
+	// "balanced<->aggressive" knob. >1 lets the LLM weigh in on shorter games; <1
+	// reserves it for longer ones. Default 1.0 (neutral).
+	StyleFactor float64
 }
 
 // EligibleFor reports whether the given game kind may use the llm path. An empty
@@ -901,6 +956,14 @@ func (f *Flags) llmGate(ctx context.Context) LLMGate {
 		// durationFlag floors a non-positive value at the default, so a misconfigured
 		// budget can never disable the timeout and leak an inference goroutine (#917).
 		LatencyBudget: f.durationFlag(ctx, keyLLMLatencyBudget, DefaultLLMLatencyBudgetSeconds),
+		// #1207 rules-first async upgrade. The master switch reads via the bool getter;
+		// the two estimate parameters read via the float getter (the flagd numeric-flag
+		// gotcha above — a numeric flag read through ObjectValue silently TYPE_MISMATCHes
+		// to its default). All three fail closed: switch off, defaults that keep short
+		// games rules-only, so a down control plane reverts to immediate rules.
+		InGameAsyncUpgrade: f.boolFlag(ctx, keyLLMInGameAsyncUpgrade, DefaultLLMInGameAsyncUpgrade),
+		SecondsPerPlayer:   f.floatFlag(ctx, keyLLMSecondsPerPlayer, DefaultLLMSecondsPerPlayer),
+		StyleFactor:        f.floatFlag(ctx, keyLLMStyleFactor, DefaultLLMStyleFactor),
 	}
 }
 

--- a/services/flagd/agent.json
+++ b/services/flagd/agent.json
@@ -160,6 +160,32 @@
       },
       "defaultVariant": "default"
     },
+    "llm.in_game_async_upgrade": {
+      "state": "ENABLED",
+      "variants": {
+        "on": true,
+        "off": false
+      },
+      "defaultVariant": "off"
+    },
+    "llm.seconds_per_player": {
+      "state": "ENABLED",
+      "variants": {
+        "default": 3,
+        "fast": 2,
+        "slow": 5
+      },
+      "defaultVariant": "default"
+    },
+    "llm.style_factor": {
+      "state": "ENABLED",
+      "variants": {
+        "balanced": 1.0,
+        "conservative": 0.75,
+        "aggressive": 1.5
+      },
+      "defaultVariant": "balanced"
+    },
     "prompt.context_note": {
       "state": "ENABLED",
       "variants": {

--- a/services/flagd/ci/agent.json
+++ b/services/flagd/ci/agent.json
@@ -160,6 +160,32 @@
       },
       "defaultVariant": "default"
     },
+    "llm.in_game_async_upgrade": {
+      "state": "ENABLED",
+      "variants": {
+        "on": true,
+        "off": false
+      },
+      "defaultVariant": "off"
+    },
+    "llm.seconds_per_player": {
+      "state": "ENABLED",
+      "variants": {
+        "default": 3,
+        "fast": 2,
+        "slow": 5
+      },
+      "defaultVariant": "default"
+    },
+    "llm.style_factor": {
+      "state": "ENABLED",
+      "variants": {
+        "balanced": 1.0,
+        "conservative": 0.75,
+        "aggressive": 1.5
+      },
+      "defaultVariant": "balanced"
+    },
     "prompt.context_note": {
       "state": "ENABLED",
       "variants": {


### PR DESCRIPTION
## The inversion

In-game decisions are now **rules-first / immediate by default**. The async in-game LLM is demoted from "fires on every admitted `mode=\"llm\"` cycle" to an explicit, **length-gated async UPGRADE** layered *under* the existing `mode=\"llm\"` — no third mode, so the existing #847 gate / budget / trace tests stay valid.

`decide()` evaluates an upgrade gate just before `fireInferAsync`: when it fails it `return l.Rules.Evaluate(ctx, c)` (immediate rules); only on pass does it fire async exactly as before. The async plumbing, pile-up guard, re-validation, and trace wiring are untouched. Retro and proposer (already correct/off the hot path) and `async_infer.go` / `async_apply.go` core machinery were not touched.

Short real games — the only place the latency race ever bit, since shadow games are already rules-only via `llm.eligible_game_kinds` — now get an instant rules decision instead of deferring a beat to an async result that may land after the game has moved on. The shadow/real distinction becomes **emergent** from the length estimate.

## Two ratified design decisions

1. **Late-LLM = separate intervention.** No new suppression rule. When a fired upgrade's result lands after rules already acted in an earlier cycle, it dispatches through the same `runDecision` chain as its *own* intervention, bounded by the existing `policy.max_interventions_per_minute` rate limiter; the per-game `inflight` CAS still prevents concurrent fires. This intentionally **reverses reason fork (B)** documented in `async_infer.go:24-49`, and is documented inline at the gate. The double-fire-within-context is intended and rate-limited.

2. **Derived length estimate (no static table).** `expected_seconds = ActivePlayerCount × llm.seconds_per_player × llm.style_factor`. `ActivePlayerCount` comes from `Session.ActivePlayerCount`, falling back to `len(c.Players)` when nil. The async upgrade fires only when `expected_seconds >= llm.latency_budget_seconds` (the existing 8s budget). 2p/6s shadow-sized game → rules-only; 8p endurance → LLM upgrade fires.

## Three new flags (`agent.json` + `ci/agent.json`, flagSetId `agent`)

| Flag | Type | Default | Role |
|---|---|---|---|
| `llm.in_game_async_upgrade` | bool | off | master switch; off → `mode=\"llm\"` short-circuits to rules in game |
| `llm.seconds_per_player` | number | 3 | per-player time budget for the estimate |
| `llm.style_factor` | number | 1.0 | balanced↔aggressive knob scaling the expected length |

Read in `flags/flags.go` via the **typed** getters (`boolFlag` / `floatFlag`) — a numeric flag read via `ObjectValue` silently `TYPE_MISMATCH`es to its default. Key consts, `Default*` consts, and `LLMGate` fields added; reads wired into `llmGate`. (The LLM gate defaults live in `flags.go`, not `decision/config.go`, so they are mirrored there.)

## Tests

`decision/upgrade_gate_test.go` (new): switch-off → rules; sub-budget short game → rules; long game → fires; exact-budget boundary; style-factor crossover; `expectedGameSeconds` nil/fallback; full `decide()` path short-game-rules-only vs long-game-fires; and the **double-fire** path proving the late LLM result goes through `runDecision` and is bounded by the rate limiter (not a new suppression). Existing `asyncSnapshot()` updated to turn the upgrade on so the async-fire suite keeps exercising the fire path.

`gofmt -l` clean, `go vet ./...` clean, `go build ./...` clean, `go test ./...` green (decision + flags run with `-race`). Both JSON files parse with no duplicate keys.

Part of #1207

🤖 Generated with [Claude Code](https://claude.com/claude-code)