### PR TITLE
fix(agent): make llm.eligible_game_kinds a CSV string flag (#1221)

### DIFF
--- a/services/agent/flags/flags.go
+++ b/services/agent/flags/flags.go
@@ -1082,23 +1082,24 @@ func (f *Flags) llmGate(ctx context.Context) LLMGate {
 	}
 }
 
-// eligibleGameKinds resolves the llm.eligible_game_kinds array into []string. The
-// flag's variants are JSON arrays, surfaced as []any of strings (same shape as
-// interventions_allowed). On any error or unparseable shape it falls back to the
-// default ["real"] — fail-closed to shadow-games-rules-only, NOT to empty, which
-// would disable llm entirely.
+// eligibleGameKinds resolves the llm.eligible_game_kinds allow-list into []string.
+// The flag is a STRING flag whose variants are comma-separated game kinds (e.g.
+// "real,shadow"); `none` is the empty string. It is deliberately NOT a LIST/array
+// flag: array-valued variants are rejected by flagd's JSON schema
+// (`got array, want boolean`), so the whole flag fails to load and the agent
+// silently falls back to the default — exactly the #1221 bug (same class as the
+// interventions_allowed #1127 fix). A STRING flag is read cleanly by the RPC
+// resolver, so the live variant is honored. On a resolution error it falls back to
+// the default ["real"] — fail-closed to shadow-games-rules-only, NOT to empty,
+// which would disable llm entirely. The empty string (`none` variant) is a valid
+// intentional state and yields an empty list (llm disabled), distinct from an error.
 func (f *Flags) eligibleGameKinds(ctx context.Context) []string {
-	raw, err := f.client.ObjectValue(ctx, keyLLMEligibleGameKinds, defaultLLMEligibleGameKinds(), openfeature.EvaluationContext{})
+	raw, err := f.client.StringValue(ctx, keyLLMEligibleGameKinds, "real", openfeature.EvaluationContext{})
 	if err != nil {
 		f.log.Debug("flags.llm.eligible_game_kinds fell back to default", "error", err)
 		return defaultLLMEligibleGameKinds()
 	}
-	list, ok := toStringSlice(raw)
-	if !ok {
-		f.log.Warn("flags.llm.eligible_game_kinds had unexpected shape, using default", "value", raw)
-		return defaultLLMEligibleGameKinds()
-	}
-	return list
+	return parseCSVList(raw)
 }
 
 // toFloatMap coerces an OpenFeature object value into map[string]float64.
@@ -1139,26 +1140,5 @@ func toFloat(v any) (float64, bool) {
 		return float64(n), true
 	default:
 		return 0, false
-	}
-}
-
-// toStringSlice coerces an OpenFeature object value into []string. Accepts an
-// already-typed []string and the []any flagd shape with string leaves.
-func toStringSlice(raw any) ([]string, bool) {
-	switch s := raw.(type) {
-	case []string:
-		return append([]string(nil), s...), true
-	case []any:
-		out := make([]string, 0, len(s))
-		for _, v := range s {
-			str, ok := v.(string)
-			if !ok {
-				return nil, false
-			}
-			out = append(out, str)
-		}
-		return out, true
-	default:
-		return nil, false
 	}
 }

--- a/services/agent/flags/flags_test.go
+++ b/services/agent/flags/flags_test.go
@@ -345,16 +345,15 @@ func TestInterventionsAllowed_StringFlag(t *testing.T) {
 }
 
 // TestEvaluate_LLMGate_FlagdShape: the three #847 gate flags resolve through the
