### PR TITLE
fix(agent): bump ca-certificates pin to 20260611-r0 (unblock CI)

### DIFF
--- a/services/agent/Dockerfile
+++ b/services/agent/Dockerfile
@@ -28,7 +28,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH="${TARGETARCH}" \
 FROM alpine:3.23
 
 # wget powers the compose healthcheck; ca-certificates for outbound TLS
-RUN apk add --no-cache wget=1.25.0-r2 ca-certificates=20260413-r0
+RUN apk add --no-cache wget=1.25.0-r2 ca-certificates=20260611-r0
 
 COPY --from=builder /agent /agent
 


### PR DESCRIPTION
## Problem
The agent runtime image pins `ca-certificates=20260413-r0` (`services/agent/Dockerfile:31`), but Alpine 3.23 has since rolled `ca-certificates` forward to `20260611-r0`. The old version is gone from the repo index, so `apk add` fails with `breaks: world[ca-certificates=20260413-r0]` and the agent image build dies. This breaks **Integration Tests on main** and on every PR that builds the agent image (surfaced on #1217).

## Fix
Bump the pin to the now-available `20260611-r0` (the exact version the apk solver reports as available). `wget=1.25.0-r2` still resolves and is left unchanged.

## Note
These exact patch pins drift whenever Alpine rolls the package; Renovate normally bumps them but hadn't caught this one. Consider letting Renovate own these CA-cert pins (or relaxing the patch pin) as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)