### PR TITLE
feat(agent): migrate intervention + rollout safety gates to flagd flags (#1213)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -695,10 +695,12 @@ services:
       # tests use, so writers and the served files never desync. The per-domain
       # *_FLAG_PATH overrides below still win when set (explicit escape hatch).
       - FLAGD_FLAG_DIR=/etc/flagd
-      # Action sink (#730): when enabled the agent applies decisions by rewriting
-      # the flagd interventions file in place (bind-mounted below). Default off so
-      # the scaffold stays inert.
-      - AGENT_INTERVENTIONS_ENABLED=${AGENT_INTERVENTIONS_ENABLED:-false}
+      # Action sink (#730/#1213): when the LIVE `interventions_enabled` flag
+      # (agent.json) is on the agent applies decisions by rewriting the flagd
+      # interventions file in place (bind-mounted below). The gate is a flagd flag now
+      # (migrated from AGENT_INTERVENTIONS_ENABLED, #1213) — read per Apply, fail-closed
+      # off (default variant) so the scaffold stays inert and a flagd outage never
+      # writes. Flip the flag, no restart needed.
       - INTERVENTIONS_FLAG_PATH=/etc/flagd/interventions.json
       # Demo/verification only: emit a synthetic `noop` decision (full audit
       # trace) every ~5s. Off by default; never for production sessions. With the
@@ -706,11 +708,13 @@ services:
       # (not_allowed) — flip that flag to the `probe` variant to dispatch. See
       # docs/agent-act-runbook.md.
       - AGENT_PROBE_DECISIONS=${AGENT_PROBE_DECISIONS:-}
-      # Progressive rollout expansion (#734): when enabled the agent advances the
-      # Bluetooth backend rollout controller-by-controller by rewriting the flagd
-      # rollout file in place (current_controller_count). Default off → the loop
-      # decides and spans expansions but does not apply them (dry-run).
-      - AGENT_ROLLOUT_ENABLED=${AGENT_ROLLOUT_ENABLED:-false}
+      # Progressive rollout expansion (#734/#1213): when the LIVE `rollout_enabled`
+      # flag (agent.json) is on the agent advances the Bluetooth backend rollout
+      # controller-by-controller by rewriting the flagd rollout file in place
+      # (current_controller_count). The gate is a flagd flag now (migrated from
+      # AGENT_ROLLOUT_ENABLED, #1213) — read per SetControllerCount, fail-closed off
+      # (default variant) → the loop decides and spans expansions but does not apply
+      # them (dry-run), and a flagd outage stays dry-run. Flip the flag, no restart.
       - ROLLOUT_FLAG_PATH=/etc/flagd/rollout.json
       # Auto-remediation / rollback (#736): on fitness failure during an active
       # rollout the agent rolls current_controller_count back to "none", gated on

--- a/docs/agent-act-runbook.md
+++ b/docs/agent-act-runbook.md
@@ -18,12 +18,13 @@ must both be open for an intervention to reach the game:
 
 | Gate | Where | Stock value | Act value | Restart? |
 |------|-------|-------------|-----------|----------|
-| **1. Sink** `AGENT_INTERVENTIONS_ENABLED` | compose env on the `agent` container | `false` (NoopActions — discards) | `true` (real `actions.Writer`) | **Yes** — restart `agent` |
+| **1. Sink** `interventions_enabled` | `services/flagd/agent.json` flag set (#1213) | `off` (discards — decision recorded, not written) | `on` (real `actions.Writer` writes) | **No** — flagd flag flip, re-read at use-time |
 | **2. Kill switch** `enabled` | `services/flagd/agent.json` flag domain | `off` | `on` | **No** — flagd hot-reload (<100 ms) |
 
-Both gates are also the **safe defaults** when their backing config is missing
-(flagd unreachable → `enabled=false`; env unset → NoopActions), so the agent
-always comes up **inert**.
+Both gates are also the **safe defaults** when their backing config is missing —
+**fail-closed**: flagd unreachable or the flag undefined resolves to `off` for
+both `enabled` and `interventions_enabled`, so the agent always comes up
+**inert** (#1213).
 
 The kill switch is a **flag flip** — instant, no restart. That is the demo
 panic button.
@@ -41,9 +42,10 @@ With `docker compose up`, the agent:
 - **Traces**: emits the `agent.signal_received → agent.decision → agent.action`
   audit trace whenever the engine returns ≥ 1 decision (idle cycles cost no
   spans).
-- **Dispatches nothing**: the action sink is `NoopActions`
-  (`AGENT_INTERVENTIONS_ENABLED` unset), so even a permitted, fitting decision is
-  discarded. And `enabled=off` short-circuits the loop before any rule runs,
+- **Dispatches nothing**: the sink gate `interventions_enabled` is `off`
+  (fail-closed default), so a fully-permitted, fitting decision is recorded and
+  spanned but **not written** to `interventions.json`. And `enabled=off`
+  short-circuits the loop before any rule runs,
   emitting only a throttled `agent.disabled` kill-switch trace.
 
 So the **whole OBSERVE/DECIDE/trace pipeline runs**, visible end to end in
@@ -54,21 +56,33 @@ the reason this runbook exists.
 
 ## Going live — open both gates
 
-### Step 1 — Swap in the real action sink (env, requires restart)
+### Step 1 — Open the sink gate (flag, no restart)
 
-`AGENT_INTERVENTIONS_ENABLED=true` swaps `NoopActions` for `actions.Writer`,
-which applies decisions by rewriting `services/flagd/interventions.json` in place
-(the game coordinator watches that file and converges on its contents — there is
-no gRPC from the agent to the game services). This env is read **once at
-startup**, so it requires an agent restart:
+Flipping `interventions_enabled` to `on` lets the gated sink dispatch through the
+real `actions.Writer`, which applies decisions by rewriting
+`services/flagd/interventions.json` in place (the game coordinator watches that
+file and converges on its contents — there is no gRPC from the agent to the game
+services). As of #1213 this is a **flagd flag** in the `agent` flag set, re-read
+**at use-time** (per `Apply`, never cached at startup), so flipping it takes
+effect on the next decision with **no agent restart**. It is **fail-closed**:
+`off`, undefined, or flagd unreachable → the decision is recorded and spanned but
+**not written**.
 
-```bash
-AGENT_INTERVENTIONS_ENABLED=true docker compose up -d agent
-# or set it in your .env / compose override, then:
-docker compose up -d --no-deps agent
+Edit `interventions_enabled` in `services/flagd/agent.json` — change its
+`defaultVariant` from `off` to `on` (or flip the same flag in the live flagd flag
+set):
+
+```json
+"interventions_enabled": {
+  "state": "ENABLED",
+  "variants": { "on": true, "off": false },
+  "defaultVariant": "on"
+}
 ```
 
-Confirm from the agent log:
+Save. flagd's file-watch fires within **~100 ms–1 s**; no restart. The next
+`Apply` reads `on` and writes through the real `Writer`. Confirm from the agent
+log:
 
 ```
 Agent intervention writes enabled (#730) path=/etc/flagd/interventions.json
@@ -208,7 +222,7 @@ can verify the trace pipeline without a live game. See the agent README →
   `agent.signal_received → agent.decision` spans still emit — OBSERVE→DECIDE and the
   span schema are fully exercised; only `agent.action` is withheld.
 - **Full path**: flip `interventions_allowed` to the **`probe`** variant
-  (`["noop"]`) in `agent.json`, plus `AGENT_INTERVENTIONS_ENABLED=true` and
+  (`["noop"]`) in `agent.json`, plus `interventions_enabled=on` and
   `enabled=on`. `noop` is a harmless no-op in the `Writer` (returns success
   without writing any flag), so the decision flows through every gate, reaches
   the real sink, and completes the `agent.action` span — all without changing the
@@ -278,10 +292,11 @@ Cross-reference: [agent README → Span schema (#724)](../services/agent/README.
 
 Walk the two gates plus the permission layer, in order:
 
-1. **Sink gate** — is `AGENT_INTERVENTIONS_ENABLED=true` on the `agent`
-   container, and was the container **restarted** since? The startup log must
-   show `Agent intervention writes enabled (#730)`. Without it the sink is
-   `NoopActions` and discards everything (no error, no write).
+1. **Sink gate** — is `interventions_enabled` `on` in `agent.json` (the live
+   flagd flag, #1213)? It is re-read **per `Apply`**, so a flip takes effect with
+   no restart; `off`/undefined/flagd-unreachable is **fail-closed** and discards
+   everything (decision recorded, no write — no error). The first enabled write
+   logs `Agent intervention writes enabled (#730)`.
 2. **Kill switch** — is `enabled` `on` in `agent.json`? If `off`, the loop
    short-circuits and you'll see `agent.disabled` traces (`agent.enabled=false`),
    not `agent.decision`.
@@ -332,7 +347,7 @@ The agent repairs corruption on its own:
    the file. If it no longer parses, the agent **restores the last-known-good
    snapshot** (the bytes it read at the top of that write cycle, which parsed)
    in place, and the `Apply` records `result=error`.
-2. **Startup self-heal** — on agent start (when `AGENT_INTERVENTIONS_ENABLED=true`),
+2. **Startup self-heal** — on agent start (when `interventions_enabled` is `on`),
    the agent validates the file and, if it is missing or unparseable, writes a
    **neutral document** (every flag at its neutral `defaultVariant`, empty
    targeting, no agent-driven variants — embedded in the agent binary, so it is

--- a/docs/agent-demo-runbook.md
+++ b/docs/agent-demo-runbook.md
@@ -182,8 +182,8 @@ interventions.
   the same span schema, so the demo arc is identical either way (the fallback to
   rules is itself a talking point — see act 3 / failure modes).
 - **Interventions**: with the ACT path open (see the
-  [ACT runbook](agent-act-runbook.md) — `AGENT_INTERVENTIONS_ENABLED=true` +
-  `enabled=on` + a permitting `interventions_allowed` variant), a permitted
+  [ACT runbook](agent-act-runbook.md) — `interventions_enabled=on` (flagd flag,
+  #1213) + `enabled=on` + a permitting `interventions_allowed` variant), a permitted
   decision rewrites `interventions.json` and the coordinator applies it,
   incrementing `agent_interventions_applied_total` (agent side) and
   `game_interventions_total` (coordinator side). The dedicated **Act 2b** below
@@ -215,15 +215,14 @@ matters for the demo, so it is worth narrating.
 act widens:
 
 ```bash
-# Gate 1 (sink) — env, read at startup, so this recreates the agent.
+# Gate 1 (sink) — flagd flag `interventions_enabled`, re-read at use-time (#1213),
+#   so flipping it takes effect on the next decision with NO agent restart.
 # Gate 2 (kill-switch enabled=on) + mode are handled by the enable script.
-AGENT_INTERVENTIONS_ENABLED=true \
-  docker compose \
-    -f docker-compose.yml -f docker-compose.override.yml \
-    -f docker-compose.ci.yml -f docker-compose.dry-run.yml \
-    --profile agent --profile dashboard up -d agent
+# Flip interventions_enabled -> on in services/flagd/agent.json (or the live flag):
+#   "interventions_enabled": { "defaultVariant": "on" }
+# flagd hot-reloads within ~100 ms-1 s; the next Apply writes through the real sink.
 
-# confirm the real sink is wired (not NoopActions):
+# confirm the real sink is wired (writes enabled):
 docker compose logs agent | grep 'Agent intervention writes enabled' | tail -1
 
 # Gates 2 + mode on (live flip, ~1 s, no restart):

--- a/services/agent/README.md
+++ b/services/agent/README.md
@@ -367,7 +367,8 @@ observed count returns to 0; a later failure can then trigger a fresh rollback.
 | rollback in flight (settling) | `> 0` | — | none | `none` |
 | at stable default      | `0` | — | none (nothing to roll back) | `none` |
 
-**Dry-run** (`AGENT_ROLLOUT_ENABLED=false`): the rollback is **decided and
+**Dry-run** (`rollout_enabled` flag `off` — flagd flag, #1213; the fail-closed
+default): the rollback is **decided and
 spanned** (`remediation.action="rollback"`, **`rollout.dry_run=true`**) but the
 `DryRunRolloutWriter`'s `SetControllerCount("none")` is a no-op —
 decided-but-not-applied, consistent with dry-run expansion. The `rollout.dry_run`
@@ -395,7 +396,7 @@ attribute builder** (`infraDecisionAttributes`), so **every** decision span — 
 | `fitness.passing` | bool | yes | did the Bluetooth fitness check pass this cycle |
 | `fitness.violations` | string | yes (**empty when passing**, never absent) | the failing checks, e.g. `movement_update_hz[AA:BB] 8.3<10` |
 | `remediation.action` | string | yes | `none \| expand \| rollback \| recommended_only` |
-| `rollout.dry_run` | bool | yes | did the actuator only **rehearse** this decision (no write to `rollout.json`) rather than apply it — `true` for the dry-run actuator (`AGENT_ROLLOUT_ENABLED=false`, the compose default) and when there is no actuator; `false` for the real `RolloutWriter`. Lets a trace tell a rehearsed `expand`/`rollback` apart from a real one. |
+| `rollout.dry_run` | bool | yes | did the actuator only **rehearse** this decision (no write to `rollout.json`) rather than apply it — `true` when the `rollout_enabled` flag is `off` (flagd flag, #1213; the fail-closed default, re-read per cycle) and when there is no actuator; `false` when `rollout_enabled` is `on` and the real `RolloutWriter` applies. Lets a trace tell a rehearsed `expand`/`rollback` apart from a real one. |
 
 plus the observed `bluetooth.*` window signals (`target_backend` + `rollout_count`
 always; `event_gap_ms` / `dropped_events_pct` / `movement_update_hz` /
@@ -507,10 +508,12 @@ The two decision hooks:
 - **Rules engine** (#726) — `ObjectiveRules`, the objective-weighted decision
   logic below. Active by default; its objectives are driven live by the flag.
 - **Action sink** (#730) — applies permitted intents via OpenFeature/flagd.
-  **No-op by default**: with `AGENT_INTERVENTIONS_ENABLED=true` the real
-  `actions.Writer` is wired in and dispatched decisions are written to the
-  flagd `interventions` domain (see **Action sink** below); otherwise decisions
-  are traced and discarded.
+  **No-op by default**: the gated sink consults the live `interventions_enabled`
+  flag (flagd flag, #1213; re-read per `Apply`). With it `on` the real
+  `actions.Writer` is dispatched and decisions are written to the flagd
+  `interventions` domain (see **Action sink** below); `off`/undefined/flagd-
+  unreachable is **fail-closed** — decisions are traced and discarded. Flip the
+  flag in flagd, no restart.
 
 The flags wrapper lives in [`flags/`](flags/) and uses the OpenFeature Go SDK
 with the flagd **RPC** resolver against flagd's gRPC evaluation port. Flag keys
@@ -1048,8 +1051,8 @@ variant (`["noop"]`) in [`services/flagd/agent.json`](../flagd/agent.json):
 
 `noop` is a **harmless no-op in the action sink**: the `Writer` recognizes it and
 returns success **without writing any flag** (`actions/writer.go`,
-`InterventionNoop`). So with the `probe` variant + `AGENT_INTERVENTIONS_ENABLED=true`
-+ `enabled=on`, a probe decision flows through allow-list, battery, and rate-limit
+`InterventionNoop`). So with the `probe` variant + `interventions_enabled=on`
+(flagd flag, #1213) + `enabled=on`, a probe decision flows through allow-list, battery, and rate-limit
 gates, reaches the real `Writer`, and completes the `agent.action` span — all
 without touching the game. Revert by flipping `interventions_allowed` back to
 `ambient` (or `none`).

--- a/services/agent/README.md
+++ b/services/agent/README.md
@@ -304,9 +304,9 @@ failure sets the span status to error and records the error.
 
 **Env gates:**
 
-| Env | Default | Effect |
+| Env / flag | Default | Effect |
 |-----|---------|--------|
-| `AGENT_ROLLOUT_ENABLED` | `false` | `true` → real `RolloutWriter` applies flips (`rollout.dry_run=false`). `false` → **dry-run**: the loop still decides and spans expansions (`remediation.action="expand"`, `rollout.controller_count` set, **`rollout.dry_run=true`**) but does **not** write `rollout.json` (decided-but-not-applied; logged `agent.rollout_dry_run`). |
+| `rollout_enabled` (**flagd flag**, `agent.json`) | `off` | **#1213: migrated from the `AGENT_ROLLOUT_ENABLED` env var to a LIVE flag**, read per `SetControllerCount`/`DryRun` (never cached at startup). `on` → real `RolloutWriter` applies flips (`rollout.dry_run=false`). `off` (or flagd unreachable — **fail-closed**) → **dry-run**: the loop still decides and spans expansions (`remediation.action="expand"`, `rollout.controller_count` set, **`rollout.dry_run=true`**) but does **not** write `rollout.json` (decided-but-not-applied; logged `agent.rollout_dry_run`). Flip the flag in flagd, no restart. |
 | `ROLLOUT_FLAG_PATH` | `/etc/flagd/rollout.json` | rollout flag file path (read for `remediation_allowed`, written on expand/rollback) |
 | `AGENT_ROLLOUT_DWELL_SECONDS` | `15` | per-stage dwell before re-expansion |
 | `AGENT_ROLLOUT_COOLDOWN_SECONDS` | `30` | post-rollback cooldown: re-expansion is suppressed this long after a rollback |
@@ -937,7 +937,7 @@ All configuration is via environment variables:
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | set in compose | Self-telemetry export (decision audit traces → collector → Jaeger); no-op when unset |
 | `OTEL_SERVICE_NAME` | `agent` | Service identity; also drives the self-ingestion skip |
 | `AGENT_PROBE_DECISIONS` | _unset_ | `true` enables the demo/verification probe: a synthetic `noop` decision (and thus a full audit trace) at most every 5 s. Never for production sessions. See [Probe mode](#probe-mode-agent_probe_decisions) |
-| `AGENT_INTERVENTIONS_ENABLED` | `false` | `true` swaps the no-op action sink for the real intervention **Writer** (#730). Default off keeps the scaffold inert |
+| `interventions_enabled` (**flagd flag**, `agent.json`) | `off` | **#1213: migrated from the `AGENT_INTERVENTIONS_ENABLED` env var to a LIVE flag**, read per `Apply` against the live `Flags` (never cached at startup). `on` → the gated action sink writes a fully-permitted decision to the interventions file via the real **Writer** (#730); `off` (or flagd unreachable — **fail-closed**) → the decision is still recorded/spanned but **not** written (inert scaffold). Distinct from the `enabled` kill switch (gates whether the loop **decides**) and `interventions_allowed` (gates **which** intervention types may dispatch); this gates whether a permitted decision is **applied**. Flip the flag in flagd, no restart. |
 | `INTERVENTIONS_FLAG_PATH` | `/etc/flagd/interventions.json` | Path of the flagd interventions file the Writer rewrites (must be the bind-mounted file flagd watches) |
 | `AGENT_GAME_SUMMARY_DIR` | `/var/lib/joustmania/agent/summaries` | Directory the M7-1 game narrative builder (#928) writes one JSON game summary per game into (real **and** shadow), created if missing; atomic temp+rename so a reader never sees a partial file |
 | `AGENT_EXPERIMENTS_ENABLED` | `false` | **Bootstrap default for the live `experiments_enabled` flag** gating the #991 experiment cohort loop (epic #982). When on, the `experiment.Registry` (built with the real spawner/targeting/verdict/promoter seams) runs the declare→spawn→conclude→verdict→(gated)promote loop. Since #1044 the loop is always built + run and self-gates on the live flag; **default off ⇒ the loop is behaviorally inert — no shadow spawns, no targeting writes, no promotions (the only residual work is one ~30 s no-op tick).** Promotion still routes through the existing `code_improvement` gates + kill-switch |
@@ -1174,8 +1174,10 @@ A run gets an `agent.shadow_game.run` span with `run_id`, `mode`, `game_id`,
 
 ### Trigger (env, one-shot)
 
-The trigger is intentionally minimal — one env-gated path, mirroring
-`AGENT_INTERVENTIONS_ENABLED` / `AGENT_ROLLOUT_ENABLED`. When
+The trigger is intentionally minimal — one env-gated path. It mirrors the
+original env-gate shape the actuation gates used before **#1213** migrated those
+two to LIVE `agent.json` flags (`interventions_enabled` / `rollout_enabled`);
+`AGENT_SHADOW_GAME` is a one-shot startup trigger, so it stays an env var. When
 `AGENT_SHADOW_GAME=true`, the agent sweeps orphans then runs ONE shadow game at
 startup, then continues its normal observe loop.
 

--- a/services/agent/action_sink_test.go
+++ b/services/agent/action_sink_test.go
@@ -1,44 +1,68 @@
 package main
 
 import (
+	"context"
 	"io"
 	"log/slog"
 	"testing"
 
 	"github.com/joustmania/agent/actions"
+	"github.com/joustmania/agent/decision"
 )
 
 func discardLogger() *slog.Logger { return slog.New(slog.NewTextHandler(io.Discard, nil)) }
 
-// TestActionSinkDisabledByDefault: with the env var unset the agent stays inert
-// (nil sink -> loop keeps NoopActions), so the scaffold applies nothing.
-func TestActionSinkDisabledByDefault(t *testing.T) {
-	t.Setenv("AGENT_INTERVENTIONS_ENABLED", "")
-	if sink := actionSink(discardLogger()); sink != nil {
-		t.Fatalf("expected nil sink when disabled, got %T", sink)
-	}
-}
+// fakeGate is a static InterventionGate/RolloutGate for the wiring tests: it
+// reports a constant gate value regardless of context, standing in for the live
+// *flags.Flags.
+type fakeGate bool
 
-func TestActionSinkDisabledOnFalse(t *testing.T) {
-	t.Setenv("AGENT_INTERVENTIONS_ENABLED", "false")
-	if sink := actionSink(discardLogger()); sink != nil {
-		t.Fatalf("expected nil sink when false, got %T", sink)
-	}
-}
+func (g fakeGate) InterventionsEnabled(context.Context) bool { return bool(g) }
+func (g fakeGate) RolloutEnabled(context.Context) bool       { return bool(g) }
 
-// TestActionSinkEnabled: AGENT_INTERVENTIONS_ENABLED=true wires the real Writer.
-func TestActionSinkEnabled(t *testing.T) {
-	t.Setenv("AGENT_INTERVENTIONS_ENABLED", "true")
+// TestActionSinkIsLiveGated: post-#1213 the sink wiring ALWAYS returns a
+// GatedActionSink (the gate is read per Apply against the live flag), never nil and
+// never a bare *Writer. The startup-time AGENT_INTERVENTIONS_ENABLED env gate is
+// gone — the gate moved into the sink and is read live.
+func TestActionSinkIsLiveGated(t *testing.T) {
 	t.Setenv("INTERVENTIONS_FLAG_PATH", "/tmp/does-not-matter.json")
-	sink := actionSink(discardLogger())
-	if _, ok := sink.(*actions.Writer); !ok {
-		t.Fatalf("expected *actions.Writer when enabled, got %T", sink)
+	sink := actionSink(fakeGate(true), discardLogger())
+	if _, ok := sink.(*actions.GatedActionSink); !ok {
+		t.Fatalf("expected *actions.GatedActionSink from the live-gated wiring, got %T", sink)
 	}
 }
 
-func TestActionSinkEnabledCaseInsensitive(t *testing.T) {
-	t.Setenv("AGENT_INTERVENTIONS_ENABLED", "TRUE")
-	if sink := actionSink(discardLogger()); sink == nil {
-		t.Fatal("expected non-nil sink for TRUE")
+// TestActionSinkGateOffSuppressesApply: with the live gate OFF (the fail-closed
+// default state, and what a flagd outage resolves to) the gated sink applies
+// nothing — exactly the inert-scaffold behavior the old env default produced.
+func TestActionSinkGateOffSuppressesApply(t *testing.T) {
+	t.Setenv("INTERVENTIONS_FLAG_PATH", "/tmp/does-not-matter.json")
+	sink := actionSink(fakeGate(false), discardLogger())
+	// A bad path would error on a real write; the gate-off path must short-circuit
+	// BEFORE the writer is ever called, so Apply returns nil without touching disk.
+	if err := sink.Apply(context.Background(), decision.Decision{Intervention: "audio_cue"}); err != nil {
+		t.Fatalf("gate-off Apply should be a no-op, got error: %v", err)
+	}
+}
+
+// TestRolloutActuatorIsLiveGated: post-#1213 the rollout wiring ALWAYS returns a
+// GatedRolloutActuator (the gate is read per SetControllerCount/DryRun against the
+// live flag), never a bare RolloutWriter or a fixed DryRunRolloutWriter.
+func TestRolloutActuatorIsLiveGated(t *testing.T) {
+	act := rolloutActuator(context.Background(), fakeGate(true), discardLogger())
+	if _, ok := act.(*actions.GatedRolloutActuator); !ok {
+		t.Fatalf("expected *actions.GatedRolloutActuator from the live-gated wiring, got %T", act)
+	}
+}
+
+// TestRolloutActuatorDryRunTracksGate: DryRun() reflects the LIVE gate state, not a
+// boot-time snapshot. Gate off (fail-closed default / flagd outage) ⇒ dry-run true;
+// gate on ⇒ dry-run false.
+func TestRolloutActuatorDryRunTracksGate(t *testing.T) {
+	if off := rolloutActuator(context.Background(), fakeGate(false), discardLogger()); !off.DryRun() {
+		t.Fatal("gate OFF must report DryRun()=true (rehearsal)")
+	}
+	if on := rolloutActuator(context.Background(), fakeGate(true), discardLogger()); on.DryRun() {
+		t.Fatal("gate ON must report DryRun()=false (applied)")
 	}
 }

--- a/services/agent/actions/gated.go
+++ b/services/agent/actions/gated.go
@@ -1,0 +1,135 @@
+package actions
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/joustmania/agent/decision"
+)
+
+// InterventionGate resolves the LIVE interventions_enabled safety gate (#1213) at
+// USE-TIME. *flags.Flags satisfies it via InterventionsEnabled; tests supply a
+// fake. It is read on EVERY Apply (never cached at construction) so flipping the
+// flag in flagd starts/stops actuation with no restart, and a flagd outage at the
+// moment of an apply FAILS CLOSED (InterventionsEnabled returns the fail-closed
+// default false) so the agent never writes interventions.json when it cannot
+// confirm the gate is on (#1177/#1217).
+type InterventionGate interface {
+	InterventionsEnabled(ctx context.Context) bool
+}
+
+// RolloutGate resolves the LIVE rollout_enabled safety gate (#1213) at USE-TIME.
+// *flags.Flags satisfies it via RolloutEnabled; tests supply a fake. It is read on
+// every SetControllerCount and DryRun call (never cached) so flipping the flag in
+// flagd starts/stops applying with no restart, and a flagd outage FAILS CLOSED
+// (RolloutEnabled returns false ⇒ dry-run) so the agent never flips the rollout
+// stage when it cannot confirm the gate is on (#1177/#1217).
+type RolloutGate interface {
+	RolloutEnabled(ctx context.Context) bool
+}
+
+// GatedActionSink wraps the real intervention Writer behind the LIVE
+// interventions_enabled flag (#1213). It REPLACES the old startup-time
+// AGENT_INTERVENTIONS_ENABLED env gate (which selected the Writer-or-nil sink ONCE
+// in main.go and so could never react to a flag flip and failed open to whatever
+// sink was chosen at boot). Apply re-evaluates the gate per decision against the
+// live Flags: when on it delegates to the real Writer; when off (or flagd
+// unreachable) it discards the decision exactly like NoopActions, so a fully-gated,
+// decided intervention is still recorded/spanned by the loop but never applied.
+type GatedActionSink struct {
+	gate   InterventionGate
+	writer decision.ActionSink
+	log    *slog.Logger
+}
+
+// NewGatedActionSink wraps writer behind gate. writer is the real sink applied when
+// the gate is on (typically *Writer); gate is the live interventions_enabled
+// source. log nil → slog.Default().
+func NewGatedActionSink(gate InterventionGate, writer decision.ActionSink, log *slog.Logger) *GatedActionSink {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &GatedActionSink{gate: gate, writer: writer, log: log}
+}
+
+// Apply evaluates the LIVE interventions_enabled gate (#1213) and delegates to the
+// real writer only when it is on; otherwise it is a no-op (the decision was already
+// recorded/spanned by the loop). Fail-closed: a flagd error inside the gate
+// resolves to false, so the agent does NOT write when the control plane is
+// unreachable.
+func (s *GatedActionSink) Apply(ctx context.Context, d decision.Decision) error {
+	if !s.gate.InterventionsEnabled(ctx) {
+		s.log.Debug("agent.intervention_gated_off",
+			"intervention", d.Intervention, "flag", keyInterventionsEnabledLog)
+		return nil
+	}
+	return s.writer.Apply(ctx, d)
+}
+
+// keyInterventionsEnabledLog is the flag key surfaced in the gated-off log line.
+// Mirrors flags.keyInterventionsEnabled (kept local so actions does not need the
+// flags key const exported).
+const keyInterventionsEnabledLog = "interventions_enabled"
+
+// GatedRolloutActuator wraps the real RolloutWriter behind the LIVE rollout_enabled
+// flag (#1213). It REPLACES the old startup-time AGENT_ROLLOUT_ENABLED env gate
+// (which selected RolloutWriter-or-DryRunRolloutWriter ONCE in main.go). On every
+// SetControllerCount it re-evaluates the gate: when on it delegates the real flip to
+// the wrapped RolloutWriter; when off (or flagd unreachable) it is a dry-run — it
+// logs the would-be flip and writes nothing. DryRun() likewise reports the LIVE gate
+// state, so the loop stamps rollout.dry_run correctly per cycle.
+//
+// rootCtx is the agent's long-lived context, used to evaluate the gate (rollout
+// flips happen on the infra loop's own goroutine, which has no per-decision ctx like
+// the ActionSink does). The ladder helpers delegate to the wrapped writer (the
+// value↔variant mapping stays single-sourced).
+type GatedRolloutActuator struct {
+	rootCtx context.Context
+	gate    RolloutGate
+	writer  *RolloutWriter
+	dry     *DryRunRolloutWriter
+	log     *slog.Logger
+}
+
+// NewGatedRolloutActuator wraps writer behind gate, evaluating against rootCtx. log
+// nil → slog.Default().
+func NewGatedRolloutActuator(rootCtx context.Context, gate RolloutGate, writer *RolloutWriter, log *slog.Logger) *GatedRolloutActuator {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &GatedRolloutActuator{
+		rootCtx: rootCtx,
+		gate:    gate,
+		writer:  writer,
+		dry:     NewDryRunRolloutWriter(log),
+		log:     log,
+	}
+}
+
+// SetControllerCount delegates to the real writer when the LIVE rollout_enabled gate
+// is on; otherwise it is a dry-run (logs, writes nothing). Fail-closed: a flagd
+// error inside the gate resolves to false ⇒ dry-run.
+func (a *GatedRolloutActuator) SetControllerCount(variant string) error {
+	if !a.gate.RolloutEnabled(a.rootCtx) {
+		return a.dry.SetControllerCount(variant)
+	}
+	return a.writer.SetControllerCount(variant)
+}
+
+// NextStage / StageVariantForValue delegate to the wrapped writer so the
+// value↔variant ladder mapping is single-sourced regardless of the gate.
+func (a *GatedRolloutActuator) NextStage(current int) (variant string, value int, ok bool) {
+	return a.writer.NextStage(current)
+}
+
+func (a *GatedRolloutActuator) StageVariantForValue(value int) (string, bool) {
+	return a.writer.StageVariantForValue(value)
+}
+
+// DryRun reports the LIVE gate state: true (rehearsal) when rollout_enabled is off
+// or flagd is unreachable, false (applied) when it is on. The loop lifts this onto
+// every rollout decision span as rollout.dry_run, so a Jaeger consumer sees the
+// CURRENT gate state per cycle, not a boot-time snapshot.
+func (a *GatedRolloutActuator) DryRun() bool {
+	return !a.gate.RolloutEnabled(a.rootCtx)
+}

--- a/services/agent/actions/gated_test.go
+++ b/services/agent/actions/gated_test.go
@@ -1,0 +1,98 @@
+package actions
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/joustmania/agent/decision"
+)
+
+// staticGate is a constant InterventionGate/RolloutGate for the gated-wrapper unit
+// tests.
+type staticGate bool
+
+func (g staticGate) InterventionsEnabled(context.Context) bool { return bool(g) }
+func (g staticGate) RolloutEnabled(context.Context) bool       { return bool(g) }
+
+// recordingSink records whether Apply was called (the real Writer stand-in for the
+// intervention-gate tests).
+type recordingSink struct {
+	applied bool
+	err     error
+}
+
+func (r *recordingSink) Apply(context.Context, decision.Decision) error {
+	r.applied = true
+	return r.err
+}
+
+// TestGatedActionSink_GateOff_NoApply: with the gate OFF (the fail-closed default,
+// and what a flagd outage resolves to) the gated sink does NOT call the wrapped
+// writer and returns nil — a decided, fully-gated intervention is never written.
+func TestGatedActionSink_GateOff_NoApply(t *testing.T) {
+	inner := &recordingSink{}
+	sink := NewGatedActionSink(staticGate(false), inner, nil)
+	if err := sink.Apply(context.Background(), decision.Decision{Intervention: "audio_cue"}); err != nil {
+		t.Fatalf("gate-off Apply must be a no-op, got %v", err)
+	}
+	if inner.applied {
+		t.Fatal("gate-off Apply must NOT call the wrapped writer")
+	}
+}
+
+// TestGatedActionSink_GateOn_Delegates: with the gate ON the gated sink delegates to
+// the wrapped writer (and propagates its error).
+func TestGatedActionSink_GateOn_Delegates(t *testing.T) {
+	sentinel := errors.New("write failed")
+	inner := &recordingSink{err: sentinel}
+	sink := NewGatedActionSink(staticGate(true), inner, nil)
+	if err := sink.Apply(context.Background(), decision.Decision{Intervention: "audio_cue"}); !errors.Is(err, sentinel) {
+		t.Fatalf("gate-on Apply must delegate (and propagate the writer error), got %v", err)
+	}
+	if !inner.applied {
+		t.Fatal("gate-on Apply must call the wrapped writer")
+	}
+}
+
+// TestGatedRolloutActuator_GateOff_DryRun: with the gate OFF SetControllerCount is a
+// dry-run (no write — it tolerates a non-existent path) and DryRun() reports true.
+func TestGatedRolloutActuator_GateOff_DryRun(t *testing.T) {
+	// A path that does NOT exist: the real writer would error on a read-modify-write,
+	// so a nil error proves the gate short-circuited to the dry-run path.
+	w := NewRolloutWriter("/nonexistent/dir/rollout.json", nil)
+	act := NewGatedRolloutActuator(context.Background(), staticGate(false), w, nil)
+	if !act.DryRun() {
+		t.Fatal("gate OFF must report DryRun()=true")
+	}
+	if err := act.SetControllerCount(StageOneVariant); err != nil {
+		t.Fatalf("gate-off SetControllerCount must be a dry-run no-op, got %v", err)
+	}
+}
+
+// TestGatedRolloutActuator_GateOn_Applies: with the gate ON DryRun() reports false
+// and SetControllerCount delegates to the real writer (which errors on a bad path,
+// proving the write was actually attempted rather than rehearsed).
+func TestGatedRolloutActuator_GateOn_Applies(t *testing.T) {
+	w := NewRolloutWriter("/nonexistent/dir/rollout.json", nil)
+	act := NewGatedRolloutActuator(context.Background(), staticGate(true), w, nil)
+	if act.DryRun() {
+		t.Fatal("gate ON must report DryRun()=false")
+	}
+	if err := act.SetControllerCount(StageOneVariant); err == nil {
+		t.Fatal("gate-on SetControllerCount must attempt the real write (and error on the bad path)")
+	}
+}
+
+// TestGatedRolloutActuator_LadderDelegates: the ladder helpers delegate to the
+// wrapped writer regardless of gate state, so the value↔variant mapping stays
+// single-sourced.
+func TestGatedRolloutActuator_LadderDelegates(t *testing.T) {
+	act := NewGatedRolloutActuator(context.Background(), staticGate(false), NewRolloutWriter("", nil), nil)
+	if v, val, ok := act.NextStage(StageNoneValue); !ok || v != StageOneVariant || val != StageOneValue {
+		t.Fatalf("NextStage(none) = (%q,%d,%v), want (one,1,true)", v, val, ok)
+	}
+	if v, ok := act.StageVariantForValue(StageThreeValue); !ok || v != StageThreeVariant {
+		t.Fatalf("StageVariantForValue(3) = (%q,%v), want (three,true)", v, ok)
+	}
+}

--- a/services/agent/actions/rollout_writer.go
+++ b/services/agent/actions/rollout_writer.go
@@ -218,8 +218,9 @@ func (w *RolloutWriter) DryRun() bool { return false }
 
 // DryRunRolloutWriter satisfies the same actuator seam as RolloutWriter but
 // NEVER writes the rollout file: SetControllerCount logs the would-be flip and
-// returns nil. It is the disabled-mode (AGENT_ROLLOUT_ENABLED=false) actuator —
-// the loop still decides and spans the expansion (remediation.action="expand"),
+// returns nil. It is the disabled-mode actuator (the LIVE rollout_enabled flag off,
+// #1213; GatedRolloutActuator delegates here when the gate is off) — the loop still
+// decides and spans the expansion (remediation.action="expand"),
 // it just is not applied. The ladder helpers delegate to the real package
 // functions, so the value↔variant mapping stays single-sourced.
 type DryRunRolloutWriter struct {

--- a/services/agent/decision/infra_loop.go
+++ b/services/agent/decision/infra_loop.go
@@ -211,9 +211,10 @@ type InfraLoop struct {
 //
 // rollout may be nil, in which case the loop NEVER expands (every active-rollout
 // cycle records remediation.action="none"); it still gates, evaluates fitness,
-// and emits the observe span. When AGENT_ROLLOUT_ENABLED is off, main.go passes a
-// dry-run actuator (real ladder, no-op write) instead, so the disabled path is
-// recorded as decided-but-not-applied rather than not-decided.
+// and emits the observe span. main.go always passes a GatedRolloutActuator (#1213):
+// it dry-runs (real ladder, no-op write) whenever the LIVE rollout_enabled flag is
+// off or flagd is unreachable, so the disabled path is recorded as
+// decided-but-not-applied rather than not-decided.
 func NewInfraLoop(log *slog.Logger, dwell time.Duration, fitness BluetoothFitnessSource, rollout RolloutActuator) *InfraLoop {
 	if log == nil {
 		log = slog.Default()

--- a/services/agent/decision/infra_telemetry.go
+++ b/services/agent/decision/infra_telemetry.go
@@ -37,9 +37,9 @@ const (
 	// back the rollout); the infra-domain parallel to AttrDecisionAction.
 	AttrRemediationAction = "remediation.action"
 	// AttrRolloutDryRun is whether the actuator only REHEARSED the decision (true)
-	// rather than applying it to rollout.json (false). True for the dry-run
-	// actuator (AGENT_ROLLOUT_ENABLED=false, the compose default) and for a nil
-	// actuator (the loop never writes); false for the real RolloutWriter. Present
+	// rather than applying it to rollout.json (false). True when the LIVE
+	// rollout_enabled flag is off (#1213; the default + fail-closed state) and for a
+	// nil actuator (the loop never writes); false when the gate is on. Present
 	// on EVERY decision span so a Jaeger consumer can tell a rehearsed
 	// expand/rollback apart from an applied one — they were otherwise identical.
 	AttrRolloutDryRun = "rollout.dry_run"

--- a/services/agent/flags/flags.go
+++ b/services/agent/flags/flags.go
@@ -159,6 +159,23 @@ const (
 	keyVerdictMinPairs             = "verdict_min_pairs"
 	keyExperimentMaxGames          = "experiment_max_games"
 	keyExperimentShadowConcurrency = "experiment_shadow_effective_concurrency"
+
+	// Runtime SAFETY gates migrated from env to agent.json flags (#1213). These
+	// were the AGENT_INTERVENTIONS_ENABLED / AGENT_ROLLOUT_ENABLED env masters read
+	// ONCE at startup in main.go to select which action sink / rollout actuator was
+	// wired (#730/#734). Migrating them to flags makes the gate hot-reloadable —
+	// flip it in flagd and the agent stops/starts ACTUATING with no restart.
+	//
+	// They are SAFETY gates, not tuning knobs: unlike the #1215 game-cap migration
+	// (fail-OPEN to a default), these MUST fail CLOSED. When flagd is undefined or
+	// unreachable the gate resolves to the NOT-ACTING state (off), matching the
+	// fail-closed env default (`:-false` in docker-compose.yml) — see DefaultInterventionsEnabled
+	// / DefaultRolloutEnabled and the per-USE wiring (not cached-at-init, #1217).
+	//
+	// Read via the TYPED bool getter (boolFlag/BooleanValue), NOT ObjectValue — a
+	// flag read via ObjectValue silently TYPE_MISMATCHes to its default (#903/#1127).
+	keyInterventionsEnabled = "interventions_enabled"
+	keyRolloutEnabled       = "rollout_enabled"
 )
 
 // Safe defaults applied when flagd is unreachable or a flag is undefined.
@@ -338,6 +355,25 @@ const (
 	// agent.disabled span are emitted (decision.throttle_seconds; was decision.go
 	// throttleInterval = 1s).
 	DefaultDecisionThrottleSeconds = 1.0
+
+	// Runtime SAFETY-gate defaults (#1213), mirroring the services/flagd/agent.json
+	// interventions_enabled / rollout_enabled defaultVariants AND the fail-closed
+	// env default these replace (AGENT_INTERVENTIONS_ENABLED / AGENT_ROLLOUT_ENABLED,
+	// both `:-false` in docker-compose.yml). These defaults are deliberately the SAFE
+	// state, applied when flagd is undefined or UNREACHABLE (#1177): a missing/down
+	// control plane must NOT actuate — the agent does not write interventions.json /
+	// does not flip the rollout stage. Fail CLOSED, never fail open to acting.
+
+	// DefaultInterventionsEnabled is fail-closed OFF: when flagd is unreachable the
+	// agent's ActionSink does NOT write interventions.json — a decided, fully-gated
+	// intervention is RECORDED/spanned but never applied (the no-op sink behavior the
+	// old AGENT_INTERVENTIONS_ENABLED=false produced).
+	DefaultInterventionsEnabled = false
+	// DefaultRolloutEnabled is fail-closed OFF: when flagd is unreachable the rollout
+	// actuator is a DRY-RUN — the infra loop still decides+spans the expansion
+	// (rollout.dry_run=true) but never flips current_controller_count in rollout.json
+	// (the old AGENT_ROLLOUT_ENABLED=false behavior).
+	DefaultRolloutEnabled = false
 )
 
 // defaultObjectives is the fallback objectives weighting. Returned as a fresh
@@ -835,6 +871,34 @@ func (f *Flags) BluetoothFitness(ctx context.Context) BluetoothFitness {
 		MaxDroppedEventsPct: f.floatFlag(ctx, keyBluetoothMaxDroppedEventsPct, DefaultBluetoothMaxDroppedEventsPct),
 		MinMovementUpdateHz: f.floatFlag(ctx, keyBluetoothMinMovementUpdateHz, DefaultBluetoothMinMovementUpdateHz),
 	}
+}
+
+// InterventionsEnabled resolves the runtime intervention-actuation gate (#1213,
+// interventions_enabled). It is the migrated AGENT_INTERVENTIONS_ENABLED env
+// master: when true the agent's ActionSink WRITES decisions to interventions.json;
+// when false (or flagd unreachable) it records/spans the decision but applies
+// nothing. Read at USE-TIME (per Apply), NOT cached at startup — flipping the flag
+// in flagd starts/stops actuation with no restart, and a flagd outage at any moment
+// FAILS CLOSED (DefaultInterventionsEnabled=false) so the agent never writes when it
+// cannot confirm the gate is on (#1177). Distinct from the `enabled` kill switch
+// (which gates whether the loop DECIDES) and from interventions_allowed (which gates
+// WHICH intervention types may dispatch): this gates whether a fully-permitted
+// decision is actually APPLIED to disk.
+func (f *Flags) InterventionsEnabled(ctx context.Context) bool {
+	return f.boolFlag(ctx, keyInterventionsEnabled, DefaultInterventionsEnabled)
+}
+
+// RolloutEnabled resolves the runtime rollout-actuation gate (#1213,
+// rollout_enabled). It is the migrated AGENT_ROLLOUT_ENABLED env master: when true
+// the infra loop's actuator FLIPS current_controller_count in rollout.json; when
+// false (or flagd unreachable) it is a DRY-RUN — the loop decides+spans the
+// expansion (rollout.dry_run=true) but writes nothing. Read at USE-TIME (per
+// SetControllerCount / DryRun call), NOT cached at startup — flipping the flag in
+// flagd starts/stops applying with no restart, and a flagd outage at any moment
+// FAILS CLOSED (DefaultRolloutEnabled=false) so the agent never flips the rollout
+// stage when it cannot confirm the gate is on (#1177).
+func (f *Flags) RolloutEnabled(ctx context.Context) bool {
+	return f.boolFlag(ctx, keyRolloutEnabled, DefaultRolloutEnabled)
 }
 
 // stringFlag resolves a string flag, falling back to def on any error.

--- a/services/agent/flags/flags_test.go
+++ b/services/agent/flags/flags_test.go
@@ -786,3 +786,66 @@ func TestExperiment_FlagOverridesEnvDefault(t *testing.T) {
 		}
 	})
 }
+
+// TestInterventionsEnabled covers the #1213 intervention safety gate: a configured
+// value resolves via the TYPED bool getter, and the gate FAILS CLOSED (off) when the
+// flag is UNDEFINED (no value) or flagd is UNREACHABLE (error). A safety gate must
+// resolve to the not-acting state when the control plane cannot confirm it is on.
+func TestInterventionsEnabled(t *testing.T) {
+	t.Run("configured on resolves", func(t *testing.T) {
+		ev := stubEvaluator{booleans: map[string]bool{keyInterventionsEnabled: true}}
+		if !New(ev, nil).InterventionsEnabled(context.Background()) {
+			t.Fatal("interventions_enabled=true must resolve true")
+		}
+	})
+	t.Run("undefined flag fails closed (off)", func(t *testing.T) {
+		// No value set for the key -> stub returns the passed default
+		// (DefaultInterventionsEnabled=false). This is the fail-closed safe state.
+		ev := stubEvaluator{}
+		if New(ev, nil).InterventionsEnabled(context.Background()) {
+			t.Fatal("an UNDEFINED interventions_enabled flag must fail closed to false (#1177)")
+		}
+	})
+	t.Run("flagd unreachable fails closed (off)", func(t *testing.T) {
+		ev := stubEvaluator{errs: map[string]error{keyInterventionsEnabled: errors.New("flagd unreachable")}}
+		if New(ev, nil).InterventionsEnabled(context.Background()) {
+			t.Fatal("an UNREACHABLE flagd must fail closed to false (#1177)")
+		}
+	})
+}
+
+// TestRolloutEnabled covers the #1213 rollout safety gate: a configured value
+// resolves via the TYPED bool getter, and the gate FAILS CLOSED (off ⇒ dry-run) when
+// the flag is UNDEFINED or flagd is UNREACHABLE.
+func TestRolloutEnabled(t *testing.T) {
+	t.Run("configured on resolves", func(t *testing.T) {
+		ev := stubEvaluator{booleans: map[string]bool{keyRolloutEnabled: true}}
+		if !New(ev, nil).RolloutEnabled(context.Background()) {
+			t.Fatal("rollout_enabled=true must resolve true")
+		}
+	})
+	t.Run("undefined flag fails closed (off)", func(t *testing.T) {
+		ev := stubEvaluator{}
+		if New(ev, nil).RolloutEnabled(context.Background()) {
+			t.Fatal("an UNDEFINED rollout_enabled flag must fail closed to false (#1177)")
+		}
+	})
+	t.Run("flagd unreachable fails closed (off)", func(t *testing.T) {
+		ev := stubEvaluator{errs: map[string]error{keyRolloutEnabled: errors.New("flagd unreachable")}}
+		if New(ev, nil).RolloutEnabled(context.Background()) {
+			t.Fatal("an UNREACHABLE flagd must fail closed to false (#1177)")
+		}
+	})
+}
+
+// TestSafetyGateDefaultsAreFailClosed pins the package-level safe defaults: both
+// safety gates default OFF (the not-acting state), matching the fail-closed env
+// default (AGENT_*_ENABLED `:-false`) they replace.
+func TestSafetyGateDefaultsAreFailClosed(t *testing.T) {
+	if DefaultInterventionsEnabled {
+		t.Error("DefaultInterventionsEnabled must be false (fail-closed)")
+	}
+	if DefaultRolloutEnabled {
+		t.Error("DefaultRolloutEnabled must be false (fail-closed)")
+	}
+}

--- a/services/agent/gamerunner/env.go
+++ b/services/agent/gamerunner/env.go
@@ -12,9 +12,11 @@ import (
 // single, minimal trigger path for phase 4 (see PR notes for the flagd-nonce
 // alternative): when AGENT_SHADOW_GAME=true the agent runs ONE shadow game at
 // startup using the SHADOW_GAME_* spec, then continues its normal loop. It
-// keeps the PR self-contained in services/agent (no flagd-schema change) and
-// mirrors the existing AGENT_INTERVENTIONS_ENABLED / AGENT_ROLLOUT_ENABLED
-// env-gate shape.
+// keeps the PR self-contained in services/agent (no flagd-schema change). It
+// mirrors the original env-gate shape the interventions/rollout actuation gates
+// used before #1213 migrated those two to LIVE agent.json flags
+// (interventions_enabled / rollout_enabled); AGENT_SHADOW_GAME remains a one-shot
+// startup trigger, so it stays an env var.
 const (
 	envEnabled     = "AGENT_SHADOW_GAME"
 	envMode        = "SHADOW_GAME_MODE"

--- a/services/agent/main.go
+++ b/services/agent/main.go
@@ -135,33 +135,34 @@ func parseLevel(s string) slog.Level {
 	}
 }
 
-// actionSink returns the intervention Writer when AGENT_INTERVENTIONS_ENABLED is
-// true, or nil to leave the loop's default NoopActions in place (scaffold stays
-// inert). Returning decision.ActionSink keeps main()'s wiring to one line and
-// makes the gate unit-testable.
-func actionSink(logger *slog.Logger) decision.ActionSink {
-	if !strings.EqualFold(getEnv("AGENT_INTERVENTIONS_ENABLED", ""), "true") {
-		return nil
-	}
-	logger.Warn("Agent intervention writes enabled (#730)",
+// actionSink returns the intervention sink for every per-game loop, gated by the
+// LIVE interventions_enabled flag (#1213, migrated from AGENT_INTERVENTIONS_ENABLED).
+// It ALWAYS returns a non-nil GatedActionSink wrapping the real Writer: the gate is
+// re-read on EVERY Apply against agentFlags, so flipping interventions_enabled in
+// flagd starts/stops actuation with no restart, and a flagd outage FAILS CLOSED
+// (DefaultInterventionsEnabled=false ⇒ the wrapped Writer is never called, the
+// decision is recorded/spanned but not written). This REPLACES the old startup-time
+// env gate that selected Writer-or-nil ONCE and could neither react to a flip nor
+// fail safe on a boot-time flagd outage (#1217). Returning decision.ActionSink keeps
+// main()'s wiring to one line and makes the gate unit-testable.
+func actionSink(gate actions.InterventionGate, logger *slog.Logger) decision.ActionSink {
+	logger.Info("Agent intervention writes gated by LIVE interventions_enabled flag (#1213; default fail-closed off)",
 		"path", getEnv("INTERVENTIONS_FLAG_PATH", actions.DefaultPath))
-	return actions.NewWriterFromEnv(logger)
+	return actions.NewGatedActionSink(gate, actions.NewWriterFromEnv(logger), logger)
 }
 
-// rolloutActuator returns the rollout write seam for the infra loop (#734). When
-// AGENT_ROLLOUT_ENABLED=true it is the real RolloutWriter (flips
-// current_controller_count in ROLLOUT_FLAG_PATH); otherwise it is a dry-run
-// actuator that decides+spans expansions but never writes the file. Mirrors the
-// actionSink env-gate shape, but always returns a non-nil actuator so the loop
-// reports disabled expansions as decided-but-not-applied.
-func rolloutActuator(logger *slog.Logger) decision.RolloutActuator {
-	if strings.EqualFold(getEnv("AGENT_ROLLOUT_ENABLED", ""), "true") {
-		logger.Warn("Agent rollout expansion enabled (#734)",
-			"path", getEnv("ROLLOUT_FLAG_PATH", actions.DefaultRolloutPath))
-		return actions.NewRolloutWriterFromEnv(logger)
-	}
-	logger.Info("Agent rollout expansion disabled (dry-run; decisions spanned, not applied)")
-	return actions.NewDryRunRolloutWriter(logger)
+// rolloutActuator returns the rollout write seam for the infra loop (#734), gated by
+// the LIVE rollout_enabled flag (#1213, migrated from AGENT_ROLLOUT_ENABLED). It
+// ALWAYS returns a non-nil GatedRolloutActuator wrapping the real RolloutWriter: the
+// gate is re-read on every SetControllerCount / DryRun against agentFlags, so
+// flipping rollout_enabled in flagd starts/stops applying with no restart, and a
+// flagd outage FAILS CLOSED (DefaultRolloutEnabled=false ⇒ dry-run: the loop
+// decides+spans the expansion but writes nothing). This REPLACES the old startup-time
+// env gate that selected RolloutWriter-or-DryRun ONCE (#1217).
+func rolloutActuator(rootCtx context.Context, gate actions.RolloutGate, logger *slog.Logger) decision.RolloutActuator {
+	logger.Info("Agent rollout expansion gated by LIVE rollout_enabled flag (#1213; default fail-closed dry-run)",
+		"path", getEnv("ROLLOUT_FLAG_PATH", actions.DefaultRolloutPath))
+	return actions.NewGatedRolloutActuator(rootCtx, gate, actions.NewRolloutWriterFromEnv(logger), logger)
 }
 
 // buildPromoter constructs the M7-8 code-improvement Promoter (#936) with the
@@ -521,7 +522,12 @@ func main() {
 	//     read-modify-write of the flagd interventions file under its own mutex,
 	//     keyed by the decision's target), so one Writer is closed over by every loop.
 	//   - SHARED flag source (agentFlags) and tracer: stateless / concurrency-safe.
-	sharedSink := actionSink(logger) // nil leaves the loop's default NoopActions in place
+	// SHARED gated action sink (#1213): one GatedActionSink wrapping the real Writer,
+	// closed over by every per-game loop. The interventions_enabled gate is re-read
+	// per Apply against the live agentFlags, so the gate is hot-reloadable and
+	// fail-closed on a flagd outage (the old AGENT_INTERVENTIONS_ENABLED env master,
+	// migrated). The Writer holds no per-game state, so sharing is safe.
+	sharedSink := actionSink(agentFlags, logger)
 	// Shared GLOBAL LLM request budget (#847, the gate's third layer). Constructed
 	// ONCE here and injected into every per-game Loop below, so all concurrent
 	// games draw down a SINGLE per-minute request cap (llm.max_requests_per_minute)
@@ -715,10 +721,12 @@ func main() {
 			// the rules engine. Each loop gets its own probe clock.
 			loop.Rules = decision.NewProbeRules(probeInterval, nil)
 		}
-		// Action sink (#730): when AGENT_INTERVENTIONS_ENABLED=true, decisions are
-		// applied by rewriting the flagd interventions file (INTERVENTIONS_FLAG_PATH).
-		// Default (nil sink) keeps the scaffold inert (NoopActions discards decisions).
-		// The one Writer is safe to share across loops (no per-game state).
+		// Action sink (#730/#1213): the shared GatedActionSink applies decisions by
+		// rewriting the flagd interventions file (INTERVENTIONS_FLAG_PATH) ONLY when the
+		// LIVE interventions_enabled flag is on; otherwise it discards them (NoopActions
+		// behavior) — gate read per Apply, fail-closed on a flagd outage. The one sink is
+		// safe to share across loops (no per-game state). The nil guard is defensive: a
+		// nil sink would leave the loop's default NoopActions in place.
 		if sharedSink != nil {
 			loop.Actions = sharedSink
 		}
@@ -741,9 +749,12 @@ func main() {
 	// cannot keep the infra loop live on its own). On any evaluation error the
 	// accessor falls back to the flagd-schema defaults.
 	bluetoothFitness := decision.NewFlagBluetoothFitness(agentFlags)
-	// Rollout actuator (#734): real RolloutWriter when AGENT_ROLLOUT_ENABLED=true,
-	// else a dry-run actuator (decides+spans but does not write rollout.json).
-	infraLoop := decision.NewInfraLoop(logger, rolloutDwell(), bluetoothFitness, rolloutActuator(logger))
+	// Rollout actuator (#734/#1213): a GatedRolloutActuator wrapping the real
+	// RolloutWriter — it flips current_controller_count in rollout.json ONLY when the
+	// LIVE rollout_enabled flag is on, else it dry-runs (decides+spans but does not
+	// write). Gate read per SetControllerCount/DryRun against agentFlags, fail-closed
+	// (dry-run) on a flagd outage. ctx is the agent's long-lived context.
+	infraLoop := decision.NewInfraLoop(logger, rolloutDwell(), bluetoothFitness, rolloutActuator(ctx, agentFlags, logger))
 	// Auto-remediation gate (#736): remediation_allowed lives in the ROLLOUT flagd
 	// domain (rollout.json), so the loop reads it directly from that file (the agent
 	// already owns the path). When false, fitness failures are RECOMMENDED only (span,

--- a/services/flagd/agent.json
+++ b/services/flagd/agent.json
@@ -513,6 +513,22 @@
         "wide": 8
       },
       "defaultVariant": "default"
+    },
+    "interventions_enabled": {
+      "state": "ENABLED",
+      "variants": {
+        "off": false,
+        "on": true
+      },
+      "defaultVariant": "off"
+    },
+    "rollout_enabled": {
+      "state": "ENABLED",
+      "variants": {
+        "off": false,
+        "on": true
+      },
+      "defaultVariant": "off"
     }
   }
 }

--- a/services/flagd/ci/agent.json
+++ b/services/flagd/ci/agent.json
@@ -513,6 +513,22 @@
         "wide": 8
       },
       "defaultVariant": "default"
+    },
+    "interventions_enabled": {
+      "state": "ENABLED",
+      "variants": {
+        "off": false,
+        "on": true
+      },
+      "defaultVariant": "off"
+    },
+    "rollout_enabled": {
+      "state": "ENABLED",
+      "variants": {
+        "off": false,
+        "on": true
+      },
+      "defaultVariant": "off"
     }
   }
 }

--- a/services/grafana/dashboards/agent-operations.json
+++ b/services/grafana/dashboards/agent-operations.json
@@ -556,7 +556,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "Interventions the agent actually dispatched through the action sink, per minute, split by action. Counts only decisions that passed EVERY gate (kill-switch, allow-list, battery, rate-limit) and reached the real Writer — so a bar here is an intervention that took effect, not merely a permitted decision. Empty until interventions APPLY: needs the ACT sink (AGENT_INTERVENTIONS_ENABLED=true) plus a permitting interventions_allowed variant (the demo uses shadow_experimental; see docs/agent-demo-runbook.md Act 2b and the #1127 allow-list fix). Source: agent_interventions_applied_total{action} (#790). Validated live: grant_shield series present.",
+      "description": "Interventions the agent actually dispatched through the action sink, per minute, split by action. Counts only decisions that passed EVERY gate (kill-switch, allow-list, battery, rate-limit) and reached the real Writer — so a bar here is an intervention that took effect, not merely a permitted decision. Empty until interventions APPLY: needs the interventions_enabled flagd flag ON (#1213) plus a permitting interventions_allowed variant (the demo uses shadow_experimental; see docs/agent-demo-runbook.md Act 2b and the #1127 allow-list fix). Source: agent_interventions_applied_total{action} (#790). Validated live: grant_shield series present.",
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/tests/integration/test_intervention_flow.py
+++ b/tests/integration/test_intervention_flow.py
@@ -456,28 +456,32 @@ async def test_permission_layer_blocks_disallowed_intervention(flag_files, docke
 
 
 def test_agent_interventions_disabled_by_default():
-    """Writer gate: the agent ActionSink is gated by AGENT_INTERVENTIONS_ENABLED
-    and defaults OFF, so it never mutates interventions.json in the integration
-    compose.
+    """Writer gate: the agent ActionSink is gated by the LIVE ``interventions_enabled``
+    flagd flag (#1213, migrated from the AGENT_INTERVENTIONS_ENABLED env var) and the
+    flag defaults OFF, so the agent never mutates interventions.json by default.
 
-    The agent's decision loop cannot be driven deterministically from this
-    harness (it lives in the ``agent`` compose profile and is not started for
-    integration tests), so per the PR plan this scenario is covered by the Go
-    unit tests (services/agent/actions/writer_test.go) for the actual no-write
-    behavior. Here we assert the compose default keeps the gate OFF, which is
-    the property that makes those unit tests load-bearing for the e2e contract.
+    The agent's decision loop cannot be driven deterministically from this harness
+    (it lives in the ``agent`` compose profile and is not started for integration
+    tests), so per the PR plan the no-write behavior is covered by the Go unit tests
+    (services/agent/actions/gated_test.go + action_sink_test.go). Here we assert the
+    flagd flag default keeps the gate OFF (fail-closed), which is the property that
+    makes those unit tests load-bearing for the e2e contract. We check BOTH the base
+    and CI flag configs since flagd serves ci/agent.json in CI (#801).
     """
-    compose_path = os.path.abspath(
-        os.path.join(os.path.dirname(__file__), "../../docker-compose.yml")
+    flagd_dir = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "../../services/flagd")
     )
-    with open(compose_path) as fh:
-        compose_text = fh.read()
-
-    assert "AGENT_INTERVENTIONS_ENABLED" in compose_text, (
-        "agent service should reference the AGENT_INTERVENTIONS_ENABLED gate"
-    )
-    # The gate must default to false (env default ``:-false`` or explicit false).
-    assert (
-        "AGENT_INTERVENTIONS_ENABLED:-false" in compose_text
-        or "AGENT_INTERVENTIONS_ENABLED=false" in compose_text
-    ), "AGENT_INTERVENTIONS_ENABLED must default to false in docker-compose.yml"
+    for rel in ("agent.json", "ci/agent.json"):
+        with open(os.path.join(flagd_dir, rel)) as fh:
+            flags = json.load(fh)["flags"]
+        assert "interventions_enabled" in flags, (
+            f"{rel} should define the interventions_enabled safety gate (#1213)"
+        )
+        # The gate must FAIL CLOSED: the default variant resolves to false.
+        flag = flags["interventions_enabled"]
+        default_variant = flag["defaultVariant"]
+        assert flag["variants"][default_variant] is False, (
+            f"interventions_enabled in {rel} must default OFF (fail-closed); "
+            f"defaultVariant {default_variant!r} resolves to "
+            f"{flag['variants'][default_variant]!r}"
+        )

--- a/tools/demo/README.md
+++ b/tools/demo/README.md
@@ -70,8 +70,9 @@ make dry-run
 ./scripts/agent-killswitch.sh on    # the agent loop is inert until you do this
 
 # (Optional) to see the agent ACT, not just decide — see docs/agent-act-runbook.md:
-#   AGENT_INTERVENTIONS_ENABLED=true on the agent container (restart), and
-#   widen interventions_allowed if you want a difficulty intervention to dispatch.
+#   flip interventions_enabled -> on in services/flagd/agent.json (flagd flag, #1213;
+#   re-read at use-time, no agent restart), and widen interventions_allowed if you
+#   want a difficulty intervention to dispatch.
 
 # 2. Fire a scenario.
 cd services/game_coordinator

--- a/tools/demo/demo_driver.py
+++ b/tools/demo/demo_driver.py
@@ -423,7 +423,8 @@ Where to watch the agent react
 Prerequisites for the agent to ACT (see docs/agent-act-runbook.md)
 ------------------------------------------------------------------
   The agent only DECIDES (and traces) unless both gates are open:
-    1. AGENT_INTERVENTIONS_ENABLED=true on the agent container (restart) — real sink
+    1. agent.json `interventions_enabled` = on (flagd flag, #1213; re-read at
+       use-time, no agent restart)                               — real sink
     2. agent.json `enabled` = on   (flag flip, hot-reload)        — kill switch
   And the permission layer (`interventions_allowed`) must include the rule's
   intervention. To SEE a *blocked* decision, run --scenario blocked_battery with the

--- a/tools/demo/validation_harness.py
+++ b/tools/demo/validation_harness.py
@@ -523,7 +523,7 @@ def evaluate(scenario: Scenario, obs: Observations) -> ScenarioResult:
             # decided but never acted, while we expected an allowed dispatch
             res.reasons.append(
                 "NOTE: agent.decision spans present but no agent.action — decisions were made but "
-                "not dispatched (act gates closed: AGENT_INTERVENTIONS_ENABLED / agent.json enabled)"
+                "not dispatched (act gates closed: agent.json interventions_enabled / enabled flags)"
             )
             res.where.append("docs/agent-act-runbook.md: open the act gates to see agent.action")
 


### PR DESCRIPTION
Migrates the two runtime **safety gates** in `services/agent/` (Go) from env vars to LIVE `agent.json` flagd flags, read via typed bool getters and re-evaluated at **use-time** (never cached at init):

| env var (removed) | flagd flag (`agent.json`) | read site |
|---|---|---|
| `AGENT_INTERVENTIONS_ENABLED` | `interventions_enabled` | per `ActionSink.Apply` |
| `AGENT_ROLLOUT_ENABLED` | `rollout_enabled` | per `SetControllerCount` / `DryRun` |

Out of scope (deliberately kept as fail-closed env masters): `AGENT_AUTONOMOUS_ENABLED`, `AGENT_CODE_IMPROVEMENT_ENABLED`.

## Overlap-with-`enabled` analysis (NOT a duplicate)
These are **distinct layers**, so the migration is not a redundant gate:
- **`enabled`** (kill switch) — gates whether the decision loop *decides at all* (loop short-circuits).
- **`interventions_allowed`** — gates *which* intervention types may dispatch (per-cycle allow-list).
- **`interventions_enabled`** (this PR) — gates whether a *fully-permitted* decision is actually **applied to disk** (written to `interventions.json`).

A decision can pass `enabled` + `interventions_allowed` and still be a recorded-but-not-applied no-op when `interventions_enabled` is off. Likewise `rollout_enabled` is the apply gate for the infra rollout actuator (`enabled` does not cover it — the infra loop runs independently).

## Fail-closed semantics (these are SAFETY gates, not tuning knobs)
Unlike the #1215 game-cap migration (fail-**open** to a default), a safety gate must resolve to the **safe / not-acting state** when flagd is undefined or unreachable. `DefaultInterventionsEnabled` / `DefaultRolloutEnabled` are both `false`, matching the former `:-false` env default. So a flagd outage → the agent does **not** write `interventions.json` and stays **dry-run** for rollout. Documented with `#1177` references in `flags.go`.

## Read at use-time, not cached-at-init (#1217)
The old code read the env var **once at startup** in `main.go` to *select which sink/actuator object* was wired — exactly the cached-at-init pattern that failed open in #1217. New `GatedActionSink` / `GatedRolloutActuator` wrap the real `Writer` / `RolloutWriter` and consult the live `agentFlags` gate on every Apply / SetControllerCount / DryRun, so flipping the flag in flagd takes effect with no restart, and `rollout.dry_run` on the span reflects the live gate per cycle.

## CI flag defaults
`ci/agent.json` gains both flags with `defaultVariant: off` (same as base) — the #801 drift guard (`lib/tests/test_flagd_ci_drift.py`) requires matching keys; defaults may differ but **no integration test needs the gate ON**. The agent only runs in the `gateway` / `dry-run` compose profile, where the `enabled` master is off anyway, so the fail-closed default breaks nothing. `test_agent_interventions_disabled_by_default` was updated to assert the flagd flag default OFF in **both** base and ci configs (replacing the assertion on the now-removed compose env var).

## Verify
- `gofmt -l .` clean, `go vet ./...` clean, `go build ./...` ok
- `go test -race ./...` green (flags / actions / decision included)
- New unit tests: fail-closed-on-undefined + fail-closed-on-unreachable for both gates; gated-wrapper delegation/no-op; live-gated wiring
- `test_flagd_ci_drift.py` passes (ci/agent.json tracks base key-for-key)

Part of #1213

🤖 Generated with [Claude Code](https://claude.com/claude-code)