### PR TITLE
feat(agent): migrate verdict-tuning knobs to flagd flags (#1214)

### DIFF
--- a/services/agent/README.md
+++ b/services/agent/README.md
@@ -948,10 +948,11 @@ All configuration is via environment variables:
 | `AGENT_SHADOW_EFFECTIVE_CONCURRENCY` | `4` | **Effective** in-flight shadow-spawn concurrency, bounding how many concurrent shadow starts the registry holds at once. Since #1018 (option b) the game-coordinator runs shadow games **concurrently** (the single-game guard is REAL-only; shadows run in parallel up to `GAME_MAX_SHADOW_GAMES`), so the registry can keep several in flight without each being a doomed "Game already in progress" start. Default 4 makes #1003's same-tick atomic pair reservation activate (it needs >= 2 to reserve BOTH arms in one tick). Clamped to `AGENT_MAX_SHADOW_GAMES`. A coordinator-at-capacity rejection (cap full) is still treated as **backpressure** (release + retry next tick), not a spawn failure |
 | `AGENT_EXPERIMENT_TICK_SECONDS` | `30` | Cadence of the registry's `AllocateAndSpawn` (refills free shadow capacity) |
 | `AGENT_EXPERIMENT_DIR` | `/var/lib/joustmania/agent/experiments` | Durable experiment journal root (intent/events/summary per experiment); the registry rehydrates from it on startup |
-| `AGENT_VERDICT_MIN_N` | `8` | #979 min games per arm before a conclusive verdict (else inconclusive) |
-| `AGENT_VERDICT_EFFECT_THRESHOLD` | `0.5` | #979 minimum \|Cohen's d\| for a promote/discard verdict |
-| `AGENT_VERDICT_MIN_RAW_EFFECT` | `0.02` | #1042 practical-significance floor: minimum RAW effect (\|mean_d\| paired / \|mean_exp − mean_ctl\| two-arm) for a promote/discard. Below it ⇒ inconclusive regardless of how large the standardized d_z / Cohen's d is — stops near-deterministic shadow games promoting on a trivially-tiny but perfectly-consistent delta. 0.02 = 2% of the ~0..1 fitness range |
-| `AGENT_VERDICT_SD_FLOOR` | `0.0001` | #1042 minimum-SD floor (defense in depth): floors the d_z / Cohen's d denominator so the standardized stat stays finite when the spread collapses toward 0 (sd→0). 1e-4 is two orders below any real-play spread, so it never distorts a real-noise verdict |
+| `AGENT_VERDICT_MIN_N` | `8` | #979 min games per arm before a conclusive verdict (else inconclusive). **Bootstrap default for the live `verdict_min_n` flag** (#1044) |
+| `verdict_effect_threshold` (flag) | `0.5` | #979 minimum \|Cohen's d\| for a promote/discard verdict. **Migrated to a live `agent.json` flag (#1214)** — no longer an env var; the `0.5` default is the fail-open fallback (`DefaultEffectThreshold`) |
+| `verdict_min_raw_effect` (flag) | `0.02` | #1042 practical-significance floor: minimum RAW effect (\|mean_d\| paired / \|mean_exp − mean_ctl\| two-arm) for a promote/discard. Below it ⇒ inconclusive regardless of how large the standardized d_z / Cohen's d is — stops near-deterministic shadow games promoting on a trivially-tiny but perfectly-consistent delta. 0.02 = 2% of the ~0..1 fitness range. **Migrated to a live `agent.json` flag (#1214)** — fail-open fallback `DefaultMinRawEffect` |
+| `verdict_sd_floor` (flag) | `0.0001` | #1042 minimum-SD floor (defense in depth): floors the d_z / Cohen's d denominator so the standardized stat stays finite when the spread collapses toward 0 (sd→0). 1e-4 is two orders below any real-play spread, so it never distorts a real-noise verdict. **Migrated to a live `agent.json` flag (#1214)** — fail-open fallback `DefaultSDFloor` |
+| `verdict_anchor_margin` (flag) | `0.02` | #992 recent-real regression margin: a PROMOTE is downgraded to inconclusive only when the experimental arm regresses below the recent-real baseline by MORE than this. Mirrors the #1042 raw-effect floor. **Migrated to a live `agent.json` flag (#1214)** — fail-open fallback `DefaultAnchorMargin` |
 | `AGENT_EXPERIMENT_SEED_FLAG` | _unset_ | When set (and the loop is enabled), declares ONE env-seeded experiment at startup on this game.json flag — the simplest declaration trigger for the demo. Paired with `AGENT_EXPERIMENT_SEED_VALUE` / `_OBJECTIVE` / `_TARGET_N` / `_HYPOTHESIS` |
 | `AGENT_EXPERIMENT_SEED_VALUE` | _unset_ | The seed experiment's experimental value. Parsed as a number when it parses as a float, else bool for `true`/`false`, else a JSON object/array when the text begins with `{`/`[` and parses as valid JSON (#1090 — lets an object-valued FFA lever such as `windows` or `thresholds` be seeded), else the raw string. Its JSON kind must match the flag's existing variants (the Gate's type guard rejects a mistyped seed at the targeting write) |
 | `AGENT_EXPERIMENT_SEED_OBJECTIVE` | `balanced` | The seed experiment's fitness objective (`endurance` / `balanced` / `accelerate` / `chaos`) |
@@ -976,6 +977,10 @@ All configuration is via environment variables:
 > | `experiment_max_games` | `AGENT_EXPERIMENT_MAX_GAMES` |
 > | `verdict_min_n` | `AGENT_VERDICT_MIN_N` |
 > | `verdict_min_pairs` | `AGENT_VERDICT_MIN_PAIRS` |
+> | `verdict_effect_threshold` (#1214) | _none — `DefaultEffectThreshold` (0.5)_ |
+> | `verdict_min_raw_effect` (#1214) | _none — `DefaultMinRawEffect` (0.02)_ |
+> | `verdict_sd_floor` (#1214) | _none — `DefaultSDFloor` (1e-4)_ |
+> | `verdict_anchor_margin` (#1214) | _none — `DefaultAnchorMargin` (0.02)_ |
 >
 > **Startup-gate inversion:** the loop + dynamic declarer are now **always built and
 > run**; they self-gate each tick on the live `experiments_enabled` /
@@ -993,9 +998,19 @@ All configuration is via environment variables:
 > declarer knobs `AGENT_EXPERIMENT_DYNAMIC_CANDIDATES` / `_DENYLIST` — a top-level
 > flagd **LIST** flag hits a `get_object_value` `TYPE_MISMATCH` (only the in-process
 > resolver reads list flags; the agent uses the RPC resolver), so a list flag here
-> would be silently broken. `AGENT_VERDICT_EFFECT_THRESHOLD` and the #1042
-> practical-significance floors (`AGENT_VERDICT_MIN_RAW_EFFECT`,
-> `AGENT_VERDICT_SD_FLOOR`) also stay env for now (not part of this migration).
+> would be silently broken.
+>
+> **#1214 — verdict-tuning cluster completed.** The four remaining verdict knobs
+> (`verdict_effect_threshold`, `verdict_min_raw_effect`, `verdict_sd_floor`,
+> `verdict_anchor_margin`) are now live `agent.json` flags too, finishing the cluster
+> `verdict_min_n` / `verdict_min_pairs` started in #1044. These four were migrated
+> **fully** — their `AGENT_VERDICT_EFFECT_THRESHOLD` / `_MIN_RAW_EFFECT` / `_SD_FLOOR` /
+> `_ANCHOR_MARGIN` env vars are **removed**; the verdict's `Default*` constants are the
+> fail-open fallback the flag resolves to when flagd is undefined/unreachable. They are
+> read via the **typed float getter** (never `ObjectValue` — the #903/#1127
+> TYPE_MISMATCH trap) and live-mirrored onto the verdict each tick via the registry's
+> `Reconfigure` → `Verdict.SetThresholds` / `SetFloatThresholds`, exactly the
+> `verdict_min_n` / `verdict_min_pairs` seam.
 
 > The Go agent uses the flagd **RPC** resolver (gRPC evaluation port `8013`),
 > not the in-process sync port `8015` that the Python services use.

--- a/services/agent/experiment/registry.go
+++ b/services/agent/experiment/registry.go
@@ -1639,6 +1639,23 @@ func (r *Registry) Reconfigure(effectiveConcurrency, maxGames, minN, minPairs in
 	}
 }
 
+// ReconfigureVerdictFloats live-mirrors the four migrated FLOAT verdict knobs (#1214)
+// onto the verdict so a hot-reload of verdict_effect_threshold / verdict_min_raw_effect
+// / verdict_sd_floor / verdict_anchor_margin takes effect on the NEXT verdict with no
+// restart — the float analog of the minN/minPairs mirroring in Reconfigure. The
+// experiment loop calls it each tick from the live agent.json flags, alongside
+// Reconfigure; the env-derived value is the bootstrap default the flag falls back to.
+// These knobs are verdict-only (the registry itself reads none of them), so unlike
+// minN this method only forwards to the verdict — it touches no registry state and
+// takes no registry lock. SetFloatThresholds ignores a non-positive value per knob, so
+// a transient flagd hiccup never loosens a gate. A non-*Verdict CohortStat (a custom
+// test seam) is left untouched.
+func (r *Registry) ReconfigureVerdictFloats(effectThreshold, minRawEffect, sdFloor, anchorMargin float64) {
+	if v, ok := r.verdict.(*Verdict); ok {
+		v.SetFloatThresholds(effectThreshold, minRawEffect, sdFloor, anchorMargin)
+	}
+}
+
 // Live returns the ids of experiments that may be allocated shadow capacity —
 // i.e. those in RUNNING (targeting written, ready to accrue games), sorted. A
 // PROPOSED experiment occupies a registry slot but is not yet spawnable, so it is

--- a/services/agent/experiment/verdict.go
+++ b/services/agent/experiment/verdict.go
@@ -56,7 +56,8 @@ const (
 	// DefaultEffectThreshold is the minimum |Cohen's d| (standardized mean
 	// difference) for a promote/discard verdict. 0.5 ≈ Cohen's "medium" effect.
 	// Below this magnitude (with N met) the arms are within-noise ⇒ INCONCLUSIVE.
-	// Tune via AGENT_VERDICT_EFFECT_THRESHOLD.
+	// Tune via the verdict_effect_threshold agent.json flag (#1214); this is the
+	// fail-open fallback when flagd is undefined/unreachable.
 	DefaultEffectThreshold = 0.5
 
 	// DefaultMinPairs is the minimum number of COMPLETED Common-Random-Numbers pairs
@@ -81,8 +82,9 @@ const (
 	// VALUE 0.02 = 2% of the ~0..1 fitness range. Rationale: a fitness change smaller
 	// than 2% of the achievable range is below what we'd act on for a party game — it is
 	// in the don't-care band — while every genuinely meaningful effect in practice (and
-	// in the test suite, deltas ≥0.05) clears it comfortably. Tune via
-	// AGENT_VERDICT_MIN_RAW_EFFECT.
+	// in the test suite, deltas ≥0.05) clears it comfortably. Tune via the
+	// verdict_min_raw_effect agent.json flag (#1214); this is the fail-open fallback
+	// when flagd is undefined/unreachable.
 	DefaultMinRawEffect = 0.02
 
 	// DefaultSDFloor is the minimum-standard-deviation floor (#1042, defense in depth):
@@ -94,19 +96,22 @@ const (
 	// VALUE 1e-4: two orders of magnitude below any real-play spread (real per-game
 	// fitness noise is ~0.01+), so it never distorts a real-noise verdict — it only bites
 	// in the degenerate sd→0 regime, where the raw-effect floor is the real gate anyway.
-	// Tune via AGENT_VERDICT_SD_FLOOR.
+	// Tune via the verdict_sd_floor agent.json flag (#1214); this is the fail-open
+	// fallback when flagd is undefined/unreachable.
 	DefaultSDFloor = 1e-4
 )
 
 const (
-	minNEnv      = "AGENT_VERDICT_MIN_N"
-	effectEnv    = "AGENT_VERDICT_EFFECT_THRESHOLD"
-	minPairsEnv  = "AGENT_VERDICT_MIN_PAIRS"
-	minRawEffEnv = "AGENT_VERDICT_MIN_RAW_EFFECT"
-	sdFloorEnv   = "AGENT_VERDICT_SD_FLOOR"
-	// anchorMarginEnv tunes the recent-real regression margin (#992). Falls back to
-	// DefaultAnchorMargin (which mirrors the #1042 raw-effect floor).
-	anchorMarginEnv = "AGENT_VERDICT_ANCHOR_MARGIN"
+	// minNEnv / minPairsEnv stay env-derived (the registry reads them via
+	// MinNFromEnv/MinPairsFromEnv as the BOOTSTRAP DEFAULT the live verdict_min_n /
+	// verdict_min_pairs agent.json flags fall back to, #1044). The other four verdict
+	// knobs (effect threshold, min raw effect, sd floor, anchor margin) were migrated
+	// fully to agent.json flags in #1214 — their env consts are GONE; the verdict's
+	// Default* constants are the fail-open fallback the flags resolve to, and the live
+	// values flow in via the registry's Reconfigure → SetThresholds (mirroring the
+	// min_n/min_pairs seam).
+	minNEnv     = "AGENT_VERDICT_MIN_N"
+	minPairsEnv = "AGENT_VERDICT_MIN_PAIRS"
 )
 
 // DefaultAnchorMargin is the recent-real regression margin (#992): a PROMOTE
@@ -115,7 +120,9 @@ const (
 // (the #1042 practical-significance floor) on purpose — the same "don't act on a
 // fitness change smaller than ~2% of the [0,1] range" don't-care band applies to
 // the secondary cross-check, so a shadow-winner that is within noise of recent
-// real play is NOT treated as a regression. Tune via AGENT_VERDICT_ANCHOR_MARGIN.
+// real play is NOT treated as a regression. Tune via the verdict_anchor_margin
+// agent.json flag (#1214); this is the fail-open fallback when flagd is
+// undefined/unreachable.
 const DefaultAnchorMargin = DefaultMinRawEffect
 
 // RecentRealBaseline is the injected secondary-anchor accessor (#992): given the
@@ -194,11 +201,15 @@ func (g effectSizeGate) Effect(experimental, control journal.Welford) (float64, 
 // FitnessMeasurer and decision loop already use), so a positive effect means the
 // experimental arm beat control.
 type Verdict struct {
-	// mu guards the live-tunable thresholds (minN / minPairs) so SetThresholds
-	// (#1044, called from the experiment loop's tick goroutine) and Evaluate (called
-	// under the registry lock from a ConcludeGame goroutine) never race. The other
-	// fields (effectThreshold / stat) are construction-immutable and read without the
-	// lock.
+	// mu guards EVERY live-tunable threshold so SetThresholds (#1044/#1214, called from
+	// the experiment loop's tick goroutine via the registry's Reconfigure) and Evaluate
+	// (called under the registry lock from a ConcludeGame goroutine) never race. Since
+	// #1214 this covers not just minN / minPairs but the four migrated float knobs
+	// (effectThreshold / minRawEffect / sdFloor / anchorMargin) too — they became LIVE
+	// agent.json flags (verdict_effect_threshold / verdict_min_raw_effect /
+	// verdict_sd_floor / verdict_anchor_margin), so they are now read under the lock and
+	// hot-reloaded the same way min_n/min_pairs were. recentRealBaseline / stat stay
+	// construction-immutable (stat's sdFloor is kept in sync on a live update below).
 	mu sync.RWMutex
 	// minN is the minimum Count both arms must reach for a conclusive TWO-ARM verdict
 	// (the fallback path). Live-tunable via SetThresholds (#1044, verdict_min_n).
@@ -209,17 +220,22 @@ type Verdict struct {
 	minPairs int
 	// effectThreshold is the minimum |effect| for a promote/discard verdict. It gates
 	// both the two-arm Cohen's d and the paired d_z (both are standardized effects).
+	// Live-tunable via SetThresholds (#1214, verdict_effect_threshold); read under mu.
 	effectThreshold float64
 	// minRawEffect is the PRACTICAL-significance floor (#1042): the minimum RAW effect
 	// magnitude (|mean_d| paired / |mean_exp − mean_ctl| two-arm) a promote/discard
 	// requires, on top of the standardized effectThreshold. Below it ⇒ INCONCLUSIVE no
-	// matter how large the standardized effect is. Construction-immutable.
+	// matter how large the standardized effect is. Live-tunable via SetThresholds
+	// (#1214, verdict_min_raw_effect); read under mu.
 	minRawEffect float64
 	// sdFloor is the minimum-SD floor (#1042) applied to the d_z denominator in the
-	// paired path (the two-arm path's floor lives in effectSizeGate.sdFloor).
-	// Construction-immutable.
+	// paired path (the two-arm path's floor lives in effectSizeGate.sdFloor, kept in
+	// sync on a live update). Live-tunable via SetThresholds (#1214, verdict_sd_floor);
+	// read under mu.
 	sdFloor float64
-	// stat is the swappable comparison strategy (default effectSizeGate).
+	// stat is the swappable comparison strategy (default effectSizeGate). The default
+	// gate's sdFloor is kept in sync with v.sdFloor on a live update (SetThresholds), so
+	// the two-arm path tracks the verdict_sd_floor flag too.
 	stat CohortStat
 	// recentRealBaseline is the SECONDARY-ANCHOR accessor (#992): the recent-real
 	// fitness baseline for an objective. nil ⇒ the anchor is absent (the verdict is
@@ -227,7 +243,8 @@ type Verdict struct {
 	// PROMOTE: a shadow-winner that would regress vs recent real play is downgraded to
 	// INCONCLUSIVE. Construction-immutable; wired via WithRecentRealBaseline.
 	recentRealBaseline RecentRealBaseline
-	// anchorMargin is the recent-real regression margin (#992). Construction-immutable.
+	// anchorMargin is the recent-real regression margin (#992). Live-tunable via
+	// SetThresholds (#1214, verdict_anchor_margin); read under mu.
 	anchorMargin float64
 }
 
@@ -265,6 +282,38 @@ func (v *Verdict) SetThresholds(minN, minPairs int) {
 	}
 	if minPairs > 0 {
 		v.minPairs = minPairs
+	}
+}
+
+// SetFloatThresholds live-updates the four migrated float verdict knobs (#1214) so a
+// hot-reload of verdict_effect_threshold / verdict_min_raw_effect / verdict_sd_floor
+// / verdict_anchor_margin takes effect on the NEXT Evaluate with no restart — the
+// float analog of SetThresholds (mirroring the min_n/min_pairs seam). A non-positive
+// value is IGNORED per knob (keeps the current value), the same fail-safe floor the
+// constructor uses: a transient flagd hiccup that resolves a knob to 0 must not
+// silently loosen the gate. The verdict_sd_floor update is also propagated into the
+// default two-arm stat (effectSizeGate.sdFloor) so the two-arm path tracks the flag
+// too; a caller-supplied custom stat is left untouched (it owns its own denominator).
+// It is safe to call concurrently with Evaluate; both take v.mu.
+func (v *Verdict) SetFloatThresholds(effectThreshold, minRawEffect, sdFloor, anchorMargin float64) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	if effectThreshold > 0 {
+		v.effectThreshold = effectThreshold
+	}
+	if minRawEffect > 0 {
+		v.minRawEffect = minRawEffect
+	}
+	if sdFloor > 0 {
+		v.sdFloor = sdFloor
+		// Keep the default two-arm gate's floor in sync (it lives in a separate struct).
+		// Only the default effectSizeGate is rebuilt; a custom CohortStat owns its own.
+		if _, ok := v.stat.(effectSizeGate); ok {
+			v.stat = effectSizeGate{sdFloor: sdFloor}
+		}
+	}
+	if anchorMargin > 0 {
+		v.anchorMargin = anchorMargin
 	}
 }
 
@@ -359,30 +408,26 @@ func MinPairsFromEnv() int {
 	return DefaultMinPairs
 }
 
-// NewVerdictFromEnv builds a Verdict from AGENT_VERDICT_MIN_N /
-// AGENT_VERDICT_MIN_PAIRS / AGENT_VERDICT_EFFECT_THRESHOLD, falling back to the
-// defaults on an unset, empty, or invalid value. The default Cohen's d strategy is
-// used for the two-arm fallback path.
+// NewVerdictFromEnv builds the default Verdict for the experiment loop. The min-N /
+// min-pairs gates are seeded from AGENT_VERDICT_MIN_N / AGENT_VERDICT_MIN_PAIRS (the
+// registry's bootstrap defaults), and the four float knobs — effect threshold, min
+// raw effect, sd floor, anchor margin — are seeded from their Default* constants.
+//
+// Since #1214 those four floats are NO LONGER read from env: they are LIVE agent.json
+// flags (verdict_effect_threshold / verdict_min_raw_effect / verdict_sd_floor /
+// verdict_anchor_margin). The constants here are the FAIL-OPEN fallback (the value the
+// flag resolves to when flagd is undefined/unreachable); the live flag values are
+// applied on the first — and every — experiment tick via the registry's Reconfigure →
+// Verdict.SetThresholds / SetFloatThresholds, exactly the seam the min_n/min_pairs
+// siblings use. The anchor margin starts at DefaultAnchorMargin and is re-seeded by
+// WithRecentRealBaseline before the live flag takes over. The default Cohen's d
+// strategy is used for the two-arm fallback path.
 func NewVerdictFromEnv() *Verdict {
 	minN := MinNFromEnv()
 	minPairs := MinPairsFromEnv()
-	threshold := floatFromEnv(effectEnv, DefaultEffectThreshold)
-	minRawEffect := floatFromEnv(minRawEffEnv, DefaultMinRawEffect)
-	sdFloor := floatFromEnv(sdFloorEnv, DefaultSDFloor)
-	// stat=nil so NewVerdictWithFloors builds the default gate WITH the resolved sdFloor.
-	return NewVerdictWithFloors(minN, minPairs, threshold, minRawEffect, sdFloor, nil)
-}
-
-// floatFromEnv resolves a positive float knob from env, falling back to def on an
-// unset, empty, non-numeric, or non-positive value (the same fail-safe convention
-// MinNFromEnv / the effectThreshold parse use).
-func floatFromEnv(key string, def float64) float64 {
-	if v := strings.TrimSpace(os.Getenv(key)); v != "" {
-		if f, err := strconv.ParseFloat(v, 64); err == nil && f > 0 {
-			return f
-		}
-	}
-	return def
+	// stat=nil so NewVerdictWithFloors builds the default gate WITH the default sdFloor;
+	// the live verdict_sd_floor flag is applied later via SetFloatThresholds.
+	return NewVerdictWithFloors(minN, minPairs, DefaultEffectThreshold, DefaultMinRawEffect, DefaultSDFloor, nil)
 }
 
 // Evaluate computes the current verdict for an experiment from its rolling
@@ -408,12 +453,20 @@ func floatFromEnv(key string, def float64) float64 {
 // so the registry leaves any prior verdict untouched rather than overwriting it
 // with a vacuous one.
 func (v *Verdict) Evaluate(s journal.Summary) (journal.Verdict, bool) {
-	// Snapshot the live-tunable gates ONCE under the lock (#1044) so a concurrent
-	// SetThresholds cannot tear them mid-evaluation; the rest of the method uses the
-	// locals.
+	// Snapshot the live-tunable gates ONCE under the lock (#1044/#1214) so a concurrent
+	// SetThresholds / SetFloatThresholds cannot tear them mid-evaluation; the rest of the
+	// method (and the paired/anchor helpers, which take the snapshot as args) use the
+	// locals. Since #1214 the four float knobs and the comparison strategy are snapshot
+	// here too — they became LIVE flags, so a hot-reload between two Evaluate calls is
+	// honored, but a SINGLE evaluation always sees one coherent set.
 	v.mu.RLock()
 	minN := v.minN
 	minPairs := v.minPairs
+	effectThreshold := v.effectThreshold
+	minRawEffect := v.minRawEffect
+	sdFloor := v.sdFloor
+	anchorMargin := v.anchorMargin
+	stat := v.stat
 	v.mu.RUnlock()
 
 	// PAIRED PATH (#1004): when seed-matched (experimental, control) pairs have
@@ -433,7 +486,7 @@ func (v *Verdict) Evaluate(s journal.Summary) (journal.Verdict, bool) {
 		if a, ok := s.Arms[ArmExperimental]; ok && a != nil {
 			expMean = a.Welford.Mean
 		}
-		return v.evaluatePaired(*s.PairDiff, minPairs, s.Objective, expMean)
+		return v.evaluatePaired(*s.PairDiff, minPairs, effectThreshold, minRawEffect, sdFloor, anchorMargin, s.Objective, expMean)
 	}
 
 	expStat, expOK := s.Arms[ArmExperimental]
@@ -460,8 +513,9 @@ func (v *Verdict) Evaluate(s journal.Summary) (journal.Verdict, bool) {
 		}, true
 	}
 
-	// Effect-size gate: compute the standardized effect via the swappable strategy.
-	effect, ok := v.stat.Effect(exp, ctl)
+	// Effect-size gate: compute the standardized effect via the swappable strategy
+	// (snapshot above so a live verdict_sd_floor change can't swap it mid-evaluation).
+	effect, ok := stat.Effect(exp, ctl)
 	if !ok {
 		// Variance undefined / degenerate (e.g. zero-spread arms) — N is met but we
 		// cannot standardize the difference, so treat it as no signal.
@@ -476,34 +530,34 @@ func (v *Verdict) Evaluate(s journal.Summary) (journal.Verdict, bool) {
 	// PRACTICAL-significance floor (#1042): even a large standardized effect must be
 	// backed by a raw mean difference worth acting on. A tiny-but-consistent delta
 	// (near-deterministic arms ⇒ huge Cohen's d on a meaningless gap) is INCONCLUSIVE.
-	if math.Abs(effect) >= v.effectThreshold && math.Abs(delta) < v.minRawEffect {
+	if math.Abs(effect) >= effectThreshold && math.Abs(delta) < minRawEffect {
 		return journal.Verdict{
 			Outcome:     OutcomeInconclusive,
 			Delta:       delta,
 			Significant: false,
 			Reason: fmt.Sprintf("not practically significant: |delta|=%.4f < min_raw_effect=%.4f (effect=%.3f, n=%d/%d)",
-				math.Abs(delta), v.minRawEffect, effect, exp.Count, ctl.Count),
+				math.Abs(delta), minRawEffect, effect, exp.Count, ctl.Count),
 		}, true
 	}
 
 	switch {
-	case effect >= v.effectThreshold:
+	case effect >= effectThreshold:
 		promote := journal.Verdict{
 			Outcome:     CohortOutcomePromote,
 			Delta:       delta,
 			Significant: true,
 			Reason: fmt.Sprintf("experimental better: effect=%.3f >= threshold=%.2f, |delta|=%.4f >= min_raw=%.4f (n=%d/%d)",
-				effect, v.effectThreshold, math.Abs(delta), v.minRawEffect, exp.Count, ctl.Count),
+				effect, effectThreshold, math.Abs(delta), minRawEffect, exp.Count, ctl.Count),
 		}
 		// SECONDARY anchor (#992): gate the promote against recent real play.
-		return v.applyRecentRealAnchor(promote, s.Objective, exp.Mean), true
-	case effect <= -v.effectThreshold:
+		return v.applyRecentRealAnchor(promote, anchorMargin, s.Objective, exp.Mean), true
+	case effect <= -effectThreshold:
 		return journal.Verdict{
 			Outcome:     CohortOutcomeDiscard,
 			Delta:       delta,
 			Significant: true,
 			Reason: fmt.Sprintf("experimental worse: effect=%.3f <= -threshold=%.2f, |delta|=%.4f >= min_raw=%.4f (n=%d/%d)",
-				effect, v.effectThreshold, math.Abs(delta), v.minRawEffect, exp.Count, ctl.Count),
+				effect, effectThreshold, math.Abs(delta), minRawEffect, exp.Count, ctl.Count),
 		}, true
 	default:
 		return journal.Verdict{
@@ -511,7 +565,7 @@ func (v *Verdict) Evaluate(s journal.Summary) (journal.Verdict, bool) {
 			Delta:       delta,
 			Significant: false,
 			Reason: fmt.Sprintf("within noise: |effect|=%.3f < threshold=%.2f (n=%d/%d)",
-				math.Abs(effect), v.effectThreshold, exp.Count, ctl.Count),
+				math.Abs(effect), effectThreshold, exp.Count, ctl.Count),
 		}, true
 	}
 }
@@ -541,7 +595,10 @@ func (v *Verdict) Evaluate(s journal.Summary) (journal.Verdict, bool) {
 // experimentalValue is the experimental arm's mean fitness (the value a promotion
 // would make the real default) — exp.Mean in the two-arm path, the experimental
 // arm mean in the paired path. objective selects the per-objective baseline.
-func (v *Verdict) applyRecentRealAnchor(verdict journal.Verdict, objective string, experimentalValue float64) journal.Verdict {
+// anchorMargin is the live regression margin snapshotted by Evaluate under v.mu
+// (#1214, verdict_anchor_margin), passed in rather than re-read off v so the whole
+// evaluation sees one coherent set of thresholds.
+func (v *Verdict) applyRecentRealAnchor(verdict journal.Verdict, anchorMargin float64, objective string, experimentalValue float64) journal.Verdict {
 	if verdict.Outcome != CohortOutcomePromote {
 		return verdict // anchor gates promotion only; discard/inconclusive unaffected.
 	}
@@ -558,18 +615,18 @@ func (v *Verdict) applyRecentRealAnchor(verdict journal.Verdict, objective strin
 	// Regression test: the experimental value must not fall below recent real play by
 	// more than the margin. margin mirrors the #1042 practical-significance floor, so a
 	// shadow winner within noise of recent real play is NOT treated as a regression.
-	if experimentalValue < baseline-v.anchorMargin {
+	if experimentalValue < baseline-anchorMargin {
 		return journal.Verdict{
 			Outcome:     OutcomeInconclusive,
 			Delta:       verdict.Delta,
 			Significant: false,
 			Reason: fmt.Sprintf("promote gated by recent-real regression: experimental=%.4f < recent_real=%.4f - margin=%.4f (objective=%q); %s",
-				experimentalValue, baseline, v.anchorMargin, objective, verdict.Reason),
+				experimentalValue, baseline, anchorMargin, objective, verdict.Reason),
 		}
 	}
 	// Anchor cleared — annotate the promote reason so the cross-check is observable.
 	verdict.Reason += fmt.Sprintf(" | recent-real anchor: held (experimental=%.4f >= recent_real=%.4f - margin=%.4f)",
-		experimentalValue, baseline, v.anchorMargin)
+		experimentalValue, baseline, anchorMargin)
 	return verdict
 }
 
@@ -590,7 +647,11 @@ func (v *Verdict) applyRecentRealAnchor(verdict journal.Verdict, objective strin
 // Delta carries mean(d) (the average per-pair fitness improvement) for the audit
 // trail. The bool is always true: a non-nil non-empty PairDiff is a meaningful
 // (possibly interim) verdict the registry should record.
-func (v *Verdict) evaluatePaired(pd journal.Welford, minPairs int, objective string, experimentalMean float64) (journal.Verdict, bool) {
+// effectThreshold / minRawEffect / sdFloor / anchorMargin are the live float knobs
+// (#1214, verdict_effect_threshold / verdict_min_raw_effect / verdict_sd_floor /
+// verdict_anchor_margin) snapshotted by Evaluate under v.mu and passed in, so the
+// paired path and the two-arm path see one coherent threshold set per evaluation.
+func (v *Verdict) evaluatePaired(pd journal.Welford, minPairs int, effectThreshold, minRawEffect, sdFloor, anchorMargin float64, objective string, experimentalMean float64) (journal.Verdict, bool) {
 	meanD := pd.Mean
 
 	if pd.Count < minPairs {
@@ -621,8 +682,8 @@ func (v *Verdict) evaluatePaired(pd journal.Welford, minPairs int, objective str
 	// the raw-effect floor below is now the gate that keeps a zero-spread no-op
 	// inconclusive, so a zero-spread set with a meaningful meanD can legitimately
 	// conclude (floored d_z is large AND |meanD| clears the practical floor).
-	if v.sdFloor > 0 && sdD < v.sdFloor {
-		sdD = v.sdFloor
+	if sdFloor > 0 && sdD < sdFloor {
+		sdD = sdFloor
 	}
 	if sdD == 0 {
 		// Only reachable if the SD floor was disabled (sdFloor<=0) AND the spread is
@@ -642,34 +703,34 @@ func (v *Verdict) evaluatePaired(pd journal.Welford, minPairs int, objective str
 	// a huge d_z on near-deterministic shadow games (the dry-run's d_z=-34 on a ~0.0004
 	// fitness gap). Require |meanD| to clear the minimum meaningful delta before
 	// promote/discard, regardless of d_z magnitude — otherwise INCONCLUSIVE.
-	if math.Abs(dz) >= v.effectThreshold && math.Abs(meanD) < v.minRawEffect {
+	if math.Abs(dz) >= effectThreshold && math.Abs(meanD) < minRawEffect {
 		return journal.Verdict{
 			Outcome:     OutcomeInconclusive,
 			Delta:       meanD,
 			Significant: false,
 			Reason: fmt.Sprintf("paired not practically significant: |mean_d|=%.4f < min_raw_effect=%.4f (d_z=%.3f, pairs=%d)",
-				math.Abs(meanD), v.minRawEffect, dz, pd.Count),
+				math.Abs(meanD), minRawEffect, dz, pd.Count),
 		}, true
 	}
 
 	switch {
-	case dz >= v.effectThreshold:
+	case dz >= effectThreshold:
 		promote := journal.Verdict{
 			Outcome:     CohortOutcomePromote,
 			Delta:       meanD,
 			Significant: true,
 			Reason: fmt.Sprintf("paired: experimental better: d_z=%.3f >= threshold=%.2f, |mean_d|=%.4f >= min_raw=%.4f (pairs=%d)",
-				dz, v.effectThreshold, math.Abs(meanD), v.minRawEffect, pd.Count),
+				dz, effectThreshold, math.Abs(meanD), minRawEffect, pd.Count),
 		}
 		// SECONDARY anchor (#992): gate the paired promote against recent real play.
-		return v.applyRecentRealAnchor(promote, objective, experimentalMean), true
-	case dz <= -v.effectThreshold:
+		return v.applyRecentRealAnchor(promote, anchorMargin, objective, experimentalMean), true
+	case dz <= -effectThreshold:
 		return journal.Verdict{
 			Outcome:     CohortOutcomeDiscard,
 			Delta:       meanD,
 			Significant: true,
 			Reason: fmt.Sprintf("paired: experimental worse: d_z=%.3f <= -threshold=%.2f, |mean_d|=%.4f >= min_raw=%.4f (pairs=%d)",
-				dz, v.effectThreshold, math.Abs(meanD), v.minRawEffect, pd.Count),
+				dz, effectThreshold, math.Abs(meanD), minRawEffect, pd.Count),
 		}, true
 	default:
 		return journal.Verdict{
@@ -677,7 +738,7 @@ func (v *Verdict) evaluatePaired(pd journal.Welford, minPairs int, objective str
 			Delta:       meanD,
 			Significant: false,
 			Reason: fmt.Sprintf("paired within noise: |d_z|=%.3f < threshold=%.2f (pairs=%d)",
-				math.Abs(dz), v.effectThreshold, pd.Count),
+				math.Abs(dz), effectThreshold, pd.Count),
 		}, true
 	}
 }

--- a/services/agent/experiment/verdict_test.go
+++ b/services/agent/experiment/verdict_test.go
@@ -252,55 +252,110 @@ func TestVerdict_DefaultsOnNonPositiveConfig(t *testing.T) {
 }
 
 func TestVerdictFromEnv(t *testing.T) {
+	// minN / minPairs stay env-derived (the registry's bootstrap default the live
+	// verdict_min_n / verdict_min_pairs flags fall back to).
 	t.Setenv(minNEnv, "5")
-	t.Setenv(effectEnv, "0.8")
 	v := NewVerdictFromEnv()
 	if v.minN != 5 {
 		t.Fatalf("env minN = %d, want 5", v.minN)
 	}
-	if v.effectThreshold != 0.8 {
-		t.Fatalf("env effectThreshold = %v, want 0.8", v.effectThreshold)
+	// The four migrated float knobs (#1214) are NO LONGER read from env — they are LIVE
+	// agent.json flags. NewVerdictFromEnv seeds them from the Default* constants (the
+	// fail-open fallback); the live flag value arrives later via SetFloatThresholds.
+	if v.effectThreshold != DefaultEffectThreshold {
+		t.Fatalf("effectThreshold = %v, want default %v (no longer env-read)", v.effectThreshold, DefaultEffectThreshold)
 	}
 
 	// Invalid / empty values fall back to defaults.
 	t.Setenv(minNEnv, "not-a-number")
-	t.Setenv(effectEnv, "")
 	v2 := NewVerdictFromEnv()
 	if v2.minN != DefaultMinNPerArm || v2.effectThreshold != DefaultEffectThreshold {
 		t.Fatalf("invalid env should fall back to defaults, got minN=%d threshold=%v", v2.minN, v2.effectThreshold)
 	}
 }
 
-// TestVerdictFromEnv_Floors (#1042): the practical-significance floor and SD floor are
-// configurable via AGENT_VERDICT_MIN_RAW_EFFECT / AGENT_VERDICT_SD_FLOOR, with
-// fallback to defaults on unset/invalid values.
+// TestVerdictFromEnv_Floors (#1214) — the practical-significance floor, SD floor,
+// effect threshold and anchor margin are NO LONGER env-read: NewVerdictFromEnv seeds
+// them from the Default* constants (the flags' fail-open fallback). This asserts the
+// construction defaults; the live-flag override is covered by TestVerdict_SetFloatThresholds.
 func TestVerdictFromEnv_Floors(t *testing.T) {
-	t.Setenv(minRawEffEnv, "0.05")
-	t.Setenv(sdFloorEnv, "0.001")
+	// Even with the legacy env vars set, the four floats default to the code constants
+	// (env is ignored now — the values come from flags via SetFloatThresholds).
+	t.Setenv("AGENT_VERDICT_MIN_RAW_EFFECT", "0.05")
+	t.Setenv("AGENT_VERDICT_SD_FLOOR", "0.001")
 	v := NewVerdictFromEnv()
-	if v.minRawEffect != 0.05 {
-		t.Fatalf("env minRawEffect = %v, want 0.05", v.minRawEffect)
+	if v.minRawEffect != DefaultMinRawEffect {
+		t.Fatalf("minRawEffect = %v, want default %v (env no longer read, #1214)", v.minRawEffect, DefaultMinRawEffect)
 	}
-	if v.sdFloor != 0.001 {
-		t.Fatalf("env sdFloor = %v, want 0.001", v.sdFloor)
+	if v.sdFloor != DefaultSDFloor {
+		t.Fatalf("sdFloor = %v, want default %v (env no longer read, #1214)", v.sdFloor, DefaultSDFloor)
 	}
-	// The default gate must be built WITH the resolved sdFloor so the two-arm path is
-	// floored too.
+	// The default gate is built WITH the default sdFloor so the two-arm path is floored.
 	g, ok := v.stat.(effectSizeGate)
 	if !ok {
 		t.Fatalf("default stat should be effectSizeGate, got %T", v.stat)
 	}
-	if g.sdFloor != 0.001 {
-		t.Fatalf("two-arm gate sdFloor = %v, want 0.001 (must inherit the env SD floor)", g.sdFloor)
+	if g.sdFloor != DefaultSDFloor {
+		t.Fatalf("two-arm gate sdFloor = %v, want default %v", g.sdFloor, DefaultSDFloor)
+	}
+}
+
+// TestVerdict_SetFloatThresholds (#1214) is the live-tuning acceptance for the four
+// migrated float verdict knobs: SetFloatThresholds updates effectThreshold /
+// minRawEffect / sdFloor / anchorMargin (and keeps the two-arm gate's sdFloor in sync),
+// while a non-positive value per knob is IGNORED (keeps the current value) — the same
+// fail-safe floor SetThresholds uses for min_n/min_pairs.
+func TestVerdict_SetFloatThresholds(t *testing.T) {
+	v := NewVerdictFromEnv()
+
+	v.SetFloatThresholds(0.8, 0.05, 0.001, 0.03)
+	if v.effectThreshold != 0.8 {
+		t.Fatalf("effectThreshold = %v, want 0.8 after SetFloatThresholds", v.effectThreshold)
+	}
+	if v.minRawEffect != 0.05 {
+		t.Fatalf("minRawEffect = %v, want 0.05 after SetFloatThresholds", v.minRawEffect)
+	}
+	if v.sdFloor != 0.001 {
+		t.Fatalf("sdFloor = %v, want 0.001 after SetFloatThresholds", v.sdFloor)
+	}
+	if v.anchorMargin != 0.03 {
+		t.Fatalf("anchorMargin = %v, want 0.03 after SetFloatThresholds", v.anchorMargin)
+	}
+	// The two-arm gate's floor must track the live verdict_sd_floor value.
+	if g, ok := v.stat.(effectSizeGate); !ok || g.sdFloor != 0.001 {
+		t.Fatalf("two-arm gate sdFloor not synced to live value: %+v (ok=%v)", v.stat, ok)
 	}
 
-	// Invalid / non-positive fall back to defaults.
-	t.Setenv(minRawEffEnv, "garbage")
-	t.Setenv(sdFloorEnv, "-1")
-	v2 := NewVerdictFromEnv()
-	if v2.minRawEffect != DefaultMinRawEffect || v2.sdFloor != DefaultSDFloor {
-		t.Fatalf("invalid floor env should fall back to defaults, got rawEffect=%v sdFloor=%v",
-			v2.minRawEffect, v2.sdFloor)
+	// Non-positive values per knob are ignored (keep the current value).
+	v.SetFloatThresholds(0, -1, 0, -2)
+	if v.effectThreshold != 0.8 || v.minRawEffect != 0.05 || v.sdFloor != 0.001 || v.anchorMargin != 0.03 {
+		t.Fatalf("non-positive SetFloatThresholds must keep current values, got eff=%v raw=%v sd=%v anchor=%v",
+			v.effectThreshold, v.minRawEffect, v.sdFloor, v.anchorMargin)
+	}
+}
+
+// TestVerdict_SetFloatThresholds_DrivesVerdict (#1214) proves the live float knob
+// actually drives the verdict outcome: a borderline standardized effect that PROMOTEs
+// under the default effect threshold flips to INCONCLUSIVE once SetFloatThresholds
+// raises verdict_effect_threshold above it — the flag value drives the gate.
+func TestVerdict_SetFloatThresholds_DrivesVerdict(t *testing.T) {
+	v := NewVerdict(8, DefaultEffectThreshold, nil)
+	// Arms with a clear, practically-significant separation: a medium-ish Cohen's d that
+	// clears the 0.5 default threshold (promote) but not a raised 2.0 threshold.
+	exp := armFrom(spread(12, 0.70, 0.10)...)
+	ctl := armFrom(spread(12, 0.50, 0.10)...)
+
+	got, ok := v.Evaluate(summaryWith(exp, ctl))
+	if !ok || got.Outcome != CohortOutcomePromote {
+		t.Fatalf("with default threshold expected PROMOTE, got outcome=%v ok=%v reason=%q", got.Outcome, ok, got.Reason)
+	}
+
+	// Raise the live effect threshold above the observed effect: the SAME data now reads
+	// as within-noise ⇒ INCONCLUSIVE. The flag value drove the verdict.
+	v.SetFloatThresholds(2.0, 0, 0, 0)
+	got2, ok2 := v.Evaluate(summaryWith(exp, ctl))
+	if !ok2 || got2.Outcome != OutcomeInconclusive {
+		t.Fatalf("after raising effect threshold expected INCONCLUSIVE, got outcome=%v ok=%v reason=%q", got2.Outcome, ok2, got2.Reason)
 	}
 }
 

--- a/services/agent/experiment_loop.go
+++ b/services/agent/experiment_loop.go
@@ -471,6 +471,10 @@ func (e *experimentLoop) config(ctx context.Context) flags.ExperimentConfig {
 			VerdictMinPairs:            e.expDefaults.VerdictMinPairs,
 			MaxGames:                   e.expDefaults.MaxGames,
 			ShadowEffectiveConcurrency: e.expDefaults.ShadowEffectiveConcurrency,
+			VerdictEffectThreshold:     e.expDefaults.VerdictEffectThreshold,
+			VerdictMinRawEffect:        e.expDefaults.VerdictMinRawEffect,
+			VerdictSDFloor:             e.expDefaults.VerdictSDFloor,
+			VerdictAnchorMargin:        e.expDefaults.VerdictAnchorMargin,
 		}
 	}
 	return e.flags.Experiment(ctx, e.expDefaults)
@@ -517,6 +521,12 @@ func (e *experimentLoop) allocateIfEnabled(ctx context.Context) {
 	// concurrency / games-budget / min-N takes effect on THIS tick's allocation +
 	// verdict evaluation.
 	e.registry.Reconfigure(cfg.ShadowEffectiveConcurrency, cfg.MaxGames, cfg.VerdictMinN, cfg.VerdictMinPairs)
+	// #1214: mirror the four migrated FLOAT verdict knobs onto the verdict the same way,
+	// so a hot-reloaded verdict_effect_threshold / verdict_min_raw_effect /
+	// verdict_sd_floor / verdict_anchor_margin takes effect on THIS tick's verdict
+	// evaluations. Verdict-only (the registry reads none of them), so it is a separate
+	// forward to the verdict alongside Reconfigure.
+	e.registry.ReconfigureVerdictFloats(cfg.VerdictEffectThreshold, cfg.VerdictMinRawEffect, cfg.VerdictSDFloor, cfg.VerdictAnchorMargin)
 	// Heuristic dynamic declaration (#995): both gates are on (checked above) and the
 	// declarer is opted-in (live experiment_dynamic_enabled, #1044), so let the agent
 	// CHOOSE a fresh experiment to declare — bounded by the LIVE concurrent-experiment
@@ -1265,6 +1275,15 @@ func experimentDefaultsFromEnv() flags.ExperimentDefaults {
 		VerdictMinPairs:            experiment.MinPairsFromEnv(),
 		MaxGames:                   experiment.MaxGamesPerExperimentFromEnv(),
 		ShadowEffectiveConcurrency: experiment.EffectiveConcurrencyFromEnv(),
+		// Verdict-tuning float knobs (#1214): the BOOTSTRAP default each live agent.json
+		// flag (verdict_effect_threshold / verdict_min_raw_effect / verdict_sd_floor /
+		// verdict_anchor_margin) falls back to. These four were migrated FULLY to flags
+		// (no AGENT_VERDICT_* env any more), so the bootstrap default is the verdict's own
+		// Default* constant — the same fail-open value the verdict was constructed with.
+		VerdictEffectThreshold: experiment.DefaultEffectThreshold,
+		VerdictMinRawEffect:    experiment.DefaultMinRawEffect,
+		VerdictSDFloor:         experiment.DefaultSDFloor,
+		VerdictAnchorMargin:    experiment.DefaultAnchorMargin,
 	}
 }
 

--- a/services/agent/flags/flags.go
+++ b/services/agent/flags/flags.go
@@ -160,6 +160,25 @@ const (
 	keyExperimentMaxGames          = "experiment_max_games"
 	keyExperimentShadowConcurrency = "experiment_shadow_effective_concurrency"
 
+	// Verdict-tuning float knobs migrated from env to agent.json flags (#1214),
+	// finishing the cluster verdict_min_n / verdict_min_pairs started in #1044. These
+	// were the AGENT_VERDICT_EFFECT_THRESHOLD / _MIN_RAW_EFFECT / _SD_FLOOR /
+	// _ANCHOR_MARGIN env knobs read ONCE at startup by experiment.NewVerdictFromEnv.
+	// Migrating them makes each numeric verdict gate hot-reloadable — flip it in flagd
+	// and the NEXT verdict evaluation uses the new threshold with no restart, exactly
+	// like the min_n/min_pairs siblings (live-mirrored onto the Verdict via the
+	// registry's Reconfigure → Verdict.SetThresholds, #1044/#1051).
+	//
+	// They are TUNING knobs, not safety gates: each FAILS OPEN to the current code
+	// default (the same numeric value the env var defaulted to) when flagd is
+	// undefined/unreachable — matching the min_n/min_pairs behavior. They are read via
+	// the TYPED float getter (floatFlag/FloatValue), NEVER ObjectValue — a numeric flag
+	// read via ObjectValue silently TYPE_MISMATCHes to its default (#903/#1127).
+	keyVerdictEffectThreshold = "verdict_effect_threshold"
+	keyVerdictMinRawEffect    = "verdict_min_raw_effect"
+	keyVerdictSDFloor         = "verdict_sd_floor"
+	keyVerdictAnchorMargin    = "verdict_anchor_margin"
+
 	// Runtime SAFETY gates migrated from env to agent.json flags (#1213). These
 	// were the AGENT_INTERVENTIONS_ENABLED / AGENT_ROLLOUT_ENABLED env masters read
 	// ONCE at startup in main.go to select which action sink / rollout actuator was
@@ -681,6 +700,18 @@ type ExperimentDefaults struct {
 	MaxGames int
 	// ShadowEffectiveConcurrency is AGENT_SHADOW_EFFECTIVE_CONCURRENCY.
 	ShadowEffectiveConcurrency int
+	// VerdictEffectThreshold is the verdict's standardized-effect gate
+	// (#1214; was AGENT_VERDICT_EFFECT_THRESHOLD, default 0.5).
+	VerdictEffectThreshold float64
+	// VerdictMinRawEffect is the practical-significance floor (#1042)
+	// (#1214; was AGENT_VERDICT_MIN_RAW_EFFECT, default 0.02).
+	VerdictMinRawEffect float64
+	// VerdictSDFloor is the minimum-SD denominator floor (#1042)
+	// (#1214; was AGENT_VERDICT_SD_FLOOR, default 1e-4).
+	VerdictSDFloor float64
+	// VerdictAnchorMargin is the recent-real regression margin (#992)
+	// (#1214; was AGENT_VERDICT_ANCHOR_MARGIN, default 0.02).
+	VerdictAnchorMargin float64
 }
 
 // ExperimentConfig is the LIVE-resolved experiment runtime configuration (#1044),
@@ -710,9 +741,22 @@ type ExperimentConfig struct {
 	// ShadowEffectiveConcurrency is the in-flight shadow-spawn concurrency cap
 	// (experiment_shadow_effective_concurrency).
 	ShadowEffectiveConcurrency int
+	// VerdictEffectThreshold is the live standardized-effect gate (verdict_effect_threshold,
+	// #1214): the minimum |Cohen's d| / |d_z| for a promote/discard verdict.
+	VerdictEffectThreshold float64
+	// VerdictMinRawEffect is the live practical-significance floor (verdict_min_raw_effect,
+	// #1214): the minimum RAW effect magnitude a promote/discard requires (#1042).
+	VerdictMinRawEffect float64
+	// VerdictSDFloor is the live minimum-SD denominator floor (verdict_sd_floor, #1214):
+	// floors the d_z / Cohen's d denominator so the standardized stat stays finite (#1042).
+	VerdictSDFloor float64
+	// VerdictAnchorMargin is the live recent-real regression margin (verdict_anchor_margin,
+	// #1214): a PROMOTE is downgraded only when the experimental arm regresses below the
+	// recent-real baseline by MORE than this (#992).
+	VerdictAnchorMargin float64
 }
 
-// Experiment evaluates the eight migrated experiment runtime knobs (#1044) for one
+// Experiment evaluates the migrated experiment runtime knobs (#1044, #1214) for one
 // experiment tick. Read LIVE (never cached) so a hot-reload of any knob takes
 // effect on the next tick. Each flag falls back to the matching ExperimentDefaults
 // field (the env-derived bootstrap default) on any evaluation error or flag
@@ -730,6 +774,13 @@ func (f *Flags) Experiment(ctx context.Context, def ExperimentDefaults) Experime
 		VerdictMinPairs:            f.intFlag(ctx, keyVerdictMinPairs, def.VerdictMinPairs),
 		MaxGames:                   f.intFlag(ctx, keyExperimentMaxGames, def.MaxGames),
 		ShadowEffectiveConcurrency: f.intFlag(ctx, keyExperimentShadowConcurrency, def.ShadowEffectiveConcurrency),
+		// Verdict-tuning float knobs (#1214). Typed float getter (the flagd numeric-flag
+		// gotcha — see llmGate); fail-OPEN to the env-derived default (the verdict's code
+		// default) on any error/absence, exactly like the min_n/min_pairs siblings above.
+		VerdictEffectThreshold: f.floatFlag(ctx, keyVerdictEffectThreshold, def.VerdictEffectThreshold),
+		VerdictMinRawEffect:    f.floatFlag(ctx, keyVerdictMinRawEffect, def.VerdictMinRawEffect),
+		VerdictSDFloor:         f.floatFlag(ctx, keyVerdictSDFloor, def.VerdictSDFloor),
+		VerdictAnchorMargin:    f.floatFlag(ctx, keyVerdictAnchorMargin, def.VerdictAnchorMargin),
 	}
 }
 

--- a/services/agent/flags/flags_test.go
+++ b/services/agent/flags/flags_test.go
@@ -696,6 +696,11 @@ func TestExperiment_FlagOverridesEnvDefault(t *testing.T) {
 		VerdictMinPairs:            5,
 		MaxGames:                   50,
 		ShadowEffectiveConcurrency: 4,
+		// #1214 verdict-tuning float defaults (the verdict's Default* constants).
+		VerdictEffectThreshold: 0.5,
+		VerdictMinRawEffect:    0.02,
+		VerdictSDFloor:         0.0001,
+		VerdictAnchorMargin:    0.02,
 	}
 
 	t.Run("flags present override every env default", func(t *testing.T) {
@@ -704,7 +709,14 @@ func TestExperiment_FlagOverridesEnvDefault(t *testing.T) {
 				keyExperimentsEnabled:       true,
 				keyExperimentDynamicEnabled: true,
 			},
-			floats: map[string]float64{keyExperimentTickSeconds: 10},
+			floats: map[string]float64{
+				keyExperimentTickSeconds: 10,
+				// #1214 verdict-tuning float knobs, read via the TYPED float getter.
+				keyVerdictEffectThreshold: 0.8,
+				keyVerdictMinRawEffect:    0.05,
+				keyVerdictSDFloor:         0.001,
+				keyVerdictAnchorMargin:    0.03,
+			},
 			ints: map[string]int64{
 				keyExperimentDynamicMaxConcur:  6,
 				keyVerdictMinN:                 16,
@@ -723,6 +735,10 @@ func TestExperiment_FlagOverridesEnvDefault(t *testing.T) {
 			VerdictMinPairs:            10,
 			MaxGames:                   100,
 			ShadowEffectiveConcurrency: 8,
+			VerdictEffectThreshold:     0.8,
+			VerdictMinRawEffect:        0.05,
+			VerdictSDFloor:             0.001,
+			VerdictAnchorMargin:        0.03,
 		}
 		if got != want {
 			t.Fatalf("Experiment with flags present = %+v, want %+v", got, want)
@@ -741,9 +757,29 @@ func TestExperiment_FlagOverridesEnvDefault(t *testing.T) {
 			VerdictMinPairs:            def.VerdictMinPairs,
 			MaxGames:                   def.MaxGames,
 			ShadowEffectiveConcurrency: def.ShadowEffectiveConcurrency,
+			VerdictEffectThreshold:     def.VerdictEffectThreshold,
+			VerdictMinRawEffect:        def.VerdictMinRawEffect,
+			VerdictSDFloor:             def.VerdictSDFloor,
+			VerdictAnchorMargin:        def.VerdictAnchorMargin,
 		}
 		if got != want {
 			t.Fatalf("Experiment with flags absent = %+v, want env defaults %+v", got, want)
+		}
+	})
+
+	t.Run("verdict float flags fail open to defaults on flagd error (#1214)", func(t *testing.T) {
+		errAll := map[string]error{
+			keyVerdictEffectThreshold: errors.New("down"),
+			keyVerdictMinRawEffect:    errors.New("down"),
+			keyVerdictSDFloor:         errors.New("down"),
+			keyVerdictAnchorMargin:    errors.New("down"),
+		}
+		got := New(stubEvaluator{errs: errAll}, nil).Experiment(context.Background(), def)
+		if got.VerdictEffectThreshold != def.VerdictEffectThreshold ||
+			got.VerdictMinRawEffect != def.VerdictMinRawEffect ||
+			got.VerdictSDFloor != def.VerdictSDFloor ||
+			got.VerdictAnchorMargin != def.VerdictAnchorMargin {
+			t.Fatalf("verdict float flags under flagd error did not fail open to defaults: %+v", got)
 		}
 	})
 

--- a/services/flagd/agent.json
+++ b/services/flagd/agent.json
@@ -496,6 +496,42 @@
       },
       "defaultVariant": "default"
     },
+    "verdict_effect_threshold": {
+      "state": "ENABLED",
+      "variants": {
+        "small": 0.2,
+        "default": 0.5,
+        "large": 0.8
+      },
+      "defaultVariant": "default"
+    },
+    "verdict_min_raw_effect": {
+      "state": "ENABLED",
+      "variants": {
+        "loose": 0.01,
+        "default": 0.02,
+        "strict": 0.05
+      },
+      "defaultVariant": "default"
+    },
+    "verdict_sd_floor": {
+      "state": "ENABLED",
+      "variants": {
+        "tight": 0.00001,
+        "default": 0.0001,
+        "loose": 0.001
+      },
+      "defaultVariant": "default"
+    },
+    "verdict_anchor_margin": {
+      "state": "ENABLED",
+      "variants": {
+        "loose": 0.01,
+        "default": 0.02,
+        "strict": 0.05
+      },
+      "defaultVariant": "default"
+    },
     "experiment_max_games": {
       "state": "ENABLED",
       "variants": {

--- a/services/flagd/ci/agent.json
+++ b/services/flagd/ci/agent.json
@@ -496,6 +496,42 @@
       },
       "defaultVariant": "default"
     },
+    "verdict_effect_threshold": {
+      "state": "ENABLED",
+      "variants": {
+        "small": 0.2,
+        "default": 0.5,
+        "large": 0.8
+      },
+      "defaultVariant": "default"
+    },
+    "verdict_min_raw_effect": {
+      "state": "ENABLED",
+      "variants": {
+        "loose": 0.01,
+        "default": 0.02,
+        "strict": 0.05
+      },
+      "defaultVariant": "default"
+    },
+    "verdict_sd_floor": {
+      "state": "ENABLED",
+      "variants": {
+        "tight": 0.00001,
+        "default": 0.0001,
+        "loose": 0.001
+      },
+      "defaultVariant": "default"
+    },
+    "verdict_anchor_margin": {
+      "state": "ENABLED",
+      "variants": {
+        "loose": 0.01,
+        "default": 0.02,
+        "strict": 0.05
+      },
+      "defaultVariant": "default"
+    },
     "experiment_max_games": {
       "state": "ENABLED",
       "variants": {


### PR DESCRIPTION
Finishes the verdict-tuning flag cluster started by #1044. Migrates the four remaining env-only verdict knobs in `services/agent/experiment/verdict.go` to live `agent.json` flags, read via typed getters in `services/agent/flags/flags.go`.

## The four flags (all float)
| env var (removed) | flag | type | preserved default |
|---|---|---|---|
| `AGENT_VERDICT_EFFECT_THRESHOLD` | `verdict_effect_threshold` | float | `0.5` (`DefaultEffectThreshold`) |
| `AGENT_VERDICT_MIN_RAW_EFFECT` | `verdict_min_raw_effect` | float | `0.02` (`DefaultMinRawEffect`) |
| `AGENT_VERDICT_SD_FLOOR` | `verdict_sd_floor` | float | `1e-4` (`DefaultSDFloor`) |
| `AGENT_VERDICT_ANCHOR_MARGIN` | `verdict_anchor_margin` | float | `0.02` (`DefaultAnchorMargin`) |

## Mirror of the `verdict_min_n` / `verdict_min_pairs` siblings
Same wiring end-to-end as the #1044 siblings:
- Declared in `services/flagd/agent.json` + `ci/agent.json` with the same block shape (3 numeric variants, `defaultVariant: default`).
- Keys/struct fields added to `ExperimentDefaults` + `ExperimentConfig`, read via the **typed float getter** `floatFlag`/`FloatValue` (NEVER `ObjectValue` — the #903/#1127 silent-TYPE_MISMATCH trap).
- Live-mirrored onto the verdict each experiment tick via the registry: `Reconfigure` (min_n/min_pairs) + new `ReconfigureVerdictFloats` → `Verdict.SetThresholds` / new `Verdict.SetFloatThresholds`.

## Fail-open defaults
These are TUNING knobs, so they **fail OPEN** to the verdict's `Default*` constants when flagd is undefined/unreachable — matching the min_n/min_pairs siblings. The env consts + `floatFromEnv` reader are removed; the constants are now the fail-open fallback the flags resolve to. The four floats are snapshotted under `v.mu` in `Evaluate` and passed to `evaluatePaired` / `applyRecentRealAnchor`, so a hot-reload is honored between evaluations while a single evaluation sees one coherent threshold set. The `verdict_sd_floor` update also syncs the two-arm `effectSizeGate` denominator.

## CI parity
Added to BOTH `agent.json` and `ci/agent.json` with identical defaults — no `AGENT_VERDICT_*` docker-compose override exists, so the CI config needs no different value. The #801 drift guard (`lib/tests/test_flagd_ci_drift.py`) passes (key parity).

## Tests
- `go test -race ./experiment/... ./flags/...` + `go test ./...` — all green; `gofmt -l .` empty; `go vet ./...` clean.
- Extended the flags `Experiment` override/fail-open test with the four floats.
- Rewrote the verdict env tests (the four floats are no longer env-read) and added `SetFloatThresholds` unit + verdict-driving tests (a raised `verdict_effect_threshold` flips a PROMOTE to INCONCLUSIVE on the same data).
- `test_flagd_ci_drift.py` passes.

Part of #1214

🤖 Generated with [Claude Code](https://claude.com/claude-code)