-// typed getters into the LLMGate struct. eligible_game_kinds is an array object,
+// typed getters into the LLMGate struct. eligible_game_kinds is a comma-separated
+// STRING (#1221: array variants are schema-rejected by flagd),
 // min_decision_interval_seconds is float seconds -> Duration, max_requests_per_minute
 // is an int.
 func TestEvaluate_LLMGate_FlagdShape(t *testing.T) {
 	stub := stubEvaluator{
-		objects: map[string]any{
-			keyLLMEligibleGameKinds: []any{"real", "shadow"},
-		},
-		floats: map[string]float64{keyLLMMinDecisionInterval: 30, keyLLMLatencyBudget: 4},
-		ints:   map[string]int64{keyLLMMaxRequestsPerMin: 12},
+		strings: map[string]string{keyLLMEligibleGameKinds: "real,shadow"},
+		floats:  map[string]float64{keyLLMMinDecisionInterval: 30, keyLLMLatencyBudget: 4},
+		ints:    map[string]int64{keyLLMMaxRequestsPerMin: 12},
 	}
 	got := New(stub, nil).Evaluate(context.Background()).LLMGate
 	if !reflect.DeepEqual(got.EligibleGameKinds, []string{"real", "shadow"}) {
@@ -402,16 +401,17 @@ func TestEvaluate_LLMGate_NonPositiveLatencyBudgetFallsBack(t *testing.T) {
 	}
 }
 
-// TestEvaluate_LLMGate_BadEligibilityShapeFallsBack: an unparseable
-// eligible_game_kinds value falls back to ["real"], NOT empty (fail-closed to
+// TestEvaluate_LLMGate_UnreadableEligibilityFallsBack: when eligible_game_kinds
+// cannot be resolved (a flagd read error — e.g. the #1221 schema rejection of the
+// old array variants), the gate falls back to ["real"], NOT empty (fail-closed to
 // shadow-rules-only, not to llm-disabled).
-func TestEvaluate_LLMGate_BadEligibilityShapeFallsBack(t *testing.T) {
-	stub := stubEvaluator{objects: map[string]any{
-		keyLLMEligibleGameKinds: map[string]any{"unexpected": true},
+func TestEvaluate_LLMGate_UnreadableEligibilityFallsBack(t *testing.T) {
+	stub := stubEvaluator{errs: map[string]error{
+		keyLLMEligibleGameKinds: errors.New("flagd schema rejection"),
 	}}
 	got := New(stub, nil).Evaluate(context.Background()).LLMGate
 	if !reflect.DeepEqual(got.EligibleGameKinds, []string{"real"}) {
-		t.Errorf("EligibleGameKinds = %v, want default [real] on bad shape", got.EligibleGameKinds)
+		t.Errorf("EligibleGameKinds = %v, want default [real] on read error", got.EligibleGameKinds)
 	}
 }
 

--- a/services/flagd/agent.json
+++ b/services/flagd/agent.json
@@ -117,9 +117,9 @@
     "llm.eligible_game_kinds": {
       "state": "ENABLED",
       "variants": {
-        "none": [],
-        "real_only": ["real"],
-        "real_and_shadow": ["real", "shadow"]
+        "none": "",
+        "real_only": "real",
+        "real_and_shadow": "real,shadow"
       },
       "defaultVariant": "real_only"
     },
@@ -517,7 +517,7 @@
     "verdict_sd_floor": {
       "state": "ENABLED",
       "variants": {
-        "tight": 0.00001,
+        "tight": 1e-05,
         "default": 0.0001,
         "loose": 0.001
       },

--- a/services/flagd/ci/agent.json
+++ b/services/flagd/ci/agent.json
@@ -117,9 +117,9 @@
     "llm.eligible_game_kinds": {
       "state": "ENABLED",
       "variants": {
-        "none": [],
-        "real_only": ["real"],
-        "real_and_shadow": ["real", "shadow"]
+        "none": "",
+        "real_only": "real",
+        "real_and_shadow": "real,shadow"
       },
       "defaultVariant": "real_only"
     },
@@ -517,7 +517,7 @@
     "verdict_sd_floor": {
       "state": "ENABLED",
       "variants": {
-        "tight": 0.00001,
+        "tight": 1e-05,
         "default": 0.0001,
         "loose": 0.001
       },


### PR DESCRIPTION
## Problem
`llm.eligible_game_kinds` used **array-valued flagd variants** (`["real","shadow"]`). flagd's JSON schema only accepts boolean/number/string/object variant values, so it rejected the whole flag at load (`got array, want boolean`) in **both** `agent.json` and `ci/agent.json`. The agent's getter read it via `ObjectValue`, errored, and silently fell back to the hard-coded `["real"]` default — **the flag was dead**, and shadow games could never be made LLM-eligible. This blocked the #1207 in-game LLM upgrade from ever firing on shadow games.

## Fix
Switch `llm.eligible_game_kinds` to a **comma-separated STRING** variant shape (`none`="", `real_only`="real", `real_and_shadow`="real,shadow"), read via `StringValue` + `parseCSVList` — mirroring the `interventions_allowed` #1127 fix. Drop the now-dead `toStringSlice` helper. **Defaults unchanged** (`real_only`, fail-closed; error → `["real"]`). Empty string (`none`) → empty list (llm disabled), distinct from an error.

## Verification (live, verification #12)
Reproduced + fixed on the live dry-run stack:
- **Before:** flagd logged `flag definition does not conform to the schema` for `llm.eligible_game_kinds`; every in-game cycle gated out as `llm_not_eligible`; **0** in-game LLM spans.
- **After (this fix built into the agent):** flagd accepts the flag (no schema rejection); with the flag flipped to `real_and_shadow`, shadow games pass eligibility (no more `llm_not_eligible`), the #1207 async upgrade fires — **149 `agent.signal_received` anchors under `gameplay_phase`**, and **13 in-game decisions tagged `inference.used=gemma4:latest`** (LLM upgrade landed in-game) alongside 137 rules-first decisions.
- Unit tests updated (CSV fixture + error-fallback test); `go test -race ./flags/...`, decision/experiment/root packages all green; `gofmt`/`vet` clean.

Pre-existing bug (not introduced by #1207/#1216). Part of #1221

🤖 Generated with [Claude Code](https://claude.com/claude-code)